### PR TITLE
fix: track mind "active" as an open turn, not stream setup

### DIFF
--- a/packages/daemon/src/lib/events/mind-activity-tracker.ts
+++ b/packages/daemon/src/lib/events/mind-activity-tracker.ts
@@ -20,8 +20,42 @@ function getState(mind: string): MindState {
   return state;
 }
 
-// Event types that don't indicate real processing activity
-const IGNORED_EVENTS = new Set(["done", "usage", "log"]);
+// Events that do not open or advance a turn, so they never mark a mind active.
+// `session_start` fires once when the persistent SDK stream opens (at boot and
+// again after each compaction/resume), not when a turn runs — treating it as
+// active wedged idle-booted minds "active" forever. `usage`/`log` are metadata.
+// (`done` is handled explicitly before this check.)
+const IGNORED_EVENTS = new Set(["session_start", "usage", "log"]);
+
+/**
+ * Arm (or refresh) the inactivity watchdog. "Active" means an open turn, so it
+ * is cleared by the turn's `done`. This watchdog is the safety net for a turn
+ * that opens (a delivery, or the mind's own processing events) but never emits
+ * a matching `done` — e.g. the SDK hangs mid-turn, or the `done` emit is lost.
+ * Every real event refreshes the timer, so a mind that emits events at least
+ * every IDLE_TIMEOUT_MS stays active while working; a mind silent longer than
+ * that (e.g. one long tool call) trips the watchdog and re-emits mind_active on
+ * its next event.
+ */
+function armIdleTimer(mind: string, state: MindState): void {
+  if (state.idleTimer) {
+    clearTimeout(state.idleTimer);
+  }
+  state.idleTimer = setTimeout(() => {
+    state.idleTimer = null;
+    // The timer only fires when no event refreshed it during the window, so the
+    // mind is genuinely idle. Clear active (heals a wedged session that never
+    // emitted `done`) and publish the idle transition for the timeline/cleanup.
+    state.active = false;
+    publish({
+      type: "mind_idle",
+      mind,
+      summary: `${mind} is idle`,
+    }).catch((err) => {
+      log.error("[mind-activity] failed to publish mind_idle", log.errorData(err));
+    });
+  }, IDLE_TIMEOUT_MS);
+}
 
 /** Called when a mind event is received. Tracks active/idle transitions. */
 export function onMindEvent(mind: string, type: string, channel?: string): void {
@@ -31,29 +65,13 @@ export function onMindEvent(mind: string, type: string, channel?: string): void 
     // The frontend clears the active dot on mind_done; without this reset,
     // subsequent turns within the idle window would skip re-emitting.
     state.active = false;
-    // Start idle timer — publish mind_idle if no new activity (for cleanup)
-    if (state.idleTimer) {
-      clearTimeout(state.idleTimer);
-    }
-    state.idleTimer = setTimeout(() => {
-      state.idleTimer = null;
-      if (!state.active) {
-        publish({
-          type: "mind_idle",
-          mind,
-          summary: `${mind} is idle`,
-        }).catch((err) => {
-          log.error("[mind-activity] failed to publish mind_idle", log.errorData(err));
-        });
-      }
-    }, IDLE_TIMEOUT_MS);
+    // Arm idle timer — publishes mind_idle later if no new activity (cleanup).
+    armIdleTimer(mind, state);
   } else if (!IGNORED_EVENTS.has(type)) {
-    // Any real processing event (session_start, text, tool_use, etc.)
-    // Clear any pending idle timer — mind is still working
-    if (state.idleTimer) {
-      clearTimeout(state.idleTimer);
-      state.idleTimer = null;
-    }
+    // A turn is open: a delivery, or the mind's own processing events (text,
+    // tool_use, thinking, ...). Refresh the inactivity watchdog so the mind
+    // stays active while working but self-heals to idle if no `done` arrives.
+    armIdleTimer(mind, state);
 
     if (!state.active) {
       state.active = true;

--- a/test/mind-activity-tracker.test.ts
+++ b/test/mind-activity-tracker.test.ts
@@ -36,8 +36,8 @@ describe("mind-activity-tracker", () => {
     received.length = 0;
   });
 
-  test("session_start event transitions from idle to active", async () => {
-    onMindEvent("test-mind", "session_start");
+  test("delivery event transitions from idle to active", async () => {
+    onMindEvent("test-mind", "delivery", "@alice");
     await wait();
     const active = received.filter((e) => e.type === "mind_active" && e.mind === "test-mind");
     assert.equal(active.length, 1);
@@ -51,8 +51,18 @@ describe("mind-activity-tracker", () => {
     assert.equal(active.length, 1);
   });
 
-  test("repeated events do not re-publish active", async () => {
+  test("session_start does not mark the mind active", async () => {
+    // The persistent SDK stream opening (session_start) is not a turn — a mind
+    // that boots and sits idle must stay idle, not show as active.
     onMindEvent("test-mind", "session_start");
+    await wait();
+    const active = received.filter((e) => e.type === "mind_active" && e.mind === "test-mind");
+    assert.equal(active.length, 0);
+    assert.deepEqual(getActiveMinds(), []);
+  });
+
+  test("repeated events do not re-publish active", async () => {
+    onMindEvent("test-mind", "delivery");
     onMindEvent("test-mind", "text");
     onMindEvent("test-mind", "tool_use");
     await wait();
@@ -60,7 +70,8 @@ describe("mind-activity-tracker", () => {
     assert.equal(active.length, 1);
   });
 
-  test("log and usage events are ignored", async () => {
+  test("session_start, log and usage events are ignored", async () => {
+    onMindEvent("test-mind", "session_start");
     onMindEvent("test-mind", "log");
     onMindEvent("test-mind", "usage");
     await wait();
@@ -69,19 +80,19 @@ describe("mind-activity-tracker", () => {
   });
 
   test("done event starts idle timer, not immediate idle", async () => {
-    onMindEvent("test-mind", "session_start");
+    onMindEvent("test-mind", "delivery");
     await wait();
     received.length = 0;
 
     onMindEvent("test-mind", "done");
     await wait();
-    // Should NOT be idle yet — timer pending (2 min)
+    // Should NOT be idle yet — timer pending (IDLE_TIMEOUT_MS, 5 min)
     const idle = received.filter((e) => e.type === "mind_idle");
     assert.equal(idle.length, 0);
   });
 
   test("markIdle publishes mind_idle immediately", async () => {
-    onMindEvent("test-mind", "session_start");
+    onMindEvent("test-mind", "delivery");
     await wait();
     received.length = 0;
 
@@ -99,21 +110,91 @@ describe("mind-activity-tracker", () => {
   });
 
   test("new activity after done re-emits mind_active", async () => {
-    onMindEvent("test-mind", "session_start");
+    onMindEvent("test-mind", "delivery");
     await wait();
     received.length = 0;
 
     onMindEvent("test-mind", "done");
-    // New activity before idle fires — should re-emit mind_active
-    onMindEvent("test-mind", "session_start");
+    // New turn before idle fires — should re-emit mind_active
+    onMindEvent("test-mind", "delivery");
     await wait();
     const active = received.filter((e) => e.type === "mind_active" && e.mind === "test-mind");
     assert.equal(active.length, 1);
   });
 
+  test("an open turn with no following done self-heals to idle after timeout", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+
+    // A turn opens (delivery) but the mind hangs and never emits `done`.
+    // It must not stay wedged active forever.
+    onMindEvent("wedge-mind", "delivery");
+    assert.deepEqual(getActiveMinds(), ["wedge-mind"]);
+
+    // After the idle window with no further activity, it should flip to idle.
+    t.mock.timers.tick(5 * 60 * 1000 + 1);
+    assert.deepEqual(getActiveMinds(), []);
+
+    // ...and publish a mind_idle transition so the timeline/dot clears.
+    t.mock.timers.reset();
+    await wait();
+    const idle = received.filter((e) => e.type === "mind_idle" && e.mind === "wedge-mind");
+    assert.equal(idle.length, 1);
+  });
+
+  test("done with no new activity still publishes idle cleanup after timeout", async (t) => {
+    onMindEvent("clean-mind", "delivery");
+    await wait();
+    received.length = 0;
+
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    onMindEvent("clean-mind", "done");
+    t.mock.timers.tick(5 * 60 * 1000 + 1);
+    t.mock.timers.reset();
+    await wait();
+    const idle = received.filter((e) => e.type === "mind_idle" && e.mind === "clean-mind");
+    assert.equal(idle.length, 1);
+  });
+
+  test("ongoing activity keeps the mind active past the idle window", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+
+    onMindEvent("busy-mind", "delivery");
+    // Events keep arriving within the window — the watchdog must keep refreshing.
+    t.mock.timers.tick(4 * 60 * 1000);
+    onMindEvent("busy-mind", "tool_use");
+    t.mock.timers.tick(4 * 60 * 1000);
+    onMindEvent("busy-mind", "text");
+    t.mock.timers.tick(4 * 60 * 1000);
+    assert.deepEqual(getActiveMinds(), ["busy-mind"]);
+
+    // No idle flicker: the dot must not blink off while the mind is working.
+    t.mock.timers.reset();
+    await wait();
+    const idle = received.filter((e) => e.type === "mind_idle" && e.mind === "busy-mind");
+    assert.equal(idle.length, 0);
+  });
+
+  test("a healed mind re-emits mind_active when it next does work", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+
+    onMindEvent("revived-mind", "delivery");
+    assert.deepEqual(getActiveMinds(), ["revived-mind"]);
+    t.mock.timers.tick(5 * 60 * 1000 + 1);
+    assert.deepEqual(getActiveMinds(), []);
+
+    // After self-healing to idle, a fresh event must bring it back to active.
+    onMindEvent("revived-mind", "delivery", "@alice");
+    assert.deepEqual(getActiveMinds(), ["revived-mind"]);
+
+    t.mock.timers.reset();
+    await wait();
+    const active = received.filter((e) => e.type === "mind_active" && e.mind === "revived-mind");
+    assert.equal(active.length, 2);
+  });
+
   test("getActiveMinds returns currently active minds", async () => {
     assert.deepEqual(getActiveMinds(), []);
-    onMindEvent("mind-a", "session_start");
+    onMindEvent("mind-a", "delivery");
     onMindEvent("mind-b", "text");
     await wait();
     assert.deepEqual(getActiveMinds().sort(), ["mind-a", "mind-b"]);
@@ -122,7 +203,7 @@ describe("mind-activity-tracker", () => {
   });
 
   test("stopAll cleans up timers", async () => {
-    onMindEvent("mind-a", "session_start");
+    onMindEvent("mind-a", "delivery");
     onMindEvent("mind-b", "text");
     await wait();
 


### PR DESCRIPTION
## Problem

`gardener` showed as **active** on the dashboard for ~6 hours despite doing nothing. Investigation on the live host confirmed its SDK subprocess was alive but idle (flat CPU, zero turns since its last restart), yet the daemon's `getActiveMinds()` returned `["gardener"]`.

This is **distinct** from the delivery-counter wedged-turn fix (#311) — there were no open turns in the `turns` table. The stuck signal is the in-memory `mind-activity-tracker` that drives the active dot.

## Root cause

The tracker marked a mind active on any non-ignored event and only armed the idle-timeout fallback inside the `done` branch. Two compounding issues:

1. **`session_start` marked the mind active**, but it fires once when the persistent SDK stream opens (at boot, and again after each compaction/resume) — *not* when a turn runs. A mind that restarts into an idle session emits `session_start` with no following turn, so it never emits a matching `done` and stays shown as active forever.
2. Even for a real turn, the only path that armed the idle-timeout fallback was `done`, so a turn that opened but never completed (SDK hang, lost emit) could wedge active indefinitely.

**Why `gardener` specifically:** it edits its own `SOUL.md`/`MEMORY.md` while tending, which triggers frequent identity-reload restarts (127 recorded). Those are self-triggered at the *end* of a work cycle, so it routinely reboots with nothing queued → boots straight into an idle session → wedged. It's not restart frequency (mimsy restarts 3.5× more) — it's that gardener characteristically restarts *into idleness*, and any completed turn in any session would otherwise have cleared the flag.

## Fix

Make "active" mean an **open turn**:

- Stop treating `session_start` as activating (a booted-but-idle mind stays idle). A turn is opened by `delivery` or the mind's own processing events (`text`/`tool_use`/`thinking`/…) and closed by `done`.
- Arm/refresh an inactivity watchdog on every turn event — not just `done` — so a turn that never completes self-heals to idle after `IDLE_TIMEOUT` (5 min) of silence.

`mind_started`/`mind_stopped` (the "mind is up" signal) are separate, so a booted mind still shows as running — just not processing.

## Tests

`test/mind-activity-tracker.test.ts` rewritten to the new semantics: `session_start` asserts **not** active; turns open with `delivery`; wedge/self-heal, post-`done` cleanup, recovery-after-heal, and no-flicker cases covered. 15/15 pass.

## Tradeoff

The watchdog can only flip off a genuinely *open* turn silent for >5 min (e.g. one long tool call); it re-emits active on the next event. `session_start` noise is gone entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)