### PR TITLE
chore: change default daemon port from 4200 to 1618

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Templates have a `.init/` directory containing identity and config files. On `vo
 
 ### Web dashboard
 
-The daemon serves a Hono web server (default port 4200) with a Svelte frontend.
+The daemon serves a Hono web server (default port 1618) with a Svelte frontend.
 
 - **Backend** (`src/web/`): Hono API routes for auth, minds, chat, conversations, logs, variants, files, connectors, schedules, channels, env, keys, pages, prompts, skills, file-sharing
 - **Frontend** (`src/web/ui/`): Svelte SPA with login, dashboard, and mind detail pages (chat, logs, files, variants, connections tabs)
@@ -157,7 +157,7 @@ The daemon serves a Hono web server (default port 4200) with a Svelte frontend.
 | `volute auth logout` | Remove stored credentials |
 | `volute pages publish [--mind <name>] [--system]` | Publish pages (mind's or --system for shared/pages/) |
 | `volute pages status [--mind <name>] [--system]` | Show publish status (mind's or --system) |
-| `volute up [--port N] [--foreground]` | Start the daemon (default: 4200) |
+| `volute up [--port N] [--foreground]` | Start the daemon (default: 1618) |
 | `volute down` | Stop the daemon |
 | `volute restart [--port N]` | Restart the daemon |
 | `volute service install [--port N] [--host H]` | Install as user-level auto-start service |
@@ -330,7 +330,7 @@ Mind-scoped commands (`send`, `history`, `variant`, `schedule`, `channel`, `file
 
 ```sh
 docker build -t volute .
-docker run -d -p 4200:4200 -v volute-data:/data -v volute-minds:/minds volute
+docker run -d -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
 ```
 
 Or with docker-compose: `docker compose up -d`. The container runs with `VOLUTE_ISOLATION=user` enabled, so each mind gets its own Linux user inside the container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN ln -s /opt/volute/dist/cli.js /usr/local/bin/volute
 ENV VOLUTE_HOME=/data
 ENV VOLUTE_MINDS_DIR=/minds
 ENV VOLUTE_ISOLATION=user
-EXPOSE 4200
+EXPOSE 1618
 VOLUME /data
 VOLUME /minds
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ volute mind start atlas
 volute send @atlas "hey, what can you do?"
 ```
 
-You now have a running AI mind with persistent memory, auto-committing file changes, and session resume across restarts. Open `http://localhost:4200` for the web dashboard.
+You now have a running AI mind with persistent memory, auto-committing file changes, and session resume across restarts. Open `http://localhost:1618` for the web dashboard.
 
 ## The daemon
 
 One background process runs everything. `volute up` starts it; `volute down` stops it.
 
 ```sh
-volute up              # start (default port 4200)
+volute up              # start (default port 1618)
 volute up --port 8080  # custom port
 volute down            # stop all minds and shut down
 volute status          # check daemon status, version, and minds
@@ -204,7 +204,7 @@ volute env remove API_KEY
 
 ## Web dashboard
 
-The daemon serves a web UI at `http://localhost:4200` (or whatever port you chose).
+The daemon serves a web UI at `http://localhost:1618` (or whatever port you chose).
 
 - Real-time chat with full tool call visibility
 - File browser and editor
@@ -250,7 +250,7 @@ Set the model via `home/.config/volute.json` in the mind directory, or the `VOLU
 
 ```sh
 docker build -t volute .
-docker run -d -p 4200:4200 -v volute-data:/data -v volute-minds:/minds volute
+docker run -d -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
 ```
 
 Or with docker-compose:
@@ -259,7 +259,7 @@ Or with docker-compose:
 docker compose up -d
 ```
 
-The container runs with per-mind user isolation enabled — each mind gets its own Linux user, so minds can't see each other's files. Open `http://localhost:4200` for the web dashboard.
+The container runs with per-mind user isolation enabled — each mind gets its own Linux user, so minds can't see each other's files. Open `http://localhost:1618` for the web dashboard.
 
 ### Bare metal (Linux / Raspberry Pi)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   volute:
     build: .
     ports:
