### PR TITLE
fix: sandbox and privileged script execution fail open

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -425,5 +425,8 @@ if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith
     process.env.VOLUTE_SANDBOX = "0";
   }
 
-  startDaemon({ port, hostname, foreground, tailscale });
+  startDaemon({ port, hostname, foreground, tailscale }).catch((err) => {
+    log.error("daemon failed to start", log.errorData(err));
+    process.exit(1);
+  });
 }

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -6,7 +6,14 @@ import { getAiConfig, resolveApiKey } from "../ai-service.js";
 import { sendSystemMessageDirect } from "../chat/system-chat.js";
 import { loadMergedEnv } from "../config/env.js";
 import { chownMindDir, isIsolationEnabled, wrapForIsolation } from "../mind/isolation.js";
-import { findMind, mindDir, setMindRunning, stateDir, voluteSystemDir } from "../mind/registry.js";
+import {
+  findMind,
+  mindDir,
+  mindTmpDir,
+  setMindRunning,
+  stateDir,
+  voluteSystemDir,
+} from "../mind/registry.js";
 import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
 import { getPrompt } from "../prompts.js";
 import { clearJsonMap, loadJsonMap, saveJsonMap } from "../util/json-state.js";
@@ -111,10 +118,15 @@ export class MindManager {
     const logsDir = resolve(mindStateDir, "logs");
     mkdirSync(logsDir, { recursive: true });
 
+    // Per-mind tmp dir so minds never share a writable /tmp (a cross-mind channel).
+    const mindTmp = mindTmpDir(dir);
+    mkdirSync(mindTmp, { recursive: true });
+
     // State dir is created by root — chown so the mind user can write to it.
     if (isIsolationEnabled()) {
       try {
         chownMindDir(mindStateDir, baseName);
+        chownMindDir(mindTmp, baseName);
       } catch (err) {
         throw new Error(
           `Cannot start mind ${name}: failed to set ownership on state directory ${mindStateDir}: ${err instanceof Error ? err.message : err}`,
@@ -136,6 +148,7 @@ export class MindManager {
       VOLUTE_MIND_DIR: dir,
       VOLUTE_MIND_PORT: String(port),
       VOLUTE_DAEMON_TOKEN: mindToken,
+      TMPDIR: mindTmp,
       PATH: `${mindLocalBin}:${currentPath}`,
       // Strip CLAUDECODE so the Agent SDK can spawn Claude Code subprocesses
       CLAUDECODE: undefined,
@@ -309,7 +322,7 @@ export class MindManager {
       [spawnCmd, spawnArgs] = await wrapForSandbox(baseBin, baseArgs, dir, name, [
         dir,
         mindStateDir,
-        "/tmp",
+        mindTmp,
       ]);
     } else {
       spawnCmd = baseBin;

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -1,7 +1,8 @@
 import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { sendSystemMessage } from "../chat/system-chat.js";
-import { mindDir, voluteSystemDir } from "../mind/registry.js";
+import { mindDir, mindTmpDir, voluteSystemDir } from "../mind/registry.js";
+import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
 import { readVoluteConfig, type Schedule, writeVoluteConfig } from "../mind/volute-config.js";
 import { exec } from "../util/exec.js";
 import { clearJsonMap, loadJsonMap, saveJsonMapAsync } from "../util/json-state.js";
@@ -189,7 +190,19 @@ export class Scheduler {
     }
   }
 
-  protected runScript(script: string, cwd: string, mindName: string): Promise<string> {
+  protected async runScript(script: string, cwd: string, mindName: string): Promise<string> {
+    // Mind-authored scripts must never run in the daemon's trust domain. Under
+    // sandbox mode, wrap with the mind's sandbox (exec only applies user
+    // isolation, never the sandbox). Isolation and sandbox modes are mutually
+    // exclusive, so we pass mindName to exec only in the non-sandbox case.
+    if (isSandboxEnabled()) {
+      const dir = this.mindDirs.get(mindName) ?? mindDir(mindName);
+      const [cmd, args] = await wrapForSandbox("bash", ["-c", script], dir, mindName, [
+        dir,
+        mindTmpDir(dir),
+      ]);
+      return exec(cmd, args, { cwd });
+    }
     return exec("bash", ["-c", script], { cwd, mindName });
   }
 

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -265,6 +265,15 @@ export function stateDir(name: string): string {
   return resolve(voluteSystemDir(), "state", name);
 }
 
+/**
+ * Per-mind temp directory (inside the mind's own project dir so it's covered by
+ * the sandbox's allowRead/allowWrite and, under user isolation, chowned to the
+ * mind). Used as the mind's TMPDIR so minds never share a writable /tmp.
+ */
+export function mindTmpDir(dir: string): string {
+  return resolve(dir, ".mind", "tmp");
+}
+
 export async function nextPort(): Promise<number> {
   const db = await getDb();
   const rows = await db.select({ port: minds.port }).from(minds);

--- a/packages/daemon/src/lib/mind/sandbox.ts
+++ b/packages/daemon/src/lib/mind/sandbox.ts
@@ -21,10 +21,30 @@ const slog = log.child("sandbox");
 
 let sandboxManager: SandboxManagerType | null = null;
 
+/** Raised when sandbox isolation is required but unavailable, so callers fail closed. */
+export class SandboxUnavailableError extends Error {
+  constructor(reason: string, cause?: unknown) {
+    super(
+      `${reason} — refusing to run unsandboxed. Fix the sandbox runtime, or set VOLUTE_SANDBOX_OPTIONAL=1 to allow running without isolation.`,
+      cause ? { cause } : undefined,
+    );
+    this.name = "SandboxUnavailableError";
+  }
+}
+
 /** Check if sandbox isolation is enabled via config. */
 export function isSandboxEnabled(): boolean {
   if (process.env.VOLUTE_SANDBOX === "0") return false;
   return readGlobalConfig().setup?.isolation === "sandbox";
+}
+
+/**
+ * Explicit opt-out that lets a sandbox-mode daemon degrade to running minds
+ * WITHOUT isolation when the runtime can't be set up. For local dev only —
+ * never set this on a shared/system install.
+ */
+export function isSandboxOptional(): boolean {
+  return process.env.VOLUTE_SANDBOX_OPTIONAL === "1";
 }
 
 /** Find a ripgrep binary: VOLUTE_RIPGREP_PATH env var, then system PATH. */
@@ -69,10 +89,8 @@ export async function initSandbox(): Promise<void> {
         // macOS sandbox profiles use native glob matching — ripgrep not needed
         slog.warn(`sandbox dependency issues (non-fatal on macOS): ${errors.join(", ")}`);
       } else {
-        slog.error(
-          `sandbox dependencies missing — minds will run without sandbox isolation: ${errors.join(", ")}`,
-        );
-        return;
+        // Fail closed: without these deps the sandbox can't restrict minds.
+        throw new SandboxUnavailableError(`sandbox dependencies missing: ${errors.join(", ")}`);
       }
     }
 
@@ -93,10 +111,26 @@ export async function initSandbox(): Promise<void> {
     await SandboxManager.initialize(config);
     sandboxManager = SandboxManager;
   } catch (err) {
-    slog.error(
-      "sandbox runtime not available — minds will run without sandbox isolation",
-      log.errorData(err),
-    );
+    // A deliberate fail-closed signal — surface it as-is (or degrade if opted out).
+    if (err instanceof SandboxUnavailableError) {
+      if (isSandboxOptional()) {
+        slog.error(
+          "sandbox unavailable but VOLUTE_SANDBOX_OPTIONAL=1 — minds will run WITHOUT isolation",
+          log.errorData(err),
+        );
+        return;
+      }
+      throw err;
+    }
+    // Runtime import/initialize failure.
+    if (isSandboxOptional()) {
+      slog.error(
+        "sandbox runtime not available but VOLUTE_SANDBOX_OPTIONAL=1 — minds will run WITHOUT isolation",
+        log.errorData(err),
+      );
+      return;
+    }
+    throw new SandboxUnavailableError("sandbox runtime not available", err);
   }
 }
 
@@ -152,7 +186,13 @@ export async function wrapForSandbox(
   mindName: string,
   allowWrite?: string[],
 ): Promise<[string, string[]]> {
-  if (!sandboxManager) return [cmd, args];
+  if (!sandboxManager) {
+    // Fail closed unless explicitly opted out or sandbox mode is off entirely.
+    if (isSandboxEnabled() && !isSandboxOptional()) {
+      throw new SandboxUnavailableError(`cannot sandbox mind ${mindName}`);
+    }
+    return [cmd, args];
+  }
 
   const { denyRead, allowRead } = await buildSandboxReadConfig(mindName, mindDir);
   const customConfig: Partial<SandboxRuntimeConfig> = {
@@ -169,6 +209,10 @@ export async function wrapForSandbox(
     const wrapped = await sandboxManager.wrapWithSandbox(shellCmd, undefined, customConfig);
     return ["bash", ["-c", wrapped]];
   } catch (err) {
+    // Fail closed unless explicitly opted out.
+    if (isSandboxEnabled() && !isSandboxOptional()) {
+      throw new SandboxUnavailableError(`failed to sandbox mind ${mindName}`, err);
+    }
     slog.error(
       `failed to sandbox mind ${mindName} — running without isolation`,
       log.errorData(err),

--- a/packages/daemon/src/lib/mind/spawn-server.ts
+++ b/packages/daemon/src/lib/mind/spawn-server.ts
@@ -1,6 +1,9 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { closeSync, mkdirSync, openSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { isIsolationEnabled, wrapForIsolation } from "./isolation.js";
+import { mindTmpDir } from "./registry.js";
+import { isSandboxEnabled, wrapForSandbox } from "./sandbox.js";
 
 type SpawnResult = { child: ChildProcess; actualPort: number } | null;
 
@@ -16,20 +19,33 @@ function tsxBin(cwd: string): string {
  *
  * In attached mode (default): spawns with piped stdio and detects "listening on :PORT" in output.
  * Use this when the parent stays alive (e.g. within another server process).
+ *
+ * When `mindName` is given, the mind-authored server is wrapped with the same
+ * isolation/sandbox as `startMind` so it never runs in the daemon's trust domain
+ * (`template: "codex"` is excluded from sandbox wrapping, matching startMind).
  */
-export function spawnServer(
+export async function spawnServer(
   cwd: string,
   port: number,
-  options?: { detached?: boolean; logDir?: string },
+  options?: { detached?: boolean; logDir?: string; mindName?: string; template?: string },
 ): Promise<SpawnResult> {
-  if (options?.detached) {
-    return spawnDetached(cwd, port, options.logDir);
+  let cmd = tsxBin(cwd);
+  let args = ["src/server.ts", "--port", String(port)];
+  if (options?.mindName) {
+    if (isIsolationEnabled()) {
+      [cmd, args] = await wrapForIsolation(cmd, args, options.mindName);
+    } else if (isSandboxEnabled() && options.template !== "codex") {
+      [cmd, args] = await wrapForSandbox(cmd, args, cwd, options.mindName, [cwd, mindTmpDir(cwd)]);
+    }
   }
-  return spawnAttached(cwd, port);
+  if (options?.detached) {
+    return spawnDetached(cmd, args, cwd, options.logDir);
+  }
+  return spawnAttached(cmd, args, cwd);
 }
 
-function spawnAttached(cwd: string, port: number): Promise<SpawnResult> {
-  const child = spawn(tsxBin(cwd), ["src/server.ts", "--port", String(port)], {
+function spawnAttached(cmd: string, args: string[], cwd: string): Promise<SpawnResult> {
+  const child = spawn(cmd, args, {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -64,13 +80,18 @@ function spawnAttached(cwd: string, port: number): Promise<SpawnResult> {
  * Spawn with stdout/stderr redirected to a log file, then detect the port
  * by reading the log. The child survives parent exit and continues logging.
  */
-function spawnDetached(cwd: string, port: number, logDir?: string): Promise<SpawnResult> {
+function spawnDetached(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  logDir?: string,
+): Promise<SpawnResult> {
   const logsDir = logDir ?? resolve(cwd, ".mind", "logs");
   mkdirSync(logsDir, { recursive: true });
   const logPath = resolve(logsDir, "mind.log");
   const logFd = openSync(logPath, "a");
 
-  const child = spawn(tsxBin(cwd), ["src/server.ts", "--port", String(port)], {
+  const child = spawn(cmd, args, {
     cwd,
     stdio: ["ignore", logFd, logFd],
     detached: true,

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -189,7 +189,11 @@ const app = new Hono<AuthEnv>()
 
     // Verify variant before merge
     if (!body.skipVerify) {
-      const result = await spawnServer(variantEntry.dir, 0, { detached: true });
+      const result = await spawnServer(variantEntry.dir, 0, {
+        detached: true,
+        mindName: variantName,
+        template: variantEntry.template,
+      });
       if (!result) {
         return c.json(
           { error: "Failed to start server for verification. Use skipVerify to skip." },

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -7,6 +7,7 @@ import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
 import {
   buildSandboxReadConfig,
   isSandboxEnabled,
+  SandboxUnavailableError,
   shellEscape,
   wrapForSandbox,
 } from "../packages/daemon/src/lib/mind/sandbox.js";
@@ -146,6 +147,56 @@ describe("shellEscape", () => {
 
 describe("wrapForSandbox passthrough", () => {
   it("returns original command when sandbox is not initialized", async () => {
+    const [cmd, args] = await wrapForSandbox("/usr/bin/tsx", ["server.ts"], "/tmp/mind", "alice");
+    assert.equal(cmd, "/usr/bin/tsx");
+    assert.deepEqual(args, ["server.ts"]);
+  });
+});
+
+describe("wrapForSandbox fail-closed", () => {
+  const origSandbox = process.env.VOLUTE_SANDBOX;
+  const origOptional = process.env.VOLUTE_SANDBOX_OPTIONAL;
+
+  function enableSandboxMode() {
+    delete process.env.VOLUTE_SANDBOX;
+    mkdirSync(voluteSystemDir(), { recursive: true });
+    writeFileSync(configPath(), JSON.stringify({ setup: { isolation: "sandbox" } }));
+    _resetConfigCache();
+  }
+
+  afterEach(() => {
+    _resetConfigCache();
+    try {
+      unlinkSync(configPath());
+    } catch {}
+    if (origSandbox === undefined) delete process.env.VOLUTE_SANDBOX;
+    else process.env.VOLUTE_SANDBOX = origSandbox;
+    if (origOptional === undefined) delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    else process.env.VOLUTE_SANDBOX_OPTIONAL = origOptional;
+  });
+
+  it("throws when sandbox is enabled but unavailable and opt-out is unset", async () => {
+    // In unit tests the sandbox runtime is never initialized, so the manager is
+    // null — this is exactly the "enabled but unavailable" degrade case.
+    enableSandboxMode();
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    await assert.rejects(
+      () => wrapForSandbox("/usr/bin/tsx", ["server.ts"], "/tmp/mind", "alice"),
+      SandboxUnavailableError,
+    );
+  });
+
+  it("passes through when VOLUTE_SANDBOX_OPTIONAL=1", async () => {
+    enableSandboxMode();
+    process.env.VOLUTE_SANDBOX_OPTIONAL = "1";
+    const [cmd, args] = await wrapForSandbox("/usr/bin/tsx", ["server.ts"], "/tmp/mind", "alice");
+    assert.equal(cmd, "/usr/bin/tsx");
+    assert.deepEqual(args, ["server.ts"]);
+  });
+
+  it("passes through when sandbox is disabled", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
     const [cmd, args] = await wrapForSandbox("/usr/bin/tsx", ["server.ts"], "/tmp/mind", "alice");
     assert.equal(cmd, "/usr/bin/tsx");
     assert.deepEqual(args, ["server.ts"]);

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
 import { Scheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
+import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
+import { SandboxUnavailableError } from "../packages/daemon/src/lib/mind/sandbox.js";
 
 type SystemDelivery = {
   mindName: string;
@@ -234,6 +239,60 @@ describe("scheduler", () => {
     });
     assert.equal(scheduler.systemDeliveries.length, 1);
     assert.ok(scheduler.systemDeliveries[0].text.includes("timer fired"));
+  });
+});
+
+describe("scheduler runScript sandboxing", () => {
+  const origSandbox = process.env.VOLUTE_SANDBOX;
+  const origOptional = process.env.VOLUTE_SANDBOX_OPTIONAL;
+
+  function configPath() {
+    return resolve(voluteSystemDir(), "config.json");
+  }
+
+  afterEach(() => {
+    _resetConfigCache();
+    try {
+      unlinkSync(configPath());
+    } catch {}
+    if (origSandbox === undefined) delete process.env.VOLUTE_SANDBOX;
+    else process.env.VOLUTE_SANDBOX = origSandbox;
+    if (origOptional === undefined) delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    else process.env.VOLUTE_SANDBOX_OPTIONAL = origOptional;
+  });
+
+  it("routes scripts through the sandbox in sandbox mode (never bare bash)", async () => {
+    // Enable sandbox mode with no opt-out. The sandbox runtime is not initialized
+    // in unit tests, so a script that went through the sandbox path fails closed
+    // instead of running bare `bash` in the daemon's trust domain.
+    delete process.env.VOLUTE_SANDBOX;
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    mkdirSync(voluteSystemDir(), { recursive: true });
+    writeFileSync(configPath(), JSON.stringify({ setup: { isolation: "sandbox" } }));
+    _resetConfigCache();
+
+    const scheduler = new Scheduler();
+    await assert.rejects(
+      () =>
+        (
+          scheduler as unknown as {
+            runScript: (s: string, cwd: string, m: string) => Promise<string>;
+          }
+        ).runScript("echo hi", "/tmp", "alice"),
+      SandboxUnavailableError,
+    );
+  });
+
+  it("runs scripts directly when sandbox is disabled", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const scheduler = new Scheduler();
+    const out = await (
+      scheduler as unknown as {
+        runScript: (s: string, cwd: string, m: string) => Promise<string>;
+      }
+    ).runScript("echo scheduled-ok", "/tmp", "alice");
+    assert.ok(out.includes("scheduled-ok"));
   });
 });
 

--- a/test/spawn-server.test.ts
+++ b/test/spawn-server.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
+import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
+import { SandboxUnavailableError } from "../packages/daemon/src/lib/mind/sandbox.js";
+import { spawnServer } from "../packages/daemon/src/lib/mind/spawn-server.js";
+
+// The merge-verification path spawns a mind-authored server.ts. It must be
+// wrapped the same way startMind wraps it (sandbox/isolation) so mind code never
+// runs in the daemon's trust domain.
+describe("spawnServer verification wrapping", () => {
+  const origSandbox = process.env.VOLUTE_SANDBOX;
+  const origOptional = process.env.VOLUTE_SANDBOX_OPTIONAL;
+
+  function configPath() {
+    return resolve(voluteSystemDir(), "config.json");
+  }
+
+  function enableSandboxMode() {
+    delete process.env.VOLUTE_SANDBOX;
+    mkdirSync(voluteSystemDir(), { recursive: true });
+    writeFileSync(configPath(), JSON.stringify({ setup: { isolation: "sandbox" } }));
+    _resetConfigCache();
+  }
+
+  afterEach(() => {
+    _resetConfigCache();
+    try {
+      unlinkSync(configPath());
+    } catch {}
+    if (origSandbox === undefined) delete process.env.VOLUTE_SANDBOX;
+    else process.env.VOLUTE_SANDBOX = origSandbox;
+    if (origOptional === undefined) delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    else process.env.VOLUTE_SANDBOX_OPTIONAL = origOptional;
+  });
+
+  it("refuses to spawn a mind server unsandboxed under sandbox mode", async () => {
+    enableSandboxMode();
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    await assert.rejects(
+      () => spawnServer("/tmp/variant-dir", 0, { mindName: "alice", template: "claude" }),
+      SandboxUnavailableError,
+    );
+  });
+
+  it("does not wrap when no mindName is given (legacy callers unaffected)", async () => {
+    enableSandboxMode();
+    // No mindName → no wrap attempt. The tsx bin under a nonexistent dir can't be
+    // spawned, so the attached spawn resolves null rather than throwing.
+    const result = await spawnServer("/tmp/nonexistent-spawn-dir", 0);
+    assert.equal(result, null);
+  });
+
+  it("skips sandbox wrap for codex-template minds", async () => {
+    enableSandboxMode();
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    // Codex is excluded from sandbox wrapping, so no SandboxUnavailableError —
+    // the (missing) tsx bin just fails to spawn and resolves null.
+    const result = await spawnServer("/tmp/nonexistent-codex-dir", 0, {
+      mindName: "alice",
+      template: "codex",
+    });
+    assert.equal(result, null);
+  });
+});


### PR DESCRIPTION
## Summary

Minds are untrusted principals that run arbitrary code, but several sandbox-mode paths **failed open** — running mind code unsandboxed as the daemon user (root on system/Docker installs) with only a log line. This fixes all four issues from #324 to fail *closed*.

1. **Fail closed on sandbox setup failure.** `initSandbox` now throws (aborting daemon startup) when sandbox mode is enabled but the runtime can't initialize or a required dep (Linux ripgrep) is missing. `wrapForSandbox` throws instead of returning the command unwrapped. Both honor an explicit `VOLUTE_SANDBOX_OPTIONAL=1` opt-out for the local-dev degrade case. New `SandboxUnavailableError`.
2. **Scheduler scripts sandboxed.** `Scheduler.runScript` now routes through `wrapForSandbox` under sandbox mode (`exec` only ever applied user isolation). Mind-registered scripts can no longer escape the sandbox.
3. **Merge-verification spawn wrapped.** `spawnServer` gained `mindName`/`template` options and wraps the mind-authored `server.ts` the same way `startMind` does (isolation under user mode, sandbox otherwise, codex excluded). `variants.ts` passes them.
4. **Per-mind tmp dir.** Replaced the shared `/tmp` entry in `allowWrite` with a per-mind `<mindDir>/.mind/tmp`, created and (under user isolation) chowned at spawn time, and exported as the mind's `TMPDIR`.

## Key files

- `packages/daemon/src/lib/mind/sandbox.ts` — `SandboxUnavailableError`, `isSandboxOptional()`, fail-closed `initSandbox`/`wrapForSandbox`
- `packages/daemon/src/lib/daemon/scheduler.ts` — sandbox-wrap `runScript`
- `packages/daemon/src/lib/mind/spawn-server.ts` — optional isolation/sandbox wrapping
- `packages/daemon/src/web/api/variants.ts` — pass `mindName`/`template` to verification spawn
- `packages/daemon/src/lib/daemon/mind-manager.ts` + `registry.ts` (`mindTmpDir`) — per-mind `TMPDIR`
- `packages/daemon/src/daemon.ts` — startup rejection now exits(1)

## Testing

- `npm run build` — passes (lint + typecheck via pre-commit also pass)
- `npm test` — full suite green (1612 tests)
- Added unit tests: `wrapForSandbox` fail-closed vs. opt-out vs. disabled (`test/sandbox.test.ts`); scheduler script sandbox routing (`test/scheduler.test.ts`); verification-spawn wrapping incl. codex bypass (`test/spawn-server.test.ts`)

**Note:** The issue also suggested Docker/e2e tests exercising a real sandbox escape (cross-mind reads, tmp isolation). Those require an actual `@anthropic-ai/sandbox-runtime` and are platform-specific (macOS seatbelt vs. Linux), so they'd be brittle in CI; the added unit tests instead assert the fail-closed decision deterministically without a live sandbox.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)