### PR TITLE
fix: resolve pi session-context paths from mind root directory

### DIFF
--- a/templates/pi/src/lib/session-context-extension.ts
+++ b/templates/pi/src/lib/session-context-extension.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { log } from "./logger.js";
 import { getSessionUpdates, resolvePiJsonl } from "./session-monitor.js";
 
 export function createSessionContextExtension(options: {
@@ -25,7 +26,8 @@ export function createSessionContextExtension(options: {
             display: true,
           },
         };
-      } catch {
+      } catch (err) {
+        log("mind", "session context extension failed:", err);
         return {};
       }
     });

--- a/templates/pi/src/server.ts
+++ b/templates/pi/src/server.ts
@@ -21,9 +21,11 @@ if (config.thinkingLevel) log("server", `thinking level: ${config.thinkingLevel}
 const systemPrompt = loadSystemPrompt();
 const pkg = loadPackageInfo();
 
+const mindDir = resolve(".");
 const mind = createMind({
   systemPrompt,
   cwd: resolve("home"),
+  mindDir,
   model: config.model,
   thinkingLevel: config.thinkingLevel,
   compactionMessage: config.compactionMessage,


### PR DESCRIPTION
## Summary
- Fix cross-session context not working for pi-agent minds — the session-context extension was resolving `.mind/pi-sessions` from `cwd` (the `home/` subdir) instead of the mind project root, producing a nonexistent path
- Pass `mindDir` explicitly from `server.ts` instead of computing it from `cwd`
- Add null guard for `session.agentSession` after failed init (removes `!` non-null assertions)
- Add error logging to bare `catch` block in session-context-extension

## Test plan
- [x] All 873 existing tests pass
- [x] Verified on a real pi-agent mind (lisa) — session context summaries now appear in the mind's thinking

🤖 Generated with [Claude Code](https://claude.com/claude-code)