### PR TITLE
fix: centralize Anthropic OAuth refresh to stop recurring 401s

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3,10 +3,12 @@ import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { format } from "node:util";
+import { setProviderRefreshHook } from "./lib/ai-service.js";
 import { ensureSystemChannel } from "./lib/chat/system-channel.js";
 import { initBridgeManager } from "./lib/daemon/bridge-manager.js";
+import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
 import { initMailPoller } from "./lib/daemon/mail-poller.js";
-import { initMindManager } from "./lib/daemon/mind-manager.js";
+import { getMindManager, initMindManager } from "./lib/daemon/mind-manager.js";
 import { startMindFull } from "./lib/daemon/mind-service.js";
 import { initScheduler } from "./lib/daemon/scheduler.js";
 import { initSleepManager } from "./lib/daemon/sleep-manager.js";
@@ -315,6 +317,15 @@ export async function startDaemon(opts: {
   });
   cleanExpiredLogs().catch((err) => {
     log.warn("failed to clean expired logs", log.errorData(err));
+  });
+
+  // When the daemon rotates a provider's OAuth token, push the fresh token into
+  // running minds so they don't refresh the rotating grant independently (which
+  // invalidated each other and caused recurring 401s).
+  setProviderRefreshHook((provider) => {
+    void syncProviderToMinds(provider, {
+      listRunning: () => getMindManager().getRunningMinds(),
+    }).catch((err) => log.warn("credential sync to minds failed", log.errorData(err)));
   });
 
   // Start periodic API key cache refresh for mind provider keys

--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -13,6 +13,28 @@ export type { AiConfig, AiProviderConfig } from "./config/setup.js";
 
 const aiLog = log.child("ai-service");
 
+/**
+ * Optional hook fired whenever a provider's OAuth credentials are rotated and
+ * persisted. The daemon registers this to fan the fresh token out to running
+ * minds (see credential-sync.ts), making the daemon the single refresh
+ * authority. Registered via setProviderRefreshHook to avoid an import cycle.
+ */
+type ProviderRefreshHook = (providerId: string) => void;
+let providerRefreshHook: ProviderRefreshHook | undefined;
+
+export function setProviderRefreshHook(hook: ProviderRefreshHook | undefined): void {
+  providerRefreshHook = hook;
+}
+
+/** Fire the registered refresh hook, swallowing/logging any error. */
+export function fireProviderRefreshHook(providerId: string): void {
+  try {
+    providerRefreshHook?.(providerId);
+  } catch (err) {
+    aiLog.warn(`provider refresh hook failed for ${providerId}`, log.errorData(err));
+  }
+}
+
 export function getAiConfig(): AiConfig | null {
   const config = readGlobalConfig();
   return config.ai ?? null;
@@ -175,6 +197,8 @@ export async function resolveApiKey(providerId: string): Promise<string | undefi
         // Persist refreshed credentials
         if (result.newCredentials.access !== providerConfig.oauth.access) {
           saveProviderConfig(providerId, { ...providerConfig, oauth: result.newCredentials });
+          // Fan the rotated token out to running minds (single refresh authority).
+          fireProviderRefreshHook(providerId);
         }
         return result.apiKey;
       }

