### PR TITLE
fix: reconcile turns wedged active by a leaked delivery counter

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -20,7 +20,9 @@ export const SYSTEM_MIND = "_system";
 /**
  * A turn that has received a `done` but stayed `active` this long (no further events) is
  * treated as wedged by a leaked delivery counter and force-completed by the tick sweep.
- * Comfortably longer than any real turn, so genuine in-progress work is never cut short.
+ * The sweep also requires a prior `done`, so genuine in-progress work (no `done` yet) is
+ * never cut short regardless of duration; this threshold just bounds how stale a finished
+ * turn must look before we step in.
  */
 const WEDGED_TURN_IDLE_MS = 15 * 60_000;
 
@@ -935,7 +937,7 @@ export class Summarizer {
         this.hasBackfilled = true;
       }
 
-      await this.reconcileWedgedTurns();
+      await reconcileWedgedTurns(WEDGED_TURN_IDLE_MS);
 
       const now = new Date();
       const currentHourKey = getPeriodKey(now, "hour");
@@ -967,30 +969,29 @@ export class Summarizer {
       sLog.error("tick failed", log.errorData(err));
     }
   }
+}
 
-  /**
-   * Complete + summarize turns wedged in `active` despite already finishing, and reset the
-   * leaked delivery counter that gated them. Guards against a session's `activeCount`
-   * drifting positive (deliveries outnumbering `done`s) and blocking turn completion forever.
-   */
-  private async reconcileWedgedTurns(): Promise<void> {
-    const { sweepWedgedTurns, summarizeOrphanedTurns } = await import("./turn-tracker.js");
-    const wedged = await sweepWedgedTurns(WEDGED_TURN_IDLE_MS);
-    if (wedged.length === 0) return;
+/**
+ * Complete + summarize turns wedged in `active` despite already finishing, and reset the
+ * leaked delivery counter that gated them. Guards against a session's `activeCount`
+ * drifting positive (deliveries outnumbering `done`s) and blocking turn completion
+ * indefinitely. Run on the summarizer tick; exported for direct testing.
+ */
+export async function reconcileWedgedTurns(idleMs: number): Promise<void> {
+  const { sweepWedgedTurns, summarizeOrphanedTurns } = await import("./turn-tracker.js");
+  const wedged = await sweepWedgedTurns(idleMs);
+  if (wedged.length === 0) return;
 
-    summarizeOrphanedTurns(wedged);
+  summarizeOrphanedTurns(wedged);
 
-    try {
-      const { getDeliveryManager } = await import("../delivery/delivery-manager.js");
-      const dm = getDeliveryManager();
-      for (const t of wedged) {
-        if (t.session) dm.clearSessionActive(t.mind, t.session);
-      }
-    } catch (err) {
-      if (!(err instanceof Error && err.message.includes("not initialized"))) {
-        sLog.warn("failed to reset session counters after sweep", log.errorData(err));
-      }
-    }
+  // Reset the leaked counter so the next turn in each session can complete. If the delivery
+  // manager isn't up (startup ordering) there are no in-memory counters to leak, so skipping
+  // is correct. clearSessionActive itself no-ops if a fresh delivery raced in.
+  const { tryGetDeliveryManager } = await import("../delivery/delivery-manager.js");
+  const dm = tryGetDeliveryManager();
+  if (!dm) return;
+  for (const t of wedged) {
+    if (t.session) dm.clearSessionActive(t.mind, t.session, idleMs);
   }
 }
 

--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -17,6 +17,13 @@ export type Period = "turn" | TimerPeriod;
 
 export const SYSTEM_MIND = "_system";
 
+/**
+ * A turn that has received a `done` but stayed `active` this long (no further events) is
+ * treated as wedged by a leaked delivery counter and force-completed by the tick sweep.
+ * Comfortably longer than any real turn, so genuine in-progress work is never cut short.
+ */
+const WEDGED_TURN_IDLE_MS = 15 * 60_000;
+
 // ── Period key helpers (local time) ──
 // Period keys use local time so summaries align with the user's day/hour boundaries.
 
@@ -928,6 +935,8 @@ export class Summarizer {
         this.hasBackfilled = true;
       }
 
+      await this.reconcileWedgedTurns();
+
       const now = new Date();
       const currentHourKey = getPeriodKey(now, "hour");
 
@@ -956,6 +965,31 @@ export class Summarizer {
       }
     } catch (err) {
       sLog.error("tick failed", log.errorData(err));
+    }
+  }
+
+  /**
+   * Complete + summarize turns wedged in `active` despite already finishing, and reset the
+   * leaked delivery counter that gated them. Guards against a session's `activeCount`
+   * drifting positive (deliveries outnumbering `done`s) and blocking turn completion forever.
+   */
+  private async reconcileWedgedTurns(): Promise<void> {
+    const { sweepWedgedTurns, summarizeOrphanedTurns } = await import("./turn-tracker.js");
+    const wedged = await sweepWedgedTurns(WEDGED_TURN_IDLE_MS);
+    if (wedged.length === 0) return;
+
+    summarizeOrphanedTurns(wedged);
+
+    try {
+      const { getDeliveryManager } = await import("../delivery/delivery-manager.js");
+      const dm = getDeliveryManager();
+      for (const t of wedged) {
+        if (t.session) dm.clearSessionActive(t.mind, t.session);
+      }
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("not initialized"))) {
+        sLog.warn("failed to reset session counters after sweep", log.errorData(err));
+      }
     }
   }
 }

