### PR TITLE
feat: auto-chunk long messages in channel drivers

### DIFF
--- a/src/lib/channels/telegram.ts
+++ b/src/lib/channels/telegram.ts
@@ -1,4 +1,7 @@
+import { splitMessage } from "../../connectors/sdk.js";
 import { resolveChannelId } from "../channels.js";
+
+const TELEGRAM_MAX_LENGTH = 4096;
 
 const API_BASE = "https://api.telegram.org";
 
@@ -25,14 +28,18 @@ export async function send(
 ): Promise<void> {
   const token = requireToken(env);
   const chatId = resolveChannelId(env, channelSlug);
-  const res = await fetch(`${API_BASE}/bot${token}/sendMessage`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ chat_id: chatId, text: message }),
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Telegram API error: ${res.status} ${body}`);
+  const chunks = splitMessage(message, TELEGRAM_MAX_LENGTH);
+  for (let i = 0; i < chunks.length; i++) {
+    const res = await fetch(`${API_BASE}/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: chunks[i] }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      const partial = i > 0 ? ` (${i}/${chunks.length} chunks were already sent)` : "";
+      throw new Error(`Telegram API error: ${res.status} ${body}${partial}`);
+    }
   }
 }
 

--- a/test/split-message.test.ts
+++ b/test/split-message.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { splitMessage } from "../src/connectors/sdk.js";
+
+describe("splitMessage", () => {
+  it("returns single chunk for short messages", () => {
+    assert.deepEqual(splitMessage("hello", 2000), ["hello"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    assert.deepEqual(splitMessage("", 2000), []);
+  });
+
+  it("splits at newline boundary when possible", () => {
+    const line1 = "a".repeat(1500);
+    const line2 = "b".repeat(1000);
+    const message = `${line1}\n${line2}`;
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0], line1);
+    assert.equal(chunks[1], line2);
+  });
+
+  it("hard splits when no good newline found", () => {
+    const message = "a".repeat(3000);
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0].length, 2000);
+    assert.equal(chunks[1].length, 1000);
+  });
+
+  it("prefers newline in second half of max length", () => {
+    // Newline at position 1500 (in second half of 2000) should be used
+    const before = "a".repeat(1500);
+    const after = "b".repeat(1000);
+    const message = `${before}\n${after}`;
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0], before);
+    assert.equal(chunks[1], after);
+  });
+
+  it("ignores newline in first half (too early)", () => {
+    // Newline at position 500 (in first half of 2000) — too early, hard split instead
+    const before = "a".repeat(500);
+    const after = "b".repeat(2500);
+    const message = `${before}\n${after}`;
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks[0].length, 2000);
+  });
+
+  it("handles multiple chunks", () => {
+    const message = "a".repeat(5000);
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks.length, 3);
+    assert.equal(chunks[0].length, 2000);
+    assert.equal(chunks[1].length, 2000);
+    assert.equal(chunks[2].length, 1000);
+  });
+
+  it("returns single chunk when message exactly equals max length", () => {
+    const message = "a".repeat(2000);
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0], message);
+  });
+
+  it("strips the split-point newline from the next chunk", () => {
+    const before = "a".repeat(1990);
+    const after = "b".repeat(100);
+    const message = `${before}\n${after}`;
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0], before);
+    assert.equal(chunks[1], after);
+  });
+
+  it("uses newline at exactly the midpoint", () => {
+    const before = "a".repeat(1000);
+    const after = "b".repeat(1500);
+    const message = `${before}\n${after}`;
+    const chunks = splitMessage(message, 2000);
+    assert.equal(chunks[0], before);
+    assert.equal(chunks[1], after);
+  });
+});


### PR DESCRIPTION
## Summary
- Channel drivers (`volute channel send`, web dashboard) now automatically chunk long messages before sending to platform APIs, matching the existing connector behavior
- Discord (2000 chars), Slack (4000 chars), Telegram (4096 chars) limits enforced via the shared `splitMessage` utility
- Error messages include partial delivery context when a mid-sequence chunk fails (e.g. `2/3 chunks were already sent`)

## Test plan
- [x] Added unit tests for `splitMessage` covering: short messages, empty string, newline-boundary splitting, hard splits, midpoint boundary, exact max length, newline stripping
- [x] All 442 tests pass
- [x] Lint and typecheck pass via pre-commit hooks
- [x] Manual test: send a message >2000 chars to a Discord channel via `volute channel send`

🤖 Generated with [Claude Code](https://claude.com/claude-code)