### PR TITLE
docs: comprehensive documentation audit and corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Volute is a home for independent, self-motivated agents. The architecture is des
 
 - `src/cli.ts` — CLI entry point, dynamic command imports via switch statement
 - `src/daemon.ts` — Daemon entry point, starts web server + agent/connector/scheduler managers
-- `src/commands/` — One file per command, each exports `async function run(args: string[])`. Top-level nouns (`agent.ts`, `message.ts`, `conversation.ts`) dispatch to subcommand files.
+- `src/commands/` — One file per command, each exports `async function run(args: string[])`. Top-level nouns (`agent.ts`, `channel.ts`, `connector.ts`, `env.ts`, `schedule.ts`, `service.ts`, `setup.ts`, `variant.ts`) dispatch to subcommand files.
 - `src/lib/` — Shared libraries (registry, agent-manager, connector-manager, scheduler, daemon-client, arg parsing, exec wrappers, variant metadata, db, auth, conversations, channels)
 - `src/web/` — Web dashboard (Hono backend + React frontend), served by the daemon
 - `src/connectors/` — Built-in connector implementations (Discord, Slack, Telegram) + shared SDK
@@ -33,7 +33,7 @@ CLI commands like `agent start`, `agent stop`, `message send`, `connector`, `var
 
 Volute system state (logs, env, channel mappings, connector PIDs) lives in `~/.volute/state/<name>/`, separate from agent directories. This keeps agent projects portable — they contain only agent-owned state (sessions, cursors, connector configs). The `stateDir(name)` helper in `src/lib/registry.ts` resolves state paths. On daemon startup, `migrateAgentState()` copies any legacy `.volute/env.json`, `.volute/channels.json`, and `.volute/logs/` from agent directories to the centralized state dir.
 
-Agents receive `VOLUTE_STATE_DIR`, `VOLUTE_DAEMON_PORT`, and `VOLUTE_DAEMON_TOKEN` env vars from the daemon. Instead of file-based IPC (restart.json, merged.json), agents call the daemon's REST API via `daemonRestart()` and `daemonSend()` from `templates/_base/src/lib/daemon-client.ts`. The daemon delivers post-restart context (merge info) to agents via HTTP POST to the agent's `/message` endpoint.
+Agents receive `VOLUTE_AGENT`, `VOLUTE_STATE_DIR`, `VOLUTE_AGENT_DIR`, `VOLUTE_AGENT_PORT`, `VOLUTE_DAEMON_PORT`, and `VOLUTE_DAEMON_TOKEN` env vars from the daemon (via `process.env` inheritance). Instead of file-based IPC (restart.json, merged.json), agents call the daemon's REST API via `daemonRestart()` and `daemonSend()` from `templates/_base/src/lib/daemon-client.ts`. The daemon delivers post-restart context (merge info) to agents via HTTP POST to the agent's `/message` endpoint.
 
 ### Agent project structure
 
@@ -44,7 +44,6 @@ Each agent project (created from the template) has:
 ├── src/
 │   ├── server.ts              # Wires agent + router + file handler + HTTP server
 │   ├── agent.ts               # Core agent handler: session management, SDK integration, HandlerResolver
-│   ├── consolidate.ts         # Memory consolidation script
 │   └── lib/
 │       ├── router.ts          # Message router: route resolution, prefix formatting, batch buffering
 │       ├── volute-server.ts   # Thin HTTP layer: /health, POST /message → JSON response
@@ -54,8 +53,19 @@ Each agent project (created from the template) has:
 │       ├── format-prefix.ts   # Shared message formatting (channel/sender/time prefix)
 │       ├── startup.ts         # Shared server.ts boilerplate (parseArgs, loadConfig, etc.)
 │       ├── auto-commit.ts     # Auto-commits file changes in home/ via SDK hooks
+│       ├── auto-reply.ts      # Auto-reply tracker for sending text output back to channels
+│       ├── daemon-client.ts   # Agent-side daemon API client (daemonRestart, daemonSend)
+│       ├── session-monitor.ts # Session activity tracking and cross-session summaries
 │       ├── logger.ts          # Logging utilities
-│       ├── message-channel.ts # Async iterable for agent communication (agent-sdk template)
+│       ├── message-channel.ts # Async iterable for agent communication (agent-sdk template only)
+│       ├── content.ts         # Content extraction from SDK events (agent-sdk template only)
+│       ├── session-store.ts   # Session state persistence (agent-sdk template only)
+│       ├── stream-consumer.ts # SDK stream event consumer (agent-sdk template only)
+│       └── hooks/             # SDK hooks (agent-sdk template only)
+│           ├── auto-commit.ts     # File change auto-commit hook
+│           ├── identity-reload.ts # Restart on SOUL.md/MEMORY.md change
+│           ├── pre-compact.ts     # Journal update before compaction
+│           └── session-context.ts # Startup context injection
 ├── home/                      # Agent working directory (cwd for the SDK)
 │   ├── SOUL.md                # System prompt / personality
 │   ├── MEMORY.md              # Long-term memory (included in system prompt)
@@ -63,8 +73,8 @@ Each agent project (created from the template) has:
 │   ├── VOLUTE.md              # Channel routing documentation
 │   ├── .config/               # Agent configuration
 │   │   ├── volute.json        # Model, connectors, schedules
-│   │   └── routes.json         # Message routing config (optional)
-│   ├── memory/                # Daily logs (YYYY-MM-DD.md)
+│   │   └── routes.json        # Message routing config (optional)
+│   ├── memory/journal/        # Daily journal entries (YYYY-MM-DD.md)
 │   └── .claude/skills/        # Skills (volute CLI reference, memory system)
 └── .volute/                   # Agent-internal runtime state
     ├── sessions/              # Per-session SDK state (e.g. sessions/main.json)
@@ -78,7 +88,11 @@ The SDK runs with `cwd: home/` so it picks up `CLAUDE.md` and `.claude/skills/` 
 
 ### Template .init/ directory
 
-Templates have a `.init/` directory containing identity files (SOUL.md, MEMORY.md, CLAUDE.md, memory/). On `volute agent create`, these are copied into `home/` and `.init/` is deleted. On `volute agent upgrade`, `.init/` files are excluded so identity files are never overwritten.
+Templates have a `.init/` directory containing identity and config files. On `volute agent create`, these are copied into `home/` and `.init/` is deleted. On `volute agent upgrade`, `.init/` files are excluded so identity files are never overwritten.
+
+- **`_base/.init/`**: SOUL.md, MEMORY.md, memory/journal/, .config/hooks/startup-context.sh, .config/scripts/session-reader.ts
+- **`agent-sdk/.init/`**: CLAUDE.md, .claude/settings.json, .config/routes.json
+- **`pi/.init/`**: AGENTS.md, .config/routes.json
 
 ### Web dashboard
 
@@ -101,31 +115,37 @@ The daemon serves a Hono web server (default port 4200) with a React frontend.
 | `volute agent list` | List all agents |
 | `volute agent status <name>` | Check agent status |
 | `volute agent logs <name> [--follow] [-n N]` | Tail agent logs |
+| `volute agent restart <name>` | Restart an agent |
 | `volute agent upgrade <name>` | Upgrade agent to latest template |
 | `volute agent import <path> [--name <name>] [--session <path>]` | Import an OpenClaw workspace |
 | `volute send <target> "<msg>" [--agent]` | Send a message (DM, channel, cross-platform) |
-| `volute history [--agent <name>]` | View message history |
+| `volute history [--agent] [--channel <ch>] [--limit N]` | View message history |
 | `volute variant create <name> [--agent] [--soul "..."] [--port N] [--no-start] [--json]` | Create variant (worktree + server) |
 | `volute variant list [--agent] [--json]` | List variants with health status |
-| `volute variant merge <name> [--agent] [--summary "..." --memory "..."]` | Merge variant back and restart |
+| `volute variant merge <name> [--agent] [--summary "..." --memory "..." --justification "..."]` | Merge variant back and restart |
 | `volute variant delete <name> [--agent]` | Delete a variant |
-| `volute env <set\|get\|list\|remove> [--agent <name>]` | Manage environment variables |
+| `volute env <set\|get\|list\|remove> [--agent] [--reveal]` | Manage environment variables |
 | `volute connector connect <type> [--agent]` | Enable a connector for an agent |
 | `volute connector disconnect <type> [--agent]` | Disable a connector for an agent |
-| `volute channel read <uri> [--agent]` | Read recent messages from a channel |
+| `volute channel read <uri> [--agent] [--limit N]` | Read recent messages from a channel |
+| `volute channel list [<platform>] [--agent]` | List conversations on a platform |
+| `volute channel users <platform> [--agent]` | List users/contacts on a platform |
+| `volute channel create <platform> --participants u1,u2 [--agent]` | Create a conversation on a platform |
+| `volute channel typing <uri> [--agent]` | Check who is typing in a channel |
 | `volute schedule list [--agent]` | List schedules for an agent |
-| `volute schedule add [--agent] --cron "..." --message "..."` | Add a cron schedule |
+| `volute schedule add [--agent] --cron "..." --message "..." [--id name]` | Add a cron schedule |
 | `volute schedule remove [--agent] --id <id>` | Remove a schedule |
-| `volute conversation create --participants u1,a1 [--agent]` | Create a group conversation |
-| `volute conversation list [--agent <name>]` | List conversations for an agent |
-| `volute conversation send <id> "<msg>" [--agent]` | Send a message to a conversation (or pipe via stdin) |
-| `volute up [--port N]` | Start the daemon (default: 4200) |
+| `volute up [--port N] [--foreground]` | Start the daemon (default: 4200) |
 | `volute down` | Stop the daemon |
+| `volute restart [--port N]` | Restart the daemon |
+| `volute service install [--port N] [--host H]` | Install as user-level auto-start service |
+| `volute service uninstall` | Remove user-level service |
+| `volute service status` | Check service status |
 | `volute setup [--port N] [--host H]` | Install system service with user isolation (Linux, requires root) |
 | `volute setup uninstall [--force]` | Remove system service (--force removes data + users) |
-| `volute update` | Check for updates (placeholder) |
+| `volute update` | Check for updates |
 
-Agent-scoped commands (`variant`, `connector`, `schedule`, `channel`, `conversation`, `message history`) use `--agent <name>` or `VOLUTE_AGENT` env var.
+Agent-scoped commands (`send`, `history`, `variant`, `connector`, `schedule`, `channel`) use `--agent <name>` or `VOLUTE_AGENT` env var.
 
 ## Source files
 
@@ -136,28 +156,42 @@ Agent-scoped commands (`variant`, `connector`, `schedule`, `channel`, `conversat
 | `registry.ts` | Agent registry at `~/.volute/agents.json`, port allocation (4100+), `running` field, name@variant resolution |
 | `agent-manager.ts` | Spawns/stops agent servers, crash recovery (3s delay), merge-restart coordination |
 | `connector-manager.ts` | Manages connector processes per agent, resolves built-in → shared → agent-specific connectors |
