### PR TITLE
fix: extension command endpoint trusts body.mind over authenticated identity

### DIFF
--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -271,8 +271,12 @@ async function loadExtension(
         } catch {
           return c.json({ error: "Invalid JSON in request body" }, 400);
         }
-        const user = c.get("user") as { username: string } | undefined;
-        const mindName = body.mind || user?.username;
+        const user = c.get("user") as { username: string; role?: string } | undefined;
+        // Minds are untrusted principals — only privileged callers (admin/system)
+        // may target another mind via body.mind. Otherwise the acting mind is the
+        // authenticated identity, so a mind cannot impersonate another.
+        const privileged = user?.role === "admin" || user?.role === "system";
+        const mindName = privileged ? body.mind || user?.username : user?.username;
         const session = c.get("mindSession") as string | undefined;
         try {
           // Collect activity publish promises so we can append correlation markers

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1269,4 +1269,72 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       body: JSON.stringify({}),
     });
   });
+
+  it("extension command endpoint ignores body.mind for non-admin callers", async () => {
+    // Register a seed admin first so subsequent registrations are non-admin.
+    // (The first brain user always becomes admin.)
+    await daemonRequest("/api/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "e2e-seed-admin", password: "seed-pass-123" }),
+    });
+
+    // Register attacker + victim as non-admin (pending) brain users, then approve.
+    async function registerAndApprove(username: string): Promise<void> {
+      const regRes = await daemonRequest("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password: "attack-pass-123" }),
+      });
+      const regBody = (await regRes.json()) as { id: number; role: string };
+      assert.equal(regRes.status, 200, `register ${username}: ${JSON.stringify(regBody)}`);
+      assert.notEqual(regBody.role, "admin", `${username} must not be the first (admin) user`);
+      // Approve via daemon token (admin).
+      const apRes = await daemonRequest(`/api/auth/users/${regBody.id}/approve`, {
+        method: "POST",
+      });
+      assert.equal(apRes.status, 200, `approve ${username}: ${apRes.status}`);
+    }
+    await registerAndApprove("e2e-notes-attacker");
+    await registerAndApprove("e2e-notes-victim");
+
+    // Log in as attacker to obtain a non-admin session token.
+    const loginRes = await daemonRequest("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "e2e-notes-attacker", password: "attack-pass-123" }),
+    });
+    const loginBody = (await loginRes.json()) as { sessionId: string };
+    assert.equal(loginRes.status, 200, `login: ${JSON.stringify(loginBody)}`);
+    const { sessionId } = loginBody;
+    assert.ok(sessionId, "login should return a session token");
+
+    // Attacker attempts to publish a note authored as the victim via body.mind.
+    const attackRes = await fetch(`${BASE_URL}/api/ext/notes/commands/write`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${sessionId}`,
+        Origin: BASE_URL,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ mind: "e2e-notes-victim", args: ["Impersonation Attempt", "body"] }),
+    });
+    assert.equal(attackRes.status, 200, `write: ${await attackRes.clone().text()}`);
+    const attackBody = (await attackRes.json()) as { output?: string; error?: string };
+    assert.ok(attackBody.output, `expected output, got ${JSON.stringify(attackBody)}`);
+    // body.mind must be ignored: the note is authored by the caller, not the victim.
+    assert.match(attackBody.output, /Published: e2e-notes-attacker\//);
+    assert.doesNotMatch(attackBody.output, /Published: e2e-notes-victim\//);
+
+    // An admin (daemon token) can still target a specific mind via body.mind.
+    const adminRes = await daemonRequest("/api/ext/notes/commands/write", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mind: "e2e-notes-victim", args: ["Admin Targeted", "body"] }),
+    });
+    assert.equal(adminRes.status, 200, `admin write: ${await adminRes.clone().text()}`);
+    const adminBody = (await adminRes.json()) as { output?: string; error?: string };
+    assert.ok(adminBody.output, `expected output, got ${JSON.stringify(adminBody)}`);
+    assert.match(adminBody.output, /Published: e2e-notes-victim\//);
+  });
 });


### PR DESCRIPTION
## Summary
Extension command endpoints (`POST /api/ext/{id}/commands/{cmd}`) derived the acting mind from the request body, honoring `body.mind` over the authenticated principal. Because minds are untrusted principals with their own non-admin tokens, a mind could impersonate another mind by passing `{ mind: "other-mind" }` — publishing, commenting, reacting, or deleting *as* that other mind (e.g. Notes resolves `ctx.mindName` to the authorship identity).

The fix honors `body.mind` only for privileged callers (`role === "admin" || role === "system"`, matching the `requireSelf`/`requireAdmin` check); otherwise the acting mind is forced to the authenticated identity (`user.username`). Admins can still legitimately target a specific mind via `--mind`.

## Key files
- `packages/daemon/src/lib/extensions.ts` — command handler: gate `body.mind` on privileged role.
- `test/daemon-e2e.test.ts` — regression test.

## Testing
- Added daemon e2e test `extension command endpoint ignores body.mind for non-admin callers`:
  - A non-admin caller posting `/api/ext/notes/commands/write` with `{ mind: "victim" }` produces a note authored by the caller, not the victim (`body.mind` ignored).
  - An admin (daemon token) can still target `{ mind: "victim" }` and the note is authored by the victim.
- Verified passing: `✔ extension command endpoint ignores body.mind for non-admin callers`.
- `npm run build` and pre-commit typecheck/lint pass.
- Other e2e failures in the suite are pre-existing/environmental (mind-dependent tests requiring an LLM API key, which fails identically on unmodified `main` in this sandbox).

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)