--- a/packages/daemon/src/lib/daemon/turn-tracker.ts
+++ b/packages/daemon/src/lib/daemon/turn-tracker.ts
@@ -202,11 +202,12 @@ export async function clearMind(mind: string): Promise<OrphanedTurn[]> {
 /**
  * Reconcile turns wedged in `active` despite already having received a `done`.
  *
- * A turn completes only when a `done` arrives AND the delivery manager reports the
- * session as not busy (activeCount === 0). That counter increments per delivery but
- * decrements per `done`; interrupts and maxWait flushes deliver mid-turn yet get folded
- * into fewer `done`s, so the counter can leak positive and gate completion forever — the
- * turn stays active, never summarized, and keeps absorbing later events.
+ * A turn with a session completes only when a `done` arrives AND the delivery manager
+ * reports the session as not busy (activeCount === 0). That counter increments per delivery
+ * and decrements per `done` (or failed delivery); interrupts and maxWait flushes deliver
+ * mid-turn yet get folded into fewer `done`s, so the counter can leak positive and gate
+ * completion indefinitely (until the mind stops or this sweep runs) — the turn stays active,
+ * never summarized, and keeps absorbing later events.
  *
  * This sweep catches that drift: an active turn that has seen ≥1 `done` and has had no
  * events for `idleMs` is genuinely finished. We mark it complete and drop any in-memory
@@ -221,13 +222,7 @@ export async function sweepWedgedTurns(idleMs: number): Promise<OrphanedTurn[]> 
   let rows: { id: string; mind: string; session: string | null }[];
   try {
     rows = await db
-      .select({
-        id: turns.id,
-        mind: turns.mind,
-        session: turns.session,
-        lastAt: sql<string>`max(${mindHistory.created_at})`,
-        doneCount: sql<number>`sum(case when ${mindHistory.type} = 'done' then 1 else 0 end)`,
-      })
+      .select({ id: turns.id, mind: turns.mind, session: turns.session })
       .from(turns)
       .innerJoin(mindHistory, eq(mindHistory.turn_id, turns.id))
       .where(eq(turns.status, "active"))

--- a/packages/daemon/src/lib/daemon/turn-tracker.ts
+++ b/packages/daemon/src/lib/daemon/turn-tracker.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
-import { turns } from "../schema.js";
+import { mindHistory, turns } from "../schema.js";
 import log from "../util/logger.js";
 import { summarizeTurn } from "./summarizer.js";
 
@@ -197,6 +197,66 @@ export async function clearMind(mind: string): Promise<OrphanedTurn[]> {
     }
   }
   return orphaned;
+}
+
+/**
+ * Reconcile turns wedged in `active` despite already having received a `done`.
+ *
+ * A turn completes only when a `done` arrives AND the delivery manager reports the
+ * session as not busy (activeCount === 0). That counter increments per delivery but
+ * decrements per `done`; interrupts and maxWait flushes deliver mid-turn yet get folded
+ * into fewer `done`s, so the counter can leak positive and gate completion forever — the
+ * turn stays active, never summarized, and keeps absorbing later events.
+ *
+ * This sweep catches that drift: an active turn that has seen ≥1 `done` and has had no
+ * events for `idleMs` is genuinely finished. We mark it complete and drop any in-memory
+ * entry so the next event opens a fresh turn. Callers summarize the returned turns and
+ * reset the leaked session counter. Idempotent and safe to run on a timer.
+ */
+export async function sweepWedgedTurns(idleMs: number): Promise<OrphanedTurn[]> {
+  const db = await getDb();
+  // UTC "YYYY-MM-DD HH:MM:SS" to match how mind_history.created_at is stored.
+  const cutoff = new Date(Date.now() - idleMs).toISOString().slice(0, 19).replace("T", " ");
+
+  let rows: { id: string; mind: string; session: string | null }[];
+  try {
+    rows = await db
+      .select({
+        id: turns.id,
+        mind: turns.mind,
+        session: turns.session,
+        lastAt: sql<string>`max(${mindHistory.created_at})`,
+        doneCount: sql<number>`sum(case when ${mindHistory.type} = 'done' then 1 else 0 end)`,
+      })
+      .from(turns)
+      .innerJoin(mindHistory, eq(mindHistory.turn_id, turns.id))
+      .where(eq(turns.status, "active"))
+      .groupBy(turns.id)
+      .having(
+        sql`max(${mindHistory.created_at}) < ${cutoff} and sum(case when ${mindHistory.type} = 'done' then 1 else 0 end) > 0`,
+      );
+  } catch (err) {
+    tlog.error("failed to query wedged turns", log.errorData(err));
+    return [];
+  }
+
+  const swept: OrphanedTurn[] = [];
+  for (const r of rows) {
+    try {
+      await db.update(turns).set({ status: "complete" }).where(eq(turns.id, r.id));
+    } catch (err) {
+      tlog.error(`failed to complete wedged turn ${r.id}`, log.errorData(err));
+      continue;
+    }
+    // Drop the matching in-memory entry so the next event opens a fresh turn instead
+    // of re-tagging onto a now-complete one. Only delete the slot if it still points at
+    // this turn — a newer turn may already have reused the session key.
+    const k = key(r.mind, r.session);
+    if (activeTurns.get(k)?.turnId === r.id) activeTurns.delete(k);
+    swept.push({ turnId: r.id, mind: r.mind, session: r.session ?? undefined });
+  }
+  if (swept.length > 0) tlog.info(`swept ${swept.length} wedged turn(s)`);
+  return swept;
 }
 
 /** Fire-and-forget summarization for a list of orphaned turns. */

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -327,14 +327,22 @@ export class DeliveryManager {
    * Reset a single session's leaked active count back to zero.
    *
    * Used by the wedged-turn sweep: when a session's `activeCount` drifts above zero
-   * (deliveries outnumbering `done`s) it gates turn completion forever. Once the sweep
+   * (deliveries outnumbering `done`s) it gates turn completion indefinitely. Once the sweep
    * confirms the session is genuinely idle, this clears the stale count so the next turn
    * can complete normally. Batch buffers are left intact — their own maxWait timer flushes
    * any pending messages.
+   *
+   * `minIdleMs` guards against a race: if a delivery landed within that window, a fresh turn
+   * may legitimately be in flight (real `activeCount`), so zeroing would complete it early.
+   * In that case we skip — the next sweep retries if it's still wedged. Returns whether the
+   * count was reset.
    */
-  clearSessionActive(mindName: string, session: string): void {
+  clearSessionActive(mindName: string, session: string, minIdleMs: number): boolean {
     const state = this.sessionStates.get(mindName)?.get(session);
-    if (state) state.activeCount = 0;
+    if (!state) return false;
+    if (Date.now() - state.lastDeliveredAt < minIdleMs) return false;
+    state.activeCount = 0;
+    return true;
   }
 
   /**
@@ -974,5 +982,10 @@ export function getDeliveryManager(): DeliveryManager {
   if (!instance) {
     throw new Error("DeliveryManager not initialized — call initDeliveryManager() first");
   }
+  return instance;
+}
+
+/** Like getDeliveryManager but returns undefined instead of throwing when uninitialized. */
+export function tryGetDeliveryManager(): DeliveryManager | undefined {
   return instance;
 }

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -324,6 +324,20 @@ export class DeliveryManager {
   }
 
   /**
+   * Reset a single session's leaked active count back to zero.
+   *
+   * Used by the wedged-turn sweep: when a session's `activeCount` drifts above zero
+   * (deliveries outnumbering `done`s) it gates turn completion forever. Once the sweep
+   * confirms the session is genuinely idle, this clears the stale count so the next turn
+   * can complete normally. Batch buffers are left intact — their own maxWait timer flushes
+   * any pending messages.
+   */
+  clearSessionActive(mindName: string, session: string): void {
+    const state = this.sessionStates.get(mindName)?.get(session);
+    if (state) state.activeCount = 0;
+  }
+
+  /**
    * Cleanup all timers and subscriptions.
    */
   dispose(): void {

--- a/test/delivery-manager.test.ts
+++ b/test/delivery-manager.test.ts
@@ -197,6 +197,30 @@ describe("DeliveryManager", () => {
       // Calling sessionDone on nonexistent session should not throw
       manager.sessionDone("nonexistent", "main");
     });
+
+    it("clearSessionActive resets a leaked active count to zero", () => {
+      manager = new DeliveryManager();
+      const states = (manager as any).sessionStates as Map<string, Map<string, any>>;
+      states.set(
+        "leakmind",
+        new Map([
+          [
+            "s1",
+            { activeCount: 3, lastDeliverySenders: new Set(), lastDeliveryChannels: new Set() },
+          ],
+        ]),
+      );
+      assert.equal(manager.isSessionBusy("leakmind", "s1"), true);
+
+      manager.clearSessionActive("leakmind", "s1");
+      assert.equal(manager.isSessionBusy("leakmind", "s1"), false, "count should be reset to 0");
+    });
+
+    it("clearSessionActive is a no-op for an unknown session", () => {
+      manager = new DeliveryManager();
+      // Should not throw
+      manager.clearSessionActive("nope", "main");
+    });
   });
 
   describe("new-speaker batch interrupt", () => {

--- a/test/delivery-manager.test.ts
+++ b/test/delivery-manager.test.ts
@@ -198,28 +198,35 @@ describe("DeliveryManager", () => {
       manager.sessionDone("nonexistent", "main");
     });
 
-    it("clearSessionActive resets a leaked active count to zero", () => {
+    function seedSessionState(mgr: DeliveryManager, mind: string, session: string, state: any) {
+      const states = (mgr as any).sessionStates as Map<string, Map<string, any>>;
+      states.set(mind, new Map([[session, state]]));
+    }
+
+    it("clearSessionActive resets a leaked active count when the session is idle", () => {
       manager = new DeliveryManager();
-      const states = (manager as any).sessionStates as Map<string, Map<string, any>>;
-      states.set(
-        "leakmind",
-        new Map([
-          [
-            "s1",
-            { activeCount: 3, lastDeliverySenders: new Set(), lastDeliveryChannels: new Set() },
-          ],
-        ]),
-      );
+      // lastDeliveredAt long in the past → idle → safe to reset
+      seedSessionState(manager, "leakmind", "s1", { activeCount: 3, lastDeliveredAt: 0 });
       assert.equal(manager.isSessionBusy("leakmind", "s1"), true);
 
-      manager.clearSessionActive("leakmind", "s1");
+      const reset = manager.clearSessionActive("leakmind", "s1", 10 * 60_000);
+      assert.equal(reset, true);
       assert.equal(manager.isSessionBusy("leakmind", "s1"), false, "count should be reset to 0");
+    });
+
+    it("clearSessionActive does NOT reset when a delivery raced in recently", () => {
+      manager = new DeliveryManager();
+      // lastDeliveredAt is now → a fresh turn may be in flight → must not zero it
+      seedSessionState(manager, "racemind", "s1", { activeCount: 1, lastDeliveredAt: Date.now() });
+
+      const reset = manager.clearSessionActive("racemind", "s1", 10 * 60_000);
+      assert.equal(reset, false, "recent delivery should block the reset");
+      assert.equal(manager.isSessionBusy("racemind", "s1"), true, "count left intact");
     });
 
     it("clearSessionActive is a no-op for an unknown session", () => {
       manager = new DeliveryManager();
-      // Should not throw
-      manager.clearSessionActive("nope", "main");
+      assert.equal(manager.clearSessionActive("nope", "main", 10 * 60_000), false);
     });
   });
 

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -6,11 +6,20 @@ import {
   getPreviousPeriodKey,
   getTimeRange,
   type Period,
+  reconcileWedgedTurns,
   summarizePeriod,
   summarizeTurn,
 } from "../packages/daemon/src/lib/daemon/summarizer.js";
-import { clearMind } from "../packages/daemon/src/lib/daemon/turn-tracker.js";
+import {
+  assignSession,
+  clearMind,
+  createTurn,
+} from "../packages/daemon/src/lib/daemon/turn-tracker.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  initDeliveryManager,
+  tryGetDeliveryManager,
+} from "../packages/daemon/src/lib/delivery/delivery-manager.js";
 import { mindHistory, summaries, turns } from "../packages/daemon/src/lib/schema.js";
 
 describe("summarizer", () => {
@@ -429,6 +438,51 @@ describe("summarizer", () => {
       assert.ok(row, "monthly summary should exist");
       const meta = JSON.parse(row!.metadata!);
       assert.equal(meta.source_count, 3);
+    });
+  });
+
+  describe("reconcileWedgedTurns", () => {
+    it("completes a wedged turn and resets its leaked session counter", async () => {
+      const mind = "reconcile-mind";
+      const session = "rs1";
+      const idleMs = 10 * 60_000;
+
+      // A wedged turn: has a `done`, last event well past the idle window.
+      const id = await createTurn(mind);
+      assert.ok(id);
+      await assignSession(mind, id!, session);
+      const db = await getDb();
+      for (const e of [
+        { type: "text", msAgo: 30 * 60_000 },
+        { type: "done", msAgo: 20 * 60_000 },
+      ]) {
+        await db.insert(mindHistory).values({
+          mind,
+          type: e.type,
+          session,
+          turn_id: id,
+          created_at: new Date(Date.now() - e.msAgo).toISOString().slice(0, 19).replace("T", " "),
+        });
+      }
+
+      // Stand up the delivery manager singleton with a leaked, idle counter for this session.
+      const dm = initDeliveryManager();
+      try {
+        (dm as any).sessionStates.set(
+          mind,
+          new Map([[session, { activeCount: 2, lastDeliveredAt: 0 }]]),
+        );
+        assert.equal(dm.isSessionBusy(mind, session), true);
+        assert.equal(tryGetDeliveryManager(), dm);
+
+        await reconcileWedgedTurns(idleMs);
+
+        const row = await db.select().from(turns).where(eq(turns.id, id)).get();
+        assert.equal(row!.status, "complete", "wedged turn should be completed");
+        assert.equal(dm.isSessionBusy(mind, session), false, "leaked counter should be reset");
+      } finally {
+        dm.dispose();
+      }
     });
   });
 });

--- a/test/turn-tracker.test.ts
+++ b/test/turn-tracker.test.ts
@@ -10,11 +10,17 @@ import {
   getActiveTurnId,
   getLastToolUseEventId,
   markErrored,
+  sweepWedgedTurns,
   takeErrored,
   trackToolUse,
 } from "../packages/daemon/src/lib/daemon/turn-tracker.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { turns } from "../packages/daemon/src/lib/schema.js";
+import { mindHistory, turns } from "../packages/daemon/src/lib/schema.js";
+
+/** UTC "YYYY-MM-DD HH:MM:SS" — matches the format SQLite's datetime('now') stores. */
+function utcStamp(msAgo: number): string {
+  return new Date(Date.now() - msAgo).toISOString().slice(0, 19).replace("T", " ");
+}
 
 describe("turn-tracker", () => {
   const mind = "test-turn-tracker";
@@ -178,5 +184,85 @@ describe("turn-tracker", () => {
     await clearMind("errmind");
     assert.equal(takeErrored("errmind", "s1"), false, "cleared on crash/stop");
     assert.equal(takeErrored("keepmind", "s1"), true, "other mind's flag intact");
+  });
+
+  describe("sweepWedgedTurns", () => {
+    const idleMs = 10 * 60_000;
+
+    // Create a real (in-memory + DB) turn for `sweep-mind`, assign it a session, and
+    // attach mind_history events at the given ages. Returns the real turn id.
+    async function seedTurn(
+      sess: string,
+      events: { type: string; msAgo: number }[],
+    ): Promise<string> {
+      const id = await createTurn("sweep-mind");
+      assert.ok(id);
+      await assignSession("sweep-mind", id!, sess);
+      const db = await getDb();
+      for (const e of events) {
+        await db.insert(mindHistory).values({
+          mind: "sweep-mind",
+          type: e.type,
+          session: sess,
+          turn_id: id,
+          created_at: utcStamp(e.msAgo),
+        });
+      }
+      return id!;
+    }
+
+    it("completes a turn that has a done event and is idle past the threshold", async () => {
+      const id = await seedTurn("ws1", [
+        { type: "text", msAgo: 30 * 60_000 },
+        { type: "done", msAgo: 20 * 60_000 },
+      ]);
+      assert.equal(getActiveTurnId("sweep-mind", "ws1"), id, "turn is active in memory");
+
+      const swept = await sweepWedgedTurns(idleMs);
+      const mine = swept.find((t) => t.turnId === id);
+      assert.ok(mine, "wedged turn should be swept");
+      assert.equal(mine!.mind, "sweep-mind");
+      assert.equal(mine!.session, "ws1");
+
+      const db = await getDb();
+      const row = await db.select().from(turns).where(eq(turns.id, id)).get();
+      assert.equal(row!.status, "complete", "turn should be marked complete");
+      assert.equal(getActiveTurnId("sweep-mind", "ws1"), undefined, "in-memory entry cleared");
+    });
+
+    it("does NOT sweep an active turn that never received a done", async () => {
+      const id = await seedTurn("ws2", [{ type: "tool_use", msAgo: 30 * 60_000 }]);
+
+      const swept = await sweepWedgedTurns(idleMs);
+      assert.equal(
+        swept.find((t) => t.turnId === id),
+        undefined,
+        "no done → not wedged",
+      );
+
+      const db = await getDb();
+      const row = await db.select().from(turns).where(eq(turns.id, id)).get();
+      assert.equal(row!.status, "active");
+      await clearMind("sweep-mind");
+    });
+
+    it("does NOT sweep a turn whose last event is within the threshold", async () => {
+      const id = await seedTurn("ws3", [
+        { type: "done", msAgo: 12 * 60_000 },
+        { type: "text", msAgo: 1 * 60_000 },
+      ]);
+
+      const swept = await sweepWedgedTurns(idleMs);
+      assert.equal(
+        swept.find((t) => t.turnId === id),
+        undefined,
+        "recent activity → not wedged",
+      );
+
+      const db = await getDb();
+      const row = await db.select().from(turns).where(eq(turns.id, id)).get();
+      assert.equal(row!.status, "active");
+      await clearMind("sweep-mind");
+    });
   });
 });

--- a/test/turn-tracker.test.ts
+++ b/test/turn-tracker.test.ts
@@ -264,5 +264,84 @@ describe("turn-tracker", () => {
       assert.equal(row!.status, "active");
       await clearMind("sweep-mind");
     });
+
+    it("sweeps a sessionless wedged turn (null session)", async () => {
+      const id = await createTurn("sweep-nosess");
+      assert.ok(id);
+      const db = await getDb();
+      for (const e of [
+        { type: "text", msAgo: 30 * 60_000 },
+        { type: "done", msAgo: 20 * 60_000 },
+      ]) {
+        await db.insert(mindHistory).values({
+          mind: "sweep-nosess",
+          type: e.type,
+          session: null,
+          turn_id: id,
+          created_at: utcStamp(e.msAgo),
+        });
+      }
+
+      const swept = await sweepWedgedTurns(idleMs);
+      const mine = swept.find((t) => t.turnId === id);
+      assert.ok(mine, "sessionless wedged turn should be swept");
+      assert.equal(mine!.session, undefined, "null session maps to undefined");
+      assert.equal(getActiveTurnId("sweep-nosess"), undefined, "in-memory wildcard entry cleared");
+    });
+
+    it("does NOT clobber the in-memory slot when a newer turn reused the session key", async () => {
+      const oldId = await seedTurn("wsX", [
+        { type: "text", msAgo: 30 * 60_000 },
+        { type: "done", msAgo: 20 * 60_000 },
+      ]);
+      // A newer turn opens on the same session and reuses the mind:session slot.
+      const newId = await createTurn("sweep-mind");
+      assert.ok(newId);
+      await assignSession("sweep-mind", newId!, "wsX");
+      assert.equal(getActiveTurnId("sweep-mind", "wsX"), newId);
+
+      const swept = await sweepWedgedTurns(idleMs);
+      assert.ok(
+        swept.find((t) => t.turnId === oldId),
+        "old wedged turn swept",
+      );
+
+      const db = await getDb();
+      const oldRow = await db.select().from(turns).where(eq(turns.id, oldId)).get();
+      assert.equal(oldRow!.status, "complete");
+      assert.equal(
+        getActiveTurnId("sweep-mind", "wsX"),
+        newId,
+        "newer turn's in-memory entry must survive",
+      );
+      await clearMind("sweep-mind");
+    });
+
+    it("sweeps multiple wedged turns in one pass", async () => {
+      const id1 = await seedTurn("wsm1", [
+        { type: "text", msAgo: 40 * 60_000 },
+        { type: "done", msAgo: 30 * 60_000 },
+      ]);
+      const id2 = await seedTurn("wsm2", [
+        { type: "text", msAgo: 40 * 60_000 },
+        { type: "done", msAgo: 30 * 60_000 },
+      ]);
+
+      const swept = await sweepWedgedTurns(idleMs);
+      assert.ok(
+        swept.find((t) => t.turnId === id1),
+        "first turn swept",
+      );
+      assert.ok(
+        swept.find((t) => t.turnId === id2),
+        "second turn swept",
+      );
+
+      const db = await getDb();
+      for (const id of [id1, id2]) {
+        const row = await db.select().from(turns).where(eq(turns.id, id)).get();
+        assert.equal(row!.status, "complete");
+      }
+    });
   });
 });