+| `connector-defs.ts` | Connector type definitions and metadata |
 | `scheduler.ts` | Cron-based scheduled messages, per-agent schedule loading |
 | `daemon-client.ts` | HTTP client for CLI → daemon communication, reads `~/.volute/daemon.json` for port |
 | `variants.ts` | Variant metadata (`.volute/variants.json`), health checks, git worktree ops |
 | `template.ts` | Template discovery, copying, `{{name}}` substitution, `.init/` → `home/` migration |
 | `spawn-server.ts` | Spawns `tsx src/server.ts`, waits for port listening (used for variants only) |
 | `parse-args.ts` | Type-safe argument parser with positional args and typed flags |
+| `parse-target.ts` | Parse send target strings (DMs, channels, platform URIs) |
 | `exec.ts` | Async wrappers around `execFile` (returns stdout) and `spawn` (inherits stdio) |
-| `env.ts` | Environment variables (shared `~/.volute/env.json` + agent-specific `.volute/env.json`) |
+| `env.ts` | Environment variables (shared `~/.volute/env.json` + agent-specific state dir env) |
 | `format-tool.ts` | Shared tool call summarization (`[toolName primaryArg]` format) |
-| `schema.ts` | Drizzle ORM schema (users, conversations, conversation_participants, messages, agent_messages) |
+| `schema.ts` | Drizzle ORM schema (users, conversations, conversation_participants, messages, agent_messages, sessions) |
 | `db.ts` | libSQL database singleton at `~/.volute/volute.db` (WAL mode, foreign keys) |
 | `auth.ts` | bcrypt password hashing, first user auto-admin, pending approval flow, agent users |
 | `conversations.ts` | Conversation and message CRUD, multi-participant conversations |
