### PR TITLE
feat: support switching a mind's template on upgrade

### DIFF
--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -224,6 +224,11 @@ export async function setMindTemplateHash(name: string, hash: string) {
   await db.update(minds).set({ template_hash: hash }).where(eq(minds.name, name));
 }
 
+export async function setMindTemplate(name: string, template: string) {
+  const db = await getDb();
+  await db.update(minds).set({ template }).where(eq(minds.name, name));
+}
+
 export async function findMind(name: string): Promise<MindEntry | undefined> {
   const db = await getDb();
   const rows = await db.select().from(minds).where(eq(minds.name, name));

--- a/packages/daemon/src/lib/template/template.ts
+++ b/packages/daemon/src/lib/template/template.ts
@@ -152,6 +152,62 @@ export function applyInitFiles(destDir: string) {
   rmSync(initDir, { recursive: true, force: true });
 }
 
+/** Per-runtime mechanics doc filename by template. */
+const MECHANICS_DOCS: Record<string, string> = {
+  claude: "CLAUDE.md",
+  pi: "MINDS.md",
+  codex: "AGENTS.md",
+};
+
+/** Whether `template` is a known built-in template. */
+export function isKnownTemplate(template: string): boolean {
+  return template in MECHANICS_DOCS;
+}
+
+/**
+ * Swap the template-owned files under home/ (mechanics doc, .claude/settings.json,
+ * and .config/config.json) to match a different template. Used when a mind switches
+ * templates (e.g. claude → pi) during upgrade: these files are written at creation
+ * time and excluded from the template branch (updateTemplateBranch strips all of
+ * home/ except VOLUTE.md), so the normal upgrade merge never updates them.
+ * Leaves mind-authored files (SOUL.md, MEMORY.md, memory/, etc.) untouched.
+ */
+export function applyTemplateHomeFiles(homeDir: string, template: string) {
+  const root = findTemplatesRoot();
+
+  // Resolve (and verify) the new mechanics doc before deleting the old one, so a
+  // failure can't leave the mind with no mechanics doc at all.
+  const newDoc = MECHANICS_DOCS[template];
+  const newDocSrc = newDoc ? resolve(root, template, ".init", newDoc) : undefined;
+  if (!newDocSrc || !existsSync(newDocSrc)) {
+    throw new Error(`No mechanics doc for template "${template}"`);
+  }
+
+  // Mechanics doc: remove any existing one, then write the target's.
+  for (const doc of Object.values(MECHANICS_DOCS)) {
+    rmSync(resolve(homeDir, doc), { force: true });
+  }
+  cpSync(newDocSrc, resolve(homeDir, newDoc));
+
+  // .claude/settings.json is claude-only.
+  const settingsDest = resolve(homeDir, ".claude", "settings.json");
+  if (template === "claude") {
+    mkdirSync(dirname(settingsDest), { recursive: true });
+    cpSync(resolve(root, "claude", ".init", ".claude", "settings.json"), settingsDest);
+  } else {
+    rmSync(settingsDest, { force: true });
+  }
+
+  // config.json: regenerate from the target's tmpl (template-specific overrides _base).
+  const templateConfig = resolve(root, template, "home", ".config", "config.json.tmpl");
+  const configTmpl = existsSync(templateConfig)
+    ? templateConfig
+    : resolve(root, "_base", "home", ".config", "config.json.tmpl");
+  const configDest = resolve(homeDir, ".config", "config.json");
+  mkdirSync(dirname(configDest), { recursive: true });
+  writeFileSync(configDest, readFileSync(configTmpl, "utf-8"));
+}
+
 /**
  * List all files in a directory recursively (relative paths).
  */

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -88,6 +88,7 @@ import {
   readRegistry,
   removeMind,
   setMindStage,
+  setMindTemplate,
   setMindTemplateHash,
   stateDir,
   validateMindName,
@@ -113,9 +114,11 @@ import {
 } from "../../lib/template/import-utils.js";
 import {
   applyInitFiles,
+  applyTemplateHomeFiles,
   composeTemplate,
   copyTemplateToDir,
   findTemplatesRoot,
+  isKnownTemplate,
   listFiles,
   type TemplateManifest,
 } from "../../lib/template/template.js";
@@ -379,7 +382,9 @@ async function mergeUpgradeAndRestart(
   upgradeVariantName: string,
   upgradeBranch: string,
   template: string,
+  oldTemplate: string,
 ): Promise<{ ok: true; warning?: string }> {
+  const templateChanged = template !== oldTemplate;
   // Auto-commit any uncommitted changes in main worktree
   const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: dir })).trim();
   if (mainStatus) {
@@ -401,10 +406,42 @@ async function mergeUpgradeAndRestart(
     // branch may already be deleted by cleanupVariant
   }
 
+  // On an actual template switch, swap the template-owned home/ files (mechanics
+  // doc, .claude/settings.json, config.json) which the merge never touches. This
+  // must succeed *before* the DB template field is advanced: that field drives
+  // credential injection at spawn (mind-manager), so it has to stay consistent
+  // with the on-disk config. On failure, leave the field at oldTemplate and
+  // surface the failure rather than reporting a clean success.
+  let switchWarning: string | undefined;
+  if (templateChanged) {
+    try {
+      applyTemplateHomeFiles(resolve(dir, "home"), template);
+      await gitExec(["add", "home/"], { cwd: dir });
+      try {
+        await gitExec(["diff", "--cached", "--quiet"], { cwd: dir });
+      } catch {
+        await gitExec(["commit", "-m", `swap template-owned home files for ${template}`], {
+          cwd: dir,
+        });
+      }
+      chownMindDir(dir, mindName);
+      switchWarning = `Switched ${oldTemplate}→${template}: config reset to ${template} defaults, mechanics doc replaced, conversation starts fresh (sessions aren't portable across runtimes).`;
+    } catch (err) {
+      log.warn(`failed to swap template home files for ${mindName}`, log.errorData(err));
+      return {
+        ok: true,
+        warning: `Upgrade merged but template switch ${oldTemplate}→${template} failed: ${err instanceof Error ? err.message : String(err)}. The mind is still registered as ${oldTemplate}; re-run the switch or fix home/ manually.`,
+      };
+    }
+  }
+
+  // Persist the template field only after any switch swap succeeded, so the DB
+  // stays consistent with the on-disk template files.
   try {
     await setMindTemplateHash(mindName, computeTemplateHash(template));
+    await setMindTemplate(mindName, template);
   } catch (err) {
-    log.warn(`failed to update template hash for ${mindName}`, log.errorData(err));
+    log.warn(`failed to update template for ${mindName}`, log.errorData(err));
   }
 
   try {
@@ -432,7 +469,7 @@ async function mergeUpgradeAndRestart(
     };
   }
 
-  return { ok: true };
+  return { ok: true, warning: switchWarning };
 }
 
 /** Import a mind from a .volute archive (extracted to tempDir by CLI). */
