### PR TITLE
fix: keep pages extension loadable in bundled builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "discord.js": "^14.26.4",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.26",
+        "isomorphic-dompurify": "^2.36.0",
         "libsql": "^0.5.29",
         "replicate": "^1.4.0",
         "telegraf": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "discord.js": "^14.26.4",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.26",
+    "isomorphic-dompurify": "^2.36.0",
     "libsql": "^0.5.29",
     "replicate": "^1.4.0",
     "telegraf": "^4.16.3",

--- a/test/extension-bundle.test.ts
+++ b/test/extension-bundle.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { build, type Options } from "tsup";
+import tsupConfig from "../tsup.config.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Built-in extensions are bundled by tsup into ESM chunks and loaded at runtime
+ * via `discoverBuiltinExtensions`. If a dependency breaks under tsup's ESM
+ * bundling (e.g. jsdom's dynamic `require("path")`, pulled in by
+ * isomorphic-dompurify), the chunk throws on import and the extension is
+ * *silently* dropped — invisible in dev (which runs the TS source via tsx) but
+ * broken in every published build.
+ *
+ * This test builds the real bundle and imports each built-in extension chunk to
+ * prove they all load. It uses the actual `tsup.config` so a missing `external`
+ * entry is caught.
+ */
+test("built-in extensions load from the tsup bundle", async () => {
+  // Build inside the repo so external bare imports (isomorphic-dompurify) still
+  // resolve from the repo's node_modules.
+  const outDir = mkdtempSync(resolve(repoRoot, ".bundle-test-"));
+  try {
+    const jsConfig = (Array.isArray(tsupConfig) ? tsupConfig[0] : tsupConfig) as Options;
+    await build({ ...jsConfig, outDir, dts: false, silent: true, clean: true });
+
+    // Find the compiled discoverBuiltinExtensions and the chunks it imports.
+    const files = readdirSync(outDir).filter((f) => f.endsWith(".js"));
+    let specifiers: string[] | null = null;
+    for (const f of files) {
+      const src = readFileSync(resolve(outDir, f), "utf-8");
+      const start = src.indexOf("async function discoverBuiltinExtensions");
+      if (start === -1) continue;
+      const rest = src.slice(start);
+      const end = rest.indexOf("async function discoverInstalledExtensions");
+      const region = end === -1 ? rest : rest.slice(0, end);
+      specifiers = [...region.matchAll(/import\("(\.\/[^"]+)"\)/g)].map((m) => m[1]);
+      break;
+    }
+
+    assert.ok(specifiers, "could not locate discoverBuiltinExtensions in the bundle");
+    assert.equal(specifiers.length, 3, "expected 3 built-in extension chunk imports");
+
+    const ids = new Set<string>();
+    for (const spec of specifiers) {
+      const mod = await import(pathToFileURL(resolve(outDir, spec)).href);
+      const manifest = mod.default ?? mod;
+      assert.ok(manifest?.id, `bundle chunk ${spec} did not export an extension manifest`);
+      ids.add(manifest.id);
+    }
+
+    assert.deepEqual([...ids].sort(), ["notes", "pages", "plan"]);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,6 +17,11 @@ export default defineConfig([
     external: [
       "libsql",
       "sharp",
+      // Pulls in jsdom, which does a dynamic require("path") at load time.
+      // tsup's ESM __require shim can't satisfy that, so bundling it makes the
+      // pages extension throw "Dynamic require of \"path\" is not supported" and
+      // silently fail to load. Keep it external and installed at runtime.
+      "isomorphic-dompurify",
       "@earendil-works/pi-ai",
       "@earendil-works/pi-coding-agent",
       "@anthropic-ai/claude-agent-sdk",


### PR DESCRIPTION
## Problem

After updating to the latest release, the **pages** built-in extension disappeared from the web UI, mind tabs, and CLI on installed/published deployments — while local dev was unaffected.

## Root cause

Pages imports `isomorphic-dompurify` (added in #308 for server-side HTML sanitization), which pulls in **jsdom**. jsdom does a dynamic `require("path")` at load time, and tsup's ESM `__require` shim throws `Dynamic require of "path" is not supported` when the module is bundled. At startup, `discoverBuiltinExtensions()` catches the error and **silently drops** pages.

tsup auto-externalizes the root package's dependencies — but `isomorphic-dompurify` was only a dependency of the `@volute/pages` workspace, not of the root `volute` package. So tsup bundled it (and jsdom, bloating the pages chunk to ~9.7 MB) and the daemon crashed on load. Dev runs the TypeScript source via `tsx`, where Node's real loader handles jsdom fine — which is why it only broke on installed copies.

Confirmed on a live deployment: `GET /api/extensions` returned only `notes` and `plan`, and importing the bundled pages chunk reproduced the exact jsdom error.

## Fix

- Add `isomorphic-dompurify` to the root `package.json` dependencies so tsup externalizes it and npm installs it alongside the package (also listed in tsup's explicit `external` array for documentation, matching existing entries). Pages chunk drops from ~9.7 MB to ~87 KB.
- Add a regression test that builds the real tsup bundle and imports each built-in extension chunk. It fails with `Dynamic require of "path" is not supported` when the fix is reverted, and passes with it in place.

## Verification

- Rebuilt bundle: all three built-in chunks import cleanly; `DOMPurify.sanitize` still strips `onerror`/`<script>` at runtime.
- 77 existing pages tests pass; new bundle regression test passes (and fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)