### PR TITLE
feat: inject reply instructions on first message of each session

### DIFF
--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -9,6 +9,7 @@ import { toSDKContent } from "./lib/content.js";
 import { createAutoCommitHook } from "./lib/hooks/auto-commit.js";
 import { createIdentityReloadHook } from "./lib/hooks/identity-reload.js";
 import { createPreCompactHook } from "./lib/hooks/pre-compact.js";
+import { createReplyInstructionsHook } from "./lib/hooks/reply-instructions.js";
 import { createSessionContextHook } from "./lib/hooks/session-context.js";
 import { log } from "./lib/logger.js";
 import { createMessageChannel } from "./lib/message-channel.js";
@@ -93,6 +94,8 @@ export function createMind(options: {
       cwd: options.cwd,
     });
 
+    const replyInstructions = createReplyInstructionsHook(session.messageChannels);
+
     return query({
       prompt: session.channel.iterable,
       options: {
@@ -108,7 +111,7 @@ export function createMind(options: {
         hooks: {
           PostToolUse: postToolUseHooks,
           PreCompact: [{ hooks: [preCompact.hook] }],
-          UserPromptSubmit: [{ hooks: [sessionContext.hook] }],
+          UserPromptSubmit: [{ hooks: [sessionContext.hook, replyInstructions.hook] }],
         },
       },
     });

--- a/templates/claude/src/lib/hooks/reply-instructions.ts
+++ b/templates/claude/src/lib/hooks/reply-instructions.ts
@@ -1,0 +1,28 @@
+import type { HookCallback } from "@anthropic-ai/claude-agent-sdk";
+import type { MessageChannelInfo } from "../auto-reply.js";
+
+export function createReplyInstructionsHook(messageChannels: Map<string, MessageChannelInfo>) {
+  let fired = false;
+
+  const hook: HookCallback = async () => {
+    if (fired) return {};
+
+    const entry = messageChannels.values().next().value;
+    if (!entry?.channel) return {};
+
+    fired = true;
+
+    const context = entry.autoReply
+      ? `Auto-reply is enabled for this session — your text output will automatically be sent back to ${entry.channel}. To send to a different channel: volute send <channel> "message"`
+      : `To reply to this message, use: volute send ${entry.channel} "your message"`;
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit" as const,
+        additionalContext: context,
+      },
+    };
+  };
+
+  return { hook };
+}

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -15,6 +15,7 @@ import {
 import { extractImages, extractText } from "./lib/content.js";
 import { createEventHandler } from "./lib/event-handler.js";
 import { log } from "./lib/logger.js";
+import { createReplyInstructionsExtension } from "./lib/reply-instructions-extension.js";
 import { resolveModel } from "./lib/resolve-model.js";
 import { createSessionContextExtension } from "./lib/session-context-extension.js";
 import type {
@@ -123,11 +124,17 @@ export function createMind(options: {
       cwd: options.cwd,
     });
 
+    const replyInstructionsExtension = createReplyInstructionsExtension(session.messageChannels);
+
     const resourceLoader = new DefaultResourceLoader({
       cwd: options.cwd,
       settingsManager,
       systemPrompt: options.systemPrompt,
-      extensionFactories: [preCompactExtension, sessionContextExtension],
+      extensionFactories: [
+        preCompactExtension,
+        sessionContextExtension,
+        replyInstructionsExtension,
+      ],
     });
     await resourceLoader.reload();
 

--- a/templates/pi/src/lib/reply-instructions-extension.ts
+++ b/templates/pi/src/lib/reply-instructions-extension.ts
@@ -1,0 +1,30 @@
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { MessageChannelInfo } from "./auto-reply.js";
+
+export function createReplyInstructionsExtension(
+  messageChannels: Map<string, MessageChannelInfo>,
+): ExtensionFactory {
+  return (pi) => {
+    let fired = false;
+    pi.on("before_agent_start", () => {
+      if (fired) return {};
+
+      const entry = messageChannels.values().next().value;
+      if (!entry?.channel) return {};
+
+      fired = true;
+
+      const content = entry.autoReply
+        ? `Auto-reply is enabled for this session — your text output will automatically be sent back to ${entry.channel}. To send to a different channel: volute send <channel> "message"`
+        : `To reply to this message, use: volute send ${entry.channel} "your message"`;
+
+      return {
+        message: {
+          customType: "reply-instructions",
+          content,
+          display: true,
+        },
+      };
+    });
+  };
+}


### PR DESCRIPTION
## Summary

- On the first message delivered to a session, injects context explaining how to reply
- If auto-reply is on: tells the mind its text output goes back automatically, and how to reach other channels
- If auto-reply is off: tells the mind to use `volute send <channel> "message"`
- Claude template uses a `UserPromptSubmit` hook; pi template uses a `before_agent_start` extension

## Test plan

- [ ] Verify existing tests pass (542 pass, 0 fail)
- [ ] Manual test: send a message to a mind without auto-reply, confirm it receives `volute send` instructions
- [ ] Manual test: send a message to a mind with auto-reply enabled, confirm it receives auto-reply instructions
- [ ] Verify instructions only appear on the first message per session

🤖 Generated with [Claude Code](https://claude.com/claude-code)