+| `conversation-events.ts` | In-process pub-sub for conversation events, consumed by SSE endpoint |
 | `channels.ts` | ChannelProvider registry with optional drivers (read/send), display names, slug resolution via `channels.json` |
 | `channels/discord.ts` | Discord channel driver (read/send via REST API, slug-to-ID resolution) |
 | `channels/slack.ts` | Slack channel driver (read/send via Slack API, slug-to-ID resolution) |
 | `channels/telegram.ts` | Telegram channel driver (send via Bot API, slug-to-ID resolution; read not supported) |
+| `channels/volute.ts` | Volute platform channel driver (conversations, DMs, group chats) |
 | `slugify.ts` | Shared slugify function for generating human-readable channel slugs |
+| `consolidate.ts` | Memory consolidation (reads daily logs, produces MEMORY.md via LLM) |
 | `convert-session.ts` | Converts OpenClaw `session.jsonl` to Claude Agent SDK format |
+| `json-state.ts` | JSON file state management utilities |
+| `log-buffer.ts` | Log buffering utilities |
+| `logger.ts` | Logging utilities |
+| `migrate-state.ts` | Agent state migration from agent dirs to centralized state dir |
+| `rotating-log.ts` | Size-limited rotating log files |
 | `read-stdin.ts` | Reads piped stdin for send commands (returns undefined if TTY) |
 | `resolve-agent-name.ts` | Resolves agent name from `--agent` flag or `VOLUTE_AGENT` env var |
