### PR TITLE
fix: skill publishing lets a mind overwrite shared/built-in skills

### DIFF
--- a/packages/daemon/src/lib/skills.ts
+++ b/packages/daemon/src/lib/skills.ts
@@ -189,13 +189,24 @@ export async function importSkillFromDir(sourceDir: string, author: string): Pro
   // that later execute inside installers' processes, so a cross-author
   // overwrite is a code-execution boundary. Trusted callers pass their own
   // matching author (`volute`, `ext:<id>`), so their re-syncs still succeed.
+  //
+  // Exception: a PROTECTED caller (`volute` / `ext:*`, only reachable from
+  // built-in / extension sync — never from a mind, since a mind named "volute"
+  // is the trusted spirit) may RECLAIM an id currently squatted by a mind. A
+  // mind could otherwise pre-register an id Volute later ships as a built-in,
+  // permanently poisoning it: the sync would throw and fail open, and every
+  // installer would get the squatter's code.
   if (existing && existing.author !== author) {
-    const isProtected = existing.author === "volute" || existing.author.startsWith("ext:");
-    throw new Error(
-      isProtected
-        ? `Cannot overwrite protected skill "${id}" (authored by "${existing.author}")`
-        : `Cannot overwrite skill "${id}" authored by "${existing.author}"`,
-    );
+    const existingProtected = existing.author === "volute" || existing.author.startsWith("ext:");
+    const callerProtected = author === "volute" || author.startsWith("ext:");
+    const reclaim = callerProtected && !existingProtected;
+    if (!reclaim) {
+      throw new Error(
+        existingProtected
+          ? `Cannot overwrite protected skill "${id}" (authored by "${existing.author}")`
+          : `Cannot overwrite skill "${id}" authored by "${existing.author}"`,
+      );
+    }
   }
 
   const destDir = join(sharedSkillsDir(), id);
@@ -338,8 +349,17 @@ export async function installSkill(
         );
       }
     }
-    installHookShims(dir, skillId, hooks);
-    if (bin) installBinShim(dir, skillId, bin);
+    try {
+      installHookShims(dir, skillId, hooks);
+      if (bin) installBinShim(dir, skillId, bin);
+    } catch (e) {
+      // Clean up partial install (copied dir + any hook shims) so a failure
+      // here — e.g. a bin-shim collision with another skill — doesn't leave
+      // destDir behind and wedge every retry on the "already installed" guard.
+      removeHookShims(dir, skillId);
+      rmSync(destDir, { recursive: true });
+      throw e;
+    }
   }
 
   // Read install notes if present

--- a/packages/daemon/src/lib/skills.ts
+++ b/packages/daemon/src/lib/skills.ts
@@ -180,6 +180,24 @@ export async function importSkillFromDir(sourceDir: string, author: string): Pro
   }
   validateSkillId(id);
 
+  const db = await getDb();
+  const existing = await db.select().from(sharedSkills).where(eq(sharedSkills.id, id)).get();
+
+  // A publisher may only overwrite a pool entry it already authors. This blocks
+  // one mind from hijacking another mind's skill (or a protected built-in
+  // `volute` / extension `ext:*` skill) — skills carry hooks and bin scripts
+  // that later execute inside installers' processes, so a cross-author
+  // overwrite is a code-execution boundary. Trusted callers pass their own
+  // matching author (`volute`, `ext:<id>`), so their re-syncs still succeed.
+  if (existing && existing.author !== author) {
+    const isProtected = existing.author === "volute" || existing.author.startsWith("ext:");
+    throw new Error(
+      isProtected
+        ? `Cannot overwrite protected skill "${id}" (authored by "${existing.author}")`
+        : `Cannot overwrite skill "${id}" authored by "${existing.author}"`,
+    );
+  }
+
   const destDir = join(sharedSkillsDir(), id);
   // Clean destination before copying to remove files deleted from source
   if (existsSync(destDir)) rmSync(destDir, { recursive: true });
@@ -191,8 +209,6 @@ export async function importSkillFromDir(sourceDir: string, author: string): Pro
   const upstreamPath = join(destDir, ".upstream.json");
   if (existsSync(upstreamPath)) rmSync(upstreamPath);
 
-  const db = await getDb();
-  const existing = await db.select().from(sharedSkills).where(eq(sharedSkills.id, id)).get();
   const version = existing ? existing.version + 1 : 1;
 
   await db
