### PR TITLE
feat: unified service mode detection for daemon lifecycle commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npx biome check src/ test/ templates/
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - name: Configure git identity

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
       - run: npm ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ The daemon serves a Hono web server (default port 4200) with a React frontend.
 | `volute service status` | Check service status |
 | `volute setup [--port N] [--host H]` | Install system service with user isolation (Linux, requires root) |
 | `volute setup uninstall [--force]` | Remove system service (--force removes data + users) |
+| `volute status` | Show daemon status, version, and agents |
 | `volute update` | Check for updates |
 
 Agent-scoped commands (`send`, `history`, `variant`, `connector`, `schedule`, `channel`) use `--agent <name>` or `VOLUTE_AGENT` env var.
@@ -189,6 +190,7 @@ Agent-scoped commands (`send`, `history`, `variant`, `connector`, `schedule`, `c
 | `resolve-agent-name.ts` | Resolves agent name from `--agent` flag or `VOLUTE_AGENT` env var |
 | `token-budget.ts` | Per-agent token budget enforcement |
 | `typing.ts` | Typing indicator tracking |
+| `service-mode.ts` | Service mode detection (manual/systemd/launchd), service control, health polling, daemon config reader |
 | `update-check.ts` | npm update check on CLI invocation |
 | `verify.ts` | Agent verification utilities |
 | `volute-config.ts` | Agent volute.json config reader |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 # git needed for agent git init + variants
 RUN apt-get update && apt-get install -y --no-install-recommends git \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ One background process runs everything. `volute up` starts it; `volute down` sto
 volute up              # start (default port 4200)
 volute up --port 8080  # custom port
 volute down            # stop all agents and shut down
+volute status          # check daemon status, version, and agents
 ```
 
 The daemon handles agent lifecycle, crash recovery (auto-restarts after 3 seconds), connector processes, scheduled messages, and the web dashboard.
@@ -232,7 +233,7 @@ The container runs with per-agent user isolation enabled — each agent gets its
 
 ### Bare metal (Linux / Raspberry Pi)
 
-One-liner install on a fresh Debian/Ubuntu system:
+One-liner install on a fresh Linux system (Debian/Ubuntu, RHEL/Fedora, Arch, Alpine, SUSE):
 
 ```sh
 curl -fsSL <install-url> | sudo bash

--- a/install.sh
+++ b/install.sh
@@ -6,43 +6,157 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# Install system Node.js 22 if not present or too old.
-# Explicitly check /usr/bin/node — nvm installs under home dirs which
-# systemd can't access with ProtectHome=yes.
-SYSTEM_NODE="/usr/bin/node"
-if [ ! -x "$SYSTEM_NODE" ] || [ "$($SYSTEM_NODE -e 'console.log(process.versions.node.split(".")[0])')" -lt 22 ]; then
-  echo "Installing Node.js 22..."
-  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-  apt-get install -y nodejs
-fi
+# --- Distro detection ---
 
-# Install git if not present
-if ! command -v git &>/dev/null; then
+detect_distro() {
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    DISTRO="${ID:-unknown}"
+    DISTRO_LIKE="${ID_LIKE:-}"
+  else
+    DISTRO="unknown"
+    DISTRO_LIKE=""
+  fi
+}
+
+# Map ID_LIKE fallback to a known distro family
+resolve_distro() {
+  case "$DISTRO" in
+    debian|ubuntu|rhel|fedora|centos|amzn|arch|alpine|sles|opensuse*)
+      return ;;
+  esac
+  # Fallback: check ID_LIKE for a known family
+  for like in $DISTRO_LIKE; do
+    case "$like" in
+      debian|ubuntu)  DISTRO="debian"; return ;;
+      rhel|fedora)    DISTRO="rhel";   return ;;
+      arch)           DISTRO="arch";   return ;;
+      suse|opensuse*) DISTRO="sles";   return ;;
+    esac
+  done
+}
+
+# --- Node.js 24 installation ---
+
+node_needed() {
+  local system_node="/usr/bin/node"
+  if [ ! -x "$system_node" ]; then
+    return 0
+  fi
+  local major
+  major="$("$system_node" -e 'console.log(process.versions.node.split(".")[0])')"
+  [ "$major" -lt 24 ]
+}
+
+install_node() {
+  if ! node_needed; then
+    echo "Node.js >= 24 already installed, skipping."
+    return
+  fi
+  echo "Installing Node.js 24..."
+  case "$DISTRO" in
+    debian|ubuntu)
+      curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+      apt-get install -y nodejs
+      ;;
+    rhel|fedora|centos|amzn)
+      curl -fsSL https://rpm.nodesource.com/setup_24.x | bash -
+      if command -v dnf &>/dev/null; then
+        dnf install -y nodejs
+      else
+        yum install -y nodejs
+      fi
+      ;;
+    arch)
+      pacman -S --noconfirm nodejs npm
+      ;;
+    alpine)
+      apk add --no-cache nodejs npm
+      ;;
+    sles|opensuse*)
+      curl -fsSL https://rpm.nodesource.com/setup_24.x | bash -
+      zypper install -y nodejs
+      ;;
+    *)
+      echo "Error: unsupported distro '$DISTRO' for Node.js installation."
+      exit 1
+      ;;
+  esac
+}
+
+# --- Git installation ---
+
+install_git() {
+  if command -v git &>/dev/null; then
+    echo "Git already installed, skipping."
+    return
+  fi
   echo "Installing git..."
-  apt-get update && apt-get install -y --no-install-recommends git
-fi
+  case "$DISTRO" in
+    debian|ubuntu)
+      apt-get update && apt-get install -y --no-install-recommends git
+      ;;
+    rhel|fedora|centos|amzn)
+      if command -v dnf &>/dev/null; then
+        dnf install -y git
+      else
+        yum install -y git
+      fi
+      ;;
+    arch)
+      pacman -S --noconfirm git
+      ;;
+    alpine)
+      apk add --no-cache git
+      ;;
+    sles|opensuse*)
+      zypper install -y git
+      ;;
+    *)
+      echo "Error: unsupported distro '$DISTRO' for git installation."
+      exit 1
+      ;;
+  esac
+}
 
-# Verify system npm is available after Node.js install
-if [ ! -x "/usr/bin/npm" ]; then
-  echo "Error: npm not found at /usr/bin/npm after Node.js installation."
-  echo "Please install npm system-wide and re-run this script."
-  exit 1
-fi
+# --- Main ---
 
-# Install volute globally (using system npm to ensure it lands in /usr/bin)
-echo "Installing volute..."
-/usr/bin/npm install -g volute
+main() {
+  detect_distro
+  resolve_distro
 
-# Run setup (writes /etc/profile.d/volute.sh for CLI env vars)
-echo "Running volute setup..."
-/usr/bin/volute setup --host 0.0.0.0
+  echo "Detected distro: $DISTRO"
 
-# Source the profile so env vars are available in this session
-# shellcheck disable=SC1091
-[ -f /etc/profile.d/volute.sh ] && . /etc/profile.d/volute.sh
+  install_node
+  install_git
 
-echo ""
-echo "Volute is installed and running."
-echo "  systemctl status volute      Check daemon status"
-echo "  volute agent create <name>   Create a new agent"
-echo "  volute agent start <name>    Start an agent"
+  # Verify system npm is available after Node.js install
+  if [ ! -x "/usr/bin/npm" ]; then
+    echo "Error: npm not found at /usr/bin/npm after Node.js installation."
+    echo "Please install npm system-wide and re-run this script."
+    exit 1
+  fi
+
+  # Install volute globally (using system npm to ensure it lands in /usr/bin)
+  echo "Installing volute..."
+  /usr/bin/npm install -g volute
+
+  # Run setup (writes /etc/profile.d/volute.sh for CLI env vars)
+  echo "Running volute setup..."
+  /usr/bin/volute setup --host 0.0.0.0
+
+  # Source the profile so env vars are available in this session
+  # shellcheck disable=SC1091
+  [ -f /etc/profile.d/volute.sh ] && . /etc/profile.d/volute.sh
+
+  echo ""
+  echo "Volute is installed and running."
+  echo "  Run 'source /etc/profile.d/volute.sh' or start a new shell to use volute CLI commands."
+  echo ""
+  echo "  systemctl status volute      Check daemon status"
+  echo "  volute agent create <name>   Create a new agent"
+  echo "  volute agent start <name>    Start an agent"
+}
+
+main "$@"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "anthropic"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "bin": {
     "volute": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,9 @@ switch (command) {
   case "update":
     await import("./commands/update.js").then((m) => m.run(args));
     break;
+  case "status":
+    await import("./commands/status.js").then((m) => m.run(args));
+    break;
   case "--help":
   case "-h":
   case undefined:
@@ -109,6 +112,7 @@ Commands:
   volute setup uninstall [--force]        Remove system service + isolation
 
   volute update                           Update to latest version
+  volute status                           Show daemon status and agents
 
 Options:
   --version, -v                           Show version number

--- a/src/commands/daemon-restart.ts
+++ b/src/commands/daemon-restart.ts
@@ -1,49 +1,36 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { getClient, urlOf } from "../lib/api-client.js";
-import { daemonFetch } from "../lib/daemon-client.js";
-import { voluteHome } from "../lib/registry.js";
+import {
+  getServiceMode,
+  modeLabel,
+  pollHealth,
+  readDaemonConfig,
+  restartService,
+} from "../lib/service-mode.js";
 import { stopDaemon } from "./down.js";
 import { run as up } from "./up.js";
 
 export async function run(args: string[]) {
-  const result = await stopDaemon();
+  const mode = getServiceMode();
 
-  if (!result.stopped && result.reason === "systemd") {
-    const client = getClient();
-    await daemonFetch(urlOf(client.api.system.restart.$url()), { method: "POST" });
-
-    // Build base URL from daemon.json for health polling.
-    // Use raw fetch since daemonFetch exits on ECONNREFUSED,
-    // which is expected while the daemon restarts.
-    const config = JSON.parse(readFileSync(resolve(voluteHome(), "daemon.json"), "utf-8"));
-    let hostname = config.hostname || "localhost";
-    if (hostname === "0.0.0.0") hostname = "127.0.0.1";
-    if (hostname === "::") hostname = "[::1]";
-    const url = new URL("http://localhost");
-    url.hostname = hostname;
-    url.port = String(config.port ?? 4200);
-    const healthUrl = `${url.origin}/api/health`;
-
-    const maxWait = 15_000;
-    const start = Date.now();
-    while (Date.now() - start < maxWait) {
-      try {
-        const res = await fetch(healthUrl);
-        if (res.ok) {
-          console.log("Daemon restarted.");
-          return;
-        }
-      } catch {
-        // Not ready yet (ECONNREFUSED expected during restart)
-      }
-      await new Promise((r) => setTimeout(r, 500));
+  if (mode !== "manual") {
+    console.log(`Restarting volute (${modeLabel(mode)})...`);
+    try {
+      await restartService(mode);
+    } catch (err) {
+      console.error(`Failed to restart service: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
     }
