### PR TITLE
fix: upgrade message, dreaming docs, and user-local session storage

### DIFF
--- a/skills/dreaming/references/INSTALL.md
+++ b/skills/dreaming/references/INSTALL.md
@@ -19,7 +19,7 @@ Restart your mind after running this so the subagent is loaded.
 
 ## 2. Add a dream schedule
 
-Add to your mind's `volute.json` (managed by volute) under `schedules`:
+Add to `.config/volute.json` under `schedules`:
 
 ```json
 {
@@ -41,7 +41,7 @@ volute schedule add --mind <name> --id dream --cron "0 3 * * *" --message "it's 
 
 If your mind uses the sleep system, add `system:dream` to wake triggers so the dream schedule wakes the mind briefly:
 
-In `volute.json`, add to the `sleep` section:
+In `.config/volute.json`, add to the `sleep` section:
 
 ```json
 {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { daemonFetch } from "../lib/daemon-client.js";
 import { promptLine, promptPassword } from "../lib/prompt.js";
-import { voluteHome } from "../lib/registry.js";
+import { voluteUserHome } from "../lib/registry.js";
 
 export async function run(_args: string[]): Promise<void> {
   const username = await promptLine("Username: ");
@@ -30,7 +30,7 @@ export async function run(_args: string[]): Promise<void> {
     sessionId: string;
   };
 
-  const sessionPath = resolve(voluteHome(), "cli-session.json");
+  const sessionPath = resolve(voluteUserHome(), "cli-session.json");
   try {
     writeFileSync(sessionPath, JSON.stringify({ sessionId, username: name }), { mode: 0o600 });
   } catch (err) {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import { daemonFetch } from "../lib/daemon-client.js";
-import { voluteHome } from "../lib/registry.js";
+import { voluteUserHome } from "../lib/registry.js";
 
 export async function run(_args: string[]): Promise<void> {
-  const sessionPath = resolve(voluteHome(), "cli-session.json");
+  const sessionPath = resolve(voluteUserHome(), "cli-session.json");
 
   if (!existsSync(sessionPath)) {
     console.log("Not logged in");

--- a/src/lib/daemon-client.ts
+++ b/src/lib/daemon-client.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { voluteHome } from "./registry.js";
+import { voluteHome, voluteUserHome } from "./registry.js";
 
 type CliSession = { sessionId: string; username: string };
 
 function readCliSession(): CliSession | null {
-  const sessionPath = resolve(voluteHome(), "cli-session.json");
+  const sessionPath = resolve(voluteUserHome(), "cli-session.json");
   if (!existsSync(sessionPath)) return null;
   try {
     return JSON.parse(readFileSync(sessionPath, "utf-8"));

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -51,6 +51,16 @@ export function voluteHome(): string {
   return resolve(homedir(), ".volute");
 }
 
+/**
+ * Per-user config directory (~/.volute/), independent of VOLUTE_HOME.
+ * Used for user-specific state like login sessions and API keys that
+ * shouldn't live in system directories (e.g. /var/lib/volute).
+ */
+export function voluteUserHome(): string {
+  if (process.env.VOLUTE_USER_HOME) return process.env.VOLUTE_USER_HOME;
+  return resolve(homedir(), ".volute");
+}
+
 export type MindEntry = {
   name: string;
   port: number;

--- a/src/lib/systems-config.ts
+++ b/src/lib/systems-config.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { voluteHome } from "./registry.js";
+import { voluteUserHome } from "./registry.js";
 
 export type SystemsConfig = {
   apiKey: string;
@@ -11,7 +11,7 @@ export type SystemsConfig = {
 const DEFAULT_API_URL = "https://volute.systems";
 
 function configPath(): string {
-  return resolve(voluteHome(), "systems.json");
+  return resolve(voluteUserHome(), "systems.json");
 }
 
 export function readSystemsConfig(): SystemsConfig | null {
@@ -34,7 +34,7 @@ export function readSystemsConfig(): SystemsConfig | null {
 }
 
 export function writeSystemsConfig(config: SystemsConfig): void {
-  mkdirSync(voluteHome(), { recursive: true });
+  mkdirSync(voluteUserHome(), { recursive: true });
   writeFileSync(configPath(), `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
 }
 

--- a/src/lib/version-notify.ts
+++ b/src/lib/version-notify.ts
@@ -135,7 +135,7 @@ function formatNotification(
   }
 
   if (needsUpgrade) {
-    message += `\n\n---\n\nA template update is available for you. To upgrade, your operator can run:\n  volute mind upgrade ${mindName}`;
+    message += `\n\n---\n\nA template update is available for you. To upgrade, run:\n  volute mind upgrade ${mindName}`;
   }
 
   return message;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -7,3 +7,4 @@ import { resolve } from "node:path";
 const testHome = resolve(tmpdir(), `volute-test-${process.pid}`);
 mkdirSync(testHome, { recursive: true });
 process.env.VOLUTE_HOME = testHome;
+process.env.VOLUTE_USER_HOME = testHome;


### PR DESCRIPTION
## Summary
- Remove "your operator can run" from template upgrade notification — minds can and should self-upgrade
- Fix dreaming INSTALL.md to reference `.config/volute.json` (not "volute.json managed by volute")
- Add `voluteUserHome()` that always resolves to `~/.volute/` regardless of `VOLUTE_HOME`, used for `cli-session.json` and `systems.json` so system installs (`/var/lib/volute`) don't store per-user credentials there

## Test plan
- [x] All 1163 tests pass
- [x] `VOLUTE_USER_HOME` set in test setup to sandbox user-specific files

🤖 Generated with [Claude Code](https://claude.com/claude-code)