### PR TITLE
fix: rotate log files by size to prevent unbounded growth

### DIFF
--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -57,7 +57,7 @@ export async function run(args: string[]) {
     process.exit(1);
   }
 
-  // Spawn daemon as detached child process
+  // Spawn daemon as detached child process (daemon manages its own log rotation)
   mkdirSync(home, { recursive: true });
   const logFile = resolve(home, "daemon.log");
   const logFd = openSync(logFile, "a");
@@ -66,7 +66,7 @@ export async function run(args: string[]) {
     process.execPath,
     [daemonModule, "--port", String(port), "--host", hostname],
     {
-      stdio: ["ignore", logFd, logFd],
+      stdio: ["ignore", "ignore", logFd],
       detached: true,
     },
   );

--- a/src/lib/agent-manager.ts
+++ b/src/lib/agent-manager.ts
@@ -1,11 +1,12 @@
 import { type ChildProcess, execFile, type SpawnOptions, spawn } from "node:child_process";
-import { createWriteStream, existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { loadMergedEnv } from "./env.js";
 import { applyIsolation } from "./isolation.js";
 import { clearJsonMap, loadJsonMap, saveJsonMap } from "./json-state.js";
 import { agentDir, findAgent, setAgentRunning, voluteHome } from "./registry.js";
+import { RotatingLog } from "./rotating-log.js";
 import { findVariant, setVariantRunning, validateBranchName } from "./variants.js";
 
 const execFileAsync = promisify(execFile);
@@ -73,9 +74,7 @@ export class AgentManager {
     const logsDir = resolve(voluteDir, "logs");
     mkdirSync(logsDir, { recursive: true });
 
-    const logStream = createWriteStream(resolve(logsDir, "agent.log"), {
-      flags: "a",
-    });
+    const logStream = new RotatingLog(resolve(logsDir, "agent.log"));
     const agentEnv = loadMergedEnv(dir);
     const { VOLUTE_DAEMON_TOKEN: _, ...parentEnv } = process.env;
     const env = { ...parentEnv, ...agentEnv, VOLUTE_AGENT: name };

--- a/src/lib/connector-manager.ts
+++ b/src/lib/connector-manager.ts
@@ -1,17 +1,11 @@
 import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
-import {
-  createWriteStream,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { checkMissingEnvVars, getConnectorDef } from "./connector-defs.js";
 import { loadMergedEnv } from "./env.js";
 import { applyIsolation } from "./isolation.js";
 import { agentDir as getAgentDir, voluteHome } from "./registry.js";
+import { RotatingLog } from "./rotating-log.js";
 import { readVoluteConfig } from "./volute-config.js";
 
 function searchUpwards(...segments: string[]): string | null {
@@ -136,7 +130,7 @@ export class ConnectorManager {
     // Set up log file
     const logsDir = resolve(agentDir, ".volute", "logs");
     mkdirSync(logsDir, { recursive: true });
-    const logStream = createWriteStream(resolve(logsDir, `${type}.log`), { flags: "a" });
+    const logStream = new RotatingLog(resolve(logsDir, `${type}.log`));
 
     // Pass connector-specific env vars from agent env
     const agentEnv = loadMergedEnv(agentDir);

--- a/src/lib/rotating-log.ts
+++ b/src/lib/rotating-log.ts
@@ -1,0 +1,47 @@
+import { createWriteStream, existsSync, renameSync, statSync, type WriteStream } from "node:fs";
+import { Writable } from "node:stream";
+
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+
+export class RotatingLog extends Writable {
+  private stream: WriteStream;
+  private size: number;
+
+  constructor(
+    private readonly path: string,
+    private readonly maxSize = MAX_SIZE,
+  ) {
+    super();
+    this.on("error", () => {});
+    try {
+      this.size = existsSync(path) ? statSync(path).size : 0;
+    } catch {
+      this.size = 0;
+    }
+    this.stream = createWriteStream(path, { flags: "a" });
+  }
+
+  override _write(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.size += chunk.length;
+    if (this.size > this.maxSize) {
+      try {
+        renameSync(this.path, `${this.path}.1`);
+        const oldStream = this.stream;
+        this.stream = createWriteStream(this.path);
+        this.size = chunk.length;
+        oldStream.end();
+      } catch {
+        // Rotation failed — continue writing to the current stream
+      }
+    }
+    this.stream.write(chunk, callback);
+  }
+
+  override _final(callback: (error?: Error | null) => void): void {
+    this.stream.end(callback);
+  }
+}

--- a/test/rotating-log.test.ts
+++ b/test/rotating-log.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { RotatingLog } from "../src/lib/rotating-log.js";
+
+function write(log: RotatingLog, data: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    log.write(data, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function end(log: RotatingLog): Promise<void> {
+  return new Promise((resolve) => log.end(resolve));
+}
+
+describe("RotatingLog", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rotating-log-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true });
+  });
+
+  it("writes data to the log file", async () => {
+    const logPath = join(dir, "test.log");
+    const log = new RotatingLog(logPath);
+    await write(log, "hello\n");
+    await end(log);
+    assert.equal(readFileSync(logPath, "utf-8"), "hello\n");
+  });
+
+  it("appends to existing file across instances", async () => {
+    const logPath = join(dir, "test.log");
+    const log1 = new RotatingLog(logPath);
+    await write(log1, "first\n");
+    await end(log1);
+
+    const log2 = new RotatingLog(logPath);
+    await write(log2, "second\n");
+    await end(log2);
+
+    assert.equal(readFileSync(logPath, "utf-8"), "first\nsecond\n");
+  });
+
+  it("rotates when file exceeds maxSize", async () => {
+    const logPath = join(dir, "test.log");
+    const log = new RotatingLog(logPath, 20);
+    await write(log, "1234567890"); // 10 bytes
+    await write(log, "1234567890"); // 20 bytes total
+    await write(log, "new"); // 23 bytes, triggers rotation
+    await end(log);
+
+    assert(existsSync(`${logPath}.1`));
+    assert.equal(readFileSync(logPath, "utf-8"), "new");
+    assert.equal(readFileSync(`${logPath}.1`, "utf-8"), "12345678901234567890");
+  });
+
+  it("tracks size across instances for rotation", async () => {
+    const logPath = join(dir, "test.log");
+    const log1 = new RotatingLog(logPath, 20);
+    await write(log1, "1234567890"); // 10 bytes
+    await end(log1);
+
+    const log2 = new RotatingLog(logPath, 20);
+    await write(log2, "1234567890"); // 20 bytes total
+    await write(log2, "overflow"); // triggers rotation
+    await end(log2);
+
+    assert(existsSync(`${logPath}.1`));
+    assert.equal(readFileSync(logPath, "utf-8"), "overflow");
+  });
+
+  it("does not crash if rotation fails", async () => {
+    const logPath = join(dir, "test.log");
+    const log = new RotatingLog(logPath, 5);
+    // Write enough to trigger rotation, then continue writing
+    await write(log, "123456"); // triggers rotation
+    await write(log, "789"); // should still work
+    await end(log);
+    // Just verify it didn't throw
+    assert(existsSync(logPath));
+  });
+});


### PR DESCRIPTION
## Summary

- Add `RotatingLog` writable stream that rotates log files when they exceed 10MB, keeping one `.1` backup
- Daemon redirects all console methods (`log`, `error`, `warn`, `info`) through `RotatingLog` in background mode, using `util.format` for proper object serialization
- Agent and connector child process logs also use `RotatingLog` instead of raw `createWriteStream`
- Stderr fd redirect kept in `up.ts` for early crash diagnostics before `RotatingLog` initializes

## Test plan

- [x] Added 5 unit tests for `RotatingLog` (basic writes, append across instances, rotation trigger, size tracking, resilience to rotation failures)
- [x] All 269 tests pass
- [x] Build succeeds
- [ ] Manual: run daemon for extended period, verify log files stay bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)