### PR TITLE
fix: cross-tenant data exposure via history API and SSE replay buffer

### DIFF
--- a/packages/daemon/src/lib/events/event-sequencer.ts
+++ b/packages/daemon/src/lib/events/event-sequencer.ts
@@ -26,15 +26,35 @@ export function bufferEvent(data: SSEEvent): number {
   return id;
 }
 
-export function getEventsSince(sinceId: number): BufferedEvent[] {
+/** Allocate an event ID without buffering (for connection-specific events). */
+export function nextEventId(): number {
+  return nextId++;
+}
+
+/**
+ * Replay buffered events after `sinceId` that the caller is entitled to see.
+ * The buffer is global, so audience must be enforced here:
+ * - Snapshot events are connection-specific and never replayed to anyone.
+ * - Conversation events are only replayed to participants of that conversation.
+ * - Activity events are broadcast to all connections (matching the live path).
+ */
+export function getEventsSince(
+  sinceId: number,
+  allowedConversationIds: Set<string>,
+): BufferedEvent[] {
   const now = Date.now();
 
   // Find the index of the first event after sinceId
   const startIdx = buffer.findIndex((e) => e.id > sinceId);
   if (startIdx === -1) return [];
 
-  // Return events that aren't too old
-  return buffer.slice(startIdx).filter((e) => now - e.timestamp < MAX_AGE_MS);
+  return buffer.slice(startIdx).filter((e) => {
+    if (now - e.timestamp >= MAX_AGE_MS) return false;
+    const data = e.data;
+    if (data.event === "snapshot") return false;
+    if (data.event === "conversation") return allowedConversationIds.has(data.conversationId);
+    return true;
+  });
 }
 
 /** Reset state (for testing). */

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -1,7 +1,9 @@
 import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { subscribeAll, subscribe as subscribeMindEvent } from "../../lib/events/mind-events.js";
+import { getBaseName } from "../../lib/mind/registry.js";
 import {
   activity,
   channels,
@@ -13,10 +15,25 @@ import {
   users,
 } from "../../lib/schema.js";
 import log from "../../lib/util/logger.js";
+import type { AuthEnv } from "../middleware/auth.js";
 
-const history = new Hono()
+/**
+ * Resolve the mind whose history the caller may read. Minds are untrusted:
+ * a non-admin principal may only see its own history, so the client-supplied
+ * `?mind=` param is ignored and forced to the caller's own (base) name.
+ * Admin/system callers keep the requested filter.
+ */
+async function resolveMindFilter(c: Context<AuthEnv>): Promise<string | undefined> {
+  const user = c.get("user");
+  if (user.role === "admin" || user.role === "system") {
+    return c.req.query("mind") ?? undefined;
+  }
+  return getBaseName(user.username);
+}
+
+const history = new Hono<AuthEnv>()
   .get("/turns", async (c) => {
-    const mindFilter = c.req.query("mind");
+    const mindFilter = await resolveMindFilter(c);
     const turnIdFilter = c.req.query("turnId");
     const turnIdsFilter = c.req.query("turnIds");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "50", 10) || 50, 1), 200);
@@ -353,7 +370,7 @@ const history = new Hono()
     return c.json(result);
   })
   .get("/events", async (c) => {
-    const mindFilter = c.req.query("mind");
+    const mindFilter = await resolveMindFilter(c);
 
     const stream = new ReadableStream({
       start(controller) {
@@ -413,7 +430,10 @@ const history = new Hono()
     });
   })
   .get("/summaries", async (c) => {
-    const mind = c.req.query("mind") ?? "_system";
+    const user = c.get("user");
+    const privileged = user.role === "admin" || user.role === "system";
+    // Non-admin callers can only read their own summaries.
+    const mind = privileged ? (c.req.query("mind") ?? "_system") : await getBaseName(user.username);
     const period = c.req.query("period");
     const ids = c.req.query("ids"); // comma-separated summary IDs
     const from = c.req.query("from");
@@ -428,7 +448,13 @@ const history = new Hono()
         .map((s) => parseInt(s, 10))
         .filter((n) => !Number.isNaN(n));
       if (idList.length === 0) return c.json([]);
-      const rows = await db.select().from(summaries).where(inArray(summaries.id, idList));
+      // Non-admin callers are still constrained to their own mind's summaries.
+      const idConditions = [inArray(summaries.id, idList)];
+      if (!privileged) idConditions.push(eq(summaries.mind, mind));
+      const rows = await db
+        .select()
+        .from(summaries)
+        .where(and(...idConditions));
       const result = rows.map((r) => {
         let metadata: Record<string, unknown> | null = null;
         if (r.metadata) {
@@ -483,7 +509,7 @@ const history = new Hono()
     return c.json(result);
   })
   .get("/activity", async (c) => {
-    const mind = c.req.query("mind");
+    const mind = await resolveMindFilter(c);
     const from = c.req.query("from");
     const to = c.req.query("to");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "100", 10) || 100, 1), 500);

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -13,7 +13,7 @@ import {
   getUnreadCounts,
   listConversationsWithParticipants,
 } from "../../../lib/events/conversations.js";
-import { bufferEvent, getEventsSince } from "../../../lib/events/event-sequencer.js";
+import { bufferEvent, getEventsSince, nextEventId } from "../../../lib/events/event-sequencer.js";
 import { getActiveMinds } from "../../../lib/events/mind-activity-tracker.js";
 import { activity } from "../../../lib/schema.js";
 import log from "../../../lib/util/logger.js";
@@ -32,9 +32,28 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
     }
 
     try {
-      // If reconnecting with a valid sinceId, replay buffered events
+      // Fetch the caller's conversations up front — needed for replay audience
+      // filtering, the snapshot, and the live conversation subscriptions.
+      let conversations: any[] = [];
+      try {
+        conversations = await listConversationsWithParticipants(user.id);
+        if (conversations.length > 0) {
+          const convIds = conversations.map((c: any) => c.id);
+          const unreads = await getUnreadCounts(user.id, convIds);
+          for (const conv of conversations) {
+            conv.unreadCount = unreads[conv.id] ?? 0;
+          }
+        }
+      } catch (err) {
+        log.error("[v1-events] failed to fetch conversations", log.errorData(err));
+      }
+      const allowedConversationIds = new Set<string>(conversations.map((c: any) => c.id));
+
+      // If reconnecting with a valid sinceId, replay only the buffered events
+      // the caller is entitled to (their own conversation events + global
+      // activity). Other users' events and per-connect snapshots are filtered out.
       if (sinceId > 0) {
-        const missed = getEventsSince(sinceId);
+        const missed = getEventsSince(sinceId, allowedConversationIds);
         for (const event of missed) {
           await stream.writeSSE({
             id: String(event.id),
@@ -60,20 +79,6 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         log.error("[v1-events] failed to fetch recent activity", log.errorData(err));
       }
 
-      let conversations: any[] = [];
-      try {
-        conversations = await listConversationsWithParticipants(user.id);
-        if (conversations.length > 0) {
-          const convIds = conversations.map((c: any) => c.id);
-          const unreads = await getUnreadCounts(user.id, convIds);
-          for (const conv of conversations) {
-            conv.unreadCount = unreads[conv.id] ?? 0;
-          }
-        }
-      } catch (err) {
-        log.error("[v1-events] failed to fetch conversations", log.errorData(err));
-      }
-
       const snapshotData = {
         event: "snapshot" as const,
         activity: recentActivity,
@@ -82,7 +87,10 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         onlineBrains: getOnlineBrains(),
       };
 
-      const snapshotId = bufferEvent(snapshotData);
+      // The snapshot is connection-specific (this user's conversations, unread
+      // counts, etc.) — allocate an ID but do NOT buffer it, so it can never be
+      // replayed to another connection.
+      const snapshotId = nextEventId();
 
       await stream.writeSSE({
         id: String(snapshotId),

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -3,12 +3,17 @@ import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   findMind,
   mindDir,
   removeMind,
   voluteSystemDir,
 } from "../packages/daemon/src/lib/mind/registry.js";
+import { activity, mindHistory, summaries, turns } from "../packages/daemon/src/lib/schema.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 // Strip GIT_* env vars that hook runners (e.g. pre-push) inject, so that
 // spawned processes (like `volute create` which runs `git init`) don't
@@ -1267,6 +1272,115 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
+    });
+  });
+
+  describe("history API cross-tenant authorization", () => {
+    const ALICE = "e2e-hist-alice";
+    const BOB = "e2e-hist-bob";
+    const BOB_SECRET = "BOB-PRIVATE-DM-SECRET";
+    const ALICE_SECRET = "ALICE-PRIVATE-DM-SECRET";
+    let aliceSession: string;
+    let bobSummaryId: number;
+
+    // Request as mind Alice using a DB-backed session (the daemon shares this
+    // test's VOLUTE_HOME, so a session created here resolves to Alice's
+    // non-admin mind user inside the daemon).
+    function aliceRequest(path: string): Promise<Response> {
+      return fetch(`${BASE_URL}${path}`, {
+        headers: { Authorization: `Bearer ${aliceSession}`, Origin: BASE_URL },
+      });
+    }
+
+    before(async () => {
+      const db = await getDb();
+      const alice = await getOrCreateMindUser(ALICE);
+      await getOrCreateMindUser(BOB);
+      aliceSession = await createSession(alice.id);
+
+      // Seed a turn + private DM content + summary + activity for each mind.
+      for (const [mind, secret] of [
+        [ALICE, ALICE_SECRET],
+        [BOB, BOB_SECRET],
+      ] as const) {
+        const turnId = `${mind}-turn-1`;
+        await db.insert(turns).values({ id: turnId, mind, status: "done" });
+        await db.insert(mindHistory).values({
+          mind,
+          channel: "@partner",
+          sender: "partner",
+          type: "inbound",
+          content: secret,
+          turn_id: turnId,
+        });
+        await db
+          .insert(summaries)
+          .values({ mind, period: "turn", period_key: turnId, content: `${secret} summary` });
+        await db.insert(activity).values({ type: "message", mind, summary: `${secret} activity` });
+      }
+
+      const bobSummary = await db
+        .select({ id: summaries.id })
+        .from(summaries)
+        .where(eq(summaries.mind, BOB))
+        .get();
+      bobSummaryId = bobSummary!.id;
+    });
+
+    it("/turns ignores ?mind= for a mind principal and never leaks another mind", async () => {
+      const res = await aliceRequest(`/api/v1/history/turns?mind=${BOB}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      const text = JSON.stringify(body);
+      assert.ok(!text.includes(BOB_SECRET), "Alice must not see Bob's private DM content");
+      assert.ok(
+        body.every((t) => t.mind === ALICE),
+        "Alice's turn query must only return Alice's turns",
+      );
+      // Alice still sees her own turn (filter forced to self, not denied).
+      assert.ok(
+        body.some((t) => t.id === `${ALICE}-turn-1`),
+        "Alice should see her own turn",
+      );
+    });
+
+    it("/summaries ignores ?mind= for a mind principal", async () => {
+      const res = await aliceRequest(`/api/v1/history/summaries?mind=${BOB}&period=turn`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.ok(
+        body.every((s) => s.mind === ALICE),
+        "Alice must only receive her own summaries",
+      );
+      assert.ok(!JSON.stringify(body).includes(BOB_SECRET));
+    });
+
+    it("/summaries by ids cannot reach another mind's summary", async () => {
+      const res = await aliceRequest(`/api/v1/history/summaries?ids=${bobSummaryId}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.equal(body.length, 0, "Alice must not fetch Bob's summary by id");
+    });
+
+    it("/activity ignores ?mind= for a mind principal", async () => {
+      const res = await aliceRequest(`/api/v1/history/activity?mind=${BOB}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.ok(
+        body.every((a) => a.mind === ALICE),
+        "Alice must only receive her own activity",
+      );
+      assert.ok(!JSON.stringify(body).includes(BOB_SECRET));
+    });
+
+    it("admin/daemon token may still query another mind (behavior preserved)", async () => {
+      const res = await daemonRequest(`/api/v1/history/turns?mind=${BOB}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.ok(
+        body.some((t) => t.mind === BOB),
+        "Admin should still be able to read Bob's turns",
+      );
     });
   });
 });

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -3,8 +3,11 @@ import { describe, it } from "node:test";
 import {
   bufferEvent,
   getEventsSince,
+  nextEventId,
   resetSequencer,
 } from "../packages/daemon/src/lib/events/event-sequencer.js";
+
+const NO_CONVS = new Set<string>();
 
 describe("event sequencer", () => {
   it("assigns monotonically increasing IDs", () => {
@@ -60,7 +63,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(id1);
+    const events = getEventsSince(id1, NO_CONVS);
     assert.equal(events.length, 2);
     assert.equal(events[0].id, id2);
     assert.equal(events[1].id, id3);
@@ -78,7 +81,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(id);
+    const events = getEventsSince(id, NO_CONVS);
     assert.equal(events.length, 0);
   });
 
@@ -94,7 +97,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(9999);
+    const events = getEventsSince(9999, NO_CONVS);
     assert.equal(events.length, 0);
   });
 
@@ -115,32 +118,30 @@ describe("event sequencer", () => {
 
     // Events with IDs 1-5 should have been trimmed
     // Trying to replay from 0 should only get ~1000 events
-    const events = getEventsSince(0);
+    const events = getEventsSince(0, NO_CONVS);
     assert.ok(events.length <= 1000);
     // First event should have ID > 5
     assert.ok(events[0].id > 5);
   });
 
-  it("handles snapshot events in buffer", () => {
+  it("never replays snapshot events (they are connection-specific)", () => {
     resetSequencer();
     const id = bufferEvent({
       event: "snapshot",
       conversations: [],
       activity: [],
-      sites: [],
-      recentPages: [],
       activeMinds: [],
+      onlineBrains: [],
     });
     assert.ok(id > 0);
 
-    const events = getEventsSince(0);
-    assert.equal(events.length, 1);
-    assert.equal(events[0].data.event, "snapshot");
+    const events = getEventsSince(0, NO_CONVS);
+    assert.equal(events.length, 0);
   });
 
-  it("handles conversation events in buffer", () => {
+  it("only replays conversation events to participants", () => {
     resetSequencer();
-    const _id = bufferEvent({
+    bufferEvent({
       event: "conversation",
       conversationId: "conv-123",
       type: "message",
@@ -151,8 +152,60 @@ describe("event sequencer", () => {
       createdAt: "2024-01-01",
     });
 
-    const events = getEventsSince(0);
+    // A caller who is not a participant sees nothing.
+    assert.equal(getEventsSince(0, NO_CONVS).length, 0);
+    assert.equal(getEventsSince(0, new Set(["other-conv"])).length, 0);
+
+    // A participant sees the event.
+    const events = getEventsSince(0, new Set(["conv-123"]));
     assert.equal(events.length, 1);
     assert.equal(events[0].data.event, "conversation");
+  });
+
+  it("filters conversation events but keeps global activity in a mixed buffer", () => {
+    resetSequencer();
+    bufferEvent({
+      event: "activity",
+      id: 1,
+      type: "mind_started",
+      mind: "a",
+      summary: "s",
+      metadata: null,
+      created_at: "2024-01-01",
+    });
+    bufferEvent({
+      event: "conversation",
+      conversationId: "private-conv",
+      type: "message",
+      id: 2,
+      role: "user",
+      senderName: "bob",
+      content: [{ type: "text", text: "secret" }],
+      createdAt: "2024-01-01",
+    });
+
+    // Outsider gets only the global activity event, never the private message.
+    const events = getEventsSince(0, NO_CONVS);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].data.event, "activity");
+  });
+
+  it("nextEventId advances the counter without buffering", () => {
+    resetSequencer();
+    const id = nextEventId();
+    assert.ok(id > 0);
+    // Nothing buffered, so no replay.
+    assert.equal(getEventsSince(0, NO_CONVS).length, 0);
+    // Subsequent buffered events get higher IDs.
+    const bufId = bufferEvent({
+      event: "activity",
+      id: 1,
+      type: "mind_started",
+      mind: "a",
+      summary: "s",
+      metadata: null,
+      created_at: "2024-01-01",
+    });
+    assert.ok(bufId > id);
   });
 });


### PR DESCRIPTION
## Problem

Minds are untrusted principals (each authenticates with a per-mind token resolving to a non-admin `role: "user"` account and can run arbitrary code). Two authenticated-but-unauthorized surfaces let any mind read another tenant's private data:

1. **History API** (`/api/v1/history/{turns,events,summaries,activity}`) was mounted behind `authMiddleware` only. It trusted a client-supplied `?mind=` param with no caller check, so any mind could read another mind's turns, private DM content, summaries, and activity — or, with no filter, an unfiltered firehose of all minds' events.
2. **SSE replay buffer** (`GET /api/v1/events?since=`) replayed a global, unfiltered in-memory ring buffer. Live subscriptions are scoped per participant, but the replay path was not: a reconnecting client received other users' conversation messages and per-connect snapshots.

## Change

- **History API** (`packages/daemon/src/web/api/history.ts`): added `resolveMindFilter()`. For a non-admin/system caller, the client-supplied `?mind=` is ignored and forced to the caller's own base name (via `getBaseName`, so variants resolve to their parent). Applied to `/turns`, `/events`, `/summaries`, `/activity`. The `subscribeAll` firehose and unfiltered activity query are now only reachable by admin/system. The `summaries?ids=` branch is additionally constrained to the caller's own mind.
- **SSE replay** (`packages/daemon/src/lib/events/event-sequencer.ts`, `packages/daemon/src/web/api/v1/events.ts`): `getEventsSince()` is now audience-aware — conversation events are only replayed to participants, activity events remain global (matching the live path), and snapshot events are never replayed. The per-connect snapshot is no longer written into the shared buffer; it gets a non-buffered ID via the new `nextEventId()`.

## Key files touched

- `packages/daemon/src/web/api/history.ts`
- `packages/daemon/src/lib/events/event-sequencer.ts`
- `packages/daemon/src/web/api/v1/events.ts`
- `test/web-v1-events.test.ts`, `test/daemon-e2e.test.ts`

## Testing

- `npm run build` — passes.
- Unit (`test/web-v1-events.test.ts`) + `test/authz-coverage.test.ts` — pass. Added coverage: snapshots never replayed, conversation events only for participants, mixed-buffer filtering, `nextEventId` behavior.
- `test/daemon-e2e.test.ts` — new `history API cross-tenant authorization` block (5 tests) passes: a non-admin mind (Alice) gets only her own data for `/turns`, `/summaries` (incl. `?ids=`), and `/activity` even when passing `?mind=Bob`, never sees Bob's private DM content, and the admin/daemon token retains cross-mind access. Note: 5 pre-existing e2e failures (conversation/bridge tests needing a live mind server) are unrelated — they fail identically on the base branch in this environment.

## Deviation from plan

The issue suggested an e2e assertion for `/api/v1/events?since=` SSE replay. Since the ring buffer is in-memory in the daemon process and can't be seeded from the test process, that path is covered by the unit tests for `getEventsSince` audience filtering instead. History API cross-tenant denial (the directly-HTTP-testable surface) is covered at e2e.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)