### PR TITLE
fix: pi template API key fallback, sandbox network fix, and pre-warm sessions

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -163,6 +163,23 @@ export class MindManager {
                 chownMindDir(piAgentDir, baseName);
               }
               env.PI_CODING_AGENT_DIR = piAgentDir;
+
+              // Also set provider-specific env var as fallback — the sandbox may
+              // block proper-lockfile from reading auth.json, so the env var
+              // ensures getEnvApiKey() in pi-ai still resolves the key.
+              const providerEnvVars: Record<string, string> = {
+                openrouter: "OPENROUTER_API_KEY",
+                openai: "OPENAI_API_KEY",
+                anthropic: "ANTHROPIC_API_KEY",
+                google: "GEMINI_API_KEY",
+                groq: "GROQ_API_KEY",
+                cerebras: "CEREBRAS_API_KEY",
+                xai: "XAI_API_KEY",
+                mistral: "MISTRAL_API_KEY",
+                zai: "ZAI_API_KEY",
+              };
+              const providerEnv = providerEnvVars[provider];
+              if (providerEnv) env[providerEnv] = apiKey;
             } else {
               mlog.warn(
                 `no API key found for provider "${provider}" — mind ${name} may fail to start`,

--- a/packages/daemon/src/lib/mind/sandbox.ts
+++ b/packages/daemon/src/lib/mind/sandbox.ts
@@ -76,20 +76,20 @@ export async function initSandbox(): Promise<void> {
       }
     }
 
-    const config: SandboxRuntimeConfig = {
-      network: {
-        allowedDomains: ["*"],
-        deniedDomains: [],
-        allowLocalBinding: true,
-        allowAllUnixSockets: true,
-      },
+    // Omit network config so the sandbox doesn't set up a proxy. All minds
+    // need direct API access and the proxy breaks clients that don't respect
+    // HTTP_PROXY (e.g. the claude subprocess spawned by the Agent SDK).
+    // Without network.allowedDomains, wrapWithSandbox generates a seatbelt
+    // profile with `(allow network*)` — unrestricted network while filesystem
+    // restrictions still apply.
+    const config = {
       filesystem: {
         denyRead: [],
         allowWrite: [],
         denyWrite: [],
       },
       ...(ripgrepConfig ? { ripgrep: ripgrepConfig } : {}),
-    };
+    } as unknown as SandboxRuntimeConfig;
     await SandboxManager.initialize(config);
     sandboxManager = SandboxManager;
   } catch (err) {

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1226,7 +1226,7 @@ const app = new Hono<AuthEnv>()
     }
     try {
       const res = await fetch(`http://127.0.0.1:${entry.port}/context`, {
-        signal: AbortSignal.timeout(3000),
+        signal: AbortSignal.timeout(10000),
       });
       if (!res.ok) {
         const status = res.status >= 500 ? 502 : 404;

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -573,5 +573,9 @@ export function createMind(options: {
     };
   }
 
+  // Pre-warm the main session so the SDK subprocess starts immediately
+  // instead of waiting for the first message (which adds minutes of latency).
+  getOrCreateSession("main");
+
   return { resolve, waitForCommits: autoCommit.waitForCommits, getContextInfo };
 }

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -628,5 +628,9 @@ export function createMind(options: {
     };
   }
 
+  // Pre-warm the main session so the thread is created immediately
+  // instead of waiting for the first message.
+  getOrCreateSession("main");
+
   return { resolve, getContextInfo };
 }


### PR DESCRIPTION
## Summary
- **Pi template API key fix**: Set provider-specific env vars (`OPENROUTER_API_KEY`, etc.) as fallback when the sandbox blocks `proper-lockfile` from reading `auth.json` — fixes pi template minds crashing with "No API key found"
- **Sandbox network fix**: Remove network proxy config from sandbox init — the proxy breaks clients that don't respect `HTTP_PROXY` (the claude subprocess spawned by the Agent SDK), causing persistent `UND_ERR_ABORTED` failures on every API call. Filesystem restrictions still apply.
- **Pre-warm sessions**: Eagerly create the "main" session in claude and codex templates at startup so the SDK subprocess/thread initializes before the first user message arrives (saves minutes of cold-start latency)
- **Context proxy timeout**: Bump from 3s to 10s — pi template `/context` endpoint takes ~4s

## Test plan
- [x] Glomp (pi/openrouter) responds successfully instead of crashing
- [x] Block (claude) responds successfully with sandbox active (no more `UND_ERR_ABORTED`)
- [x] Eagle (codex) responds in seconds after restart thanks to pre-warming
- [x] Filesystem sandbox still active (EPERM on reads outside mind dir)
- [x] All 1532 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)