### PR TITLE
fix: install deps when spirit switches templates

### DIFF
--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -8,6 +8,7 @@ import {
   composeTemplate,
   copyTemplateToDir,
   findTemplatesRoot,
+  renderComposedPackageJson,
 } from "../template/template.js";
 import { exec } from "../util/exec.js";
 import log from "../util/logger.js";
@@ -190,9 +191,9 @@ export async function syncSpiritTemplate(): Promise<void> {
     if (existsSync(newSrc)) {
       cpSync(newSrc, resolve(dir, "src"), { recursive: true });
     }
-    // Copy new package.json and re-install
-    const newPkg = resolve(newComposed.composedDir, "package.json");
-    if (existsSync(newPkg)) {
+    // Render + copy new package.json and re-install
+    const newPkg = renderComposedPackageJson(newComposed.composedDir, "volute");
+    if (newPkg) {
       cpSync(newPkg, resolve(dir, "package.json"));
       await exec("npm", ["install"], { cwd: dir, env: npmEnv() });
     }
@@ -247,10 +248,10 @@ export async function syncSpiritTemplate(): Promise<void> {
   }
 
   // Re-install if package.json changed or node_modules is missing (self-healing)
-  const composedPkg = resolve(composedDir, "package.json");
+  const composedPkg = renderComposedPackageJson(composedDir, "volute");
   const currentPkg = resolve(dir, "package.json");
   const nodeModulesMissing = !existsSync(resolve(dir, "node_modules"));
-  if (existsSync(composedPkg)) {
+  if (composedPkg) {
     const composedContent = readFileSync(composedPkg, "utf-8");
     const currentContent = existsSync(currentPkg) ? readFileSync(currentPkg, "utf-8") : "";
     if (composedContent !== currentContent || nodeModulesMissing) {

--- a/packages/daemon/src/lib/template/template.ts
+++ b/packages/daemon/src/lib/template/template.ts
@@ -131,6 +131,26 @@ export function copyTemplateToDir(
 }
 
 /**
+ * Render the composed template's package.json from package.json.tmpl.
+ *
+ * composeTemplate() leaves package.json as package.json.tmpl — the rename +
+ * {{name}} substitution normally happen in copyTemplateToDir(). Callers that
+ * read composedDir/package.json directly (e.g. syncSpiritTemplate) must render
+ * it first, otherwise a template switch silently skips updating deps / npm
+ * install. Idempotent; returns the rendered package.json path, or null if the
+ * template ships no package.json.tmpl.
+ */
+export function renderComposedPackageJson(composedDir: string, mindName: string): string | null {
+  const dest = resolve(composedDir, "package.json");
+  if (existsSync(dest)) return dest;
+  const tmpl = resolve(composedDir, "package.json.tmpl");
+  if (!existsSync(tmpl)) return null;
+  const content = readFileSync(tmpl, "utf-8").replaceAll("{{name}}", mindName);
+  writeFileSync(dest, content);
+  return dest;
+}
+
+/**
  * Copy .init/ files into home/ and remove .init/.
  * Called during mind creation (not during upgrades).
  */

--- a/test/template-compose.test.ts
+++ b/test/template-compose.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import {
   composeTemplate,
   findTemplatesRoot,
+  renderComposedPackageJson,
 } from "../packages/daemon/src/lib/template/template.js";
 
 describe("template composition", () => {
@@ -165,6 +166,32 @@ describe("template composition", () => {
 
       // Skills no longer bundled in template (managed via shared pool)
       assert.ok(!existsSync(resolve(composedDir, "_skills")), "_skills should not exist");
+    } finally {
+      rmSync(composedDir, { recursive: true, force: true });
+    }
+  });
+
+  it("renders package.json from the composed template's .tmpl", () => {
+    // Regression: composeTemplate() leaves package.json unrendered as
+    // package.json.tmpl (the rename happens only in copyTemplateToDir). Callers
+    // like syncSpiritTemplate that read composedDir/package.json directly get
+    // nothing, so a template switch never updates deps or runs npm install.
+    const { composedDir } = composeTemplate(templatesRoot, "pi");
+    try {
+      assert.ok(
+        !existsSync(resolve(composedDir, "package.json")),
+        "composeTemplate should not produce a plain package.json",
+      );
+
+      const pkgPath = renderComposedPackageJson(composedDir, "volute");
+      assert.ok(pkgPath && existsSync(pkgPath), "package.json should be rendered");
+
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      assert.equal(pkg.name, "volute", "{{name}} should be substituted");
+      assert.ok(
+        pkg.dependencies["@earendil-works/pi-coding-agent"],
+        "pi template deps should be present",
+      );
     } finally {
       rmSync(composedDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

The system spirit went offline (crash-looping on startup) with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@earendil-works/pi-coding-agent'
  imported from <spirit>/src/agent.ts
```

Its `src/` had been switched to the **pi** template, but `package.json` and `node_modules` were still from the **codex** template — so the pi SDK wasn't installed.

## Root cause

`syncSpiritTemplate()` reads `composedDir/package.json` directly, but `composeTemplate()` leaves it as `package.json.tmpl` — the rename to `package.json` (and `{{name}}` substitution) happens only in `copyTemplateToDir()`, which `syncSpiritTemplate` never calls. So the guard `existsSync(composedDir/package.json)` was **always false**, and on a template switch (e.g. when the spirit's model resolves to a different provider/template) the `package.json` copy and `npm install` were **silently skipped**. The spirit ended up with the new template's source and the old template's dependencies, and crashed on startup.

This affected both the template-change branch and the "self-healing" branch of `syncSpiritTemplate`.

## Fix

Add `renderComposedPackageJson()` to materialize `package.json` from `package.json.tmpl` (with `{{name}}` substitution), and use it in both `syncSpiritTemplate` code paths so a template switch actually updates `package.json` and reinstalls deps.

## Test

`test/template-compose.test.ts` gains a regression test asserting that `composeTemplate()` produces no plain `package.json` and that `renderComposedPackageJson()` renders one with the substituted name and the expected deps. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)