### PR TITLE
fix: use ProtectSystem=true to fix useradd locking

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -60,8 +60,8 @@ function generateUnit(voluteBin: string, port?: number, host?: string): string {
     "Environment=VOLUTE_ISOLATION=user",
     "Restart=on-failure",
     "RestartSec=5",
-    "ProtectSystem=strict",
-    `ReadWritePaths=${DATA_DIR} ${AGENTS_DIR} /etc`,
+    "ProtectSystem=true",
+    `ReadWritePaths=${DATA_DIR} ${AGENTS_DIR}`,
     "PrivateTmp=yes",
   ];
 


### PR DESCRIPTION
## Summary
- `ProtectSystem=strict` with `ReadWritePaths=/etc` creates bind mounts that break `useradd`'s hard-link-based locking mechanism (`cannot lock /etc/group; try again later`)
- Switch to `ProtectSystem=true` which protects `/usr` and `/boot` but leaves `/etc` naturally writable — no bind mount, so locking works

## Test plan
- [ ] `sudo volute setup` to regenerate the unit file
- [ ] `systemctl daemon-reload && systemctl restart volute`
- [ ] `volute agent create <name>` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)