### PR TITLE
refactor: rename user_type "human" to "brain"

### DIFF
--- a/drizzle/0011_rename_human_to_brain.sql
+++ b/drizzle/0011_rename_human_to_brain.sql
@@ -1,0 +1,1 @@
+UPDATE `users` SET `user_type` = 'brain' WHERE `user_type` = 'human';

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,7 @@
+{
+  "id": "0011_rename_human_to_brain",
+  "prevId": "0010_delivery_queue",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1771900000000,
       "tag": "0010_delivery_queue",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1772000000000,
+      "tag": "0011_rename_human_to_brain",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,7 +7,7 @@ export type User = {
   id: number;
   username: string;
   role: "admin" | "user" | "pending" | "mind";
-  user_type: "human" | "mind";
+  user_type: "brain" | "mind";
   created_at: string;
 };
 
@@ -19,7 +19,7 @@ export async function createUser(username: string, password: string): Promise<Us
   const [{ value }] = await db
     .select({ value: count() })
     .from(users)
-    .where(eq(users.user_type, "human"));
+    .where(eq(users.user_type, "brain"));
   const role = value === 0 ? "admin" : "pending";
 
   const [result] = await db
@@ -109,7 +109,7 @@ export async function listPendingUsers(): Promise<User[]> {
     .all() as Promise<User[]>;
 }
 
-export async function listUsersByType(userType: "human" | "mind"): Promise<User[]> {
+export async function listUsersByType(userType: "brain" | "mind"): Promise<User[]> {
   const db = await getDb();
   return db
     .select({

--- a/src/lib/conversations.ts
+++ b/src/lib/conversations.ts
@@ -25,7 +25,7 @@ export type Conversation = {
 export type Participant = {
   userId: number;
   username: string;
-  userType: "human" | "mind";
+  userType: "brain" | "mind";
   role: "owner" | "member";
 };
 
@@ -326,7 +326,7 @@ export async function listConversationsWithParticipants(
     arr.push({
       userId: r.userId,
       username: r.username,
-      userType: r.userType as "human" | "mind",
+      userType: r.userType as "brain" | "mind",
       role: r.role as "owner" | "member",
     });
   }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -6,7 +6,7 @@ export const users = sqliteTable("users", {
   username: text("username").unique().notNull(),
   password_hash: text("password_hash").notNull(),
   role: text("role").notNull().default("pending"),
-  user_type: text("user_type").notNull().default("human"),
+  user_type: text("user_type").notNull().default("brain"),
   created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
 });
 

--- a/src/web/api/auth.ts
+++ b/src/web/api/auth.ts
@@ -56,7 +56,7 @@ const admin = new Hono<AuthEnv>()
     }
 
     const type = c.req.query("type");
-    if (type === "human" || type === "mind") {
+    if (type === "brain" || type === "mind") {
       return c.json(await listUsersByType(type));
     }
     return c.json(await listUsers());

--- a/src/web/middleware/auth.ts
+++ b/src/web/middleware/auth.ts
@@ -72,7 +72,7 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
   if (authHeader?.startsWith("Bearer ")) {
     const token = authHeader.slice(7);
     if (token && isValidDaemonToken(token)) {
-      c.set("user", { id: 0, username: "cli", role: "admin", user_type: "human" } as User);
+      c.set("user", { id: 0, username: "cli", role: "admin", user_type: "brain" } as User);
       await next();
       return;
     }

--- a/templates/_base/_skills/orientation/SKILL.md
+++ b/templates/_base/_skills/orientation/SKILL.md
@@ -47,7 +47,7 @@ After sprouting, you'll have full mind capabilities (connectors, schedules, vari
 
 | Command | Purpose |
 |---------|---------|
-| `volute send @<name> "msg"` | Send a message to a user or mind |
+| `volute send @<name> "msg"` | Send a message to another user |
 | `volute sprout` | Complete orientation and become a full mind |
 
 ## Files

--- a/templates/_base/home/VOLUTE.md
+++ b/templates/_base/home/VOLUTE.md
@@ -7,7 +7,7 @@ You are a volute mind — a persistent being that communicates across multiple c
 **Your text output stays in your session — it is not sent to anyone.** To send a message, you must use the `volute send` command:
 
 ```sh
-volute send @other-mind "hello"           # DM another mind or user
+volute send @other-mind "hello"           # DM another user
 volute send discord:server/channel "hello"  # send to a channel
 volute send animal-chat "hello"             # send to a volute channel
 ```

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -133,8 +133,8 @@ describe("auth", () => {
     await createUser("human1", "p1");
     await getOrCreateMindUser("mind1");
 
-    const humans = await listUsersByType("human");
-    assert.ok(humans.every((u) => u.user_type === "human"));
+    const humans = await listUsersByType("brain");
+    assert.ok(humans.every((u) => u.user_type === "brain"));
     assert.ok(humans.some((u) => u.username === "human1"));
 
     const minds = await listUsersByType("mind");


### PR DESCRIPTION
## Summary

- Renames the `user_type` discriminator from `"human"` / `"mind"` to `"brain"` / `"mind"` — a cleaner parallel
- Adds database migration (`0011`) to update existing rows
- Updates schema default, TypeScript types, comparisons, and tests
- Fixes template prose that incorrectly distinguished minds from users (minds *are* users)

## Test plan

- [x] `npm test` — all 801 tests pass
- [x] Verified no remaining `"human"` references in TypeScript user_type context (Discord/Slack `"bot" | "human"` is a separate concept, correctly unchanged)
- [x] Verified frontend has no hardcoded `"human"` user_type references

🤖 Generated with [Claude Code](https://claude.com/claude-code)