### PR TITLE
feat: persist agent running state across daemon restarts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,9 @@ switch (command) {
   case "down":
     await import("./commands/down.js").then((m) => m.run(args));
     break;
+  case "restart":
+    await import("./commands/daemon-restart.js").then((m) => m.run(args));
+    break;
   case "setup":
     await import("./commands/setup.js").then((m) => m.run(args));
     break;
@@ -95,6 +98,7 @@ Commands:
 
   volute up [--port N]                    Start the daemon (default: 4200)
   volute down                             Stop the daemon
+  volute restart [--port N]               Restart the daemon
 
   volute service install [--port N]       Install as system service (auto-start)
   volute service uninstall                Remove system service

--- a/src/commands/daemon-restart.ts
+++ b/src/commands/daemon-restart.ts
@@ -1,0 +1,13 @@
+import { stopDaemon } from "./down.js";
+import { run as up } from "./up.js";
+
+export async function run(args: string[]) {
+  const result = await stopDaemon();
+
+  if (!result.stopped && result.reason === "kill-failed") {
+    console.error("Cannot restart: failed to stop the running daemon.");
+    process.exit(1);
+  }
+
+  await up(args);
+}

--- a/src/lib/agent-manager.ts
+++ b/src/lib/agent-manager.ts
@@ -253,11 +253,13 @@ export class AgentManager {
     this.stopping.delete(name);
     if (this.restartAttempts.delete(name)) this.saveCrashAttempts();
 
-    const [baseName, variantName] = name.split("@", 2);
-    if (variantName) {
-      setVariantRunning(baseName, variantName, false);
-    } else {
-      setAgentRunning(name, false);
+    if (!this.shuttingDown) {
+      const [baseName, variantName] = name.split("@", 2);
+      if (variantName) {
+        setVariantRunning(baseName, variantName, false);
+      } else {
+        setAgentRunning(name, false);
+      }
     }
 
     console.error(`[daemon] stopped agent ${name}`);


### PR DESCRIPTION
## Summary
- Skip setting `running=false` in registry during graceful daemon shutdown (`stopAll`), so agents marked as running auto-restore on next `volute up`
- Extract `stopDaemon()` helper from `down.ts` with proper PID validation, error reporting, and SIGKILL cleanup
- Add `volute restart` command (graceful down + up) using the shared helper

## Test plan
- [x] Existing tests pass (429/429)
- [x] New e2e test: running agent persists `running: true` across daemon SIGTERM, auto-restores on next startup
- [x] New e2e test: stopped agent stays `running: false` across daemon restart, is NOT auto-started
- [x] Manual: `volute up && volute agent start <name> && volute down && volute up` — agent should auto-restart
- [x] Manual: `volute restart` — equivalent to down + up, agents should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)