--- a/packages/daemon/src/lib/daemon/credential-sync.ts
+++ b/packages/daemon/src/lib/daemon/credential-sync.ts
@@ -1,0 +1,135 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { getAiConfig } from "../ai-service.js";
+import { chownMindDir, isIsolationEnabled } from "../mind/isolation.js";
+import { findMind, mindDir } from "../mind/registry.js";
+import log from "../util/logger.js";
+
+const slog = log.child("cred-sync");
+
+export type AnthropicOauth = {
+  access: string;
+  refresh: string;
+  expires: number;
+};
+
+/**
+ * Write the Claude Code OAuth credentials file for a mind so the Agent SDK
+ * authenticates natively. The SDK reads CLAUDE_CONFIG_DIR/.credentials.json and
+ * reloads it when the file's mtime changes, so rewriting this file pushes a
+ * fresh token into a running mind without a restart. Returns the config dir.
+ */
+export function writeClaudeCredentials(
+  homeDir: string,
+  baseName: string,
+  oauth: AnthropicOauth,
+): string {
+  const claudeDir = resolve(homeDir, ".claude");
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(
+    resolve(claudeDir, ".credentials.json"),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: oauth.access,
+        refreshToken: oauth.refresh,
+        expiresAt: oauth.expires ? new Date(oauth.expires).toISOString() : null,
+        scopes: ["user:inference", "user:profile"],
+      },
+    }),
+    { mode: 0o600 },
+  );
+  if (isIsolationEnabled()) {
+    chownMindDir(claudeDir, baseName);
+  }
+  return claudeDir;
+}
+
+/**
+ * Set a provider's api_key entry in a pi mind's auth.json, preserving any other
+ * providers already present. Used both at mind startup and by the refresh
+ * fan-out. The pi template watches this file and reloads on change.
+ */
+export function writePiProviderKey(
+  piAgentDir: string,
+  baseName: string,
+  provider: string,
+  key: string,
+): void {
+  mkdirSync(piAgentDir, { recursive: true });
+  const authPath = resolve(piAgentDir, "auth.json");
+  const authData: Record<string, unknown> = existsSync(authPath)
+    ? JSON.parse(readFileSync(authPath, "utf-8"))
+    : {};
+  authData[provider] = { type: "api_key", key };
+  writeFileSync(authPath, JSON.stringify(authData, null, 2), { mode: 0o600 });
+  if (isIsolationEnabled()) {
+    chownMindDir(piAgentDir, baseName);
+  }
+}
+
+type MindLookup = {
+  name: string;
+  template?: string;
+  dir?: string;
+  parent?: string;
+};
+
+type SyncDeps = {
+  /** Current OAuth credentials for the provider (defaults to global config). */
+  getOauth?: () => AnthropicOauth | undefined;
+  /** Names of currently-running minds (injected by the daemon to avoid a cycle). */
+  listRunning?: () => string[];
+  /** Resolve a mind name to its registry entry. */
+  lookup?: (name: string) => Promise<MindLookup | undefined>;
+};
+
+/** True if a pi mind's auth.json already has an entry for the given provider. */
+function piUsesProvider(piAgentDir: string, provider: string): boolean {
+  try {
+    const authPath = resolve(piAgentDir, "auth.json");
+    if (!existsSync(authPath)) return false;
+    const data = JSON.parse(readFileSync(authPath, "utf-8")) as Record<string, unknown>;
+    return data[provider] != null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Push a freshly-rotated provider token into every running mind that uses it.
+ * Only `anthropic` (OAuth, claude + pi minds) is handled today. This is the
+ * fan-out that makes the daemon the single refresh authority: when the daemon
+ * rotates the token, running minds adopt it via file reload rather than each
+ * refreshing the rotating grant independently (which invalidated each other).
+ */
+export async function syncProviderToMinds(provider: string, deps: SyncDeps = {}): Promise<void> {
+  if (provider !== "anthropic") return;
+
+  const getOauth = deps.getOauth ?? (() => getAiConfig()?.providers.anthropic?.oauth);
+  const oauth = getOauth();
+  if (!oauth?.access) return;
+
+  const listRunning = deps.listRunning ?? (() => []);
+  const lookup = deps.lookup ?? findMind;
+
+  for (const name of listRunning()) {
+    try {
+      const entry = await lookup(name);
+      if (!entry) continue;
+      const dir = entry.dir ?? mindDir(name);
+      const baseName = entry.parent ?? name;
+      const template = entry.template;
+
+      if (template === "claude" || !template) {
+        writeClaudeCredentials(resolve(dir, "home"), baseName, oauth);
+      } else if (template === "pi") {
+        const piAgentDir = resolve(dir, ".mind", "pi-agent");
+        if (piUsesProvider(piAgentDir, "anthropic")) {
+          writePiProviderKey(piAgentDir, baseName, "anthropic", oauth.access);
+        }
+      }
+    } catch (err) {
+      slog.warn(`failed to sync ${provider} credentials to mind ${name}`, log.errorData(err));
+    }
+  }
+}

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -12,6 +12,7 @@ import { getPrompt } from "../prompts.js";
 import { clearJsonMap, loadJsonMap, saveJsonMap } from "../util/json-state.js";
 import log from "../util/logger.js";
 import { RotatingLog } from "../util/rotating-log.js";
+import { writeClaudeCredentials, writePiProviderKey } from "./credential-sync.js";
 import { generateMindToken, revokeMindToken } from "./mind-tokens.js";
 import { RestartTracker } from "./restart-tracker.js";
 import { clearMind as clearTurnState, summarizeOrphanedTurns } from "./turn-tracker.js";
@@ -150,18 +151,11 @@ export class MindManager {
             const provider = modelStr.split(":")[0];
             const apiKey = await resolveApiKey(provider);
             if (apiKey) {
-              // Write API key to pi-coding-agent auth storage so the mind can use it
+              // Write API key to pi-coding-agent auth storage so the mind can use it.
+              // The pi template watches auth.json and reloads, so the daemon can
+              // push a refreshed OAuth token here without restarting the mind.
               const piAgentDir = resolve(dir, ".mind", "pi-agent");
-              mkdirSync(piAgentDir, { recursive: true });
-              const authPath = resolve(piAgentDir, "auth.json");
-              const authData: Record<string, unknown> = existsSync(authPath)
-                ? JSON.parse(readFileSync(authPath, "utf-8"))
-                : {};
-              authData[provider] = { type: "api_key", key: apiKey };
-              writeFileSync(authPath, JSON.stringify(authData, null, 2), { mode: 0o600 });
-              if (isIsolationEnabled()) {
-                chownMindDir(piAgentDir, baseName);
-              }
+              writePiProviderKey(piAgentDir, baseName, provider, apiKey);
               env.PI_CODING_AGENT_DIR = piAgentDir;
 
               // Also set provider-specific env var as fallback — the sandbox may
@@ -262,35 +256,17 @@ export class MindManager {
         const ai = getAiConfig();
         const anthropicConfig = ai?.providers.anthropic;
         if (anthropicConfig?.oauth) {
+          // Resolve once (refreshes + persists the rotated token to config if
+          // needed), then write the current credentials from config so the
+          // access/refresh/expires are consistent. We point CLAUDE_CONFIG_DIR to
+          // the mind's .claude dir so credentials are per-mind. The daemon keeps
+          // this file fresh (credential-sync) so the SDK never refreshes the
+          // rotating grant itself.
           const key = await resolveApiKey("anthropic");
-          if (key) {
-            // Write credentials in the format Claude Code's Agent SDK expects.
-            // The SDK reads from CLAUDE_CONFIG_DIR/.credentials.json (or
-            // ~/.claude/.credentials.json). We point CLAUDE_CONFIG_DIR to the
-            // mind's .claude dir so credentials are per-mind and don't collide
-            // with the host user's own Claude Code config.
-            const homeDir = resolve(dir, "home");
-            const claudeDir = resolve(homeDir, ".claude");
-            mkdirSync(claudeDir, { recursive: true });
+          const oauth = getAiConfig()?.providers.anthropic?.oauth;
+          if (key && oauth) {
+            const claudeDir = writeClaudeCredentials(resolve(dir, "home"), baseName, oauth);
             env.CLAUDE_CONFIG_DIR = claudeDir;
-            const credsPath = resolve(claudeDir, ".credentials.json");
-            writeFileSync(
-              credsPath,
-              JSON.stringify({
-                claudeAiOauth: {
-                  accessToken: key,
-                  refreshToken: anthropicConfig.oauth.refresh,
-                  expiresAt: anthropicConfig.oauth.expires
-                    ? new Date(anthropicConfig.oauth.expires).toISOString()
-                    : null,
-                  scopes: ["user:inference", "user:profile"],
-                },
-              }),
-              { mode: 0o600 },
-            );
-            if (isIsolationEnabled()) {
-              chownMindDir(claudeDir, baseName);
-            }
           }
         } else if (anthropicConfig?.apiKey) {
           env.ANTHROPIC_API_KEY = anthropicConfig.apiKey;

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, watchFile } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import {
   AuthStorage,
@@ -82,6 +82,29 @@ export function createMind(options: {
   const model = resolveModel(modelStr);
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage);
+
+  // The daemon centrally refreshes the system OAuth token and rewrites auth.json
+  // with the fresh token. Watch the file and reload so a running mind adopts the
+  // new token without a restart (mirrors the Claude Agent SDK credential reload).
+  // This is why the mind itself does not refresh the rotating grant.
+  const piAuthPath = process.env.PI_CODING_AGENT_DIR
+    ? resolvePath(process.env.PI_CODING_AGENT_DIR, "auth.json")
+    : null;
+  if (piAuthPath) {
+    try {
+      watchFile(piAuthPath, { interval: 2000 }, (curr, prev) => {
+        if (curr.mtimeMs === prev.mtimeMs) return;
+        try {
+          authStorage.reload();
+          log("mind", "reloaded auth.json after credential refresh");
+        } catch (err) {
+          log("mind", "failed to reload auth.json:", err);
+        }
+      });
+    } catch (err) {
+      log("mind", "failed to watch auth.json for credential refresh:", err);
+    }
+  }
 
   // --- Subagents (config-driven) ---
 

--- a/test/credential-sync.test.ts
+++ b/test/credential-sync.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  syncProviderToMinds,
+  writeClaudeCredentials,
+  writePiProviderKey,
+} from "../packages/daemon/src/lib/daemon/credential-sync.js";
+
+function tmpRoot(label: string): string {
+  const dir = resolve(
+    tmpdir(),
+    `volute-credsync-${process.pid}-${label}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+const OAUTH = { access: "sk-ant-oat01-NEW", refresh: "sk-ant-ort01-NEW", expires: 1782152959152 };
+
+describe("writeClaudeCredentials", () => {
+  it("writes the claudeAiOauth credentials file and returns the config dir", () => {
+    const dir = tmpRoot("claude");
+    const homeDir = resolve(dir, "home");
+    mkdirSync(homeDir, { recursive: true });
+
+    const claudeDir = writeClaudeCredentials(homeDir, "mymind", OAUTH);
+
+    assert.equal(claudeDir, resolve(homeDir, ".claude"));
+    const creds = JSON.parse(readFileSync(resolve(claudeDir, ".credentials.json"), "utf-8"));
+    assert.deepEqual(creds, {
+      claudeAiOauth: {
+        accessToken: OAUTH.access,
+        refreshToken: OAUTH.refresh,
+        expiresAt: new Date(OAUTH.expires).toISOString(),
+        scopes: ["user:inference", "user:profile"],
+      },
+    });
+  });
+});
+
+describe("writePiProviderKey", () => {
+  it("sets the provider api_key entry while preserving other providers", () => {
+    const dir = tmpRoot("pi");
+    const piAgentDir = resolve(dir, ".mind", "pi-agent");
+    mkdirSync(piAgentDir, { recursive: true });
+    writeFileSync(
+      resolve(piAgentDir, "auth.json"),
+      JSON.stringify({ openai: { type: "api_key", key: "openai-key" } }),
+    );
+
+    writePiProviderKey(piAgentDir, "mymind", "anthropic", OAUTH.access);
+
+    const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
+    assert.deepEqual(auth, {
+      openai: { type: "api_key", key: "openai-key" },
+      anthropic: { type: "api_key", key: OAUTH.access },
+    });
+  });
+
+  it("creates auth.json when none exists", () => {
+    const dir = tmpRoot("pi-fresh");
+    const piAgentDir = resolve(dir, ".mind", "pi-agent");
+    writePiProviderKey(piAgentDir, "mymind", "anthropic", OAUTH.access);
+    const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
+    assert.deepEqual(auth, { anthropic: { type: "api_key", key: OAUTH.access } });
+  });
+});
+
+describe("syncProviderToMinds", () => {
+  it("updates claude creds + pi-with-anthropic auth, skips others", async () => {
+    const root = tmpRoot("sync");
+
+    // claude mind
+    const claudeDir = resolve(root, "claudey");
+    mkdirSync(resolve(claudeDir, "home"), { recursive: true });
+
+    // pi mind that already uses anthropic
+    const piDir = resolve(root, "piggy");
+    const piAgent = resolve(piDir, ".mind", "pi-agent");
+    mkdirSync(piAgent, { recursive: true });
+    writeFileSync(
+      resolve(piAgent, "auth.json"),
+      JSON.stringify({ anthropic: { type: "api_key", key: "OLD" } }),
+    );
+
+    // pi mind that does NOT use anthropic
+    const piOtherDir = resolve(root, "piother");
+    const piOtherAgent = resolve(piOtherDir, ".mind", "pi-agent");
+    mkdirSync(piOtherAgent, { recursive: true });
+    writeFileSync(
+      resolve(piOtherAgent, "auth.json"),
+      JSON.stringify({ openai: { type: "api_key", key: "openai-key" } }),
+    );
+
+    // codex mind — should be untouched
+    const codexDir = resolve(root, "codexy");
+    mkdirSync(codexDir, { recursive: true });
+
+    const entries: Record<string, { name: string; template?: string; dir: string }> = {
+      claudey: { name: "claudey", template: "claude", dir: claudeDir },
+      piggy: { name: "piggy", template: "pi", dir: piDir },
+      piother: { name: "piother", template: "pi", dir: piOtherDir },
+      codexy: { name: "codexy", template: "codex", dir: codexDir },
+    };
+
+    await syncProviderToMinds("anthropic", {
+      getOauth: () => OAUTH,
+      listRunning: () => Object.keys(entries),
+      lookup: async (name) => entries[name],
+    });
+
+    // claude updated
+    const claudeCreds = JSON.parse(
+      readFileSync(resolve(claudeDir, "home", ".claude", ".credentials.json"), "utf-8"),
+    );
+    assert.equal(claudeCreds.claudeAiOauth.accessToken, OAUTH.access);
+
+    // pi-with-anthropic updated
+    const piAuth = JSON.parse(readFileSync(resolve(piAgent, "auth.json"), "utf-8"));
+    assert.equal(piAuth.anthropic.key, OAUTH.access);
+
+    // pi-without-anthropic untouched (no anthropic entry added)
+    const piOtherAuth = JSON.parse(readFileSync(resolve(piOtherAgent, "auth.json"), "utf-8"));
+    assert.equal(piOtherAuth.anthropic, undefined);
+    assert.equal(piOtherAuth.openai.key, "openai-key");
+
+    // codex untouched
+    assert.equal(existsSync(resolve(codexDir, "home", ".claude", ".credentials.json")), false);
+  });
+
+  it("no-ops for non-anthropic providers and when oauth is missing", async () => {
+    await syncProviderToMinds("openai-codex", {
+      getOauth: () => OAUTH,
+      listRunning: () => {
+        throw new Error("should not enumerate minds for non-anthropic provider");
+      },
+      lookup: async () => undefined,
+    });
+    await syncProviderToMinds("anthropic", {
+      getOauth: () => undefined,
+      listRunning: () => {
+        throw new Error("should not enumerate minds when oauth missing");
+      },
+      lookup: async () => undefined,
+    });
+  });
+});

--- a/test/provider-refresh-hook.test.ts
+++ b/test/provider-refresh-hook.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  fireProviderRefreshHook,
+  setProviderRefreshHook,
+} from "../packages/daemon/src/lib/ai-service.js";
+
+describe("provider refresh hook", () => {
+  afterEach(() => setProviderRefreshHook(undefined));
+
+  it("fires the registered hook with the provider id", () => {
+    const calls: string[] = [];
+    setProviderRefreshHook((p) => calls.push(p));
+    fireProviderRefreshHook("anthropic");
+    assert.deepEqual(calls, ["anthropic"]);
+  });
+
+  it("is a no-op when no hook is registered", () => {
+    setProviderRefreshHook(undefined);
+    assert.doesNotThrow(() => fireProviderRefreshHook("anthropic"));
+  });
+
+  it("swallows errors thrown by the hook", () => {
+    setProviderRefreshHook(() => {
+      throw new Error("boom");
+    });
+    assert.doesNotThrow(() => fireProviderRefreshHook("anthropic"));
+  });
+});


### PR DESCRIPTION
## Problem

Minds frequently hit `API Error: 401 ... authentication_error` that clears on restart but recurs within hours. Observed on the `bardo` system install across both claude minds (`gardener`, `mimsy`) and pi minds using Anthropic OAuth.

## Root cause

Minds authenticate with a Claude **subscription OAuth grant** (one `sk-ant-ort01…` refresh token), not an API key. Anthropic OAuth uses **rotating refresh tokens** — every refresh issues a new refresh token and invalidates the one just used (confirmed in `@mariozechner/pi-ai`'s `refreshAnthropicToken`; access tokens live ~8h). That single grant was being refreshed by **multiple uncoordinated clients**:

- the daemon (`refreshApiKeyCache` 60s timer + `resolveApiKey`), persisting to `config.json`, and
- **each claude mind's embedded Agent SDK**, handed the refresh token in its own `home/.claude/.credentials.json` and refreshing independently, in memory.

When any client refreshed, the rotated token orphaned everyone else's copy → the next mind whose access token expired returned 401. Restart re-copied the current token (worked briefly) until the next rotation orphaned it again. Verified live: `config.json` and `gardener`'s credential file had **diverged to different refresh tokens** descended from the same login, while a more recently started mind still matched config.

Pi minds had a related failure: the access token was written as a static `api_key` in `auth.json` that never refreshed and was never reloaded.

## Fix

Make the daemon the **single refresh authority** and push rotated tokens into running minds, which stop refreshing the grant themselves and instead reload from the updated file — no restarts, isolation unchanged.

- **`credential-sync.ts`** (new): `writeClaudeCredentials` / `writePiProviderKey` / `syncProviderToMinds` — fan a freshly rotated token out to running claude (`.credentials.json`; the SDK reloads on mtime change) and pi (`auth.json`) minds.
- **`ai-service`**: fire a registered hook whenever an OAuth token is rotated and persisted (`setProviderRefreshHook` / `fireProviderRefreshHook`), covering all daemon refresh paths exactly once per rotation.
- **`mind-manager`**: reuse the shared writers at startup; write claude creds from the post-resolve config so access/refresh/expires stay consistent.
- **`daemon`**: register the hook to fan out to running minds.
- **pi template**: watch `auth.json` and reload `AuthStorage` so a running pi mind adopts the pushed token without a restart.

The daemon's existing `needsRefresh` (refresh at <15 min before expiry) keeps minds' tokens fresh ahead of the SDK's own refresh window, so minds never refresh the rotating grant.

Scope: anthropic provider only. Codex/`openai-codex` has the analogous self-refresh divergence but was not reported here; the fan-out is provider-keyed so it can be added later.

## Testing

- New unit tests: `test/credential-sync.test.ts` (writers + fan-out targeting), `test/provider-refresh-hook.test.ts` (hook registration/firing).
- Full suite green (1540/1540); lint clean; daemon + all three template typechecks pass.

## Deploy notes

After release/deploy: existing running minds may still hold divergent in-memory tokens — restart claude minds once to converge (or let the first scheduled fan-out converge them); `volute mind upgrade` pi minds to pick up the `auth.json` watcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)