### PR TITLE
fix: clear typing indicator when Discord message arrives

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -349,8 +349,11 @@ const app = new Hono<AuthEnv>()
       });
     }
 
-    // Enrich payload with currently-typing senders (exclude the receiving agent)
+    // Enrich payload with currently-typing senders (exclude the receiving agent
+    // and the message sender — they just sent a message, so they're not typing)
     const typingMap = getTypingMap();
+    const sender = (parsed?.sender as string) ?? "";
+    if (sender) typingMap.delete(channel, sender);
     const currentlyTyping = typingMap.get(channel).filter((s) => s !== baseName);
     let forwardBody = body;
     if (parsed && currentlyTyping.length > 0) {


### PR DESCRIPTION
## Summary

- Clear sender's typing state when their message arrives (Discord only fires `TypingStart`, no stop event)
- Fix in two places: connector sends `reportTyping(false)`, daemon deletes sender from typing map when forwarding
- Fix sender name mismatch between `TypingStart` (was using guild nickname) and `MessageCreate` (global display name) so typing map entries clear correctly
- Replace empty `.catch(() => {})` blocks in Discord connector with logging

## Test plan

- [x] All 430 tests pass
- [x] Send a DM to an agent via Discord — agent should not see a typing indicator from the sender
- [x] In a batched channel, send a message then start typing again — batch should reflect the new typing state

🤖 Generated with [Claude Code](https://claude.com/claude-code)