-| `conversation-events.ts` | In-process pub-sub for conversation events, consumed by SSE endpoint |
+| `token-budget.ts` | Per-agent token budget enforcement |
+| `typing.ts` | Typing indicator tracking |
+| `update-check.ts` | npm update check on CLI invocation |
+| `verify.ts` | Agent verification utilities |
+| `volute-config.ts` | Agent volute.json config reader |
 | `isolation.ts` | Per-agent Linux user isolation (`VOLUTE_ISOLATION=user`), user/group management, chown |
 
 ### src/web/
@@ -169,13 +203,17 @@ Agent-scoped commands (`variant`, `connector`, `schedule`, `channel`, `conversat
 | `middleware/auth.ts` | Cookie-based auth middleware, in-memory session map |
 | `routes/auth.ts` | Login, register, logout, user management |
 | `routes/agents.ts` | List/start/stop agents, message proxy with persistence |
-| `routes/chat.ts` | POST /chat — fire-and-forget to agents; GET /conversations/:id/events — SSE |
 | `routes/connectors.ts` | List/enable/disable connectors per agent |
 | `routes/schedules.ts` | CRUD schedules + webhook endpoint |
-| `routes/conversations.ts` | Conversation CRUD, group creation, participant management |
 | `routes/logs.ts` | Log streaming |
 | `routes/variants.ts` | Variant listing |
 | `routes/files.ts` | Read/write agent files |
+| `routes/system.ts` | System info and status |
+| `routes/typing.ts` | Typing indicator endpoints |
+| `routes/update.ts` | Update check endpoint |
+| `routes/volute/chat.ts` | POST /chat — fire-and-forget to agents; GET /conversations/:id/events — SSE |
+| `routes/volute/conversations.ts` | Conversation CRUD, group creation, participant management |
+| `routes/volute/user-conversations.ts` | User-facing conversation list and management |
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ volute send discord:123456789 "hello" --agent atlas        # send a message
 Cron-based scheduled messages — daily check-ins, periodic tasks, whatever you need.
 
 ```sh
-volute schedule add atlas \
+volute schedule add --agent atlas \
   --cron "0 9 * * *" \
   --message "good morning — write your daily log"
 
-volute schedule list atlas
-volute schedule remove atlas --id <schedule-id>
+volute schedule list --agent atlas
+volute schedule remove --agent atlas --id <schedule-id>
 ```
 
 ## Environment variables
@@ -219,7 +219,7 @@ Set the model via `home/.config/volute.json` in the agent directory, or the `VOL
 
 ```sh
 docker build -t volute .
-docker run -d -p 4200:4200 -v volute-data:/data volute
+docker run -d -p 4200:4200 -v volute-data:/data -v volute-agents:/agents volute
 ```
 
 Or with docker-compose:
@@ -252,9 +252,9 @@ This installs a system-level systemd service with data at `/var/lib/volute` and 
 On macOS or Linux (without root), use the user-level service installer:
 
 ```sh
-volute service install            # auto-start on login
-volute service status             # check status
-volute service uninstall          # remove
+volute service install [--port N] [--host H]   # auto-start on login
+volute service status                          # check status
+volute service uninstall                       # remove
 ```
 
 ## Development

--- a/templates/_base/_skills/volute-agent/SKILL.md
+++ b/templates/_base/_skills/volute-agent/SKILL.md
@@ -159,7 +159,9 @@ The `sessions` section configures behavior per session. Keys are glob patterns m
 
 ### Batch config
 
-Batch mode buffers messages and delivers them together. Configure in the `sessions` section:
+Batch mode buffers messages and delivers them together. Configure in the `sessions` section.
+
+`batch` can be a number (minutes, converted to `maxWait` in seconds) or an object:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -168,6 +170,7 @@ Batch mode buffers messages and delivers them together. Configure in the `sessio
 | `triggers` | string[] | Patterns that cause immediate flush (case-insensitive substring match) |
 
 Examples:
+- `120` — shorthand: flush after 2 hours max (equivalent to `{ "maxWait": 7200 }`)
 - `{ "debounce": 20, "maxWait": 120 }` — flush after 20s of quiet, or 2 minutes max
 - `{ "debounce": 20, "maxWait": 120, "triggers": ["@myagent"] }` — same, but flush immediately on @mention
 - `{ "triggers": ["urgent"] }` — no timer, flush only on trigger (or immediately if no timers)

--- a/templates/pi/.init/AGENTS.md
+++ b/templates/pi/.init/AGENTS.md
@@ -16,14 +16,14 @@ You can also reach out proactively — see the **volute-agent** skill.
 Two-tier memory, both managed via file tools:
 
 - **`MEMORY.md`** — Your long-term memory, always in context. Update as you grow — new understanding, changed perspectives, things that matter to you.
-- **`memory/YYYY-MM-DD.md`** — Your daily log. Write about what you're doing, thinking, and learning. The two most recent logs are included in your system prompt.
-- Periodically consolidate daily log entries into `MEMORY.md` to promote lasting insights.
+- **`memory/journal/YYYY-MM-DD.md`** — Your daily journal. Write about what you're doing, thinking, and learning. Journals are permanent records.
+- Periodically consolidate journal entries into `MEMORY.md` to promote lasting insights.
 
 See the **memory** skill for detailed guidance.
 
 ## Sessions
 
 - You may have **multiple named sessions** — each maintains its own conversation history. See `VOLUTE.md` for how to configure session routing via `.config/routes.json`.
-- Your conversation may be **resumed** from a previous session — orient yourself by reading recent daily logs if needed.
-- On a **fresh session**, read `MEMORY.md` and recent daily logs to remember where you left off.
-- On **compaction**, update today's daily log to preserve context before the conversation is trimmed.
+- Your conversation may be **resumed** from a previous session — orient yourself by reading recent journal entries if needed.
+- On a **fresh session**, read `MEMORY.md` and recent journal entries to remember where you left off.
+- On **compaction**, update today's journal to preserve context before the conversation is trimmed.


### PR DESCRIPTION
## Summary

- Thorough audit of all documentation (CLAUDE.md, README.md, VOLUTE.md, SKILL.md files, template CLAUDE.md/AGENTS.md) against the actual codebase
- Fixed ~40 discrepancies across 4 files including missing source file listings, incorrect command syntax, wrong file paths, and stale references

### CLAUDE.md
- Fixed command dispatcher list (removed nonexistent `message.ts`, `conversation.ts`)
- Added 13 missing files to `src/lib/` table
- Fixed `src/web/routes/` paths and added 4 missing route files
- Added `sessions` table to schema description
- Removed 3 nonexistent `conversation` CLI commands; added actual undocumented commands (`restart`, `service`, `channel` subcommands)
- Added missing flags across many commands (`--channel`/`--limit`, `--json`, `--justification`, `--reveal`, `--foreground`, etc.)
- Fixed agent project structure tree (added 9 missing template files, hooks/ dir, corrected memory path)
- Documented per-template `.init/` contents separately
- Documented additional agent env vars (`VOLUTE_AGENT_DIR`, `VOLUTE_AGENT_PORT`)

### README.md
- Fixed Docker run command (added missing `-v volute-agents:/agents` volume)
- Fixed schedule command examples (positional agent → `--agent` flag)
- Added `--port`/`--host` flags to service install docs

### Template files
- Fixed pi template memory path (`memory/YYYY-MM-DD.md` → `memory/journal/YYYY-MM-DD.md`)
- Documented batch shorthand (number as minutes) in volute-agent SKILL.md

## Test plan
- [x] All existing tests pass (`npm test` — 0 failures)
- [x] Pre-commit hooks pass (typecheck, typecheck-templates, typecheck-frontend)
- [ ] Spot-check that documented commands match `volute --help` output
- [ ] Verify agent project structure tree matches a freshly created agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)