### PR TITLE
test: extend authz-coverage net to query-param and extension routes

### DIFF
--- a/packages/daemon/src/lib/events/event-sequencer.ts
+++ b/packages/daemon/src/lib/events/event-sequencer.ts
@@ -26,15 +26,35 @@ export function bufferEvent(data: SSEEvent): number {
   return id;
 }
 
-export function getEventsSince(sinceId: number): BufferedEvent[] {
+/** Allocate an event ID without buffering (for connection-specific events). */
+export function nextEventId(): number {
+  return nextId++;
+}
+
+/**
+ * Replay buffered events after `sinceId` that the caller is entitled to see.
+ * The buffer is global, so audience must be enforced here:
+ * - Snapshot events are connection-specific and never replayed to anyone.
+ * - Conversation events are only replayed to participants of that conversation.
+ * - Activity events are broadcast to all connections (matching the live path).
+ */
+export function getEventsSince(
+  sinceId: number,
+  allowedConversationIds: Set<string>,
+): BufferedEvent[] {
   const now = Date.now();
 
   // Find the index of the first event after sinceId
   const startIdx = buffer.findIndex((e) => e.id > sinceId);
   if (startIdx === -1) return [];
 
-  // Return events that aren't too old
-  return buffer.slice(startIdx).filter((e) => now - e.timestamp < MAX_AGE_MS);
+  return buffer.slice(startIdx).filter((e) => {
+    if (now - e.timestamp >= MAX_AGE_MS) return false;
+    const data = e.data;
+    if (data.event === "snapshot") return false;
+    if (data.event === "conversation") return allowedConversationIds.has(data.conversationId);
+    return true;
+  });
 }
 
 /** Reset state (for testing). */

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -12,7 +12,7 @@ import type {
   SystemSection,
 } from "@volute/extensions";
 import type { Context, Hono, MiddlewareHandler } from "hono";
-import type { AuthEnv } from "../web/middleware/auth.js";
+import { type AuthEnv, requireSelf } from "../web/middleware/auth.js";
 import { getUser, getUserByUsername } from "./auth.js";
 import { announceToSystem } from "./chat/system-channel.js";
 import { readGlobalConfig, writeGlobalConfig } from "./config/setup.js";
@@ -189,6 +189,10 @@ async function buildContext(
   return {
     db,
     authMiddleware: authMw,
+    // Reuse the daemon's canonical guard so extension routes authorize the same
+    // way core routes do (admin/system or the mind whose base name matches the
+    // route param). Its type is compatible with the SDK MiddlewareHandler.
+    requireSelf: (paramName?: string) => requireSelf(paramName) as unknown as MiddlewareHandler,
     resolveUser: (c) => {
       const user = c.get("user");
       if (!user || typeof user !== "object") return null;

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -1,7 +1,9 @@
 import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { subscribeAll, subscribe as subscribeMindEvent } from "../../lib/events/mind-events.js";
+import { getBaseName } from "../../lib/mind/registry.js";
 import {
   activity,
   channels,
@@ -13,10 +15,25 @@ import {
   users,
 } from "../../lib/schema.js";
 import log from "../../lib/util/logger.js";
+import type { AuthEnv } from "../middleware/auth.js";
 
-const history = new Hono()
+/**
+ * Resolve the mind whose history the caller may read. Minds are untrusted:
+ * a non-admin principal may only see its own history, so the client-supplied
+ * `?mind=` param is ignored and forced to the caller's own (base) name.
+ * Admin/system callers keep the requested filter.
+ */
+async function resolveMindFilter(c: Context<AuthEnv>): Promise<string | undefined> {
+  const user = c.get("user");
+  if (user.role === "admin" || user.role === "system") {
+    return c.req.query("mind") ?? undefined;
+  }
+  return getBaseName(user.username);
+}
+
+const history = new Hono<AuthEnv>()
   .get("/turns", async (c) => {
-    const mindFilter = c.req.query("mind");
+    const mindFilter = await resolveMindFilter(c);
     const turnIdFilter = c.req.query("turnId");
     const turnIdsFilter = c.req.query("turnIds");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "50", 10) || 50, 1), 200);
@@ -353,7 +370,7 @@ const history = new Hono()
     return c.json(result);
   })
   .get("/events", async (c) => {
-    const mindFilter = c.req.query("mind");
+    const mindFilter = await resolveMindFilter(c);
 
     const stream = new ReadableStream({
       start(controller) {
@@ -413,7 +430,10 @@ const history = new Hono()
     });
   })
   .get("/summaries", async (c) => {
-    const mind = c.req.query("mind") ?? "_system";
+    const user = c.get("user");
+    const privileged = user.role === "admin" || user.role === "system";
+    // Non-admin callers can only read their own summaries.
+    const mind = privileged ? (c.req.query("mind") ?? "_system") : await getBaseName(user.username);
     const period = c.req.query("period");
     const ids = c.req.query("ids"); // comma-separated summary IDs
     const from = c.req.query("from");
@@ -428,7 +448,13 @@ const history = new Hono()
         .map((s) => parseInt(s, 10))
         .filter((n) => !Number.isNaN(n));
       if (idList.length === 0) return c.json([]);
-      const rows = await db.select().from(summaries).where(inArray(summaries.id, idList));
+      // Non-admin callers are still constrained to their own mind's summaries.
+      const idConditions = [inArray(summaries.id, idList)];
+      if (!privileged) idConditions.push(eq(summaries.mind, mind));
+      const rows = await db
+        .select()
+        .from(summaries)
+        .where(and(...idConditions));
       const result = rows.map((r) => {
         let metadata: Record<string, unknown> | null = null;
         if (r.metadata) {
@@ -483,7 +509,7 @@ const history = new Hono()
     return c.json(result);
   })
   .get("/activity", async (c) => {
-    const mind = c.req.query("mind");
+    const mind = await resolveMindFilter(c);
     const from = c.req.query("from");
     const to = c.req.query("to");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "100", 10) || 100, 1), 500);

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -13,7 +13,7 @@ import {
   getUnreadCounts,
   listConversationsWithParticipants,
 } from "../../../lib/events/conversations.js";
-import { bufferEvent, getEventsSince } from "../../../lib/events/event-sequencer.js";
+import { bufferEvent, getEventsSince, nextEventId } from "../../../lib/events/event-sequencer.js";
 import { getActiveMinds } from "../../../lib/events/mind-activity-tracker.js";
 import { activity } from "../../../lib/schema.js";
 import log from "../../../lib/util/logger.js";
@@ -32,9 +32,28 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
     }
 
     try {
-      // If reconnecting with a valid sinceId, replay buffered events
+      // Fetch the caller's conversations up front — needed for replay audience
+      // filtering, the snapshot, and the live conversation subscriptions.
+      let conversations: any[] = [];
+      try {
+        conversations = await listConversationsWithParticipants(user.id);
+        if (conversations.length > 0) {
+          const convIds = conversations.map((c: any) => c.id);
+          const unreads = await getUnreadCounts(user.id, convIds);
+          for (const conv of conversations) {
+            conv.unreadCount = unreads[conv.id] ?? 0;
+          }
+        }
+      } catch (err) {
+        log.error("[v1-events] failed to fetch conversations", log.errorData(err));
+      }
+      const allowedConversationIds = new Set<string>(conversations.map((c: any) => c.id));
+
+      // If reconnecting with a valid sinceId, replay only the buffered events
+      // the caller is entitled to (their own conversation events + global
+      // activity). Other users' events and per-connect snapshots are filtered out.
       if (sinceId > 0) {
-        const missed = getEventsSince(sinceId);
+        const missed = getEventsSince(sinceId, allowedConversationIds);
         for (const event of missed) {
           await stream.writeSSE({
             id: String(event.id),
@@ -60,20 +79,6 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         log.error("[v1-events] failed to fetch recent activity", log.errorData(err));
       }
 
-      let conversations: any[] = [];
-      try {
-        conversations = await listConversationsWithParticipants(user.id);
-        if (conversations.length > 0) {
-          const convIds = conversations.map((c: any) => c.id);
-          const unreads = await getUnreadCounts(user.id, convIds);
-          for (const conv of conversations) {
-            conv.unreadCount = unreads[conv.id] ?? 0;
-          }
-        }
-      } catch (err) {
-        log.error("[v1-events] failed to fetch conversations", log.errorData(err));
-      }
-
       const snapshotData = {
         event: "snapshot" as const,
         activity: recentActivity,
@@ -82,7 +87,10 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         onlineBrains: getOnlineBrains(),
       };
 
-      const snapshotId = bufferEvent(snapshotData);
+      // The snapshot is connection-specific (this user's conversations, unread
+      // counts, etc.) — allocate an ID but do NOT buffer it, so it can never be
+      // replayed to another connection.
+      const snapshotId = nextEventId();
 
       await stream.writeSSE({
         id: String(snapshotId),

--- a/packages/daemon/src/web/api/volute/channels.ts
+++ b/packages/daemon/src/web/api/volute/channels.ts
@@ -90,10 +90,16 @@ const app = new Hono<AuthEnv>()
   })
   .patch("/:name", zValidator("json", channelSettingsSchema), async (c) => {
     const name = c.req.param("name");
+    const user = c.get("user");
     const body = c.req.valid("json");
 
     const ch = await getChannelByName(name);
     if (!ch) return c.json({ error: "Channel not found" }, 404);
+
+    // In-handler authz: only a channel member (or admin/system) may change settings.
+    if (user.role !== "admin" && user.role !== "system" && !(await isParticipant(ch.id, user.id))) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
 
     await updateChannelSettings(name, body);
     const settings = await getChannelSettings(name);
@@ -135,6 +141,15 @@ const app = new Hono<AuthEnv>()
 
     const ch = await getChannelByName(name);
     if (!ch) return c.json({ error: "Channel not found" }, 404);
+
+    // In-handler authz: only a channel member (or admin/system) may add members.
+    if (
+      inviter.role !== "admin" &&
+      inviter.role !== "system" &&
+      !(await isParticipant(ch.id, inviter.id))
+    ) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
 
     // Resolve the invitee: try as existing user first, then as a mind
     let user = await getUserByUsername(username);

--- a/packages/extensions/notes/src/routes.ts
+++ b/packages/extensions/notes/src/routes.ts
@@ -99,14 +99,9 @@ export function createRoutes(ctx: ExtensionContext): Hono {
       return c.json(note);
     })
 
-    // Update note
-    .put("/:author/:slug", async (c) => {
-      const actor = resolveUserId(c);
-      if (!actor) return c.json({ error: "Unauthorized" }, 401);
-
+    // Update note (author-only via requireSelf)
+    .put("/:author/:slug", ctx.requireSelf("author"), async (c) => {
       const { author, slug } = c.req.param();
-      if (actor.username !== author) return c.json({ error: "Forbidden" }, 403);
-
       const body = await parseJson<{ title?: string; content?: string }>(c);
       if (!body) return c.json({ error: "Invalid JSON body" }, 400);
       const note = await updateNote(db, getUser, getUserByUsername, author, slug, body);
@@ -114,8 +109,8 @@ export function createRoutes(ctx: ExtensionContext): Hono {
       return c.json(note);
     })
 
-    // Delete note
-    .delete("/:author/:slug", async (c) => {
+    // Delete note (author-only via requireSelf; deleteNote still scopes to actor.id)
+    .delete("/:author/:slug", ctx.requireSelf("author"), async (c) => {
       const actor = resolveUserId(c);
       if (!actor) return c.json({ error: "Unauthorized" }, 401);
 

--- a/packages/extensions/notes/src/routes.ts
+++ b/packages/extensions/notes/src/routes.ts
@@ -109,13 +109,14 @@ export function createRoutes(ctx: ExtensionContext): Hono {
       return c.json(note);
     })
 
-    // Delete note (author-only via requireSelf; deleteNote still scopes to actor.id)
+    // Delete note. requireSelf("author") authorizes the caller (the author, or
+    // admin/system); pass the author's own id so an admin/system caller can
+    // delete any author's note — consistent with PUT, which has no actor scoping.
     .delete("/:author/:slug", ctx.requireSelf("author"), async (c) => {
-      const actor = resolveUserId(c);
-      if (!actor) return c.json({ error: "Unauthorized" }, 401);
-
       const { author, slug } = c.req.param();
-      const deleted = await deleteNote(db, getUserByUsername, author, slug, actor.id);
+      const authorUser = await getUserByUsername(author);
+      if (!authorUser) return c.json({ error: "Note not found" }, 404);
+      const deleted = await deleteNote(db, getUserByUsername, author, slug, authorUser.id);
       if (!deleted) return c.json({ error: "Note not found or not authorized" }, 404);
       return c.json({ ok: true });
     })

--- a/packages/extensions/pages/src/routes.ts
+++ b/packages/extensions/pages/src/routes.ts
@@ -51,13 +51,8 @@ export function createRoutes(ctx: ExtensionContext): Hono {
         })),
       );
     })
-    .put("/publish/:name", async (c) => {
-      const user = ctx.resolveUser(c);
-      if (!user) return c.json({ error: "Unauthorized" }, 401);
+    .put("/publish/:name", ctx.requireSelf("name"), async (c) => {
       const name = c.req.param("name");
-      if (user.role !== "admin" && user.username !== name) {
-        return c.json({ error: "Forbidden" }, 403);
-      }
       const config = ctx.getSystemsConfig();
       if (!config) return c.json({ error: "Not connected to volute.systems" }, 400);
       const body = await c.req.text();
@@ -76,13 +71,8 @@ export function createRoutes(ctx: ExtensionContext): Hono {
         return c.json({ error: `Connection failed: ${(err as Error).message}` }, 502);
       }
     })
-    .get("/status/:name", async (c) => {
-      const user = ctx.resolveUser(c);
-      if (!user) return c.json({ error: "Unauthorized" }, 401);
+    .get("/status/:name", ctx.requireSelf("name"), async (c) => {
       const name = c.req.param("name");
-      if (user.role !== "admin" && user.username !== name) {
-        return c.json({ error: "Forbidden" }, 403);
-      }
       const config = ctx.getSystemsConfig();
       if (!config) return c.json({ error: "Not connected to volute.systems" }, 400);
       try {

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -36,6 +36,15 @@ export type SystemsConfig = {
 export type ExtensionContext = {
   db: Database | null;
   authMiddleware: MiddlewareHandler;
+  /**
+   * Canonical per-resource authorization guard. Returns middleware that allows
+   * admin/system callers and the mind whose (base) name equals the value of the
+   * given route param; everyone else gets 403. Extensions should mount this on
+   * mind-scoped routes (e.g. `/:author/...`, `/publish/:name`) instead of
+   * hand-rolling `user.username === param` checks, so authorization is uniform
+   * and statically verifiable.
+   */
+  requireSelf: (paramName?: string) => MiddlewareHandler;
   resolveUser: (c: Context) => User | null;
   getUser: (id: number) => Promise<User | null>;
   getUserByUsername: (username: string) => Promise<User | null>;

--- a/test/authz-coverage.test.ts
+++ b/test/authz-coverage.test.ts
@@ -67,18 +67,41 @@ const AUTHZ_EXEMPT: Record<string, string> = {
     "in-handler authz: add-member requires the caller be a channel member (or admin/system)",
 };
 
-const GUARDS = ["requireSelf", "requireAdmin", "requireAdminOrSystem"];
+// The route's mind identifier is the first :name/:mind/:author param in the path.
+const MIND_PARAM_RE = /:(name|mind|author)\b/;
+
+// A middleware window truly guards a mind-scoped route only if it carries a
+// system-wide guard (requireAdmin*) OR a requireSelf() whose param names the
+// route's actual mind param — `requireSelf("author")` on a `/:name` route must
+// NOT count. This is what makes presence-of-a-token load-bearing.
+function guardMatches(path: string, middlewareWindow: string): boolean {
+  if (middlewareWindow.includes("requireAdmin")) return true; // covers requireAdminOrSystem too
+  const self = middlewareWindow.match(/requireSelf\(\s*(?:"([^"]*)")?\s*\)/);
+  if (!self) return false;
+  const guardParam = self[1] ?? "name"; // requireSelf() defaults to the "name" param
+  const pathParam = path.match(MIND_PARAM_RE)?.[1];
+  // If the path has a mind param, the guard must name it; if not, any self-guard is fine.
+  return pathParam ? guardParam === pathParam : true;
+}
+
 // Capture group 3 = the middleware window between the path string and the start
 // of the handler arrow (`=>`). Middleware (requireSelf(), zValidator(...)) live
 // here, whether the route is written on one line or across several.
 const ROUTE_RE = /\.(get|post|put|patch|delete)\(\s*"(\/:(?:name|mind)[^"]*)"([\s\S]*?)=>/g;
 
+// Skip build artifacts and dependencies so compiled route copies can't pollute
+// the scan (route counts, exemption matching) with duplicates of source files.
+const SCAN_SKIP_DIRS = new Set(["dist", "node_modules", ".git"]);
+
 function listTsFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = `${dir}/${entry.name}`;
-    if (entry.isDirectory()) out.push(...listTsFiles(full));
-    else if (entry.name.endsWith(".ts")) out.push(full);
+    if (entry.isDirectory()) {
+      if (SCAN_SKIP_DIRS.has(entry.name)) continue;
+      out.push(...listTsFiles(`${dir}/${entry.name}`));
+    } else if (entry.name.endsWith(".ts")) {
+      out.push(`${dir}/${entry.name}`);
+    }
   }
   return out;
 }
@@ -94,7 +117,7 @@ function extractRoutes(): Route[] {
       const method = m[1].toUpperCase();
       const path = m[2];
       const middlewareWindow = m[3];
-      const guarded = GUARDS.some((g) => middlewareWindow.includes(g));
+      const guarded = guardMatches(path, middlewareWindow);
       routes.push({ key: `${rel} ${method} ${path}`, guarded });
     }
   }
@@ -143,16 +166,24 @@ describe("mind-scoped route authorization coverage", () => {
 // client-supplied query param (`?mind=`, `?name=`, `?author=`) — precisely the
 // blind spot behind the #320 cross-tenant history leak, where any mind could
 // read another mind's turns/summaries/activity via `?mind=`. This net flags any
-// handler that reads such a param unless its enclosing route carries an authz
-// signal: a middleware guard, OR an in-handler role/self check (`user.role`,
-// `.username`, `getBaseName`, `resolveMindFilter`, `privileged`).
+// handler that reads such a param unless it is authorized by EITHER a middleware
+// guard (tight path→=> window) OR a dataflow guard evaluated within the very
+// statement that reads the param (the value flows through getBaseName /
+// resolveMindFilter, or is gated behind a role check). The statement scope is
+// deliberate: a verbatim #320 regression — `const mindFilter = c.req.query("mind")`
+// with the guard stripped — must fail this net, and it does.
 // ---------------------------------------------------------------------------
 
 const QUERY_READ_RE = /c\.req\.query\(\s*"(mind|name|author)"\s*\)/g;
 const ROUTE_START_RE = /\.(get|post|put|patch|delete)\(\s*"([^"]*)"/g;
-// In-handler authorization signals: a role/self comparison or a shared resolver
-// that constrains the query to the caller's own mind.
-const INLINE_AUTHZ_RE = /\brole\b|\.username\b|resolveMindFilter|getBaseName|privileged/;
+// Dataflow authorization signals evaluated ONLY within the statement that reads
+// the query param: the read must be constrained to the caller's own mind
+// (getBaseName / resolveMindFilter) or gated behind a role check (privileged /
+// `.role`). Scoping to the statement — not the whole handler region — is what
+// makes this load-bearing: an incidental `role:`/`.username` token elsewhere in
+// the handler (a Drizzle column select, a response field) can no longer mask an
+// unguarded read like `const mindFilter = c.req.query("mind")`.
+const DATAFLOW_AUTHZ_RE = /resolveMindFilter|getBaseName|\bprivileged\b|\.role\b/;
 
 // Query-param reads that are genuinely public (feeds/listings of already-public
 // content) and therefore need no per-caller authorization. Documented, honest.
@@ -174,14 +205,26 @@ function scanFiles(dir: string): ScanFile[] {
   }));
 }
 
-type RouteStart = { idx: number; method: string; path: string };
+type RouteStart = { idx: number; afterIdx: number; method: string; path: string };
 
 function routeStarts(text: string): RouteStart[] {
   const starts: RouteStart[] = [];
   for (const m of text.matchAll(ROUTE_START_RE)) {
-    starts.push({ idx: m.index ?? 0, method: m[1].toUpperCase(), path: m[2] });
+    const idx = m.index ?? 0;
+    starts.push({ idx, afterIdx: idx + m[0].length, method: m[1].toUpperCase(), path: m[2] });
   }
   return starts;
+}
+
+// The single JS statement containing `idx` — from the previous statement
+// boundary (`;`/`{`/`}`) to the next `;`. Captures a whole assignment even when
+// prettier wraps a ternary across lines.
+function enclosingStatement(text: string, idx: number): string {
+  let start = idx;
+  while (start > 0 && !";{}".includes(text[start - 1])) start--;
+  let end = idx;
+  while (end < text.length && text[end] !== ";") end++;
+  return text.slice(start, end);
 }
 
 function extractQueryRoutes(): Route[] {
@@ -203,8 +246,14 @@ function extractQueryRoutes(): Route[] {
         if (!enclosing) continue;
         const endIdx = starts.find((s) => s.idx > enclosing!.idx)?.idx ?? text.length;
         if (qIdx >= endIdx) continue;
-        const region = text.slice(enclosing.idx, endIdx);
-        const guarded = INLINE_AUTHZ_RE.test(region) || GUARDS.some((g) => region.includes(g));
+        // A middleware guard (tight path→=> window, like Net 1) is sufficient...
+        const arrowIdx = text.indexOf("=>", enclosing.afterIdx);
+        const middlewareWindow =
+          arrowIdx > enclosing.afterIdx ? text.slice(enclosing.afterIdx, arrowIdx) : "";
+        // ...otherwise the query-reading statement itself must constrain the value.
+        const guarded =
+          guardMatches(enclosing.path, middlewareWindow) ||
+          DATAFLOW_AUTHZ_RE.test(enclosingStatement(text, qIdx));
         const key = `${rel} ${enclosing.method} ${enclosing.path} ?${param}`;
         merged.set(key, (merged.get(key) ?? false) || guarded);
       }
@@ -284,7 +333,9 @@ function extractExtensionRoutes(): Route[] {
       const method = m[1].toUpperCase();
       const path = m[2];
       const middlewareWindow = m[3];
-      const guarded = GUARDS.some((g) => middlewareWindow.includes(g));
+      // requireSelf("<param>") must name the route's actual mind param — e.g.
+      // requireSelf("name") on a `/:author/...` route does NOT count.
+      const guarded = guardMatches(path, middlewareWindow);
       routes.push({ key: `${rel} ${method} ${path}`, guarded });
     }
   }

--- a/test/authz-coverage.test.ts
+++ b/test/authz-coverage.test.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
  */
 
 const API_DIR = fileURLToPath(new URL("../packages/daemon/src/web/api", import.meta.url));
+const EXT_DIR = fileURLToPath(new URL("../packages/extensions", import.meta.url));
 
 // Routes intentionally without an inline middleware guard. Each MUST be either
 // non-sensitive ("public") or enforce authorization inside the handler.
@@ -60,13 +61,10 @@ const AUTHZ_EXEMPT: Record<string, string> = {
   "volute/channels.ts GET /:name/members": "channel participant list (membership metadata)",
   "volute/channels.ts POST /:name/join": "self-action: joins the caller (user.id) to the channel",
   "volute/channels.ts POST /:name/leave": "self-action: removes the caller (user.id) from channel",
-  // NOTE: the two writes below are KNOWN integrity gaps deferred to a product
-  // decision on the channel-membership model (see SECURITY follow-up). They are
-  // exempted here only to scope this PR; they should be revisited.
   "volute/channels.ts PATCH /:name":
-    "DEFERRED: no membership/owner check on channel settings write (product decision pending)",
+    "in-handler authz: settings write requires the caller be a channel member (or admin/system)",
   "volute/channels.ts POST /:name/invite":
-    "DEFERRED: no membership/owner check on add-member (product decision pending)",
+    "in-handler authz: add-member requires the caller be a channel member (or admin/system)",
 };
 
 const GUARDS = ["requireSelf", "requireAdmin", "requireAdminOrSystem"];
@@ -134,6 +132,197 @@ describe("mind-scoped route authorization coverage", () => {
       [],
       `Stale AUTHZ_EXEMPT entries (route now guarded or no longer exists) — remove them:\n` +
         stale.map((v) => `  - ${v}`).join("\n"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Net 2: query-param-scoped handlers.
+//
+// The path-param net above cannot see handlers that take the target mind from a
+// client-supplied query param (`?mind=`, `?name=`, `?author=`) — precisely the
+// blind spot behind the #320 cross-tenant history leak, where any mind could
+// read another mind's turns/summaries/activity via `?mind=`. This net flags any
+// handler that reads such a param unless its enclosing route carries an authz
+// signal: a middleware guard, OR an in-handler role/self check (`user.role`,
+// `.username`, `getBaseName`, `resolveMindFilter`, `privileged`).
+// ---------------------------------------------------------------------------
+
+const QUERY_READ_RE = /c\.req\.query\(\s*"(mind|name|author)"\s*\)/g;
+const ROUTE_START_RE = /\.(get|post|put|patch|delete)\(\s*"([^"]*)"/g;
+// In-handler authorization signals: a role/self comparison or a shared resolver
+// that constrains the query to the caller's own mind.
+const INLINE_AUTHZ_RE = /\brole\b|\.username\b|resolveMindFilter|getBaseName|privileged/;
+
+// Query-param reads that are genuinely public (feeds/listings of already-public
+// content) and therefore need no per-caller authorization. Documented, honest.
+const QUERY_AUTHZ_EXEMPT: Record<string, string> = {
+  "notes/src/routes.ts GET / ?author":
+    "public: lists published notes filtered by author; no private data",
+  "notes/src/routes.ts GET /feed ?mind":
+    "public: home/mind feed of published notes; no private data",
+  "pages/src/routes.ts GET /feed ?mind":
+    "public: home/mind feed of published pages; no private data",
+};
+
+type ScanFile = { rel: string; text: string };
+
+function scanFiles(dir: string): ScanFile[] {
+  return listTsFiles(dir).map((file) => ({
+    rel: file.slice(dir.length + 1),
+    text: readFileSync(file, "utf-8"),
+  }));
+}
+
+type RouteStart = { idx: number; method: string; path: string };
+
+function routeStarts(text: string): RouteStart[] {
+  const starts: RouteStart[] = [];
+  for (const m of text.matchAll(ROUTE_START_RE)) {
+    starts.push({ idx: m.index ?? 0, method: m[1].toUpperCase(), path: m[2] });
+  }
+  return starts;
+}
+
+function extractQueryRoutes(): Route[] {
+  const merged = new Map<string, boolean>();
+  for (const dir of [API_DIR, EXT_DIR]) {
+    for (const { rel, text } of scanFiles(dir)) {
+      const starts = routeStarts(text);
+      for (const q of text.matchAll(QUERY_READ_RE)) {
+        const qIdx = q.index ?? 0;
+        const param = q[1];
+        // Enclosing route = the nearest route registration before this read.
+        let enclosing: RouteStart | undefined;
+        for (const s of starts) {
+          if (s.idx < qIdx) enclosing = s;
+          else break;
+        }
+        // A read before any route (e.g. a top-level resolver) is not a route
+        // handler; the routes that call it are analyzed on their own merits.
+        if (!enclosing) continue;
+        const endIdx = starts.find((s) => s.idx > enclosing!.idx)?.idx ?? text.length;
+        if (qIdx >= endIdx) continue;
+        const region = text.slice(enclosing.idx, endIdx);
+        const guarded = INLINE_AUTHZ_RE.test(region) || GUARDS.some((g) => region.includes(g));
+        const key = `${rel} ${enclosing.method} ${enclosing.path} ?${param}`;
+        merged.set(key, (merged.get(key) ?? false) || guarded);
+      }
+    }
+  }
+  return [...merged].map(([key, guarded]) => ({ key, guarded }));
+}
+
+describe("query-param mind-scoped handler authorization coverage", () => {
+  const routes = extractQueryRoutes();
+
+  it("discovers query-param mind-scoped handlers (guards the regex itself)", () => {
+    assert.ok(routes.length >= 3, `expected >=3 query-param handlers, found ${routes.length}`);
+  });
+
+  it("guards or explicitly exempts every ?mind=/?name=/?author= handler", () => {
+    const violations = routes
+      .filter((r) => !r.guarded && !(r.key in QUERY_AUTHZ_EXEMPT))
+      .map((r) => r.key);
+    assert.deepEqual(
+      violations,
+      [],
+      `Query-param handler(s) that derive the target mind from a client-supplied param ` +
+        `without an authz check:\n` +
+        violations.map((v) => `  - ${v}`).join("\n") +
+        `\n\nConstrain the query to the caller's own mind (role/self check), or — only if ` +
+        `the data is genuinely public — add it to QUERY_AUTHZ_EXEMPT with a reason.`,
+    );
+  });
+
+  it("has no stale QUERY_AUTHZ_EXEMPT entries", () => {
+    const present = new Set(routes.map((r) => r.key));
+    const guarded = new Set(routes.filter((r) => r.guarded).map((r) => r.key));
+    const stale = Object.keys(QUERY_AUTHZ_EXEMPT).filter((k) => !present.has(k) || guarded.has(k));
+    assert.deepEqual(
+      stale,
+      [],
+      `Stale QUERY_AUTHZ_EXEMPT entries — remove them:\n${stale.join("\n")}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Net 3: extension routes.
+//
+// Everything under packages/extensions/*/src is outside the daemon scan root,
+// yet extensions get only `authMiddleware` from the loader — per-resource authz
+// is per-handler (and, per #322, was sometimes wrong). This net enumerates
+// extension routes whose path contains a mind identifier (`:name`, `:mind`,
+// `:author`) anywhere and requires each to carry the canonical `requireSelf`
+// (or `requireAdmin`/`requireAdminOrSystem`) middleware, or be documented here.
+// ---------------------------------------------------------------------------
+
+const EXT_ROUTE_RE =
+  /\.(get|post|put|patch|delete)\(\s*"(\/[^"]*:(?:name|mind|author)[^"]*)"([\s\S]*?)=>/g;
+
+const EXT_AUTHZ_EXEMPT: Record<string, string> = {
+  // Public reads of already-published content.
+  "notes/src/routes.ts GET /:author/:slug": "public: reads a single published note",
+  "pages/src/routes.ts GET /:name/*":
+    "public route (createPublicRoutes, no auth): serves published page snapshots; " +
+    "path traversal contained by an in-handler prefix check",
+  // Interaction endpoints: any authenticated user may react/comment on any
+  // author's note; write ownership is enforced by actor.id, not the :author.
+  "notes/src/routes.ts POST /:author/:slug/reactions":
+    "interaction: any authenticated user may react; keyed by actor.id",
+  "notes/src/routes.ts POST /:author/:slug/comments":
+    "interaction: any authenticated user may comment; keyed by actor.id",
+  "notes/src/routes.ts DELETE /:author/:slug/comments/:id":
+    "in-handler authz: deletes the caller's own comment (actor.id ownership), not author-scoped",
+};
+
+function extractExtensionRoutes(): Route[] {
+  const routes: Route[] = [];
+  for (const { rel, text } of scanFiles(EXT_DIR)) {
+    for (const m of text.matchAll(EXT_ROUTE_RE)) {
+      const method = m[1].toUpperCase();
+      const path = m[2];
+      const middlewareWindow = m[3];
+      const guarded = GUARDS.some((g) => middlewareWindow.includes(g));
+      routes.push({ key: `${rel} ${method} ${path}`, guarded });
+    }
+  }
+  return routes;
+}
+
+describe("extension mind-scoped route authorization coverage", () => {
+  const routes = extractExtensionRoutes();
+
+  it("discovers extension mind-scoped routes (guards the regex itself)", () => {
+    assert.ok(
+      routes.length >= 5,
+      `expected >=5 extension mind-scoped routes, found ${routes.length}`,
+    );
+  });
+
+  it("guards or explicitly exempts every extension :name/:mind/:author route", () => {
+    const violations = routes
+      .filter((r) => !r.guarded && !(r.key in EXT_AUTHZ_EXEMPT))
+      .map((r) => r.key);
+    assert.deepEqual(
+      violations,
+      [],
+      `Extension route(s) scoped to a mind identifier without an authz guard:\n` +
+        violations.map((v) => `  - ${v}`).join("\n") +
+        `\n\nMount ctx.requireSelf("<param>") on the route, or — only if it is genuinely ` +
+        `public or an open interaction endpoint — add it to EXT_AUTHZ_EXEMPT with a reason.`,
+    );
+  });
+
+  it("has no stale EXT_AUTHZ_EXEMPT entries", () => {
+    const present = new Set(routes.map((r) => r.key));
+    const guarded = new Set(routes.filter((r) => r.guarded).map((r) => r.key));
+    const stale = Object.keys(EXT_AUTHZ_EXEMPT).filter((k) => !present.has(k) || guarded.has(k));
+    assert.deepEqual(
+      stale,
+      [],
+      `Stale EXT_AUTHZ_EXEMPT entries — remove them:\n${stale.join("\n")}`,
     );
   });
 });

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -384,6 +384,55 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     );
   });
 
+  it("channel writes (PATCH settings, invite) require membership for non-admin callers", async () => {
+    // Admin creates a channel.
+    const createRes = await daemonRequest("/api/v1/channels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "e2e-authz-channel" }),
+    });
+    assert.equal(createRes.status, 201, `create: ${await createRes.clone().text()}`);
+
+    // A mind principal that is NOT a member of the channel.
+    const outsider = await getOrCreateMindUser("e2e-channel-outsider");
+    const outsiderSession = await createSession(outsider.id);
+    const asOutsider = (path: string, options?: RequestInit): Promise<Response> => {
+      const headers = new Headers(options?.headers);
+      headers.set("Authorization", `Bearer ${outsiderSession}`);
+      headers.set("Origin", BASE_URL);
+      return fetch(`${BASE_URL}${path}`, { ...options, headers });
+    };
+
+    // Non-member cannot change settings...
+    const patchDenied = await asOutsider("/api/v1/channels/e2e-authz-channel", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "hijacked" }),
+    });
+    assert.equal(patchDenied.status, 403, "non-member PATCH must be forbidden");
+
+    // ...nor invite others.
+    const inviteDenied = await asOutsider("/api/v1/channels/e2e-authz-channel/invite", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "e2e-channel-victim" }),
+    });
+    assert.equal(inviteDenied.status, 403, "non-member invite must be forbidden");
+
+    // Once the mind joins, it becomes a member and may change settings.
+    const joinRes = await asOutsider("/api/v1/channels/e2e-authz-channel/join", { method: "POST" });
+    assert.equal(joinRes.status, 200, `join: ${await joinRes.clone().text()}`);
+
+    const patchOk = await asOutsider("/api/v1/channels/e2e-authz-channel", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "set by member" }),
+    });
+    assert.equal(patchOk.status, 200, `member PATCH: ${await patchOk.clone().text()}`);
+    const patched = (await patchOk.json()) as { settings?: { description?: string } };
+    assert.equal(patched.settings?.description, "set by member");
+  });
+
   it("conversations: create, send message, read back", async () => {
     await ensureTestMind();
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -3,12 +3,17 @@ import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   findMind,
   mindDir,
   removeMind,
   voluteSystemDir,
 } from "../packages/daemon/src/lib/mind/registry.js";
+import { activity, mindHistory, summaries, turns } from "../packages/daemon/src/lib/schema.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 // Strip GIT_* env vars that hook runners (e.g. pre-push) inject, so that
 // spawned processes (like `volute create` which runs `git init`) don't
@@ -1267,6 +1272,115 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
+    });
+  });
+
+  describe("history API cross-tenant authorization", () => {
+    const ALICE = "e2e-hist-alice";
+    const BOB = "e2e-hist-bob";
+    const BOB_SECRET = "BOB-PRIVATE-DM-SECRET";
+    const ALICE_SECRET = "ALICE-PRIVATE-DM-SECRET";
+    let aliceSession: string;
+    let bobSummaryId: number;
+
+    // Request as mind Alice using a DB-backed session (the daemon shares this
+    // test's VOLUTE_HOME, so a session created here resolves to Alice's
+    // non-admin mind user inside the daemon).
+    function aliceRequest(path: string): Promise<Response> {
+      return fetch(`${BASE_URL}${path}`, {
+        headers: { Authorization: `Bearer ${aliceSession}`, Origin: BASE_URL },
+      });
+    }
+
+    before(async () => {
+      const db = await getDb();
+      const alice = await getOrCreateMindUser(ALICE);
+      await getOrCreateMindUser(BOB);
+      aliceSession = await createSession(alice.id);
+
+      // Seed a turn + private DM content + summary + activity for each mind.
+      for (const [mind, secret] of [
+        [ALICE, ALICE_SECRET],
+        [BOB, BOB_SECRET],
+      ] as const) {
+        const turnId = `${mind}-turn-1`;
+        await db.insert(turns).values({ id: turnId, mind, status: "done" });
+        await db.insert(mindHistory).values({
+          mind,
+          channel: "@partner",
+          sender: "partner",
+          type: "inbound",
+          content: secret,
+          turn_id: turnId,
+        });
+        await db
+          .insert(summaries)
+          .values({ mind, period: "turn", period_key: turnId, content: `${secret} summary` });
+        await db.insert(activity).values({ type: "message", mind, summary: `${secret} activity` });
+      }
+
+      const bobSummary = await db
+        .select({ id: summaries.id })
+        .from(summaries)
+        .where(eq(summaries.mind, BOB))
+        .get();
+      bobSummaryId = bobSummary!.id;
+    });
+
+    it("/turns ignores ?mind= for a mind principal and never leaks another mind", async () => {
+      const res = await aliceRequest(`/api/v1/history/turns?mind=${BOB}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      const text = JSON.stringify(body);
+      assert.ok(!text.includes(BOB_SECRET), "Alice must not see Bob's private DM content");
+      assert.ok(
+        body.every((t) => t.mind === ALICE),
+        "Alice's turn query must only return Alice's turns",
+      );
+      // Alice still sees her own turn (filter forced to self, not denied).
+      assert.ok(
+        body.some((t) => t.id === `${ALICE}-turn-1`),
+        "Alice should see her own turn",
+      );
+    });
+
+    it("/summaries ignores ?mind= for a mind principal", async () => {
+      const res = await aliceRequest(`/api/v1/history/summaries?mind=${BOB}&period=turn`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.ok(
+        body.every((s) => s.mind === ALICE),
+        "Alice must only receive her own summaries",
+      );
+      assert.ok(!JSON.stringify(body).includes(BOB_SECRET));
+    });
+
+    it("/summaries by ids cannot reach another mind's summary", async () => {
+      const res = await aliceRequest(`/api/v1/history/summaries?ids=${bobSummaryId}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.equal(body.length, 0, "Alice must not fetch Bob's summary by id");
+    });
+
+    it("/activity ignores ?mind= for a mind principal", async () => {
+      const res = await aliceRequest(`/api/v1/history/activity?mind=${BOB}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.ok(
+        body.every((a) => a.mind === ALICE),
+        "Alice must only receive her own activity",
+      );
+      assert.ok(!JSON.stringify(body).includes(BOB_SECRET));
+    });
+
+    it("admin/daemon token may still query another mind (behavior preserved)", async () => {
+      const res = await daemonRequest(`/api/v1/history/turns?mind=${BOB}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      assert.ok(
+        body.some((t) => t.mind === BOB),
+        "Admin should still be able to read Bob's turns",
+      );
     });
   });
 });

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -3,8 +3,11 @@ import { describe, it } from "node:test";
 import {
   bufferEvent,
   getEventsSince,
+  nextEventId,
   resetSequencer,
 } from "../packages/daemon/src/lib/events/event-sequencer.js";
+
+const NO_CONVS = new Set<string>();
 
 describe("event sequencer", () => {
   it("assigns monotonically increasing IDs", () => {
@@ -60,7 +63,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(id1);
+    const events = getEventsSince(id1, NO_CONVS);
     assert.equal(events.length, 2);
     assert.equal(events[0].id, id2);
     assert.equal(events[1].id, id3);
@@ -78,7 +81,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(id);
+    const events = getEventsSince(id, NO_CONVS);
     assert.equal(events.length, 0);
   });
 
@@ -94,7 +97,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(9999);
+    const events = getEventsSince(9999, NO_CONVS);
     assert.equal(events.length, 0);
   });
 
@@ -115,32 +118,30 @@ describe("event sequencer", () => {
 
     // Events with IDs 1-5 should have been trimmed
     // Trying to replay from 0 should only get ~1000 events
-    const events = getEventsSince(0);
+    const events = getEventsSince(0, NO_CONVS);
     assert.ok(events.length <= 1000);
     // First event should have ID > 5
     assert.ok(events[0].id > 5);
   });
 
-  it("handles snapshot events in buffer", () => {
+  it("never replays snapshot events (they are connection-specific)", () => {
     resetSequencer();
     const id = bufferEvent({
       event: "snapshot",
       conversations: [],
       activity: [],
-      sites: [],
-      recentPages: [],
       activeMinds: [],
+      onlineBrains: [],
     });
     assert.ok(id > 0);
 
-    const events = getEventsSince(0);
-    assert.equal(events.length, 1);
-    assert.equal(events[0].data.event, "snapshot");
+    const events = getEventsSince(0, NO_CONVS);
+    assert.equal(events.length, 0);
   });
 
-  it("handles conversation events in buffer", () => {
+  it("only replays conversation events to participants", () => {
     resetSequencer();
-    const _id = bufferEvent({
+    bufferEvent({
       event: "conversation",
       conversationId: "conv-123",
       type: "message",
@@ -151,8 +152,60 @@ describe("event sequencer", () => {
       createdAt: "2024-01-01",
     });
 
-    const events = getEventsSince(0);
+    // A caller who is not a participant sees nothing.
+    assert.equal(getEventsSince(0, NO_CONVS).length, 0);
+    assert.equal(getEventsSince(0, new Set(["other-conv"])).length, 0);
+
+    // A participant sees the event.
+    const events = getEventsSince(0, new Set(["conv-123"]));
     assert.equal(events.length, 1);
     assert.equal(events[0].data.event, "conversation");
+  });
+
+  it("filters conversation events but keeps global activity in a mixed buffer", () => {
+    resetSequencer();
+    bufferEvent({
+      event: "activity",
+      id: 1,
+      type: "mind_started",
+      mind: "a",
+      summary: "s",
+      metadata: null,
+      created_at: "2024-01-01",
+    });
+    bufferEvent({
+      event: "conversation",
+      conversationId: "private-conv",
+      type: "message",
+      id: 2,
+      role: "user",
+      senderName: "bob",
+      content: [{ type: "text", text: "secret" }],
+      createdAt: "2024-01-01",
+    });
+
+    // Outsider gets only the global activity event, never the private message.
+    const events = getEventsSince(0, NO_CONVS);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].data.event, "activity");
+  });
+
+  it("nextEventId advances the counter without buffering", () => {
+    resetSequencer();
+    const id = nextEventId();
+    assert.ok(id > 0);
+    // Nothing buffered, so no replay.
+    assert.equal(getEventsSince(0, NO_CONVS).length, 0);
+    // Subsequent buffered events get higher IDs.
+    const bufId = bufferEvent({
+      event: "activity",
+      id: 1,
+      type: "mind_started",
+      mind: "a",
+      summary: "s",
+      metadata: null,
+      created_at: "2024-01-01",
+    });
+    assert.ok(bufId > id);
   });
 });


### PR DESCRIPTION
## Summary

Extends the `test/authz-coverage.test.ts` meta-test — the CI safety net against the dominant vulnerability class (mind-scoped routes that forget per-resource authorization) — to cover the two blind spots that produced real vulnerabilities:

1. **Query-param-scoped handlers** — a new net scans the daemon API *and* `packages/extensions/*/src` for handlers that derive the target mind from `c.req.query("mind"|"name"|"author")` and flags any that lack a role/self guard. Own documented `QUERY_AUTHZ_EXEMPT` allowlist for genuinely-public feeds. This is the class behind the #320 cross-tenant history leak.
2. **Extension routes** — a new net requires a canonical guard on every extension route scoped to `:name`/`:mind`/`:author`, with a documented `EXT_AUTHZ_EXEMPT` allowlist. This is the class behind the #322 command impersonation.

Supporting production changes:
- Add `ctx.requireSelf()` to `ExtensionContext` (reuses the daemon's canonical guard) and adopt it in the **pages** (`PUT /publish/:name`, `GET /status/:name`) and **notes** (`PUT`/`DELETE /:author/:slug`) routes so extensions stop hand-rolling role checks.
- Close the two previously-`DEFERRED` channel writes (`PATCH /:name`, `POST /:name/invite`) with a channel-membership check (admin/system bypass) and update their exemption reasons to reflect the now-present in-handler authz.

Each net carries a "discovers a meaningful number of routes" sanity assertion so a broken regex can't make it vacuous, plus a "no stale exemptions" check.

## Stacking

**Stacked on #341 (#320) and #339 (#322) — merge after those; this PR's diff narrows to only the test/helper changes once they land.** The new nets are designed to pass against the *fixed* tree, so those two fix branches are merged into this branch. Their commits appear in this diff temporarily and disappear automatically once they merge.

## Exemptions burned down vs. kept
- **Burned down:** `channels.ts PATCH /:name` and `POST /:name/invite` are no longer `DEFERRED` — they now enforce membership; exemption reasons updated to "in-handler authz".
- **Kept (honest):** the two `minds.ts GET .../conversations[/messages]` exemptions retain their `NOTE: DMs default private:0` follow-up — resolving the conversation-privacy model is a deeper product change deferred as out of scope for this test PR.
- **New, documented:** public notes/pages feeds (`QUERY_AUTHZ_EXEMPT`), and public reads / open interaction endpoints in notes + the public pages route (`EXT_AUTHZ_EXEMPT`).

## Testing
- `npm run build` — pass.
- `npm test` (unit, incl. all three authz nets) — 1612/1612 pass.
- `npm run test:e2e` — the new "channel writes require membership" test passes, as do the merged-in history + extension-command tests. The 5 remaining e2e failures are pre-existing environment failures (a strict subset of the 22 failures on the origin/main baseline; they require a fully spawned mind/daemon) and are unrelated to these changes.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)