### PR TITLE
fix: create template branch during agent creation for clean upgrades

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,4 +1,5 @@
 import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
 import { exec, execInherit } from "../lib/exec.js";
 import { chownAgentDir, createAgentUser, ensureVoluteGroup } from "../lib/isolation.js";
 import { parseArgs } from "../lib/parse-args.js";
@@ -8,7 +9,11 @@ import {
   composeTemplate,
   copyTemplateToDir,
   findTemplatesRoot,
+  listFiles,
+  type TemplateManifest,
 } from "../lib/template.js";
+
+const TEMPLATE_BRANCH = "volute/template";
 
 export async function run(args: string[]) {
   const { positional, flags } = parseArgs(args, {
@@ -37,36 +42,62 @@ export async function run(args: string[]) {
   try {
     copyTemplateToDir(composedDir, dest, name, manifest);
     applyInitFiles(dest);
+
+    // Assign port and register
+    const port = nextPort();
+    addAgent(name, port);
+
+    // Install dependencies
+    console.log("Installing dependencies...");
+    await execInherit("npm", ["install"], { cwd: dest });
+
+    // git init + template branch + initial commit (after install so lockfile is included)
+    try {
+      await exec("git", ["init"], { cwd: dest });
+      await initTemplateBranch(dest, composedDir, manifest);
+    } catch (err) {
+      // Clean up partial git state so the repo isn't left on an orphan branch
+      rmSync(resolve(dest, ".git"), { recursive: true, force: true });
+      console.warn(
+        "\nWarning: git setup failed — variants and upgrades won't be available.",
+        "\nTo fix: ensure git is installed with user.name/user.email configured.",
+      );
+      console.warn("Details:", (err as Error).message ?? err);
+    }
+
+    // Set up per-agent user isolation (no-ops if VOLUTE_ISOLATION !== "user")
+    ensureVoluteGroup();
+    createAgentUser(name);
+    chownAgentDir(dest, name);
+
+    console.log(`\nCreated agent: ${name} (port ${port})`);
+    console.log(`\n  volute agent start ${name}`);
   } finally {
     rmSync(composedDir, { recursive: true, force: true });
   }
+}
 
-  // Assign port and register
-  const port = nextPort();
-  addAgent(name, port);
+/**
+ * Create the volute/template tracking branch and main branch with shared history.
+ * This enables clean 3-way merges on the first `volute agent upgrade`.
+ */
+async function initTemplateBranch(
+  projectRoot: string,
+  composedDir: string,
+  manifest: TemplateManifest,
+) {
+  // Compute template file paths (after renames, excluding .init/ identity files)
+  const templateFiles = listFiles(composedDir)
+    .filter((f) => !f.startsWith(".init/") && !f.startsWith(".init\\"))
+    .map((f) => manifest.rename[f] ?? f);
 
-  // Install dependencies
-  console.log("Installing dependencies...");
-  await execInherit("npm", ["install"], { cwd: dest });
+  // Create orphan template branch with only template files
+  await exec("git", ["checkout", "--orphan", TEMPLATE_BRANCH], { cwd: projectRoot });
+  await exec("git", ["add", "--", ...templateFiles], { cwd: projectRoot });
+  await exec("git", ["commit", "-m", "template update"], { cwd: projectRoot });
 
-  // git init + initial commit (after install so lockfile is included)
-  try {
-    await exec("git", ["init"], { cwd: dest });
-    await exec("git", ["add", "-A"], { cwd: dest });
-    await exec("git", ["commit", "-m", "initial commit"], { cwd: dest });
-  } catch {
-    console.warn(
-      "\nWarning: git init failed (git may not be installed or configured).",
-      "\nThe agent will work, but forking/variants won't be available.",
-      "\nTo fix: install git and run `git config --global user.name` / `git config --global user.email`",
-    );
-  }
-
-  // Set up per-agent user isolation (no-ops if VOLUTE_ISOLATION !== "user")
-  ensureVoluteGroup();
-  createAgentUser(name);
-  chownAgentDir(dest, name);
-
-  console.log(`\nCreated agent: ${name} (port ${port})`);
-  console.log(`\n  volute agent start ${name}`);
+  // Create main from template branch (shared history enables clean upgrades)
+  await exec("git", ["checkout", "-b", "main"], { cwd: projectRoot });
+  await exec("git", ["add", "-A"], { cwd: projectRoot });
+  await exec("git", ["commit", "-m", "initial commit"], { cwd: projectRoot });
 }


### PR DESCRIPTION
## Summary

- Create `volute/template` branch during `volute agent create` with template-only files (excluding `.init/` identity files), then branch `main` from it
- This establishes shared git history so the first `volute agent upgrade` can do a proper 3-way merge instead of `--allow-unrelated-histories` where every file conflicts
- Clean up `.git` directory on partial failure so agents aren't left with corrupted git state

## Test plan

- [x] New test: first upgrade is conflict-free when template branch created at agent creation
- [x] New test: first upgrade detects real conflicts when agent modified template files
- [x] All 271 existing tests pass
- [x] Backward compatible: `upgrade.ts` still uses `--allow-unrelated-histories` for agents created before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)