### PR TITLE
fix: linux deployment issues with nvm and systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ Or manually:
 
 ```sh
 npm install -g volute
-sudo volute setup --host 0.0.0.0
+sudo $(which volute) setup --host 0.0.0.0
 ```
+
+> **Note:** If you installed Node via nvm, `sudo volute` won't find the binary. Use `sudo $(which volute)` or `sudo su` then run `volute setup` directly.
 
 This installs a system-level systemd service with data at `/var/lib/volute` and user isolation enabled. Check status with `systemctl status volute`. Uninstall with `sudo volute setup uninstall --force`.
 

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,11 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# Install Node.js 22 if not present or too old
-if ! command -v node &>/dev/null || [ "$(node -e 'console.log(process.versions.node.split(".")[0])')" -lt 22 ]; then
+# Install system Node.js 22 if not present or too old.
+# Explicitly check /usr/bin/node — nvm installs under home dirs which
+# systemd can't access with ProtectHome=yes.
+SYSTEM_NODE="/usr/bin/node"
+if [ ! -x "$SYSTEM_NODE" ] || [ "$($SYSTEM_NODE -e 'console.log(process.versions.node.split(".")[0])')" -lt 22 ]; then
   echo "Installing Node.js 22..."
   curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
   apt-get install -y nodejs
@@ -19,16 +22,23 @@ if ! command -v git &>/dev/null; then
   apt-get update && apt-get install -y --no-install-recommends git
 fi
 
-# Install volute globally
+# Verify system npm is available after Node.js install
+if [ ! -x "/usr/bin/npm" ]; then
+  echo "Error: npm not found at /usr/bin/npm after Node.js installation."
+  echo "Please install npm system-wide and re-run this script."
+  exit 1
+fi
+
+# Install volute globally (using system npm to ensure it lands in /usr/bin)
 echo "Installing volute..."
-npm install -g volute
+/usr/bin/npm install -g volute
 
 # Run setup
 echo "Running volute setup..."
-volute setup --host 0.0.0.0
+/usr/bin/volute setup --host 0.0.0.0
 
 echo ""
 echo "Volute is installed and running."
-echo "  systemctl status volute     Check daemon status"
+echo "  systemctl status volute      Check daemon status"
 echo "  volute agent create <name>   Create a new agent"
-echo "  volute agent start <name>   Start an agent"
+echo "  volute agent start <name>    Start an agent"

--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -88,6 +88,13 @@ async function install(port?: number, host?: string): Promise<void> {
     await execFileAsync("launchctl", ["load", path]);
     console.log("Service installed and loaded. Volute daemon will start on login.");
   } else if (platform === "linux") {
+    if (process.getuid?.() === 0) {
+      console.error(
+        "Error: `volute service install` uses systemd user services, which don't work as root.",
+      );
+      console.error("Use `volute setup` instead to install a system-level service.");
+      process.exit(1);
+    }
     const path = unitPath();
     mkdirSync(resolve(homedir(), ".config", "systemd", "user"), { recursive: true });
     writeFileSync(path, generateUnit(voluteBin, port, host));


### PR DESCRIPTION
## Summary

- Skip `ProtectHome=yes` in the systemd unit when the volute binary is under a home directory (e.g. nvm at `/root/.nvm/...`), which blocks the service from starting
- Add explicit `PATH` to the systemd unit including the binary's directory and `/usr/sbin` (needed for `useradd`, `groupadd` used by agent user isolation)
- Catch `systemctl enable --now` failures gracefully instead of throwing an unhandled stack trace
- Block `volute service install` as root on Linux with a message directing to `volute setup` (systemctl --user requires a D-Bus session that root SSH sessions lack)
- `install.sh`: use `/usr/bin/node` and `/usr/bin/npm` explicitly so nvm installs don't end up in home dirs that systemd can't access
- README: note that `sudo volute` doesn't work with nvm

## Test plan

- [x] All 454 existing tests pass
- [ ] Run `volute setup` on a Pi with nvm-installed Node — verify service starts
- [ ] Run `volute service install` as root on Linux — verify it exits with a helpful message
- [ ] Run `install.sh` on a fresh Debian system — verify it uses system Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)