### PR TITLE
fix: use agent home/ dir for HOME and CLAUDE_CONFIG_DIR in isolation

### DIFF
--- a/src/lib/agent-manager.ts
+++ b/src/lib/agent-manager.ts
@@ -125,11 +125,15 @@ export class AgentManager {
       VOLUTE_AGENT_PORT: String(port),
     };
 
+    if (isIsolationEnabled()) {
+      env.HOME = resolve(dir, "home");
+    }
+
     // Node's spawn() with uid/gid doesn't set supplementary groups, so the agent
     // process can't read the shared CLAUDE_CONFIG_DIR even if it's group-readable.
     // Give each agent its own config dir with a copy of the shared credentials.
     if (isIsolationEnabled() && process.env.CLAUDE_CONFIG_DIR) {
-      const agentClaudeDir = resolve(dir, ".claude");
+      const agentClaudeDir = resolve(dir, "home", ".claude");
       try {
         mkdirSync(agentClaudeDir, { recursive: true });
       } catch (err) {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -321,7 +321,7 @@ const app = new Hono<AuthEnv>()
       chownAgentDir(dest, name);
 
       const ids = isIsolationEnabled() ? await getAgentUserIds(name) : undefined;
-      const env = ids ? { ...process.env, HOME: dest } : undefined;
+      const env = ids ? { ...process.env, HOME: resolve(dest, "home") } : undefined;
 
       // Install dependencies
       await exec("npm", ["install"], { cwd: dest, uid: ids?.uid, gid: ids?.gid, env });
@@ -442,7 +442,7 @@ const app = new Hono<AuthEnv>()
       chownAgentDir(dest, name);
 
       const ids = isIsolationEnabled() ? await getAgentUserIds(name) : undefined;
-      const env = ids ? { ...process.env, HOME: dest } : undefined;
+      const env = ids ? { ...process.env, HOME: resolve(dest, "home") } : undefined;
 
       // Install dependencies
       await exec("npm", ["install"], { cwd: dest, uid: ids?.uid, gid: ids?.gid, env });


### PR DESCRIPTION
## Summary
- Fix `CLAUDE_CONFIG_DIR` to point to `{agentDir}/home/.claude` instead of `{agentDir}/.claude`, matching where the SDK actually runs
- Fix `HOME` env var to point to `{agentDir}/home` instead of the agent root dir in create/import routes
- Set `HOME` env var in agent-manager when spawning agents under isolation, so agents don't inherit the daemon's HOME

## Test plan
- [x] All 513 existing tests pass
- [ ] Verify on a system install that agents get the correct HOME and CLAUDE_CONFIG_DIR

🤖 Generated with [Claude Code](https://claude.com/claude-code)