### PR TITLE
refactor: streamline mind upgrade — auto-merge instead of starting variant

### DIFF
--- a/skills/volute-mind/SKILL.md
+++ b/skills/volute-mind/SKILL.md
@@ -27,7 +27,7 @@ You manage yourself through the `volute` CLI. Your mind name is auto-detected vi
 | `volute mind split <name> [--soul "..."] [--port N]` | Create a variant to experiment with changes |
 | `volute mind split --list` | List your variants |
 | `volute mind join <variant-name> [--summary "..." --memory "..."]` | Merge a variant back |
-| `volute mind upgrade [--template <name>] [--continue]` | Upgrade your server code |
+| `volute mind upgrade [--diff] [--continue] [--abort]` | Upgrade your server code (--diff to preview) |
 | `volute mind connect <type>` | Enable a connector (discord, slack, etc.) |
 | `volute mind disconnect <type>` | Disable a connector |
 | `volute clock add --id <name> --cron "..." --message/--script "..."` | Schedule a recurring task |
@@ -234,12 +234,12 @@ After a merge, you receive orientation context about what changed. Update your m
 
 ## Upgrade Workflow
 
-`volute mind upgrade` merges the latest template code into a testable variant:
+`volute mind upgrade` merges the latest template code and restarts you:
 
-1. `volute mind upgrade` — creates an `upgrade` variant
-2. Resolve any merge conflicts if prompted, then `volute mind upgrade --continue`
-3. Test: `volute chat send @$VOLUTE_MIND-upgrade "hello"`
-4. `volute mind join $VOLUTE_MIND-upgrade` — merge back
+1. `volute mind upgrade --diff` — preview what would change before upgrading
+2. `volute mind upgrade` — merges template updates and restarts you
+3. If merge conflicts are detected, resolve them in the worktree path shown, then `volute mind upgrade --continue`
+4. To cancel a conflicted upgrade: `volute mind upgrade --abort`
 
 ## Custom Skills
 

--- a/src/commands/mind.ts
+++ b/src/commands/mind.ts
@@ -93,7 +93,7 @@ function printUsage() {
   volute mind wake [name]
   volute mind split <name> [--from <mind>] [--soul "..."] [--port N] [--no-start] [--json]
   volute mind join <variant-name> [--summary "..." --justification "..." --memory "..."] [--skip-verify]
-  volute mind upgrade [name] [--template <name>] [--continue] [--accept]
+  volute mind upgrade [name] [--template <name>] [--diff] [--continue] [--abort]
   volute mind import <path> [--name <name>] [--session <path>] [--template <name>]
   volute mind export <name> [--include-env] [--include-identity] [--include-history] [--include-sessions] [--all] [--output <path>]
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -6,7 +6,7 @@ export async function run(args: string[]) {
     template: { type: "string" },
     continue: { type: "boolean" },
     abort: { type: "boolean" },
-    accept: { type: "boolean" },
+    diff: { type: "boolean" },
   });
 
   const mindName = resolveMindName({ mind: positional[0] });
@@ -24,7 +24,7 @@ export async function run(args: string[]) {
         template: flags.template,
         continue: flags.continue,
         abort: flags.abort,
-        accept: flags.accept,
+        diff: flags.diff,
       }),
     },
   );
