### PR TITLE
fix: include PATH in user-level launchd plist

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -51,20 +51,23 @@ function generatePlist(
     ? "/var/lib/volute/system/daemon.log"
     : resolve(homedir(), ".volute", "system", "daemon.log");
 
-  const envEntries: string[] = [];
+  const envEntries: string[] = [
+    "  <key>EnvironmentVariables</key>",
+    "  <dict>",
+    `    <key>PATH</key>`,
+    `    <string>${escapeXml(buildServicePath(voluteBin))}</string>`,
+  ];
   if (opts.system) {
     envEntries.push(
-      "  <key>EnvironmentVariables</key>",
-      "  <dict>",
       "    <key>VOLUTE_HOME</key>",
       "    <string>/var/lib/volute</string>",
       "    <key>VOLUTE_MINDS_DIR</key>",
       "    <string>/minds</string>",
       "    <key>VOLUTE_ISOLATION</key>",
       "    <string>user</string>",
-      "  </dict>",
     );
   }
+  envEntries.push("  </dict>");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -76,7 +79,8 @@ function generatePlist(
   <array>
     ${[voluteBin, ...args].map((a) => `<string>${escapeXml(a)}</string>`).join("\n    ")}
   </array>
-${envEntries.length > 0 ? envEntries.join("\n") + "\n" : ""}  <key>RunAtLoad</key>
+${envEntries.join("\n")}
+  <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
   <true/>


### PR DESCRIPTION
## Summary
- User-level launchd plists were missing `EnvironmentVariables`, so child processes inherited launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and couldn't find `node` installed via nvm/volta/homebrew
- Now always includes PATH via `buildServicePath()` in the plist, matching what the systemd unit generator already did
- Existing installs need to re-run `volute setup --service` or manually add PATH to their plist

## Test plan
- [x] All existing tests pass (1232/1232)
- [x] Verified fix locally: reloaded launchd service with new plist, daemon starts and spawns minds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)