### PR TITLE
feat: add markdown rendering to file viewer and notes extension

### DIFF
--- a/packages/extensions/notes/ui/src/components/CommentSection.svelte
+++ b/packages/extensions/notes/ui/src/components/CommentSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { renderMarkdown } from "../lib/markdown";
+
 interface Comment {
   id: number;
   author_username: string;
@@ -65,7 +67,7 @@ function initial(name: string): string {
               <button class="delete-btn" onclick={() => onDelete?.(comment.id)}>delete</button>
             {/if}
           </div>
-          <div class="comment-body">{comment.content}</div>
+          <div class="comment-body markdown-body">{@html renderMarkdown(comment.content)}</div>
         </div>
       {/each}
     </div>
@@ -166,7 +168,6 @@ function initial(name: string): string {
   .comment-body {
     font-size: 14px;
     color: var(--text-0);
-    white-space: pre-wrap;
     word-break: break-word;
   }
 

--- a/packages/extensions/notes/ui/src/lib/markdown.ts
+++ b/packages/extensions/notes/ui/src/lib/markdown.ts
@@ -1,0 +1,8 @@
+import DOMPurify from "dompurify";
+import { Marked } from "marked";
+
+const marked = new Marked({ breaks: true, gfm: true });
+
+export function renderMarkdown(text: string): string {
+  return DOMPurify.sanitize(marked.parse(text) as string);
+}

--- a/packages/extensions/notes/ui/src/pages/NoteDetail.svelte
+++ b/packages/extensions/notes/ui/src/pages/NoteDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import CommentSection from "../components/CommentSection.svelte";
 import { type ApiNote, addComment, deleteComment, fetchNote, toggleReaction } from "../lib/api";
+import { renderMarkdown } from "../lib/markdown";
 
 let {
   author,
@@ -129,7 +130,7 @@ function hasReacted(reaction: { usernames: string[] }): boolean {
       </div>
 
       <div class="divider"></div>
-      <div class="content">{note.content}</div>
+      <div class="content markdown-body">{@html renderMarkdown(note.content)}</div>
 
       <div class="reactions-bar">
         {#if note.reactions && note.reactions.length > 0}
@@ -254,7 +255,6 @@ function hasReacted(reaction: { usernames: string[] }): boolean {
     font-size: 15px;
     color: var(--text-0);
     line-height: 1.7;
-    white-space: pre-wrap;
     word-break: break-word;
   }
 

--- a/src/web/ui/public/ext-theme.css
+++ b/src/web/ui/public/ext-theme.css
@@ -110,3 +110,96 @@ button:focus-visible {
     transform: translateY(0);
   }
 }
+
+/* Markdown rendering */
+.markdown-body {
+  word-break: break-word;
+  color: var(--text-0);
+  line-height: 1.6;
+}
+.markdown-body p {
+  margin: 0 0 8px;
+}
+.markdown-body p:last-child {
+  margin-bottom: 0;
+}
+.markdown-body pre {
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  overflow-x: auto;
+  margin: 8px 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.markdown-body code {
+  font-family: var(--mono);
+  font-size: 13px;
+  background: var(--bg-3);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.markdown-body pre code {
+  background: none;
+  padding: 0;
+}
+.markdown-body a {
+  color: var(--blue);
+  text-decoration: underline;
+}
+.markdown-body ul,
+.markdown-body ol {
+  margin: 4px 0;
+  padding-left: 20px;
+}
+.markdown-body li {
+  margin: 2px 0;
+}
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin: 12px 0 6px;
+  font-weight: 600;
+  color: var(--text-0);
+}
+.markdown-body h1 {
+  font-size: 18px;
+}
+.markdown-body h2 {
+  font-size: 16px;
+}
+.markdown-body h3 {
+  font-size: 15px;
+}
+.markdown-body blockquote {
+  border-left: 3px solid var(--border-bright);
+  margin: 8px 0;
+  padding: 4px 12px;
+  color: var(--text-1);
+}
+.markdown-body table {
+  border-collapse: collapse;
+  margin: 8px 0;
+}
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  font-size: 13px;
+}
+.markdown-body th {
+  background: var(--bg-3);
+  font-weight: 600;
+}
+.markdown-body hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 12px 0;
+}
+.markdown-body img {
+  max-width: 100%;
+}

--- a/src/web/ui/src/components/PublicFiles.svelte
+++ b/src/web/ui/src/components/PublicFiles.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { renderMarkdown } from "../lib/markdown";
+
 let { name, rootLabel }: { name: string; rootLabel?: string } = $props();
 
 type Entry = { name: string; type: "file" | "directory" };
@@ -107,6 +109,7 @@ function navigateToRoot() {
 let baseMime = $derived(fileMime.split(";")[0].trim());
 let isImage = $derived(IMAGE_TYPES.has(baseMime));
 let isText = $derived(TEXT_TYPES.has(baseMime));
+let isMarkdown = $derived(baseMime === "text/markdown" || (selectedFile?.endsWith(".md") ?? false));
 
 $effect(() => {
   return () => {
@@ -176,6 +179,8 @@ let sortedEntries = $derived(
             <div class="preview-image">
               <img src={fileContent} alt={selectedFile} />
             </div>
+          {:else if isMarkdown && fileContent !== null}
+            <div class="preview-markdown markdown-body">{@html renderMarkdown(fileContent)}</div>
           {:else if isText && fileContent !== null}
             <pre class="preview-text"><code>{fileContent}</code></pre>
           {:else}
@@ -362,6 +367,15 @@ let sortedEntries = $derived(
 
   .download-link:hover {
     text-decoration: underline;
+  }
+
+  .preview-markdown {
+    flex: 1;
+    overflow: auto;
+    padding: 16px 20px;
+    font-size: 14px;
+    line-height: 1.7;
+    color: var(--text-0);
   }
 
   .preview-text {


### PR DESCRIPTION
## Summary
- Render `.md` files in the public file viewer as formatted markdown instead of raw text
- Render note content and comments as markdown in the notes extension
- Add `.markdown-body` CSS to the extension theme so iframe-hosted extensions get markdown styles

Uses the existing `marked` + `dompurify` stack already in the project.

## Test plan
- [x] All 1158 existing tests pass
- [ ] Open a mind's files tab, select a `.md` file — verify it renders as formatted markdown
- [ ] Open a note with markdown content — verify headings, links, code blocks render properly
- [ ] Add a comment with markdown (e.g. `**bold**`, a link) — verify it renders
- [ ] Verify non-markdown text files still render as raw `<pre>` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)