### PR TITLE
feat: show spirit in sidebar with own mind page

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -21,6 +21,7 @@ export type Mind = {
   displayName?: string;
   description?: string;
   avatar?: string;
+  mindType?: "mind" | "spirit";
 };
 
 export type PlatformConnection = {

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { getDb } from "../db.js";
 import { minds } from "../schema.js";
 
@@ -96,13 +96,13 @@ function rowToEntry(row: RawMindRow): MindEntry {
   };
 }
 
-/** Read base minds (no parent, no spirits) from DB. */
+/** Read base minds and spirits (no variants) from DB. */
 export async function readRegistry(): Promise<MindEntry[]> {
   const db = await getDb();
   const rows = await db
     .select()
     .from(minds)
-    .where(and(isNull(minds.parent), eq(minds.mind_type, "mind")));
+    .where(and(isNull(minds.parent), inArray(minds.mind_type, ["mind", "spirit"])));
   return (rows as unknown as RawMindRow[]).map(rowToEntry);
 }
 

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -91,14 +91,10 @@ let onSystemPage = $derived(selection.kind !== "mind" && selection.kind !== "cha
 
 let activeSystemSection = $derived.by((): string | null => {
   if (!onSystemPage) return null;
-  if (selection.kind === "system-chat") return "system-chat";
   if (selection.kind === "system-history") return "system-history";
   if (selection.kind === "extension") return `ext:${selection.extensionId}`;
   return null;
 });
-
-// Spirit conversation ID from setup (used before SSE loads the conversation list)
-let initialSpiritConversationId = $state<string | null>(null);
 
 // Modals
 type ModalType =
@@ -158,14 +154,6 @@ let activeConversationId = $derived.by(() => {
     });
     return conv?.id ?? null;
   }
-  if (sel.kind === "system-chat") {
-    const conv = data.conversations.find((c) => {
-      if (c.type === "channel") return false;
-      const parts = c.participants ?? [];
-      return parts.length === 2 && parts.some((p) => p.username === "volute");
-    });
-    return conv?.id ?? initialSpiritConversationId;
-  }
   return null;
 });
 
@@ -188,6 +176,11 @@ let contextMind = $derived.by(() => {
   const sel = selection;
   if (sel.kind === "mind") return data.minds.find((m) => m.name === sel.name);
   return undefined;
+});
+
+let visibleMindSections = $derived.by(() => {
+  if (contextMind?.mindType === "spirit") return CORE_MIND_SECTIONS;
+  return allMindSections;
 });
 
 let rightPanelMind = $derived(
@@ -266,9 +259,6 @@ let breadcrumbs = $derived.by((): Breadcrumb[] => {
         });
       }
     }