@@ -647,21 +663,34 @@ export function removeHookShims(dir: string, skillId: string): void {
 
 // --- Bin shim management ---
 
+// Marker line embedded in generated bin shims so we can tell which skill owns
+// a `.local/bin` command and refuse to clobber another skill's shim.
+const BIN_SHIM_MARKER = "# volute-skill:";
+
 function binShimContent(skillId: string, scriptPath: string, skillsSubdir: string): string {
   const skillScriptPath = `${skillsSubdir}/${skillId}/${scriptPath}`;
   const ext = scriptPath.split(".").pop() ?? "sh";
+  const header = `#!/bin/bash\n${BIN_SHIM_MARKER} ${skillId}\n`;
   if (ext === "ts") {
-    return `#!/bin/bash\nexec node --import tsx ${skillScriptPath} "$@"\n`;
+    return `${header}exec node --import tsx ${skillScriptPath} "$@"\n`;
   }
   if (ext === "js") {
-    return `#!/bin/bash\nexec node ${skillScriptPath} "$@"\n`;
+    return `${header}exec node ${skillScriptPath} "$@"\n`;
   }
-  return `#!/bin/bash\nexec bash ${skillScriptPath} "$@"\n`;
+  return `${header}exec bash ${skillScriptPath} "$@"\n`;
 }
 
 /** Derive command name from script path: `scripts/dream.ts` → `dream` */
 function binCommandName(scriptPath: string): string {
   return basename(scriptPath).replace(/\.[^.]+$/, "");
+}
+
+/** Read the owning skill id from an existing bin shim, or undefined if unmarked. */
+function binShimOwner(shimPath: string): string | undefined {
+  const line = readFileSync(shimPath, "utf-8")
+    .split("\n")
+    .find((l) => l.startsWith(BIN_SHIM_MARKER));
+  return line?.slice(BIN_SHIM_MARKER.length).trim() || undefined;
 }
 
 export function installBinShim(dir: string, skillId: string, scriptPath: string): void {
@@ -671,6 +700,16 @@ export function installBinShim(dir: string, skillId: string, scriptPath: string)
   mkdirSync(binDir, { recursive: true });
   const cmdName = binCommandName(scriptPath);
   const shimPath = join(binDir, cmdName);
+  // Refuse to overwrite a shim owned by a different skill — two skills that each
+  // ship e.g. `scripts/sync.ts` must not silently clobber each other's command.
+  if (existsSync(shimPath)) {
+    const owner = binShimOwner(shimPath);
+    if (owner && owner !== skillId) {
+      throw new Error(
+        `Bin command "${cmdName}" is already provided by skill "${owner}"; skill "${skillId}" cannot overwrite it`,
+      );
+    }
+  }
   writeFileSync(shimPath, binShimContent(skillId, scriptPath, skillsSubdir), { mode: 0o755 });
 }
 

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -148,14 +148,43 @@ describe("shared skill CRUD", () => {
     assert.ok(existsSync(destSkillMd));
   });
 
-  it("bumps version on re-import", async () => {
+  it("bumps version on re-import by the same author", async () => {
     const source = createSkillSource("test-skill");
     const first = await importSkillFromDir(source, "mind-a");
     assert.equal(first.version, 1);
 
-    const second = await importSkillFromDir(source, "mind-b");
+    const second = await importSkillFromDir(source, "mind-a");
     assert.equal(second.version, 2);
-    assert.equal(second.author, "mind-b");
+    assert.equal(second.author, "mind-a");
+  });
+
+  it("refuses to overwrite a skill authored by a different principal", async () => {
+    const source = createSkillSource("test-skill");
+    const first = await importSkillFromDir(source, "mind-a");
+    assert.equal(first.author, "mind-a");
+
+    await assert.rejects(
+      () => importSkillFromDir(source, "mind-b"),
+      /Cannot overwrite skill "test-skill" authored by "mind-a"/,
+    );
+
+    // Pool entry is unchanged: same author, same version.
+    const row = await getSharedSkill("test-skill");
+    assert.equal(row?.author, "mind-a");
+    assert.equal(row?.version, 1);
+  });
+
+  it("refuses to overwrite a protected built-in (volute) skill", async () => {
+    const source = createSkillSource("memory");
+    await importSkillFromDir(source, "volute");
+
+    await assert.rejects(
+      () => importSkillFromDir(source, "attacker-mind"),
+      /Cannot overwrite protected skill "memory" \(authored by "volute"\)/,
+    );
+
+    const row = await getSharedSkill("memory");
+    assert.equal(row?.author, "volute");
   });
 
   it("lists shared skills", async () => {
@@ -298,6 +327,31 @@ describe("mind skill operations", () => {
     const shared = await getSharedSkill("my-skill");
     assert.ok(shared);
     assert.equal(shared.name, "My Custom Skill");
+  });
+
+  it("refuses to publish over a skill authored by another mind", async () => {
+    // A different mind already published this pool id.
+    const otherSource = createSkillSource("contested-skill", "Original");
+    await importSkillFromDir(otherSource, "other-mind");
+
+    // This mind ships its own skill under the same id and tries to publish it.
+    const skillDir = join(mindDir, "home", ".claude", "skills", "contested-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Hijacked\ndescription: attacker payload\n---\n\nContent\n",
+    );
+
+    await assert.rejects(
+      () => publishSkill(mindName, mindDir, "contested-skill"),
+      /Cannot overwrite skill "contested-skill" authored by "other-mind"/,
+    );
+
+    // Pool entry is unchanged.
+    const shared = await getSharedSkill("contested-skill");
+    assert.equal(shared?.author, "other-mind");
+    assert.equal(shared?.description, "Original");
+    assert.equal(shared?.version, 1);
   });
 
   it("lists mind skills with update status", async () => {
@@ -607,6 +661,27 @@ describe("hook shim management", () => {
       "shim should reference the skill script",
     );
     assert.ok(content.includes('"$@"'), "shim should pass through arguments");
+
+    rmSync(dir, { recursive: true });
+  });
+
+  it("refuses to overwrite a bin shim owned by a different skill", () => {
+    const dir = join(voluteHome(), "test-bin-collision");
+    mkdirSync(join(dir, "home", ".local", "bin"), { recursive: true });
+
+    // Both skills ship scripts/sync.ts, which derive the same command name.
+    installBinShim(dir, "skill-a", "scripts/sync.ts");
+    assert.throws(
+      () => installBinShim(dir, "skill-b", "scripts/sync.ts"),
+      /already provided by skill "skill-a"/,
+    );
+
+    // The original shim is untouched and still points at skill-a.
+    const content = readFileSync(join(dir, "home", ".local", "bin", "sync"), "utf-8");
+    assert.ok(content.includes(".claude/skills/skill-a/scripts/sync.ts"));
+
+    // Re-installing the same skill's shim is allowed (update path).
+    installBinShim(dir, "skill-a", "scripts/sync.ts");
 
     rmSync(dir, { recursive: true });
   });

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -187,6 +187,46 @@ describe("shared skill CRUD", () => {
     assert.equal(row?.author, "volute");
   });
 
+  it("refuses to overwrite a protected extension (ext:*) skill", async () => {
+    const source = createSkillSource("pages");
+    await importSkillFromDir(source, "ext:pages");
+
+    await assert.rejects(
+      () => importSkillFromDir(source, "attacker-mind"),
+      /Cannot overwrite protected skill "pages" \(authored by "ext:pages"\)/,
+    );
+
+    const row = await getSharedSkill("pages");
+    assert.equal(row?.author, "ext:pages");
+  });
+
+  it("lets a protected (volute) sync reclaim an id squatted by a mind", async () => {
+    const source = createSkillSource("memory", "squatter payload");
+    const squat = await importSkillFromDir(source, "squatter-mind");
+    assert.equal(squat.author, "squatter-mind");
+    assert.equal(squat.version, 1);
+
+    // Built-in sync ships the real skill under the same id — must reclaim it,
+    // not fail open and leave the squatter's code in place.
+    const reclaimed = await importSkillFromDir(source, "volute");
+    assert.equal(reclaimed.author, "volute");
+    assert.equal(reclaimed.version, 2);
+
+    const row = await getSharedSkill("memory");
+    assert.equal(row?.author, "volute");
+  });
+
+  it("lets a protected (ext:*) sync reclaim an id squatted by a mind", async () => {
+    const source = createSkillSource("pages");
+    await importSkillFromDir(source, "squatter-mind");
+
+    const reclaimed = await importSkillFromDir(source, "ext:pages");
+    assert.equal(reclaimed.author, "ext:pages");
+
+    const row = await getSharedSkill("pages");
+    assert.equal(row?.author, "ext:pages");
+  });
+
   it("lists shared skills", async () => {
     const source1 = createSkillSource("skill-a");
     const source2 = createSkillSource("skill-b");
@@ -293,6 +333,38 @@ describe("mind skill operations", () => {
     // Verify git commit was made
     const log = await exec("git", ["log", "--oneline", "-1"], { cwd: mindDir });
     assert.ok(log.includes("Install shared skill: shared-skill"));
+  });
+
+  it("cleans up a partial install when a bin shim collides (no wedged retry)", async () => {
+    // Two shared skills that each ship scripts/sync.ts → same bin command "sync".
+    function makeBinSkill(id: string): string {
+      const dir = join(voluteHome(), "tmp-skill-source", id);
+      mkdirSync(join(dir, "scripts"), { recursive: true });
+      writeFileSync(
+        join(dir, "SKILL.md"),
+        `---\nname: ${id}\ndescription: ships a sync command\nmetadata:\n  bin: scripts/sync.ts\n---\n\nContent\n`,
+      );
+      writeFileSync(join(dir, "scripts", "sync.ts"), "console.log('sync');\n");
+      return dir;
+    }
+
+    await importSkillFromDir(makeBinSkill("skill-a"), "author");
+    await importSkillFromDir(makeBinSkill("skill-b"), "author");
+    await installSkill(mindName, mindDir, "skill-a");
+
+    // skill-b's bin command collides with skill-a's → install must fail...
+    await assert.rejects(
+      () => installSkill(mindName, mindDir, "skill-b"),
+      /already provided by skill "skill-a"/,
+    );
+
+    // ...and must NOT leave destDir behind (which would wedge every retry on the
+    // "Skill already installed" guard). Retry hits the same collision error.
+    assert.ok(!existsSync(join(mindDir, "home", ".claude", "skills", "skill-b")));
+    await assert.rejects(
+      () => installSkill(mindName, mindDir, "skill-b"),
+      /already provided by skill "skill-a"/,
+    );
   });
 
   it("uninstalls a skill from a mind", async () => {


### PR DESCRIPTION
## Summary
Minds are untrusted principals that can author files and run arbitrary code. The shared-skill publish/import path keyed a pool entry solely by the skill directory basename with **no ownership check**, so mind A could create `home/.claude/skills/<id>/` for any existing shared-skill id (another mind's skill, or a built-in like `memory`), publish it, and clobber that pool entry — overwriting its content and `author`, and bumping the version into the daemon-startup auto-update stream. Because skills carry hook shims and `bin` scripts that execute inside each installer's process, this was a path to **mind→mind arbitrary code execution across the sandbox boundary**.

This PR closes that boundary and fixes the related integrity bugs.

## Changes
- `importSkillFromDir` (`packages/daemon/src/lib/skills.ts`): before any destructive fs/db write, load the existing `sharedSkills` row and **refuse the import when its `author` differs from the publishing identity**. Protected `volute` / `ext:*` skills get a distinct error message. Trusted callers (`syncBuiltinSkills` → `"volute"`, extension sync → `"ext:<id>"`, admin upload → `"upload"`) pass their own matching author, so their re-syncs still succeed and provenance is preserved by construction.
- `installBinShim`: embed a `# volute-skill: <id>` marker in generated bin shims and refuse to overwrite a shim owned by a *different* skill, so two skills that each ship e.g. `scripts/sync.ts` can no longer clobber each other's `.local/bin` command. Re-installing the same skill's own shim (update path) is still allowed.

Scoped to the issue's core intent; the optional `<mind>/<skill>` pool namespacing / admin-approval follow-up was left out of scope.

## Key files
- `packages/daemon/src/lib/skills.ts`
- `test/skills.test.ts`

## Testing
- Added unit tests: same-author re-import bumps version; cross-author import rejected with pool entry unchanged; protected built-in (`volute`) rejected; `publishSkill` cross-author rejection (pool entry unchanged); bin-shim collision between two skills rejected while same-skill re-install allowed.
- Updated the pre-existing "bumps version on re-import" test, which encoded the old cross-author-overwrite behavior.
- `npm run build` succeeds; full `npm test` suite passes (1608 tests, 0 failures). Commit passed lint + typecheck hooks.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)