### PR TITLE
fix: resolve package.json for flat dist layout in update check

### DIFF
--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -36,11 +36,11 @@ function writeCache(latest: string): void {
 
 export function getCurrentVersion(): string {
   // Walk up from this file to find package.json
-  // In built dist: dist/lib/update-check.js → ../../package.json
+  // In built dist (flat with splitting): dist/chunk-*.js → ../package.json
   // In dev via tsx: src/lib/update-check.ts → ../../package.json
-  // ../../../ — tsup may produce different dist layouts depending on chunk splitting
   const thisDir = new URL(".", import.meta.url).pathname;
   const candidates = [
+    resolve(thisDir, "../package.json"),
     resolve(thisDir, "../../package.json"),
     resolve(thisDir, "../../../package.json"),
   ];


### PR DESCRIPTION
## Summary

- `getCurrentVersion()` was returning `"0.0.0"` in production because tsup's `splitting: true` puts code in flat `dist/chunk-*.js` files, but the path candidates only looked 2-3 levels up (expecting `dist/lib/update-check.js`)
- Added `../package.json` as the first candidate to cover the flat dist layout
- `volute -v` was unaffected because `cli.ts` uses a static `import("../package.json")` instead of `import.meta.url` resolution

## Test plan

- [x] Existing `getCurrentVersion` test passes (returns semver, not `"0.0.0"`)
- [x] All tests pass
- [ ] Verify on external machine after upgrade that the spurious update banner is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)