### PR TITLE
feat: silent restarts for identity file edits

### DIFF
--- a/src/web/api/minds.ts
+++ b/src/web/api/minds.ts
@@ -1189,8 +1189,9 @@ const app = new Hono<AuthEnv>()
         }
       }
 
-      // Store context for delivery after restart
-      if (context) {
+      // Store context for delivery after restart (skip "reload" — identity file
+      // edits and compaction are self-initiated, so the mind doesn't need a notification)
+      if (context && context.type !== "reload") {
         manager.setPendingContext(name, context);
       }
 


### PR DESCRIPTION
## Summary
- When a mind edits its own identity files (SOUL.md, MEMORY.md, VOLUTE.md), the resulting restart no longer sends a "[system] You have been restarted" notification
- The mind initiated the change itself, so the restart is seamless — they simply experience the next turn as usual with updated identity loaded

## Test plan
- [x] All 1092 existing tests pass
- [ ] Verify a mind editing SOUL.md no longer receives a restart notification
- [ ] Verify merge/sprout restarts still deliver their notifications as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)