### PR DESCRIPTION
## Problem

A history turn can get stuck `active` forever, never summarized, while still absorbing later events. Observed in production: gardener's `mimsy` DM turn was open for **3 days** (2026-06-24 18:09 → today), holding 36 events, with three `done` events that never closed it.

### Root cause

A turn only completes (and gets summarized) when a `done` event arrives **and** the delivery manager reports the session as not busy. "Busy" is a per-session `activeCount` incremented on every delivery and decremented on every `done`:

```ts
const busy = body.session ? dm.isSessionBusy(baseName, body.session) : false;
if (!busy) { await completeTurn(...); }   // marks complete + summarizes
```

That counter assumes exactly one `done` per delivery. But the new-speaker interrupt and maxWait-flush paths deliver **mid-turn** (incrementing again), and the Agent SDK folds those messages into **fewer** `done`s. The counter leaks positive and gates `completeTurn` forever — the turn stays active, never summarized, and every later event in the session re-tags onto it.

The leak only clears on daemon startup (`completeOrphanedTurns`) or mind stop/restart (`clearMindSessions`). With the daemon up continuously and the mind not restarted, the stuck state persisted for days.

## Fix

Add a reconciliation sweep on the summarizer's existing 5-min tick. A turn that has received a `done` but stayed `active` with no further events for 15 minutes is treated as wedged: marked complete, summarized, its in-memory entry dropped, and the leaked session counter reset so the next turn completes normally.

- `turn-tracker`: add `sweepWedgedTurns(idleMs)`
- `delivery-manager`: add `clearSessionActive(mind, session)`
- `summarizer`: wire reconciliation into the tick

The 15-min threshold is comfortably longer than any real turn, so genuine in-progress work is never cut short; the trade-off is that a wedged turn self-heals within ~15–20 min of going quiet rather than instantly.

## Tests

- 3 sweep tests exercising the real create/assign/complete path (wedged turn swept; no-`done` turn left alone; recently-active turn left alone)
- 2 tests for the counter reset

Full suite: **1585 pass, 0 fail**; typecheck + lint clean.

## Note

The stuck production turn was already healed out-of-band by restarting the mind (turn completed + summary generated). This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)