### PR TITLE
fix: remove shared CLAUDE_CONFIG_DIR, use default $HOME/.claude per agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ COPY templates/ templates/
 ENV VOLUTE_HOME=/data
 ENV VOLUTE_AGENTS_DIR=/agents
 ENV VOLUTE_ISOLATION=user
-ENV CLAUDE_CONFIG_DIR=/data/.claude
 EXPOSE 4200
 VOLUME /data
 VOLUME /agents

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,22 +2,7 @@
 set -e
 
 # Create the shared volute group (idempotent) so agent users can access
-# group-writable directories like CLAUDE_CONFIG_DIR.
+# group-writable directories.
 groupadd -f volute
-
-# If a Claude config directory is mounted, make it and the credentials file
-# readable by the volute group so isolated agent users can access them.
-# Only touch the top-level dir and key files — a recursive chown on a large
-# bind-mounted ~/.claude is too slow.
-if [ -n "$CLAUDE_CONFIG_DIR" ] && [ -d "$CLAUDE_CONFIG_DIR" ]; then
-  chown root:volute "$CLAUDE_CONFIG_DIR"
-  chmod 2770 "$CLAUDE_CONFIG_DIR"
-  for f in .credentials.json settings.json; do
-    if [ -f "$CLAUDE_CONFIG_DIR/$f" ]; then
-      chown root:volute "$CLAUDE_CONFIG_DIR/$f"
-      chmod 640 "$CLAUDE_CONFIG_DIR/$f"
-    fi
-  done
-fi
 
 exec "$@"

--- a/src/lib/agent-manager.ts
+++ b/src/lib/agent-manager.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, execFile, type SpawnOptions, spawn } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { loadMergedEnv } from "./env.js";
@@ -133,14 +133,6 @@ export class AgentManager {
 
     if (isIsolationEnabled()) {
       env.HOME = resolve(dir, "home");
-
-      // Pre-create CLAUDE_CONFIG_DIR/projects/ with sgid so agents can create
-      // their own subdirectories within the shared config dir.
-      if (process.env.CLAUDE_CONFIG_DIR) {
-        const projectsDir = resolve(process.env.CLAUDE_CONFIG_DIR, "projects");
-        mkdirSync(projectsDir, { recursive: true });
-        chmodSync(projectsDir, 0o2770);
-      }
     }
 
     const tsxBin = resolve(dir, "node_modules", ".bin", "tsx");


### PR DESCRIPTION
## Summary

- Remove the shared `CLAUDE_CONFIG_DIR` architecture that tried to share a single `.claude` directory across all agents
- Each agent now uses its default `$HOME/.claude` directory (where `HOME` is already set to `<agent-dir>/home/` for isolated agents)
- Restore `RestrictSUIDSGID=yes` in the systemd unit since the sgid chmod that required its removal is no longer needed

The shared directory approach caused `EPERM: operation not permitted, chmod` errors on system installs because the Claude SDK tries to `chmod` with sgid bits on its config directories, which conflicts with systemd's `RestrictSUIDSGID=yes` hardening. Symlinks and copies didn't work either since `chmod` follows symlinks to the root-owned target.

## Test plan

- [x] All 519 tests pass
- [ ] Verify `volute setup` generates correct systemd unit (no `CLAUDE_CONFIG_DIR` env, has `RestrictSUIDSGID=yes`)
- [ ] Verify Docker build works without `CLAUDE_CONFIG_DIR`
- [ ] Verify agent starts correctly on system install

🤖 Generated with [Claude Code](https://claude.com/claude-code)