-      - "4200:4200"
+      - "1618:1618"
     environment:
       - TZ=${TZ:-UTC}
     volumes:

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -74,7 +74,7 @@ Start a container:
 
 ```sh
 docker run -d --name volute-test \
-  -p 14200:4200 \
+  -p 11618:1618 \
   -e "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
   volute-test
 ```

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -26,12 +26,12 @@ export async function stopDaemon(): Promise<StopResult> {
   if (!existsSync(pidPath)) {
     // Check if a daemon is running without a PID file (orphan)
     const configPath = resolve(home, "daemon.json");
-    let port = 4200;
+    let port = 1618;
     let hostname = "localhost";
     if (existsSync(configPath)) {
       try {
         const config = JSON.parse(readFileSync(configPath, "utf-8"));
-        port = config.port ?? 4200;
+        port = config.port ?? 1618;
         hostname = config.hostname || "localhost";
       } catch {}
     }

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -37,7 +37,7 @@ export async function run(args: string[]) {
     }
     const config = readGlobalConfig();
     const h = flags.host ?? config.hostname ?? "127.0.0.1";
-    const p = flags.port ?? config.port ?? 4200;
+    const p = flags.port ?? config.port ?? 1618;
     if (await pollHealth(h, p)) {
       console.log(`Volute daemon running on ${h}:${p}`);
     } else {
@@ -49,7 +49,7 @@ export async function run(args: string[]) {
 
   // Read defaults from config file, CLI flags override
   const config = readGlobalConfig();
-  const port = flags.port ?? config.port ?? 4200;
+  const port = flags.port ?? config.port ?? 1618;
   const hostname = flags.host ?? config.hostname ?? "127.0.0.1";
   const home = voluteHome();
   const pidPath = resolve(home, "daemon.pid");

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -99,7 +99,7 @@ export async function run(_args: string[]) {
   const configPath = resolve(home, "daemon.json");
 
   let daemonWasRunning = false;
-  let daemonPort = 4200;
+  let daemonPort = 1618;
   let daemonHost = "127.0.0.1";
 
   if (existsSync(pidPath)) {
@@ -117,7 +117,7 @@ export async function run(_args: string[]) {
   if (daemonWasRunning && existsSync(configPath)) {
     try {
       const config = JSON.parse(readFileSync(configPath, "utf-8"));
-      daemonPort = config.port ?? 4200;
+      daemonPort = config.port ?? 1618;
       daemonHost = config.hostname || "127.0.0.1";
     } catch {
       console.error("Warning: could not read daemon config, using default port/host");

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -310,7 +310,7 @@ export async function startDaemon(opts: {
 
 // CLI entry point
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("daemon.ts")) {
-  let port = 4200;
+  let port = 1618;
   let hostname = "127.0.0.1";
   let foreground = false;
   let tailscale = false;

--- a/src/lib/service-mode.ts
+++ b/src/lib/service-mode.ts
@@ -181,18 +181,18 @@ export function readDaemonConfig(): {
   token?: string;
 } {
   const configPath = resolve(voluteHome(), "daemon.json");
-  if (!existsSync(configPath)) return { hostname: "127.0.0.1", port: 4200 };
+  if (!existsSync(configPath)) return { hostname: "127.0.0.1", port: 1618 };
   try {
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     return {
       hostname: config.hostname || "127.0.0.1",
-      port: config.port ?? 4200,
+      port: config.port ?? 1618,
       internalPort: config.internalPort,
       token: config.token,
     };
   } catch {
     console.error("Warning: could not read daemon config, using defaults.");
-    return { hostname: "127.0.0.1", port: 4200 };
+    return { hostname: "127.0.0.1", port: 1618 };
   }
 }
 

--- a/src/web/ui/vite.config.ts
+++ b/src/web/ui/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": "http://localhost:4200",
+      "/api": "http://localhost:1618",
     },
   },
 });

--- a/test/docker-e2e.sh
+++ b/test/docker-e2e.sh
@@ -27,7 +27,7 @@ fi
 
 CONTAINER="volute-e2e-$$"
 IMAGE="volute-e2e-$$"
-HOST_PORT=14200
+HOST_PORT=11618
 PASS=0
 FAIL=0
 TOKEN=""
@@ -75,7 +75,7 @@ api() {
   shift 2
   curl -sf -X "$method" \
     -H "Authorization: Bearer $TOKEN" \
-    -H "Origin: http://127.0.0.1:4200" \
+    -H "Origin: http://127.0.0.1:1618" \
     -H "Content-Type: application/json" \
     "http://localhost:$HOST_PORT/api$path" "$@"
 }
@@ -86,7 +86,7 @@ api_raw() {
   shift 2
   curl -s -X "$method" \
     -H "Authorization: Bearer $TOKEN" \
-    -H "Origin: http://127.0.0.1:4200" \
+    -H "Origin: http://127.0.0.1:1618" \
     -H "Content-Type: application/json" \
     "http://localhost:$HOST_PORT/api$path" "$@"
 }
@@ -121,7 +121,7 @@ docker build -t "$IMAGE" . >/dev/null 2>&1
 pass "Docker image built"
 
 docker run -d --name "$CONTAINER" \
-  -p "$HOST_PORT:4200" \
+  -p "$HOST_PORT:1618" \
   -e "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
   "$IMAGE" >/dev/null
 pass "Container started"

--- a/test/integration-setup.sh
+++ b/test/integration-setup.sh
@@ -95,7 +95,7 @@ ENV_ARGS=(-e "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY")
 
 echo "Starting container on port $HOST_PORT..."
 if ! docker run -d --name "$CONTAINER" \
-  -p "$HOST_PORT:4200" \
+  -p "$HOST_PORT:1618" \
   "${ENV_ARGS[@]}" \
   "$IMAGE" >/dev/null; then
   echo "Error: failed to start container (port $HOST_PORT may be in use)" >&2
@@ -145,7 +145,7 @@ fi
 echo "Creating test user account..."
 REGISTER_RESP=$(curl -sf -X POST \
   -H "Content-Type: application/json" \
-  -H "Origin: http://127.0.0.1:4200" \
+  -H "Origin: http://127.0.0.1:1618" \
   -d '{"username":"tester","password":"tester"}' \
   "http://localhost:$HOST_PORT/api/auth/register" 2>&1) || true
 
@@ -159,7 +159,7 @@ fi
 # (the container runs as root, and @target DMs resolve the OS username as sender)
 ROOT_REGISTER_RESP=$(curl -sf -X POST \
   -H "Content-Type: application/json" \
-  -H "Origin: http://127.0.0.1:4200" \
+  -H "Origin: http://127.0.0.1:1618" \
   -d '{"username":"root","password":"root"}' \
   "http://localhost:$HOST_PORT/api/auth/register" 2>&1) || true
 
@@ -168,7 +168,7 @@ if [[ -n "$ROOT_USER_ID" ]]; then
   # Get admin session cookie to approve the pending root user
   SESSION_COOKIE=$(curl -sf -X POST \
     -H "Content-Type: application/json" \
-    -H "Origin: http://127.0.0.1:4200" \
+    -H "Origin: http://127.0.0.1:1618" \
     -c - \
     -d '{"username":"tester","password":"tester"}' \
     "http://localhost:$HOST_PORT/api/auth/login" 2>/dev/null | grep volute_session | awk '{print $NF}')
@@ -176,7 +176,7 @@ if [[ -n "$ROOT_USER_ID" ]]; then
   if [[ -n "$SESSION_COOKIE" ]]; then
     curl -sf -X POST \
       -H "Cookie: volute_session=$SESSION_COOKIE" \
-      -H "Origin: http://127.0.0.1:4200" \
+      -H "Origin: http://127.0.0.1:1618" \
       "http://localhost:$HOST_PORT/api/auth/users/$ROOT_USER_ID/approve" >/dev/null 2>&1 || true
   fi
   echo "  User 'root' created (for CLI inside container)"

--- a/test/service-mode.test.ts
+++ b/test/service-mode.test.ts
@@ -39,15 +39,15 @@ describe("getServiceMode", () => {
 
 describe("getDaemonUrl", () => {
   it("builds URL from hostname and port", () => {
-    assert.equal(getDaemonUrl("127.0.0.1", 4200), "http://127.0.0.1:4200");
+    assert.equal(getDaemonUrl("127.0.0.1", 1618), "http://127.0.0.1:1618");
   });
 
   it("maps 0.0.0.0 to localhost", () => {
-    assert.equal(getDaemonUrl("0.0.0.0", 4200), "http://localhost:4200");
+    assert.equal(getDaemonUrl("0.0.0.0", 1618), "http://localhost:1618");
   });
 
   it("maps :: to localhost", () => {
-    assert.equal(getDaemonUrl("::", 4200), "http://localhost:4200");
+    assert.equal(getDaemonUrl("::", 1618), "http://localhost:1618");
   });
 
   it("uses custom port", () => {
@@ -55,7 +55,7 @@ describe("getDaemonUrl", () => {
   });
 
   it("handles IPv6 literal", () => {
-    assert.equal(getDaemonUrl("::1", 4200), "http://[::1]:4200");
+    assert.equal(getDaemonUrl("::1", 1618), "http://[::1]:1618");
   });
 });
 


### PR DESCRIPTION
## Summary

- Changes the default daemon port from 4200 to 1618 across all source code, tests, docs, and Docker config

## Test plan

- [x] `npm test` passes (1037 tests, 0 failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)