### PR TITLE
fix: remove RestrictSUIDSGID from systemd unit, fix daemon-e2e port collision

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -74,7 +74,7 @@ function generateUnit(voluteBin: string, port?: number, host?: string): string {
     console.warn("Consider installing Node.js system-wide for stronger sandboxing.");
   }
 
-  lines.push("RestrictSUIDSGID=yes", "", "[Install]", "WantedBy=multi-user.target", "");
+  lines.push("", "[Install]", "WantedBy=multi-user.target", "");
   return lines.join("\n");
 }
 

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -124,7 +124,8 @@ export function nextPort(): number {
       if (v.port) usedPorts.add(v.port);
     }
   }
-  let port = 4100;
+  const basePort = parseInt(process.env.VOLUTE_BASE_PORT || "4100", 10);
+  let port = basePort;
   while (usedPorts.has(port)) port++;
   if (port > 65535) throw new Error("No available ports — all ports 4100-65535 are allocated");
   return port;

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -7,10 +7,12 @@ import { agentDir, findAgent, removeAgent } from "../src/lib/registry.js";
 // Strip GIT_* env vars that hook runners (e.g. pre-push) inject, so that
 // spawned processes (like `volute create` which runs `git init`) don't
 // accidentally operate on the parent repo.
+const AGENT_BASE_PORT = 15100 + Math.floor(Math.random() * 800);
 const cleanEnv: Record<string, string> = {};
 for (const [k, v] of Object.entries(process.env)) {
   if (!k.startsWith("GIT_") && v !== undefined) cleanEnv[k] = v;
 }
+cleanEnv.VOLUTE_BASE_PORT = String(AGENT_BASE_PORT);
 
 const TEST_AGENT = "e2e-test-agent";
 const PORT = 14200 + Math.floor(Math.random() * 800);
@@ -49,7 +51,7 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     daemon = spawn("npx", ["tsx", "src/daemon.ts", "--port", String(PORT), "--foreground"], {
       cwd: process.cwd(),
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN },
+      env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN, VOLUTE_BASE_PORT: String(AGENT_BASE_PORT) },
     });
 
     // Collect stderr for debugging
@@ -221,7 +223,7 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     daemon = spawn("npx", ["tsx", "src/daemon.ts", "--port", String(PORT), "--foreground"], {
       cwd: process.cwd(),
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN },
+      env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN, VOLUTE_BASE_PORT: String(AGENT_BASE_PORT) },
     });
     daemon.stderr?.on("data", (data: Buffer) => {
       process.stderr.write(`[daemon] ${data}`);
@@ -279,7 +281,7 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     daemon = spawn("npx", ["tsx", "src/daemon.ts", "--port", String(PORT), "--foreground"], {
       cwd: process.cwd(),
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN },
+      env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN, VOLUTE_BASE_PORT: String(AGENT_BASE_PORT) },
     });
     daemon.stderr?.on("data", (data: Buffer) => {
       process.stderr.write(`[daemon] ${data}`);


### PR DESCRIPTION
## Summary

- **Remove `RestrictSUIDSGID=yes` from systemd unit**: The shared `CLAUDE_CONFIG_DIR` architecture relies on sgid for group inheritance (so agents in the `volute` group can access shared directories). The systemd restriction blocked all sgid operations — even for root — causing `EPERM: operation not permitted, chmod '/var/lib/volute/.claude/projects'` on agent start. Docker was unaffected since it runs without systemd.

- **Fix daemon-e2e test port collision**: The test allocated agent ports starting at 4100 (hardcoded), which collided with real running agents on the host. Added `VOLUTE_BASE_PORT` env var to make the base port configurable, and the test now uses a randomized high range (15100+).

## Test plan

- [x] All 517 tests pass
- [ ] On a system install, run `volute setup` (or manually remove `RestrictSUIDSGID=yes` from `/etc/systemd/system/volute.service` and `systemctl daemon-reload`) then `volute agent start <name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)