### PR TITLE
fix: use launchctl bootstrap/bootout instead of legacy load/unload

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -178,7 +178,13 @@ async function installUserService(
       mkdirSync(resolve(homedir(), "Library", "LaunchAgents"), { recursive: true });
       writeFileSync(LAUNCHD_PLIST_PATH, generatePlist(voluteBin, { port, host }));
       console.log(`  Wrote ${LAUNCHD_PLIST_PATH}`);
-      await execFileAsync("launchctl", ["load", LAUNCHD_PLIST_PATH]);
+      const uid = `gui/${process.getuid!()}`;
+      try {
+        await execFileAsync("launchctl", ["bootout", `${uid}/${LAUNCHD_PLIST_LABEL}`]);
+      } catch {
+        // May not be loaded — ignore
+      }
+      await execFileAsync("launchctl", ["bootstrap", uid, LAUNCHD_PLIST_PATH]);
       console.log("  Service installed (launchd)");
       return true;
     } else if (platform === "linux") {
@@ -206,14 +212,21 @@ function installSystemService(voluteBin: string, port?: number, host?: string): 
     );
     console.log(`  Wrote ${SYSTEM_LAUNCHD_PLIST_PATH}`);
     try {
-      execFileSync("launchctl", ["load", SYSTEM_LAUNCHD_PLIST_PATH]);
+      try {
+        execFileSync("launchctl", ["bootout", `system/${LAUNCHD_PLIST_LABEL}`]);
+      } catch {
+        // May not be loaded — ignore
+      }
+      execFileSync("launchctl", ["bootstrap", "system", SYSTEM_LAUNCHD_PLIST_PATH]);
       console.log("  Service installed (LaunchDaemon)");
       return true;
     } catch (err) {
       console.warn(
         `  Warning: failed to load LaunchDaemon: ${err instanceof Error ? err.message : err}`,
       );
-      console.warn("  Try: sudo launchctl load /Library/LaunchDaemons/com.volute.daemon.plist");
+      console.warn(
+        "  Try: sudo launchctl bootstrap system /Library/LaunchDaemons/com.volute.daemon.plist",
+      );
       return false;
     }
   } else if (platform === "linux") {

--- a/src/lib/service-mode.ts
+++ b/src/lib/service-mode.ts
@@ -137,10 +137,23 @@ export async function startService(mode: ManagedServiceMode): Promise<void> {
       await execInherit("systemctl", ["--user", "start", "volute"]);
       break;
     case "system-launchd":
-      await execInherit("sudo", ["launchctl", "load", SYSTEM_LAUNCHD_PLIST_PATH]);
+      try {
+        await execInherit("sudo", ["launchctl", "bootout", `system/${LAUNCHD_PLIST_LABEL}`]);
+      } catch {
+        // May not be loaded — ignore
+      }
+      await execInherit("sudo", ["launchctl", "bootstrap", "system", SYSTEM_LAUNCHD_PLIST_PATH]);
       break;
     case "user-launchd":
-      await execInherit("launchctl", ["load", LAUNCHD_PLIST_PATH]);
+      try {
+        await execInherit("launchctl", [
+          "bootout",
+          `gui/${process.getuid!()}/${LAUNCHD_PLIST_LABEL}`,
+        ]);
+      } catch {
+        // May not be loaded — ignore
+      }
+      await execInherit("launchctl", ["bootstrap", `gui/${process.getuid!()}`, LAUNCHD_PLIST_PATH]);
       break;
   }
 }
@@ -154,10 +167,13 @@ export async function stopService(mode: ManagedServiceMode): Promise<void> {
       await execInherit("systemctl", ["--user", "stop", "volute"]);
       break;
     case "system-launchd":
-      await execInherit("sudo", ["launchctl", "unload", SYSTEM_LAUNCHD_PLIST_PATH]);
+      await execInherit("sudo", ["launchctl", "bootout", `system/${LAUNCHD_PLIST_LABEL}`]);
       break;
     case "user-launchd":
-      await execInherit("launchctl", ["unload", LAUNCHD_PLIST_PATH]);
+      await execInherit("launchctl", [
+        "bootout",
+        `gui/${process.getuid!()}/${LAUNCHD_PLIST_LABEL}`,
+      ]);
       break;
   }
 }
@@ -172,26 +188,26 @@ export async function restartService(mode: ManagedServiceMode): Promise<void> {
       break;
     case "system-launchd":
       try {
-        await execInherit("sudo", ["launchctl", "unload", SYSTEM_LAUNCHD_PLIST_PATH]);
+        await execInherit("sudo", ["launchctl", "bootout", `system/${LAUNCHD_PLIST_LABEL}`]);
       } catch (err) {
         console.warn(
-          `Warning: launchctl unload failed: ${err instanceof Error ? err.message : err}`,
+          `Warning: launchctl bootout failed: ${err instanceof Error ? err.message : err}`,
         );
       }
-      await execInherit("sudo", ["launchctl", "load", SYSTEM_LAUNCHD_PLIST_PATH]);
+      await execInherit("sudo", ["launchctl", "bootstrap", "system", SYSTEM_LAUNCHD_PLIST_PATH]);
       break;
-    case "user-launchd":
-      // launchd doesn't have a "restart" — unload then load
+    case "user-launchd": {
+      const uid = `gui/${process.getuid!()}`;
       try {
-        await execInherit("launchctl", ["unload", LAUNCHD_PLIST_PATH]);
+        await execInherit("launchctl", ["bootout", `${uid}/${LAUNCHD_PLIST_LABEL}`]);
       } catch (err) {
-        // May not be loaded — warn but continue to load
         console.warn(
-          `Warning: launchctl unload failed: ${err instanceof Error ? err.message : err}`,
+          `Warning: launchctl bootout failed: ${err instanceof Error ? err.message : err}`,
         );
       }
-      await execInherit("launchctl", ["load", LAUNCHD_PLIST_PATH]);
+      await execInherit("launchctl", ["bootstrap", uid, LAUNCHD_PLIST_PATH]);
       break;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace legacy `launchctl load`/`unload` with modern `bootstrap`/`bootout` API across `service-mode.ts` and `setup.ts`
- `load`/`unload` silently fail when a service is already registered, causing `volute up` to hang for 30s then report failure even though the plist is valid
- `bootstrap`/`bootout` properly handles re-registration and actually starts the service

## Test plan
- [x] All 1146 tests pass
- [ ] Verify `volute up` starts the daemon on a fresh install
- [ ] Verify `volute up` works when the service was previously registered (the bug case)
- [ ] Verify `volute down` stops the daemon
- [ ] Verify `volute restart` cycles the daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)