### PR TITLE
fix: systemd service detection and wrapper PATH fix

### DIFF
--- a/src/commands/daemon-restart.ts
+++ b/src/commands/daemon-restart.ts
@@ -4,6 +4,12 @@ import { run as up } from "./up.js";
 export async function run(args: string[]) {
   const result = await stopDaemon();
 
+  if (!result.stopped && result.reason === "systemd") {
+    console.error("Volute is managed by a systemd service.");
+    console.error("Use: sudo systemctl restart volute");
+    process.exit(1);
+  }
+
   if (!result.stopped && result.reason === "kill-failed") {
     console.error("Cannot restart: failed to stop the running daemon.");
     process.exit(1);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -119,7 +119,7 @@ function install(port?: number, host?: string): void {
   // so `sudo volute` works (sudo resets PATH and won't find nvm binaries)
   const binDir = dirname(voluteBin);
   if (voluteBin !== WRAPPER_PATH && !voluteBin.startsWith("/usr/bin")) {
-    const wrapper = `#!/bin/sh\nexport PATH="${binDir}:$PATH"\nexec "${voluteBin}" "$@"\n`;
+    const wrapper = `#!/bin/sh\nexport PATH="${binDir}:$PATH"\nexport VOLUTE_HOME="${DATA_DIR}"\nexport VOLUTE_AGENTS_DIR="${AGENTS_DIR}"\nexec "${voluteBin}" "$@"\n`;
     writeFileSync(WRAPPER_PATH, wrapper, { mode: 0o755 });
     console.log(`Wrote ${WRAPPER_PATH} (wrapper for ${voluteBin})`);
   }


### PR DESCRIPTION
## Summary

- Fix `volute up`, `volute down`, `volute restart`, `volute update`, and `volute service status` to detect when volute is installed as a system-level systemd service and redirect users to the appropriate `systemctl` commands
- Use `systemctl is-enabled` instead of checking for the service file, so disabled-but-not-uninstalled services do not block manual daemon management
- Fix the `/usr/local/bin/volute` wrapper to export `PATH`, `VOLUTE_HOME`, and `VOLUTE_AGENTS_DIR` so `sudo volute` commands find both the correct binaries and data directory
- Block `volute service install` when a system service already exists (prevents conflicting user-level unit)
- Show stderr on actual systemctl failures in `volute service status` instead of generic "status unknown"

## Test plan
- [x] All tests pass
- [ ] On a Pi with systemd service installed, verify:
  - `volute up` shows "Volute is managed by a systemd service" message
  - `volute down` shows "Use: sudo systemctl stop volute"
  - `volute restart` shows "Use: sudo systemctl restart volute"
  - `volute update` shows manual update instructions
  - `volute service status` shows systemctl status output
  - `volute service install` blocks with "system service already installed"
  - `sudo volute agent create <name>` succeeds (npm + VOLUTE_HOME found via wrapper)
  - After `sudo systemctl disable volute`, `volute up` works normally again