-
-    console.error("Daemon did not restart within 15s. Check logs.");
-    process.exit(1);
+    const { hostname, port } = readDaemonConfig();
+    if (await pollHealth(hostname, port)) {
+      console.log("Daemon restarted.");
+    } else {
+      console.error("Service restarted but daemon did not become healthy within 30s.");
+      process.exit(1);
+    }
+    return;
   }
 
+  // Manual mode: stop then start
+  const result = await stopDaemon();
   if (!result.stopped && result.reason === "kill-failed") {
     console.error("Cannot restart: failed to stop the running daemon.");
     process.exit(1);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,80 +1,63 @@
-import { getClient, urlOf } from "../lib/api-client.js";
-import { daemonFetch } from "../lib/daemon-client.js";
+import { getDaemonUrl, getServiceMode, modeLabel, readDaemonConfig } from "../lib/service-mode.js";
+import { checkForUpdate } from "../lib/update-check.js";
 
-type VariantInfo = {
-  name: string;
-  port: number;
-  status: "running" | "stopped" | "starting";
-};
+export async function run(_args: string[]) {
+  const mode = getServiceMode();
+  console.log(`Mode: ${modeLabel(mode)}`);
 
-type AgentInfo = {
-  name: string;
-  port: number;
-  status: "running" | "stopped" | "starting";
-  channels: Array<{ name: string; status: string }>;
-  variants?: VariantInfo[];
-};
+  const { hostname, port, token } = readDaemonConfig();
+  const baseUrl = getDaemonUrl(hostname, port);
 
-export async function run(args: string[]) {
-  const name = args[0];
-  const client = getClient();
-
-  if (!name) {
-    // List all agents
-    const res = await daemonFetch(urlOf(client.api.agents.$url()));
-    if (!res.ok) {
-      const data = (await res.json()) as { error?: string };
-      console.error(data.error ?? `Failed to get status: ${res.status}`);
-      process.exit(1);
+  // Check health
+  let running = false;
+  let version: string | undefined;
+  try {
+    const res = await fetch(`${baseUrl}/api/health`);
+    if (res.ok) {
+      const body = (await res.json()) as { ok?: boolean; version?: string };
+      if (body.ok) {
+        running = true;
+        version = body.version;
+      }
     }
-    const agents = (await res.json()) as AgentInfo[];
+  } catch {
+    // Not running
+  }
 
-    if (agents.length === 0) {
-      console.log("No agents registered. Create one with: volute agent create <name>");
-      return;
-    }
-
-    const nameW = Math.max(4, ...agents.map((a) => a.name.length));
-    const portW = Math.max(4, ...agents.map((a) => String(a.port).length));
-
-    console.log(`${"NAME".padEnd(nameW)}  ${"PORT".padEnd(portW)}  STATUS    CONNECTORS`);
-
-    for (const agent of agents) {
-      const connected = agent.channels
-        .filter((ch) => ch.status === "connected")
-        .map((ch) => ch.name);
-      const connectors = connected.length > 0 ? connected.join(", ") : "-";
-      console.log(
-        `${agent.name.padEnd(nameW)}  ${String(agent.port).padEnd(portW)}  ${agent.status.padEnd(8)}  ${connectors}`,
-      );
-    }
+  if (!running) {
+    console.log("Status: not running");
     return;
   }
 
-  // Single agent status
-  const res = await daemonFetch(urlOf(client.api.agents[":name"].$url({ param: { name } })));
+  console.log(`Status: running on ${hostname}:${port}`);
+  if (version) console.log(`Version: ${version}`);
 
-  if (!res.ok) {
-    const data = (await res.json()) as { error?: string };
-    console.error(data.error || `Failed to get status for ${name}`);
-    process.exit(1);
+  // Check for updates
+  const update = await checkForUpdate();
+  if (update.updateAvailable) {
+    console.log(`Update available: ${update.current} → ${update.latest}`);
   }
 
-  const agent = (await res.json()) as AgentInfo;
+  // List agents
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  headers.Origin = baseUrl;
 
-  console.log(`Agent: ${agent.name}`);
-  console.log(`Port: ${agent.port}`);
-  console.log(`Status: ${agent.status}`);
-
-  for (const ch of agent.channels) {
-    console.log(`${ch.name}: ${ch.status}`);
-  }
-
-  if (agent.variants && agent.variants.length > 0) {
-    console.log("");
-    console.log("Variants:");
-    for (const v of agent.variants) {
-      console.log(`  ${v.name}  port=${v.port}  ${v.status}`);
+  try {
+    const res = await fetch(`${baseUrl}/api/agents`, { headers });
+    if (res.ok) {
+      const agents = (await res.json()) as Array<{ name: string; running: boolean }>;
+      if (agents.length > 0) {
+        console.log(`\nAgents (${agents.length}):`);
+        for (const agent of agents) {
+          const status = agent.running ? "running" : "stopped";
+          console.log(`  ${agent.name}: ${status}`);
+        }
+      } else {
+        console.log("\nNo agents configured.");
+      }
     }
+  } catch {
+    // Couldn't fetch agents — not critical
   }
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,23 +1,17 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
-import { execInherit, resolveVoluteBin } from "../lib/exec.js";
+import { exec, execInherit, resolveVoluteBin } from "../lib/exec.js";
 import { voluteHome } from "../lib/registry.js";
+import {
+  getServiceMode,
+  modeLabel,
+  pollHealth,
+  readDaemonConfig,
+  restartService,
+} from "../lib/service-mode.js";
 import { checkForUpdate } from "../lib/update-check.js";
 
 export async function run(_args: string[]) {
-  // If managed by systemd, the user should update and restart via systemctl
-  try {
-    execFileSync("systemctl", ["is-enabled", "--quiet", "volute"]);
-    console.error("Volute is managed by a systemd service.");
-    console.error("To update, run:");
-    console.error("  sudo npm install -g volute@latest");
-    console.error("  sudo systemctl restart volute");
-    process.exit(1);
-  } catch {
-    // Not a systemd-managed install — proceed normally
-  }
-
   const result = await checkForUpdate();
   if (result.checkFailed) {
     console.error("Could not reach npm registry. Check your network connection and try again.");
@@ -33,11 +27,77 @@ export async function run(_args: string[]) {
 
   console.log(`\nUpdating volute ${result.current} → ${result.latest}...`);
 
+  const mode = getServiceMode();
+
+  if (mode === "system") {
+    // System service: use /usr/bin/npm (fall back to which npm) with sudo
+    let npmPath = "/usr/bin/npm";
+    if (!existsSync(npmPath)) {
+      try {
+        npmPath = (await exec("which", ["npm"])).trim();
+      } catch {
+        console.error("Could not find npm. Install npm and try again.");
+        process.exit(1);
+      }
+    }
+    try {
+      await execInherit("sudo", [npmPath, "install", "-g", "volute@latest"]);
+    } catch (err) {
+      console.error(`\nUpdate failed: ${(err as Error).message}`);
+      process.exit(1);
+    }
+    console.log("Restarting service...");
+    try {
+      await restartService(mode);
+    } catch (err) {
+      console.error(`Failed to restart: ${err instanceof Error ? err.message : err}`);
+      console.error("Try: sudo systemctl restart volute");
+      process.exit(1);
+    }
+    {
+      const { hostname, port } = readDaemonConfig();
+      if (await pollHealth(hostname, port)) {
+        console.log(`\nUpdated to volute v${result.latest}`);
+      } else {
+        console.error("Service restarted but daemon did not become healthy.");
+        process.exit(1);
+      }
+    }
+    return;
+  }
+
+  if (mode === "user-systemd" || mode === "user-launchd") {
+    // User service: npm install (no sudo), then restart service
+    try {
+      await execInherit("npm", ["install", "-g", "volute@latest"]);
+    } catch (err) {
+      console.error(`\nUpdate failed: ${(err as Error).message}`);
+      process.exit(1);
+    }
+    console.log(`Restarting service (${modeLabel(mode)})...`);
+    try {
+      await restartService(mode);
+    } catch (err) {
+      console.error(`Failed to restart: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+    {
+      const { hostname, port } = readDaemonConfig();
+      if (await pollHealth(hostname, port)) {
+        console.log(`\nUpdated to volute v${result.latest}`);
+      } else {
+        console.error("Service restarted but daemon did not become healthy.");
+        process.exit(1);
+      }
+    }
+    return;
+  }
+
+  // Manual mode: stop → install → restart (existing logic)
   const home = voluteHome();
   const pidPath = resolve(home, "daemon.pid");
   const configPath = resolve(home, "daemon.json");
 
-  // Check if daemon is running
   let daemonWasRunning = false;
   let daemonPort = 4200;
   let daemonHost = "127.0.0.1";
@@ -45,17 +105,15 @@ export async function run(_args: string[]) {
   if (existsSync(pidPath)) {
     const pid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
     try {
-      process.kill(pid, 0); // Check if alive
+      process.kill(pid, 0);
       daemonWasRunning = true;
     } catch {
-      // Not running, clean up stale PID
       try {
         unlinkSync(pidPath);
       } catch {}
     }
   }
 
-  // Read daemon config for restart
   if (daemonWasRunning && existsSync(configPath)) {
     try {
       const config = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -66,7 +124,6 @@ export async function run(_args: string[]) {
     }
   }
 
-  // Stop daemon if running
   if (daemonWasRunning) {
     console.log("Stopping daemon...");
     const pid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
@@ -78,7 +135,6 @@ export async function run(_args: string[]) {
       } catch {}
     }
 
-    // Wait for daemon to exit
     const maxWait = 10_000;
     const start = Date.now();
     while (Date.now() - start < maxWait) {
@@ -86,7 +142,6 @@ export async function run(_args: string[]) {
       await new Promise((r) => setTimeout(r, 200));
     }
 
-    // Force kill if still alive
     if (existsSync(pidPath)) {
       try {
         process.kill(-pid, "SIGKILL");
@@ -97,16 +152,13 @@ export async function run(_args: string[]) {
       }
     }
 
-    // Verify daemon actually stopped
     if (existsSync(pidPath)) {
       try {
         const stalePid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
         process.kill(stalePid, 0);
-        // Still alive — abort
         console.error("Warning: daemon process may still be running. Aborting update.");
         process.exit(1);
       } catch {
-        // Process gone, clean up stale PID file
         try {
           unlinkSync(pidPath);
         } catch {}
@@ -116,7 +168,6 @@ export async function run(_args: string[]) {
     console.log("Daemon stopped.");
   }
 
-  // Run npm install
   try {
     await execInherit("npm", ["install", "-g", "volute@latest"]);
   } catch (err) {
@@ -138,11 +189,9 @@ export async function run(_args: string[]) {
     process.exit(1);
   }
 
-  // Restart daemon with new binary
   if (daemonWasRunning) {
     console.log("Restarting daemon...");
     try {
-      // Use the newly installed binary
       await execInherit(resolveVoluteBin(), [
         "up",
         "--port",

--- a/src/lib/service-mode.ts
+++ b/src/lib/service-mode.ts
@@ -1,0 +1,205 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { execInherit } from "./exec.js";
+import { voluteHome } from "./registry.js";
+
+// --- Constants ---
+
+export const SYSTEM_SERVICE_PATH = "/etc/systemd/system/volute.service";
+export const USER_SYSTEMD_UNIT = resolve(homedir(), ".config", "systemd", "user", "volute.service");
+export const LAUNCHD_PLIST_LABEL = "com.volute.daemon";
+export const LAUNCHD_PLIST_PATH = resolve(
+  homedir(),
+  "Library",
+  "LaunchAgents",
+  `${LAUNCHD_PLIST_LABEL}.plist`,
+);
+
+export const HEALTH_POLL_TIMEOUT = 30_000;
+export const STOP_GRACE_TIMEOUT = 10_000;
+export const POLL_INTERVAL = 500;
+
+// --- Types ---
+
+export type ServiceMode = "manual" | "system" | "user-systemd" | "user-launchd";
+export type ManagedServiceMode = Exclude<ServiceMode, "manual">;
+
+// --- Detection ---
+
+export function getServiceMode(): ServiceMode {
+  // System-level systemd service
+  if (existsSync(SYSTEM_SERVICE_PATH)) {
+    try {
+      execFileSync("systemctl", ["is-enabled", "--quiet", "volute"]);
+      return "system";
+    } catch {
+      // Unit file exists but not enabled — fall through
+    }
+  }
+
+  // User-level systemd service
+  if (existsSync(USER_SYSTEMD_UNIT)) {
+    try {
+      execFileSync("systemctl", ["--user", "is-enabled", "--quiet", "volute"]);
+      return "user-systemd";
+    } catch {
+      // Unit file exists but not enabled — fall through
+    }
+  }
+
+  // macOS launchd
+  if (process.platform === "darwin" && existsSync(LAUNCHD_PLIST_PATH)) {
+    return "user-launchd";
+  }
+
+  return "manual";
+}
+
+// --- Helpers ---
+
+export function getDaemonUrl(hostname: string, port: number): string {
+  const url = new URL("http://localhost");
+  let h = hostname;
+  if (h === "0.0.0.0" || h === "::") h = "localhost";
+  else if (h.includes(":") && !h.startsWith("[")) h = `[${h}]`;
+  url.hostname = h;
+  url.port = String(port);
+  return url.origin;
+}
+
+/**
+ * Poll the health endpoint until it responds with `{ ok: true }`.
+ * Returns true if healthy within timeout, false otherwise.
+ */
+export async function pollHealth(
+  hostname: string,
+  port: number,
+  timeout: number = HEALTH_POLL_TIMEOUT,
+): Promise<boolean> {
+  const url = `${getDaemonUrl(hostname, port)}/api/health`;
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const body = await res.json().catch(() => null);
+        if (body && (body as { ok?: boolean }).ok) return true;
+      }
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+  }
+  return false;
+}
+
+/**
+ * Poll until the health endpoint stops responding.
+ * Returns true if down within timeout, false otherwise.
+ */
+export async function pollHealthDown(
+  hostname: string,
+  port: number,
+  timeout: number = STOP_GRACE_TIMEOUT,
+): Promise<boolean> {
+  const url = `${getDaemonUrl(hostname, port)}/api/health`;
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) return true;
+      const body = await res.json().catch(() => null);
+      if (!body || !(body as { ok?: boolean }).ok) return true;
+    } catch {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+  }
+  return false;
+}
+
+// --- Service control ---
+
+export async function startService(mode: ManagedServiceMode): Promise<void> {
+  switch (mode) {
+    case "system":
+      await execInherit("sudo", ["systemctl", "start", "volute"]);
+      break;
+    case "user-systemd":
+      await execInherit("systemctl", ["--user", "start", "volute"]);
+      break;
+    case "user-launchd":
+      await execInherit("launchctl", ["load", LAUNCHD_PLIST_PATH]);
+      break;
+  }
+}
+
+export async function stopService(mode: ManagedServiceMode): Promise<void> {
+  switch (mode) {
+    case "system":
+      await execInherit("sudo", ["systemctl", "stop", "volute"]);
+      break;
+    case "user-systemd":
+      await execInherit("systemctl", ["--user", "stop", "volute"]);
+      break;
+    case "user-launchd":
+      await execInherit("launchctl", ["unload", LAUNCHD_PLIST_PATH]);
+      break;
+  }
+}
+
+export async function restartService(mode: ManagedServiceMode): Promise<void> {
+  switch (mode) {
+    case "system":
+      await execInherit("sudo", ["systemctl", "restart", "volute"]);
+      break;
+    case "user-systemd":
+      await execInherit("systemctl", ["--user", "restart", "volute"]);
+      break;
+    case "user-launchd":
+      // launchd doesn't have a "restart" — unload then load
+      try {
+        await execInherit("launchctl", ["unload", LAUNCHD_PLIST_PATH]);
+      } catch (err) {
+        // May not be loaded — warn but continue to load
+        console.warn(
+          `Warning: launchctl unload failed: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+      await execInherit("launchctl", ["load", LAUNCHD_PLIST_PATH]);
+      break;
+  }
+}
+
+/** Read daemon.json for hostname, port, and token. Returns defaults if missing or corrupt. */
+export function readDaemonConfig(): { hostname: string; port: number; token?: string } {
+  const configPath = resolve(voluteHome(), "daemon.json");
+  if (!existsSync(configPath)) return { hostname: "127.0.0.1", port: 4200 };
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    return {
+      hostname: config.hostname || "127.0.0.1",
+      port: config.port ?? 4200,
+      token: config.token,
+    };
+  } catch {
+    console.error("Warning: could not read daemon config, using defaults.");
+    return { hostname: "127.0.0.1", port: 4200 };
+  }
+}
+
+/** Human-readable label for the service mode */
+export function modeLabel(mode: ServiceMode): string {
+  switch (mode) {
+    case "system":
+      return "system service (systemd)";
+    case "user-systemd":
+      return "user service (systemd)";
+    case "user-launchd":
+      return "user service (launchd)";
+    case "manual":
+      return "manual";
+  }
+}

--- a/test/service-mode.test.ts
+++ b/test/service-mode.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { describe, it } from "node:test";
+import {
+  getDaemonUrl,
+  getServiceMode,
+  HEALTH_POLL_TIMEOUT,
+  LAUNCHD_PLIST_LABEL,
+  LAUNCHD_PLIST_PATH,
+  modeLabel,
+  POLL_INTERVAL,
+  pollHealth,
+  pollHealthDown,
+  type ServiceMode,
+  STOP_GRACE_TIMEOUT,
+  SYSTEM_SERVICE_PATH,
+  USER_SYSTEMD_UNIT,
+} from "../src/lib/service-mode.js";
+
+describe("service-mode constants", () => {
+  it("has expected constant values", () => {
+    assert.equal(SYSTEM_SERVICE_PATH, "/etc/systemd/system/volute.service");
+    assert.ok(USER_SYSTEMD_UNIT.endsWith(".config/systemd/user/volute.service"));
+    assert.equal(LAUNCHD_PLIST_LABEL, "com.volute.daemon");
+    assert.ok(LAUNCHD_PLIST_PATH.endsWith("Library/LaunchAgents/com.volute.daemon.plist"));
+    assert.equal(HEALTH_POLL_TIMEOUT, 30_000);
+    assert.equal(STOP_GRACE_TIMEOUT, 10_000);
+    assert.equal(POLL_INTERVAL, 500);
+  });
+});
+
+describe("getServiceMode", () => {
+  it("returns a valid ServiceMode value", () => {
+    const mode = getServiceMode();
+    const validModes: ServiceMode[] = ["manual", "system", "user-systemd", "user-launchd"];
+    assert.ok(validModes.includes(mode), `got unexpected mode: ${mode}`);
+  });
+});
+
+describe("getDaemonUrl", () => {
+  it("builds URL from hostname and port", () => {
+    assert.equal(getDaemonUrl("127.0.0.1", 4200), "http://127.0.0.1:4200");
+  });
+
+  it("maps 0.0.0.0 to localhost", () => {
+    assert.equal(getDaemonUrl("0.0.0.0", 4200), "http://localhost:4200");
+  });
+
+  it("maps :: to localhost", () => {
+    assert.equal(getDaemonUrl("::", 4200), "http://localhost:4200");
+  });
+
+  it("uses custom port", () => {
+    assert.equal(getDaemonUrl("myhost", 5000), "http://myhost:5000");
+  });
+
+  it("handles IPv6 literal", () => {
+    assert.equal(getDaemonUrl("::1", 4200), "http://[::1]:4200");
+  });
+});
+
+describe("pollHealth", () => {
+  it("returns false when endpoint is unreachable", async () => {
+    const result = await pollHealth("127.0.0.1", 19999, 1000);
+    assert.equal(result, false);
+  });
+
+  it("returns true when endpoint responds with { ok: true }", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const port = await listen(server);
+    try {
+      const result = await pollHealth("127.0.0.1", port, 3000);
+      assert.equal(result, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("returns false when endpoint responds without ok:true", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "not-volute" }));
+    });
+    const port = await listen(server);
+    try {
+      const result = await pollHealth("127.0.0.1", port, 1000);
+      assert.equal(result, false);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("pollHealthDown", () => {
+  it("returns true immediately when endpoint is unreachable", async () => {
+    const start = Date.now();
+    const result = await pollHealthDown("127.0.0.1", 19999, 5000);
+    assert.equal(result, true);
+    assert.ok(Date.now() - start < 2000);
+  });
+
+  it("returns true when endpoint responds without ok:true", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "not-volute" }));
+    });
+    const port = await listen(server);
+    try {
+      const result = await pollHealthDown("127.0.0.1", port, 3000);
+      assert.equal(result, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("returns false (times out) when endpoint keeps responding with ok:true", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const port = await listen(server);
+    try {
+      const result = await pollHealthDown("127.0.0.1", port, 1000);
+      assert.equal(result, false);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("modeLabel", () => {
+  it("returns human-readable labels", () => {
+    assert.equal(modeLabel("system"), "system service (systemd)");
+    assert.equal(modeLabel("user-systemd"), "user service (systemd)");
+    assert.equal(modeLabel("user-launchd"), "user service (launchd)");
+    assert.equal(modeLabel("manual"), "manual");
+  });
+});
+
+/** Helper: listen on a random port and return it */
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") resolve(addr.port);
+      else reject(new Error("Could not get server address"));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Centralizes service mode detection (`manual`/`system`/`user-systemd`/`user-launchd`) into `src/lib/service-mode.ts`, replacing duplicated logic across 4 command files
- `volute up/down/restart` now transparently proxy to systemctl/launchctl when a managed service is detected
- `volute update` uses the correct npm path for system installs (`/usr/bin/npm` with sudo fallback) instead of relying on nvm's npm
- Adds `volute status` command showing service mode, daemon health, version, and agent list
- `install.sh` rewritten for multi-distro Linux support (Debian, RHEL/Fedora, Arch, Alpine, SUSE)
- Node.js version bumped from 22 to 24 across Dockerfile, package.json, and CI workflows
- Type-safe `ManagedServiceMode` prevents passing `"manual"` to service control functions at compile time
- `readDaemonConfig()` helper eliminates 5 duplicated daemon.json reading blocks
- `pollHealthDown` now verifies response body (detects non-volute processes on same port)
- Refined `StopResult` discriminated union with precise per-variant fields

## Test plan

- [x] All 511 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] All pre-commit hooks pass (lint, typecheck, typecheck-templates, typecheck-frontend)
- [x] `volute status` registered in CLI help
- [x] `bash -n install.sh` — no syntax errors
- [ ] Manual: `volute down && volute up` in manual mode
- [ ] Manual: `volute status` shows daemon info or "not running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)