-  } else if (sel.kind === "system-chat") {
-    crumbs.push({ label: "system", action: handleSystemHome });
-    crumbs.push({ label: "chat" });
   } else if (sel.kind === "system-history") {
     crumbs.push({ label: "system" });
   } else {
@@ -645,14 +635,11 @@ function handleGlobalClick(e: MouseEvent) {
   </div>
 {:else if !auth.setupComplete}
   <div class="app full-height">
-    <SetupPage onComplete={(spiritConversationId) => {
+    <SetupPage onComplete={() => {
       auth.setupComplete = true;
-      if (spiritConversationId) {
-        initialSpiritConversationId = spiritConversationId;
-      }
       connectActivity();
       requestAnimationFrame(() => {
-        selection = { kind: "system-chat" };
+        selection = { kind: "mind", name: "volute" };
       });
     }} />
   </div>
@@ -739,7 +726,7 @@ function handleGlobalClick(e: MouseEvent) {
             </div>
             {#if activeMindName}
               <div class="mind-section-tabs">
-                {#each allMindSections as sec}
+                {#each visibleMindSections as sec}
                   <button
                     class="mind-section-tab"
                     class:active={activeMindSection === sec.key}
@@ -760,15 +747,6 @@ function handleGlobalClick(e: MouseEvent) {
                   aria-label="History"
                 >
                   <span class="tab-icon">{@html icons.history}</span>
-                </button>
-                <button
-                  class="mind-section-tab"
-                  class:active={activeSystemSection === "system-chat"}
-                  onclick={() => { selection = { kind: "system-chat" }; }}
-                  use:tooltip={{ text: "Chat", position: "bottom" }}
-                  aria-label="Chat"
-                >
-                  <span class="tab-icon"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h12v8H5l-3 3V3z"/></svg></span>
                 </button>
                 {#each data.extensions as ext}
                   {#if ext.systemSection}
@@ -813,7 +791,6 @@ function handleGlobalClick(e: MouseEvent) {
               minds={data.minds}
               conversations={data.conversations}
               username={auth.user.username}
-              {initialSpiritConversationId}
               onConversationId={handleConversationId}
               onSelectConversation={handleSelectConversation}
               onOpenMind={handleOpenMindModal}

--- a/packages/web/src/ui/components/layout/MainFrame.svelte
+++ b/packages/web/src/ui/components/layout/MainFrame.svelte
@@ -11,7 +11,6 @@ let {
   minds,
   conversations,
   username,
-  initialSpiritConversationId,
   onConversationId,
   onOpenMind,
   onSelectConversation,
@@ -23,7 +22,6 @@ let {
   minds: Mind[];
   conversations: ConversationWithParticipants[];
   username: string;
-  initialSpiritConversationId?: string | null;
   onConversationId: (id: string) => void;
   onOpenMind: (mind: Mind) => void;
   onSelectConversation: (id: string) => void;
@@ -118,25 +116,6 @@ let contextLabel = $derived.by(() => {
   {:else if selection.kind === "extension"}
     <div class="frame-content">
       <iframe src="/ext/{selection.extensionId}/#{selection.path ? '/' + selection.path : ''}" class="page-iframe" title="Extension"></iframe>
-    </div>
-  {:else if selection.kind === "system-chat"}
-    {@const spiritConv = conversations.find((c) => {
-      if (c.type === "channel") return false;
-      const parts = c.participants ?? [];
-      return parts.length === 2 && parts.some((p) => p.username === "volute");
-    })}
-    <div class="frame-content mind-frame">
-      <Chat
-        name="volute"
-        {username}
-        conversationId={spiritConv?.id ?? initialSpiritConversationId ?? null}
-        {onConversationId}
-        convType="dm"
-        {minds}
-        participants={spiritConv?.participants ?? []}
-        {onOpenMind}
-        {onTypingNames}
-      />
     </div>
   {:else if selection.kind === "system-history"}
     <div class="frame-content mind-frame">

--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -94,6 +94,9 @@ function toggleSection(section: Section) {
   localStorage.setItem("volute:sidebar-collapsed", JSON.stringify([...collapsed]));
 }
 
+let spirits = $derived(minds.filter((m) => m.mindType === "spirit"));
+let regularMinds = $derived(minds.filter((m) => m.mindType !== "spirit"));
+
 let mindNames = $derived(new Set(minds.map((m) => m.name)));
 
 let mindDmMap = $derived(
@@ -114,7 +117,7 @@ let mindDmMap = $derived(
 );
 
 let sortedMinds = $derived(
-  [...minds].sort((a, b) => {
+  [...regularMinds].sort((a, b) => {
     const aActive = activeMinds.has(a.name) ? 0 : a.status === "running" ? 1 : 2;
     const bActive = activeMinds.has(b.name) ? 0 : b.status === "running" ? 1 : 2;
     if (aActive !== bActive) return aActive - bActive;
@@ -189,9 +192,7 @@ let activeChannelId = $derived.by(() => {
 });
 
 let isSystemActive = $derived(
-  selection.kind === "system-history" ||
-    selection.kind === "system-chat" ||
-    selection.kind === "extension",
+  selection.kind === "system-history" || selection.kind === "extension",
 );
 </script>
 
@@ -228,6 +229,31 @@ let isSystemActive = $derived(
           >!</button>
         {/if}
       </div>
+      {#if spirits.length > 0}
+        <div class="item-list">
+          {#each spirits as spirit}
+            {@const dmId = mindDmMap.get(spirit.name)}
+            {@const spiritUnread = dmId ? (unreadCounts.get(dmId) ?? 0) : 0}
+            <div class="mind-item-row">
+              <button
+                class="nav-item"
+                class:active={selection.kind === "mind" && selection.name === spirit.name}
+                onclick={() => onSelectMind(spirit.name)}
+              >
+                <span
+                  class="status-dot"
+                  class:iridescent={activeMinds.has(spirit.name)}
+                  style:background={activeMinds.has(spirit.name) ? undefined : mindDotColor(spirit)}
+                ></span>
+                <span class="nav-label">{spirit.displayName ?? spirit.name}</span>
+                {#if spiritUnread > 0}
+                  <span class="unread-dot"></span>
+                {/if}
+              </button>
+            </div>
+          {/each}
+        </div>
+      {/if}
     </div>
 
     <!-- Minds -->

--- a/packages/web/src/ui/lib/navigate.ts
+++ b/packages/web/src/ui/lib/navigate.ts
@@ -8,7 +8,6 @@ export type Selection =
       subpath?: string;
     }
   | { kind: "extension"; extensionId: string; path: string }
-  | { kind: "system-chat" }
   | { kind: "system-history" }
   | { kind: "channel"; slug: string };
 
@@ -83,7 +82,6 @@ export function parseSelection(extensions: ExtensionInfo[] = []): Selection {
   const path = window.location.pathname;
   const search = new URLSearchParams(window.location.search);
 
-  if (path === "/system/chat") return { kind: "system-chat" };
   if (path === "/history") return { kind: "system-history" };
   // Legacy settings URLs — these are now modals, redirect to home
   if (path === "/system/settings" || path === "/settings" || path.startsWith("/settings/"))
@@ -173,8 +171,6 @@ export function selectionToPath(selection: Selection, extensions: ExtensionInfo[
         ? `/ext/${selection.extensionId}/${selection.path}`
         : `/ext/${selection.extensionId}`;
     }
-    case "system-chat":
-      return "/system/chat";
     case "channel": {
       // Don't serialize backwards-compat conv IDs to URL
       if (selection.slug.startsWith("__conv:")) {

--- a/packages/web/src/ui/pages/SetupPage.svelte
+++ b/packages/web/src/ui/pages/SetupPage.svelte
@@ -5,7 +5,7 @@ import { fetchMe } from "../lib/auth";
 import type { AiModel } from "../lib/client";
 import { auth, handleAuth } from "../lib/stores.svelte";
 
-let { onComplete }: { onComplete: (spiritConversationId?: string) => void } = $props();
+let { onComplete }: { onComplete: () => void } = $props();
 
 type Step = "welcome" | "system" | "account" | "provider" | "starting";
 
@@ -302,7 +302,7 @@ async function completeSetup() {
     }
 
     auth.setupComplete = true;
-    onComplete(data.spiritConversationId);
+    onComplete();
   } catch (err) {
     error = err instanceof Error ? err.message : "Something went wrong";
     step = "provider";


### PR DESCRIPTION
## Summary
- Move the spirit from a hidden system-chat tab to a sidebar item under System, with activity indicator, its own mind page, and right panel (avatar, history timeline)
- Extension tabs are filtered out for spirits since they can't use those
- Uses `mindType === "spirit"` checks throughout for future-proofing multiple spirits

## Test plan
- [x] Build passes, all 1532 tests pass
- [x] Visual verification: spirit appears under System in sidebar with activity dot
- [x] Clicking spirit opens mind page with chat + right panel
- [x] Extension tabs do not appear for spirit
- [x] System page shows only History + extension tabs (no Chat)
- [x] Verify activity indicator shows when spirit is responding

🤖 Generated with [Claude Code](https://claude.com/claude-code)