### PR TITLE
feat: make agent name optional in volute agent commands

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -17,14 +17,9 @@ export async function run(args: string[]) {
     case "list":
       await import("./status.js").then((m) => m.run(args.slice(1)));
       break;
-    case "status": {
-      if (!args[1] || args[1].startsWith("-")) {
-        console.error("Usage: volute agent status <name>");
-        process.exit(1);
-      }
+    case "status":
       await import("./status.js").then((m) => m.run(args.slice(1)));
       break;
-    }
     case "logs": {
       // Transform positional name to --agent flag for compatibility
       const rest = args.slice(1);
@@ -60,12 +55,14 @@ function transformAgentFlag(args: string[]): string[] {
 function printUsage() {
   console.log(`Usage:
   volute agent create <name> [--template <name>]
-  volute agent start <name>
-  volute agent stop <name>
-  volute agent delete <name> [--force]
+  volute agent start [name]
+  volute agent stop [name]
+  volute agent delete [name] [--force]
   volute agent list
-  volute agent status <name>
-  volute agent logs <name> [--follow] [-n N]
-  volute agent upgrade <name> [--template <name>] [--continue]
-  volute agent import <path> [--name <name>] [--session <path>] [--template <name>]`);
+  volute agent status [name]
+  volute agent logs [name] [--follow] [-n N]
+  volute agent upgrade [name] [--template <name>] [--continue]
+  volute agent import <path> [--name <name>] [--session <path>] [--template <name>]
+
+Agent name can be omitted if VOLUTE_AGENT is set.`);
 }

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -2,6 +2,7 @@ import { existsSync, rmSync } from "node:fs";
 import { deleteAgentUser } from "../lib/isolation.js";
 import { parseArgs } from "../lib/parse-args.js";
 import { agentDir, findAgent, removeAgent } from "../lib/registry.js";
+import { resolveAgentName } from "../lib/resolve-agent-name.js";
 import { removeAllVariants } from "../lib/variants.js";
 
 export async function run(args: string[]) {
@@ -9,11 +10,7 @@ export async function run(args: string[]) {
     force: { type: "boolean" },
   });
 
-  const name = positional[0];
-  if (!name) {
-    console.error("Usage: volute agent delete <name> [--force]");
-    process.exit(1);
-  }
+  const name = resolveAgentName({ agent: positional[0] });
 
   const entry = findAgent(name);
   if (!entry) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,12 +1,9 @@
 import { daemonFetch } from "../lib/daemon-client.js";
 import { resolveAgent } from "../lib/registry.js";
+import { resolveAgentName } from "../lib/resolve-agent-name.js";
 
 export async function run(args: string[]) {
-  const name = args[0];
-  if (!name) {
-    console.error("Usage: volute agent start <name>");
-    process.exit(1);
-  }
+  const name = resolveAgentName({ agent: args[0] });
 
   const { entry } = resolveAgent(name);
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -15,7 +15,7 @@ type AgentInfo = {
 };
 
 export async function run(args: string[]) {
-  const name = args[0];
+  const name = args[0] || process.env.VOLUTE_AGENT;
 
   if (!name) {
     // List all agents

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,12 +1,9 @@
 import { daemonFetch } from "../lib/daemon-client.js";
 import { resolveAgent } from "../lib/registry.js";
+import { resolveAgentName } from "../lib/resolve-agent-name.js";
 
 export async function run(args: string[]) {
-  const name = args[0];
-  if (!name) {
-    console.error("Usage: volute agent stop <name>");
-    process.exit(1);
-  }
+  const name = resolveAgentName({ agent: args[0] });
 
   resolveAgent(name); // Validate agent exists
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -4,6 +4,7 @@ import { daemonFetch } from "../lib/daemon-client.js";
 import { exec, execInherit } from "../lib/exec.js";
 import { parseArgs } from "../lib/parse-args.js";
 import { nextPort, resolveAgent } from "../lib/registry.js";
+import { resolveAgentName } from "../lib/resolve-agent-name.js";
 import { composeTemplate, copyTemplateToDir, findTemplatesRoot } from "../lib/template.js";
 import { addVariant } from "../lib/variants.js";
 
@@ -16,11 +17,7 @@ export async function run(args: string[]) {
     continue: { type: "boolean" },
   });
 
-  const agentName = positional[0];
-  if (!agentName) {
-    console.error("Usage: volute agent upgrade <name> [--template <name>] [--continue]");
-    process.exit(1);
-  }
+  const agentName = resolveAgentName({ agent: positional[0] });
 
   const { dir: projectRoot } = resolveAgent(agentName);
   const template = flags.template ?? "agent-sdk";

--- a/src/lib/resolve-agent-name.ts
+++ b/src/lib/resolve-agent-name.ts
@@ -1,7 +1,7 @@
 export function resolveAgentName(flags: { agent?: string }): string {
   const name = flags.agent || process.env.VOLUTE_AGENT;
   if (!name) {
-    console.error("No agent specified. Use --agent <name> or set VOLUTE_AGENT.");
+    console.error("No agent specified. Provide a name or set VOLUTE_AGENT.");
     process.exit(1);
   }
   return name;

--- a/templates/_base/_skills/volute-agent/SKILL.md
+++ b/templates/_base/_skills/volute-agent/SKILL.md
@@ -5,12 +5,14 @@ description: This skill should be used when working with the volute CLI, underst
 
 # Self-Management
 
-You manage yourself through the `volute` CLI. Commands that operate on "your" agent use `--agent` flag or auto-detect via `VOLUTE_AGENT` env var (which is set for you).
+You manage yourself through the `volute` CLI. Your agent name is auto-detected via the `VOLUTE_AGENT` env var (which is set for you), so you never need to pass it explicitly.
 
 ## Commands
 
 | Command | Purpose |
 |---------|---------|
+| `volute agent start` | Start your server |
+| `volute agent stop` | Stop your server |
 | `volute agent status` | Check your status |
 | `volute agent logs [--follow] [-n N]` | Read your own logs |
 | `volute message history [--channel <ch>] [--limit N]` | View your activity across all channels |


### PR DESCRIPTION
## Summary
- `volute agent start/stop/delete/status/upgrade` now fall back to `VOLUTE_AGENT` env var when no name is given, so agents can run these commands on themselves without passing their own name
- Updated error message in `resolveAgentName` to be generic (no longer mentions `--agent` flag)
- Added `start` and `stop` to the volute-agent skill's command table

## Test plan
- [x] All 310 existing tests pass
- [x] Verify `volute agent start` works without name when `VOLUTE_AGENT` is set
- [x] Verify `volute agent stop` works without name when `VOLUTE_AGENT` is set
- [x] Verify `volute agent status` shows single agent (not list) when `VOLUTE_AGENT` is set
- [x] Verify commands still work with explicit name argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)