@@ -34,9 +34,9 @@ export async function run(args: string[]) {
     error?: string;
     conflicts?: boolean;
     worktreeDir?: string;
-    variant?: string;
-    port?: number;
+    diff?: string;
     message?: string;
+    warning?: string;
   };
 
   if (!res.ok && !data.conflicts) {
@@ -44,13 +44,13 @@ export async function run(args: string[]) {
     process.exit(1);
   }
 
-  if (flags.abort) {
-    console.log(`Upgrade aborted for ${mindName}.`);
+  if (flags.diff) {
+    console.log(data.diff ?? "(no changes)");
     return;
   }
 
-  if (flags.accept) {
-    console.log(`Upgrade accepted for ${mindName}.`);
+  if (flags.abort) {
+    console.log(`Upgrade aborted for ${mindName}.`);
     return;
   }
 
@@ -64,9 +64,9 @@ export async function run(args: string[]) {
     return;
   }
 
-  const variantMindName = `${mindName}-${data.variant}`;
-  console.log(`\nUpgrade variant running on port ${data.port}`);
-  console.log(`\nNext steps:`);
-  console.log(`  volute chat send @${variantMindName} "hello"    # chat with upgraded variant`);
-  console.log(`  volute mind upgrade ${mindName} --accept            # accept the upgrade`);
+  if (data.warning) {
+    console.log(`Upgrade complete for ${mindName} (with warning: ${data.warning})`);
+  } else {
+    console.log(`Upgrade complete for ${mindName}.`);
+  }
 }

--- a/src/lib/daemon/mind-manager.ts
+++ b/src/lib/daemon/mind-manager.ts
@@ -361,6 +361,8 @@ export class MindManager {
       parts.push(await getPrompt("merge_message", { name: String(context.name ?? "") }));
     } else if (context.type === "sprouted") {
       parts.push(await getPrompt("sprout_message"));
+    } else if (context.type === "upgraded") {
+      parts.push(await getPrompt("upgrade_message"));
     } else {
       parts.push(await getPrompt("restart_message"));
     }

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -18,6 +18,7 @@ export const PROMPT_KEYS = [
   "sprout_message",
   "restart_message",
   "merge_message",
+  "upgrade_message",
   "compaction_warning",
   "compaction_instructions",
   "reply_instructions",
@@ -67,6 +68,13 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
     content: '[system] Variant "${name}" has been merged and you have been restarted.',
     description: "Variant merge notification",
     variables: ["name"],
+    category: "system",
+  },
+  upgrade_message: {
+    content:
+      "[system] Your framework has been upgraded to the latest version. You have been restarted. Check your skills and CLAUDE.md for any changes.",
+    description: "Sent after a template upgrade completes",
+    variables: [],
     category: "system",
   },
   compaction_warning: {

--- a/src/web/api/minds.ts
+++ b/src/web/api/minds.ts
@@ -78,7 +78,6 @@ import {
 } from "../../lib/prompts.js";
 import {
   addMind,
-  addVariant,
   ensureVoluteHome,
   findMind,
   findVariants,
@@ -326,6 +325,73 @@ async function npmInstallAsMind(cwd: string, mindName: string): Promise<void> {
   } else {
     await exec("npm", ["install"], { cwd });
   }
+}
+
+/**
+ * Merge the upgrade branch back into main, clean up, install deps, and restart.
+ * Returns { ok, warning? } on success, throws on merge failure.
+ */
+async function mergeUpgradeAndRestart(
+  mindName: string,
+  dir: string,
+  worktreeDir: string,
+  upgradeVariantName: string,
+  upgradeBranch: string,
+  template: string,
+): Promise<{ ok: true; warning?: string }> {
+  // Auto-commit any uncommitted changes in main worktree
+  const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: dir })).trim();
+  if (mainStatus) {
+    await gitExec(["add", "-A"], { cwd: dir });
+    await gitExec(["commit", "-m", "Auto-commit before upgrade merge"], { cwd: dir });
+  }
+
+  await gitExec(["merge", upgradeBranch], { cwd: dir });
+
+  // Merge succeeded — everything below is best-effort cleanup/restart
+  try {
+    await cleanupVariant(upgradeVariantName, dir, worktreeDir);
+  } catch (err) {
+    log.warn(`failed to clean up upgrade worktree for ${mindName}`, log.errorData(err));
+  }
+  try {
+    await gitExec(["branch", "-D", upgradeBranch], { cwd: dir });
+  } catch {
+    // branch may already be deleted by cleanupVariant
+  }
+
+  try {
+    await setMindTemplateHash(mindName, computeTemplateHash(template));
+  } catch (err) {
+    log.warn(`failed to update template hash for ${mindName}`, log.errorData(err));
+  }
+
+  try {
+    await npmInstallAsMind(dir, mindName);
+  } catch (err) {
+    log.warn(`npm install failed after upgrade merge for ${mindName}`, log.errorData(err));
+    return {
+      ok: true,
+      warning: `Upgrade merged but npm install failed: ${err instanceof Error ? err.message : String(err)}. You may need to run npm install manually.`,
+    };
+  }
+
+  // Restart mind with upgrade context
+  const manager = getMindManager();
+  try {
+    if (manager.isRunning(mindName)) {
+      await manager.stopMind(mindName);
+    }
+    manager.setPendingContext(mindName, { type: "upgraded" });
+    await manager.startMind(mindName);
+  } catch (e) {
+    return {
+      ok: true,
+      warning: `Upgrade merged but mind restart failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  return { ok: true };
 }
 
 /** Import a mind from a .volute archive (extracted to tempDir by CLI). */
@@ -1427,7 +1493,13 @@ const app = new Hono<AuthEnv>()
     const dir = mindDir(mindName);
     if (!existsSync(dir)) return c.json({ error: "Mind directory missing" }, 404);
 
-    let body: { template?: string; continue?: boolean; abort?: boolean; accept?: boolean } = {};
+    let body: {
+      template?: string;
+      continue?: boolean;
+      abort?: boolean;
+      accept?: boolean;
+      diff?: boolean;
+    } = {};
     try {
       body = await c.req.json();
     } catch {
@@ -1474,7 +1546,7 @@ const app = new Hono<AuthEnv>()
     }
 
     if (body.continue) {
-      // Continue upgrade after conflict resolution
+      // Continue upgrade after conflict resolution — merge back to main
       if (!existsSync(worktreeDir)) {
         return c.json({ error: "No upgrade in progress" }, 400);
       }
@@ -1502,106 +1574,83 @@ const app = new Hono<AuthEnv>()
           throw e;
       }
 
-      // Fix ownership after root git operations so npm install can run as mind user
+      // Re-add home files that match the new .gitignore allowlist patterns
+      try {
+        await gitExec(["add", "home/"], { cwd: worktreeDir });
+      } catch (err) {
+        log.warn(`failed to re-add home files during upgrade for ${mindName}`, log.errorData(err));
+      }
+      try {
+        await gitExec(["diff", "--cached", "--quiet"], { cwd: worktreeDir });
+      } catch {
+        await gitExec(["commit", "-m", "re-add allowlisted home files"], {
+          cwd: worktreeDir,
+        });
+      }
+
+      // Fix ownership after root git operations
       chownMindDir(dir, mindName);
 
+      // Merge upgrade branch back to main, cleanup, and restart
       try {
-        await npmInstallAsMind(worktreeDir, mindName);
-
-        const variantPort = await nextPort();
-        await addVariant(upgradeVariantName, mindName, variantPort, worktreeDir, UPGRADE_BRANCH);
-
-        await getMindManager().startMind(upgradeVariantName);
-
-        return c.json({
-          ok: true,
-          name: mindName,
-          variant: UPGRADE_BRANCH,
-          port: variantPort,
-        });
+        const result = await mergeUpgradeAndRestart(
+          mindName,
+          dir,
+          worktreeDir,
+          upgradeVariantName,
+          UPGRADE_BRANCH,
+          template,
+        );
+        return c.json(result);
       } catch (err) {
-        await cleanupVariant(upgradeVariantName, dir, worktreeDir);
         return c.json(
-          { error: err instanceof Error ? err.message : "Failed to continue upgrade" },
+          { error: err instanceof Error ? err.message : "Failed to merge upgrade" },
           500,
         );
       }
     }
 
     if (body.accept) {
-      // Accept upgrade — merge the upgrade variant back into the parent mind
-      if (!existsSync(worktreeDir)) {
-        return c.json({ error: "No upgrade in progress" }, 400);
-      }
-
-      const variantEntry = await findMind(upgradeVariantName);
-      if (!variantEntry) {
-        return c.json({ error: "Upgrade variant not found in DB" }, 400);
-      }
-
-      // Auto-commit any uncommitted changes in the upgrade worktree
-      const status = (await gitExec(["status", "--porcelain"], { cwd: worktreeDir })).trim();
-      if (status) {
+      // Legacy — upgrades now auto-merge. Clean up any old-style upgrade state.
+      if (existsSync(worktreeDir)) {
         try {
-          await gitExec(["add", "-A"], { cwd: worktreeDir });
-          await gitExec(["commit", "-m", "Auto-commit before upgrade merge"], {
-            cwd: worktreeDir,
-          });
+          await cleanupVariant(upgradeVariantName, dir, worktreeDir, { stop: true });
+        } catch (err) {
+          log.warn(`failed to clean up legacy upgrade variant for ${mindName}`, log.errorData(err));
+        }
+        try {
+          await gitExec(["branch", "-D", UPGRADE_BRANCH], { cwd: dir });
+        } catch {}
+      }
+      return c.json({ error: "Upgrades now auto-merge. Run 'volute mind upgrade' again." }, 400);
+    }
+
+    if (body.diff) {
+      // Preview what the upgrade would change
+      try {
+        // Initialize git repo if missing
+        if (!existsSync(resolve(dir, ".git"))) {
+          return c.json({ error: "Mind has no git history — nothing to diff against" }, 400);
+        }
+
+        await updateTemplateBranch(dir, template, mindName);
+
+        // Show what the template branch has that main doesn't
+        let diff: string;
+        try {
+          diff = await gitExec(["diff", "HEAD...volute/template"], { cwd: dir });
         } catch {
-          return c.json({ error: "Failed to auto-commit upgrade changes before merge" }, 500);
+          // If three-dot diff fails (no common ancestor), fall back to two-dot
+          diff = await gitExec(["diff", "HEAD", "volute/template"], { cwd: dir });
         }
-      }
 
-      // Auto-commit any uncommitted changes in the main worktree
-      const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: dir })).trim();
-      if (mainStatus) {
-        try {
-          await gitExec(["add", "-A"], { cwd: dir });
-          await gitExec(["commit", "-m", "Auto-commit before upgrade merge"], { cwd: dir });
-        } catch (_e) {
-          return c.json({ error: "Failed to auto-commit main changes before merge" }, 500);
-        }
-      }
-
-      // Merge upgrade branch
-      try {
-        await gitExec(["merge", UPGRADE_BRANCH], { cwd: dir });
-      } catch {
-        return c.json({ error: "Merge failed. Resolve conflicts manually." }, 500);
-      }
-
-      await cleanupVariant(upgradeVariantName, dir, worktreeDir, { stop: true });
-
-      // Update template hash
-      try {
-        await setMindTemplateHash(mindName, computeTemplateHash(template));
+        return c.json({ ok: true, diff: diff || "(no changes)" });
       } catch (err) {
-        log.warn(`failed to update template hash for ${mindName}`, log.errorData(err));
+        return c.json(
+          { error: err instanceof Error ? err.message : "Failed to generate diff" },
+          500,
+        );
       }
-
-      // Reinstall dependencies
-      try {
-        await npmInstallAsMind(dir, mindName);
-      } catch (err) {
-        log.warn(`npm install failed after upgrade merge for ${mindName}`, log.errorData(err));
-      }
-
-      // Restart mind
-      const manager = getMindManager();
-      try {
-        if (manager.isRunning(mindName)) {
-          await manager.stopMind(mindName);
-        }
-        manager.setPendingContext(mindName, { type: "merged", name: upgradeVariantName });
-        await manager.startMind(mindName);
-      } catch (e) {
-        return c.json({
-          ok: true,
-          warning: `Upgrade merged but mind restart failed: ${e instanceof Error ? e.message : String(e)}`,
-        });
-      }
-
-      return c.json({ ok: true });
     }
 
     // Fresh upgrade
@@ -1724,27 +1773,25 @@ const app = new Hono<AuthEnv>()
       });
     }
 
-    // Install, register, start
+    // Merge upgrade branch back to main, cleanup, and restart
     try {
-      await npmInstallAsMind(worktreeDir, mindName);
-
-      const variantPort = await nextPort();
-      await addVariant(upgradeVariantName, mindName, variantPort, worktreeDir, UPGRADE_BRANCH);
-
-      await getMindManager().startMind(upgradeVariantName);
-
-      return c.json({
-        ok: true,
-        name: mindName,
-        variant: UPGRADE_BRANCH,
-        port: variantPort,
-      });
-    } catch (err) {
-      await cleanupVariant(upgradeVariantName, dir, worktreeDir);
-      return c.json(
-        { error: err instanceof Error ? err.message : "Failed to complete upgrade" },
-        500,
+      const result = await mergeUpgradeAndRestart(
+        mindName,
+        dir,
+        worktreeDir,
+        upgradeVariantName,
+        UPGRADE_BRANCH,
+        template,
       );
+      return c.json(result);
+    } catch (err) {
+      // Merge failed — clean up
+      try {
+        await cleanupVariant(upgradeVariantName, dir, worktreeDir);
+      } catch (cleanupErr) {
+        log.warn(`cleanup failed after upgrade error for ${mindName}`, log.errorData(cleanupErr));
+      }
+      return c.json({ error: err instanceof Error ? err.message : "Failed to merge upgrade" }, 500);
     }
   })
   // All conversations for a mind (across all channels)


### PR DESCRIPTION
## Summary
- Upgrades no longer create/start a variant server — they auto-merge the template and restart the mind directly
- Added `--diff` flag to preview template changes before upgrading
- Added `upgrade_message` prompt so minds get a clear post-upgrade notification instead of a confusing "variant merged" message
- Extracted `mergeUpgradeAndRestart` helper to deduplicate merge-back logic with proper partial-success handling (npm install or restart failures return `{ ok: true, warning }` instead of 500)
- Removed `--accept` flag (no longer needed; legacy callers get cleanup + helpful error)

## Test plan
- [x] All 1099 unit tests pass
- [ ] Manual test: `volute mind upgrade --diff` shows template changes
- [ ] Manual test: `volute mind upgrade` merges and restarts cleanly
- [ ] Manual test: conflicted upgrade → resolve → `--continue` completes
- [ ] Manual test: `--abort` cleans up mid-conflict state

🤖 Generated with [Claude Code](https://claude.com/claude-code)