### PR TITLE
fix: make volute update target the running binary's prefix and verify

### DIFF
--- a/packages/daemon/src/lib/update-check.ts
+++ b/packages/daemon/src/lib/update-check.ts
@@ -1,6 +1,10 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { execFile as execFileCb, execFileSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve, sep } from "node:path";
+import { promisify } from "node:util";
 import { voluteSystemDir } from "./mind/registry.js";
+
+const execFile = promisify(execFileCb);
 
 type UpdateCheckResult = {
   current: string;
@@ -107,6 +111,106 @@ export async function checkForUpdate(force = false): Promise<UpdateCheckResult> 
     return { current, latest, updateAvailable: isNewer(current, latest) };
   } catch {
     return { current, latest: current, updateAvailable: false, checkFailed: true };
+  }
+}
+
+export type VoluteInstall = {
+  /** Path resolved by `which volute` (may be a symlink, e.g. /opt/homebrew/bin/volute). */
+  binPath: string;
+  /** Symlinks resolved (e.g. /opt/homebrew/lib/node_modules/volute/dist/cli.js). */
+  realPath: string;
+  /** The `volute` package directory, or null for a linked/source checkout. */
+  packageRoot: string | null;
+  /** The npm global prefix that owns the running binary (e.g. /opt/homebrew), or null. */
+  prefix: string | null;
+  /** Version read from the running binary's package.json, or null if unreadable. */
+  version: string | null;
+  /** True when the binary is run from a source checkout / `npm link` rather than a real -g install. */
+  isLinked: boolean;
+};
+
+function readPackageVersion(pkgDir: string): string | null {
+  try {
+    return JSON.parse(readFileSync(resolve(pkgDir, "package.json"), "utf-8")).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure path analysis: given the (symlink-resolved) path of the running binary, work out the
+ * `volute` package dir and the npm global prefix that owns it. Returns isLinked=true when the
+ * binary is not inside a `node_modules/volute`, meaning it's a source checkout / `npm link`.
+ * Separated from IO so it can be unit-tested across platform layouts.
+ */
+export function analyzeInstallPath(realPath: string): {
+  packageRoot: string | null;
+  prefix: string | null;
+  isLinked: boolean;
+} {
+  const marker = `${sep}node_modules${sep}volute${sep}`;
+  const idx = realPath.indexOf(marker);
+  if (idx === -1) return { packageRoot: null, prefix: null, isLinked: true };
+
+  const packageRoot = `${realPath.slice(0, idx)}${sep}node_modules${sep}volute`;
+  const nodeModulesRoot = dirname(packageRoot); // <...>/node_modules
+  // Global installs live at <prefix>/lib/node_modules (unix) or <prefix>/node_modules (windows).
+  const libDir = dirname(nodeModulesRoot);
+  const prefix = basename(libDir) === "lib" ? dirname(libDir) : libDir;
+  return { packageRoot, prefix, isLinked: false };
+}
+
+/**
+ * Resolve where the `volute` binary that is actually on PATH lives, so updates can be
+ * installed into the prefix that owns it rather than whatever prefix the ambient npm
+ * happens to use. The two diverge under nvm/fnm/volta/Homebrew setups, which is the
+ * usual cause of "update succeeded but nothing changed".
+ */
+export function resolveVoluteInstall(): VoluteInstall | null {
+  let binPath: string;
+  try {
+    binPath = execFileSync("which", ["volute"], { encoding: "utf-8" }).trim();
+  } catch {
+    return null;
+  }
+  if (!binPath) return null;
+
+  let realPath = binPath;
+  try {
+    realPath = realpathSync(binPath);
+  } catch {}
+
+  const { packageRoot, prefix, isLinked } = analyzeInstallPath(realPath);
+  if (isLinked) {
+    // Running from a source checkout or `npm link`.
+    // Walk up from the binary to find its package.json for a best-effort version.
+    let dir = dirname(realPath);
+    let version: string | null = null;
+    for (let i = 0; i < 4 && dir !== dirname(dir); i++) {
+      version = readPackageVersion(dir);
+      if (version) break;
+      dir = dirname(dir);
+    }
+    return { binPath, realPath, packageRoot: null, prefix: null, version, isLinked: true };
+  }
+
+  return {
+    binPath,
+    realPath,
+    packageRoot,
+    prefix,
+    version: packageRoot ? readPackageVersion(packageRoot) : null,
+    isLinked: false,
+  };
+}
+
+/** Run the resolved volute binary in a fresh process and return the version it reports. */
+export async function getResolvedVersion(binPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile(binPath, ["--version"], { timeout: 15_000 });
+    return stdout.trim() || null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,8 +9,54 @@ import {
   restartService,
 } from "@volute/daemon/lib/config/service-mode.js";
 import { voluteSystemDir } from "@volute/daemon/lib/mind/registry.js";
-import { checkForUpdate } from "@volute/daemon/lib/update-check.js";
+import {
+  checkForUpdate,
+  getResolvedVersion,
+  resolveVoluteInstall,
+  type VoluteInstall,
+} from "@volute/daemon/lib/update-check.js";
 import { exec, execInherit, resolveVoluteBin } from "@volute/daemon/lib/util/exec.js";
+
+/**
+ * Build the npm invocation for a global install, targeting the prefix that owns the
+ * running `volute` binary. Falls back to the ambient npm when the owning prefix is
+ * unknown (e.g. a linked checkout, already handled before we get here).
+ */
+function buildInstall(
+  install: VoluteInstall | null,
+  latest: string,
+  npmFallback: string,
+): { cmd: string; args: string[] } {
+  const args = ["install", "-g", `volute@${latest}`];
+  const prefix = install?.prefix;
+  if (prefix) {
+    const ownNpm = resolve(prefix, "bin", "npm");
+    args.push("--prefix", prefix);
+    return { cmd: existsSync(ownNpm) ? ownNpm : npmFallback, args };
+  }
+  return { cmd: npmFallback, args };
+}
+
+/**
+ * Confirm the binary on PATH now reports the expected version. Returns true on match.
+ * This is what turns a silent "installed into the wrong prefix" failure into a real error.
+ */
+async function verifyInstalled(install: VoluteInstall | null, expected: string): Promise<boolean> {
+  if (!install?.binPath) return true; // can't verify; don't block
+  const actual = await getResolvedVersion(install.binPath);
+  if (actual === expected) return true;
+  console.error(`\nUpdate did not take effect.`);
+  console.error(`  The volute on your PATH is: ${install.binPath}`);
+  if (install.realPath !== install.binPath) console.error(`  → ${install.realPath}`);
+  console.error(`  It still reports version: ${actual ?? "unknown"} (expected ${expected}).`);
+  if (install.prefix) {
+    console.error(
+      `  npm likely installed into a different prefix than ${install.prefix}.\n` +
+        `  Check that the npm running the install shares this prefix (\`npm prefix -g\`).`,
+    );
+  }
+  return false;
+}
 
 const cmd = command({
   name: "volute update",
@@ -32,25 +78,38 @@ const cmd = command({
 
     console.log(`\nUpdating volute ${result.current} → ${result.latest}...`);
 
+    const install = resolveVoluteInstall();
+    if (install?.isLinked) {
+      console.error(
+        `\nThe volute on your PATH is running from a source checkout / npm link:\n` +
+          `  ${install.binPath} → ${install.realPath}\n` +
+          `\`npm install -g\` would not change it. Update that checkout directly instead\n` +
+          `(e.g. \`git pull && npm install && npm run build\`).`,
+      );
+      process.exit(1);
+    }
+
     const mode = getServiceMode();
 
     if (mode === "system") {
-      // System service: use /usr/bin/npm (fall back to which npm) with sudo
-      let npmPath = "/usr/bin/npm";
-      if (!existsSync(npmPath)) {
+      // System service: use the owning prefix's npm (fall back to /usr/bin/npm, then PATH) with sudo
+      let npmFallback = "/usr/bin/npm";
+      if (!existsSync(npmFallback)) {
         try {
-          npmPath = (await exec("which", ["npm"])).trim();
+          npmFallback = (await exec("which", ["npm"])).trim();
         } catch {
           console.error("Could not find npm. Install npm and try again.");
           process.exit(1);
         }
       }
+      const { cmd: npmCmd, args: npmArgs } = buildInstall(install, result.latest, npmFallback);
       try {
-        await execInherit("sudo", [npmPath, "install", "-g", "volute@latest"]);
+        await execInherit("sudo", [npmCmd, ...npmArgs]);
       } catch (err) {
         console.error(`\nUpdate failed: ${(err as Error).message}`);
         process.exit(1);
       }
+      if (!(await verifyInstalled(install, result.latest))) process.exit(1);
       console.log("Restarting service...");
       try {
         await restartService(mode);
@@ -72,13 +131,15 @@ const cmd = command({
     }
 
     if (mode === "user-systemd" || mode === "user-launchd") {
-      // User service: npm install (no sudo), then restart service
+      // User service: install into the owning prefix (no sudo), then restart service
+      const { cmd: npmCmd, args: npmArgs } = buildInstall(install, result.latest, "npm");
       try {
-        await execInherit("npm", ["install", "-g", "volute@latest"]);
+        await execInherit(npmCmd, npmArgs);
       } catch (err) {
         console.error(`\nUpdate failed: ${(err as Error).message}`);
         process.exit(1);
       }
+      if (!(await verifyInstalled(install, result.latest))) process.exit(1);
       console.log(`Restarting service (${modeLabel(mode)})...`);
       try {
         await restartService(mode);
@@ -173,8 +234,9 @@ const cmd = command({
       console.log("Daemon stopped.");
     }
 
+    const { cmd: npmCmd, args: npmArgs } = buildInstall(install, result.latest, "npm");
     try {
-      await execInherit("npm", ["install", "-g", "volute@latest"]);
+      await execInherit(npmCmd, npmArgs);
     } catch (err) {
       console.error(`\nUpdate failed: ${(err as Error).message}`);
       if (daemonWasRunning) {
@@ -194,6 +256,8 @@ const cmd = command({
       process.exit(1);
     }
 
+    const ok = await verifyInstalled(install, result.latest);
+
     if (daemonWasRunning) {
       console.log("Restarting daemon...");
       try {
@@ -209,6 +273,7 @@ const cmd = command({
       }
     }
 
+    if (!ok) process.exit(1);
     console.log(`\nUpdated to volute v${result.latest}`);
   },
 });

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
 import {
+  analyzeInstallPath,
   checkForUpdate,
   checkForUpdateCached,
   getCurrentVersion,
@@ -42,6 +43,35 @@ describe("isNewer", () => {
 
   it("strips pre-release suffix (pre-release is not newer than release)", () => {
     assert.equal(isNewer("1.0.0", "1.0.0-rc.1"), false);
+  });
+});
+
+describe("analyzeInstallPath", () => {
+  it("derives prefix from a Homebrew-style global install", () => {
+    const r = analyzeInstallPath("/opt/homebrew/lib/node_modules/volute/dist/cli.js");
+    assert.equal(r.isLinked, false);
+    assert.equal(r.packageRoot, "/opt/homebrew/lib/node_modules/volute");
+    assert.equal(r.prefix, "/opt/homebrew");
+  });
+
+  it("derives prefix from an nvm-style global install", () => {
+    const r = analyzeInstallPath(
+      "/Users/me/.nvm/versions/node/v20.0.0/lib/node_modules/volute/dist/cli.js",
+    );
+    assert.equal(r.prefix, "/Users/me/.nvm/versions/node/v20.0.0");
+    assert.equal(r.packageRoot, "/Users/me/.nvm/versions/node/v20.0.0/lib/node_modules/volute");
+  });
+
+  it("handles a prefix without a lib/ directory (windows-style)", () => {
+    const r = analyzeInstallPath("/usr/local/node_modules/volute/dist/cli.js");
+    assert.equal(r.prefix, "/usr/local");
+  });
+
+  it("flags a source checkout / npm link as linked", () => {
+    const r = analyzeInstallPath("/Users/me/src/volute/dist/cli.js");
+    assert.equal(r.isLinked, true);
+    assert.equal(r.prefix, null);
+    assert.equal(r.packageRoot, null);
   });
 });
 


### PR DESCRIPTION
## Problem

On a local install, `volute update` reports success but the running `volute` stays on the old version.

`volute update` ran `npm install -g volute@latest` using the **ambient npm** on PATH, then printed `Updated to volute v<latest>` **unconditionally** (whenever npm exited 0). When the running binary and the ambient npm resolve to different global prefixes — common with nvm/fnm/volta/Homebrew — the new version installs into a prefix nothing ever runs, and the success message is a lie.

Confirmed live on the reporter's machine:
- `which volute` → `/opt/homebrew/bin/volute` → `/opt/homebrew/lib/node_modules/volute` (Homebrew node, prefix `/opt/homebrew`)
- `npm prefix -g` → `~/.hermes/node` (a different node)
- Running binary stuck at `0.39.0` while latest is `0.40.0`.

## Fix

- **`resolveVoluteInstall()`** — resolve `which volute` → `realpath` → derive the npm global prefix that *owns* the running binary, and prefer that prefix's own npm (with an explicit `--prefix`). Applied to all three install modes (system / user-service / manual).
- **`verifyInstalled()`** — after install, re-run the on-PATH binary's `--version` in a fresh process and compare to the target. On mismatch, print an actionable diagnostic (which binary, where it resolves, what version it still reports, prefix hint) and exit non-zero, instead of claiming false success. In manual mode this runs before the daemon restart so the new version is what restarts.
- **Linked/dev guard** — if `volute` runs from a source checkout or `npm link`, abort early with guidance (`git pull && npm install && npm run build`), since `npm install -g` can't help.
- **`analyzeInstallPath()`** — extracted the pure prefix-derivation logic so it's unit-testable across platform layouts.

## Tests

Added `analyzeInstallPath` cases (Homebrew, nvm, windows-style, linked). Full suite green (1559 tests); new file 20/20. Typecheck clean under TS 6.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)