@@ -1786,7 +1823,14 @@ const app = new Hono<AuthEnv>()
       // Empty body is fine
     }
 
-    const template = body.template ?? entry.template ?? "claude";
+    const oldTemplate = entry.template ?? "claude";
+    const template = body.template ?? oldTemplate;
+    // `template` is request-controllable and flows into fs paths, composeTemplate
+    // (which process.exit()s on an unknown template), and the registry — validate
+    // against the known set before any of that.
+    if (!isKnownTemplate(template)) {
+      return c.json({ error: `Unknown template: ${template}` }, 400);
+    }
     const UPGRADE_BRANCH = "upgrade";
     const upgradeVariantName = `${mindName}-upgrade`;
     const worktreeDir = resolve(dir, ".variants", UPGRADE_BRANCH);
@@ -1880,6 +1924,7 @@ const app = new Hono<AuthEnv>()
           upgradeVariantName,
           UPGRADE_BRANCH,
           template,
+          oldTemplate,
         );
         return c.json(result);
       } catch (err) {
@@ -2050,6 +2095,7 @@ const app = new Hono<AuthEnv>()
         upgradeVariantName,
         UPGRADE_BRANCH,
         template,
+        oldTemplate,
       );
       return c.json(result);
     } catch (err) {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -425,6 +425,23 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.ok(text.includes("hello from integration test"), `Message text: ${text}`);
   });
 
+  it("upgrade: rejects an unknown template with 400", async () => {
+    await ensureTestMind();
+
+    const res = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ template: "../../evil" }),
+    });
+    assert.equal(res.status, 400, `Expected 400, got ${res.status} ${await res.clone().text()}`);
+    const body = (await res.json()) as { error?: string };
+    assert.match(body.error ?? "", /unknown template/i);
+
+    // The bogus value must not have been written to the registry.
+    const entry = await findMind(TEST_MIND);
+    assert.notEqual(entry?.template, "../../evil");
+  });
+
   it("unified chat: send via /api/v1/chat", async () => {
     // Create a conversation first
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -13,6 +13,7 @@ import {
   readRegistry,
   removeMind,
   setMindRunning,
+  setMindTemplate,
   stateDir,
   validateMindName,
   voluteHome,
@@ -90,6 +91,13 @@ describe("registry", () => {
     assert.equal((await findMind(testMind))!.running, true);
     await setMindRunning(testMind, false);
     assert.equal((await findMind(testMind))!.running, false);
+  });
+
+  it("setMindTemplate updates the template field", async () => {
+    await addMind(testMind, 4100, undefined, "claude");
+    assert.equal((await findMind(testMind))!.template, "claude");
+    await setMindTemplate(testMind, "pi");
+    assert.equal((await findMind(testMind))!.template, "pi");
   });
 
   it("removeMind deletes entry", async () => {

--- a/test/template-home-files.test.ts
+++ b/test/template-home-files.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  applyTemplateHomeFiles,
+  isKnownTemplate,
+} from "../packages/daemon/src/lib/template/template.js";
+
+describe("applyTemplateHomeFiles", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = resolve(tmpdir(), `volute-home-test-${process.pid}-${Date.now()}`);
+    // Seed a claude-shaped home/.
+    mkdirSync(resolve(homeDir, ".claude"), { recursive: true });
+    mkdirSync(resolve(homeDir, ".config"), { recursive: true });
+    writeFileSync(resolve(homeDir, "CLAUDE.md"), "old claude mechanics");
+    writeFileSync(resolve(homeDir, ".claude", "settings.json"), "{}");
+    writeFileSync(
+      resolve(homeDir, ".config", "config.json"),
+      JSON.stringify({ model: "claude-opus-4-6" }),
+    );
+    // Mind-authored files that must survive (including siblings of config.json).
+    writeFileSync(resolve(homeDir, "SOUL.md"), "my soul");
+    writeFileSync(resolve(homeDir, "MEMORY.md"), "my memory");
+    writeFileSync(resolve(homeDir, ".config", "volute.json"), '{"identity":"keep"}');
+    mkdirSync(resolve(homeDir, "memory", "journal"), { recursive: true });
+    writeFileSync(resolve(homeDir, "memory", "journal", "2026-01-01.md"), "day one");
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("swaps claude → pi: replaces mechanics doc, drops settings, resets model", () => {
+    applyTemplateHomeFiles(homeDir, "pi");
+
+    assert.ok(!existsSync(resolve(homeDir, "CLAUDE.md")), "CLAUDE.md removed");
+    assert.ok(existsSync(resolve(homeDir, "MINDS.md")), "MINDS.md added");
+    assert.ok(!existsSync(resolve(homeDir, "AGENTS.md")));
+    assert.ok(
+      !existsSync(resolve(homeDir, ".claude", "settings.json")),
+      ".claude/settings.json removed",
+    );
+
+    const cfg = JSON.parse(readFileSync(resolve(homeDir, ".config", "config.json"), "utf-8"));
+    assert.notEqual(cfg.model, "claude-opus-4-6");
+    assert.ok(String(cfg.model).startsWith("openrouter:"), `pi model, got ${cfg.model}`);
+
+    // Mind-authored files untouched — including config.json's siblings.
+    assert.equal(readFileSync(resolve(homeDir, "SOUL.md"), "utf-8"), "my soul");
+    assert.equal(readFileSync(resolve(homeDir, "MEMORY.md"), "utf-8"), "my memory");
+    assert.equal(
+      readFileSync(resolve(homeDir, ".config", "volute.json"), "utf-8"),
+      '{"identity":"keep"}',
+    );
+    assert.equal(
+      readFileSync(resolve(homeDir, "memory", "journal", "2026-01-01.md"), "utf-8"),
+      "day one",
+    );
+  });
+
+  it("swaps claude → codex: adds AGENTS.md and codex config", () => {
+    applyTemplateHomeFiles(homeDir, "codex");
+
+    assert.ok(!existsSync(resolve(homeDir, "CLAUDE.md")));
+    assert.ok(existsSync(resolve(homeDir, "AGENTS.md")), "AGENTS.md added");
+    assert.ok(!existsSync(resolve(homeDir, ".claude", "settings.json")));
+
+    const cfg = JSON.parse(readFileSync(resolve(homeDir, ".config", "config.json"), "utf-8"));
+    assert.ok("reasoningEffort" in cfg, "codex config has reasoningEffort");
+    assert.ok(String(cfg.model).startsWith("gpt"), `codex model, got ${cfg.model}`);
+  });
+
+  it("swaps pi → claude: restores CLAUDE.md, settings, claude model", () => {
+    // Start from a pi-shaped home.
+    applyTemplateHomeFiles(homeDir, "pi");
+    assert.ok(existsSync(resolve(homeDir, "MINDS.md")));
+
+    applyTemplateHomeFiles(homeDir, "claude");
+
+    assert.ok(existsSync(resolve(homeDir, "CLAUDE.md")), "CLAUDE.md restored");
+    assert.ok(!existsSync(resolve(homeDir, "MINDS.md")), "MINDS.md removed");
+    assert.ok(
+      existsSync(resolve(homeDir, ".claude", "settings.json")),
+      ".claude/settings.json restored",
+    );
+
+    const cfg = JSON.parse(readFileSync(resolve(homeDir, ".config", "config.json"), "utf-8"));
+    assert.ok(String(cfg.model).startsWith("claude"), `claude model, got ${cfg.model}`);
+  });
+
+  it("throws on an unknown template without deleting the existing mechanics doc", () => {
+    assert.throws(() => applyTemplateHomeFiles(homeDir, "bogus"), /mechanics doc/i);
+    // Atomicity: the destructive swap must not have started.
+    assert.ok(existsSync(resolve(homeDir, "CLAUDE.md")), "CLAUDE.md preserved on failure");
+  });
+});
+
+describe("isKnownTemplate", () => {
+  it("accepts built-in templates and rejects others", () => {
+    assert.ok(isKnownTemplate("claude"));
+    assert.ok(isKnownTemplate("pi"));
+    assert.ok(isKnownTemplate("codex"));
+    assert.ok(!isKnownTemplate("bogus"));
+    assert.ok(!isKnownTemplate("../../evil"));
+  });
+});


### PR DESCRIPTION
## Summary

Makes `volute mind upgrade <name> --template <target>` a clean cross-template migration (e.g. `claude` → `pi`/`codex`). The `--template` flag already existed and re-composed the mind's infrastructure via a git merge, but left the mind in a broken, inconsistent state. This PR fixes the three things that broke a switched mind.

### Problems fixed

1. **Stale `template` DB field.** `mergeUpgradeAndRestart` only updated `template_hash`, never the `template` column. That field drives credential injection and sandbox policy at spawn (`mind-manager.ts`), so after a `claude→pi` switch the mind still got Anthropic creds + sandbox wrapping → auth failure. A later plain upgrade also reverted infra to the old template.
2. **Wrong template-owned `home/` files.** The per-runtime mechanics doc (`CLAUDE.md`/`MINDS.md`/`AGENTS.md`), `.claude/settings.json`, and `.config/config.json` are written only at creation and stripped from the template branch, so a switch kept the old doc and a model invalid for the new runtime.
3. **Sessions.** Cross-runtime session conversion is impossible (opaque, incompatible SDK identifiers in separate dirs), so a switch necessarily starts a fresh session — handled naturally, with a warning surfaced to the user.

### Changes

- Add `setMindTemplate()` and persist it (with the hash) in `mergeUpgradeAndRestart`, **only after** any on-disk swap succeeds, so the DB stays consistent with the on-disk config that credential injection reads.
- Add `applyTemplateHomeFiles()` to swap the mechanics doc, fix `.claude/settings.json`, and regenerate `config.json` from the target template on an actual switch. It verifies the new mechanics doc exists **before** deleting the old one, so a failure can't leave the mind doc-less.
- Validate `template` against the known set (`isKnownTemplate`) in the upgrade route — it's request-controllable and flows into fs paths, `composeTemplate` (which `process.exit()`s on unknown), and the registry; unvalidated input was a daemon-DoS / registry-poisoning vector.
- Surface a switch failure as a warning instead of reporting clean success (consistent with the existing npm-install/restart failure handling).

### Testing

- New unit tests for `setMindTemplate`, `isKnownTemplate`, and `applyTemplateHomeFiles` (claude→pi, claude→codex, pi→claude, mind-authored-file survival, atomicity on failure).
- New daemon-e2e test asserting the upgrade route rejects an unknown/traversal template with `400` and doesn't persist it.
- Full unit suite green (1601 tests); typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)