### PR TITLE
feat: allow adding custom (freeform) AI models

### DIFF
--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -9,12 +9,13 @@ import {
 import {
   type AiConfig,
   type AiProviderConfig,
+  type CustomModel,
   readGlobalConfig,
   writeGlobalConfig,
 } from "./config/setup.js";
 import log from "./util/logger.js";
 
-export type { AiConfig, AiProviderConfig } from "./config/setup.js";
+export type { AiConfig, AiProviderConfig, CustomModel } from "./config/setup.js";
 
 const aiLog = log.child("ai-service");
 
@@ -206,12 +207,135 @@ export function setEnabledModels(modelIds: string[]): void {
   writeGlobalConfig({ ...config, ai });
 }
 
-/** Returns all models from configured providers. */
+/** Get the admin-defined custom models (not in pi-ai's built-in catalog). */
+export function getCustomModels(): CustomModel[] {
+  return getAiConfig()?.customModels ?? [];
+}
+
+/** Register a custom model for a provider (no-op if it already exists). */
+export function addCustomModel(provider: string, id: string, name?: string): void {
+  const ai = getAiConfig() ?? { providers: {} };
+  const customModels = ai.customModels ?? [];
+  if (!customModels.some((m) => m.provider === provider && m.id === id)) {
+    customModels.push({ provider, id, ...(name ? { name } : {}) });
+  }
+  ai.customModels = customModels;
+  const config = readGlobalConfig();
+  writeGlobalConfig({ ...config, ai });
+}
+
+/** Remove a custom model and drop it from the enabled list. */
+export function removeCustomModel(provider: string, id: string): void {
+  const ai = getAiConfig();
+  if (!ai) return;
+  const customModels = (ai.customModels ?? []).filter(
+    (m) => !(m.provider === provider && m.id === id),
+  );
+  ai.customModels = customModels.length > 0 ? customModels : undefined;
+  if (!ai.customModels) delete ai.customModels;
+  if (ai.models) {
+    ai.models = ai.models.filter((mid) => mid !== id);
+    if (ai.models.length === 0) delete ai.models;
+  }
+  const config = readGlobalConfig();
+  writeGlobalConfig({ ...config, ai });
+}
+
+/** Length of the shared leading prefix of two strings. */
+function sharedPrefixLength(a: string, b: string): number {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+}
+
+/**
+ * Pick the built-in model of `provider` that best represents a custom model
+ * `id`: the sibling sharing the longest id prefix (assumed same family, so
+ * likely matching api/compat/caps), breaking ties toward the largest context
+ * window. When no family overlaps, this selects the largest-context sibling.
+ * Returns undefined when the provider has no built-in models.
+ *
+ * NOTE: the pi template has its own copy of this heuristic in
+ * templates/pi/src/lib/resolve-model.ts (the template can't import daemon code);
+ * keep the two in sync.
+ */
+function pickSibling(provider: string, id: string): Model<Api> | undefined {
+  const siblings = getBuiltinModels(provider as never) as Model<Api>[];
+  if (siblings.length === 0) return undefined;
+  let best = siblings[0];
+  let bestPrefix = -1;
+  for (const s of siblings) {
+    const prefix = sharedPrefixLength(s.id, id);
+    if (prefix > bestPrefix || (prefix === bestPrefix && s.contextWindow > best.contextWindow)) {
+      bestPrefix = prefix;
+      best = s;
+    }
+  }
+  return best;
+}
+
+/**
+ * Build a usable Model for a custom id by cloning a sibling built-in model of
+ * the same provider (inherits api/baseUrl/compat/caps) and overriding id/name.
+ * Cost is zeroed since we don't know the real pricing. Returns undefined when
+ * the provider has no built-in template.
+ */
+export function buildCustomModel(
+  provider: string,
+  id: string,
+  name?: string,
+): Model<Api> | undefined {
+  const sibling = pickSibling(provider, id);
+  if (!sibling) return undefined;
+  return {
+    ...sibling,
+    id,
+    name: name ?? id,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  };
+}
+
+/**
+ * Drop any custom models that pi-ai has since added to its built-in catalog
+ * (built-in always wins). Writes only when something is pruned. Returns the
+ * remaining custom models.
+ */
+function pruneAbsorbedCustomModels(): CustomModel[] {
+  const ai = getAiConfig();
+  const custom = ai?.customModels ?? [];
+  if (custom.length === 0 || !ai) return custom;
+  const kept = custom.filter((cm) => !getBuiltinModel(cm.provider as never, cm.id as never));
+  if (kept.length !== custom.length) {
+    ai.customModels = kept.length > 0 ? kept : undefined;
+    if (!ai.customModels) delete ai.customModels;
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, ai });
+  }
+  return kept;
+}
+
+/** Returns all models from configured providers, including custom models. */
 export async function getAvailableModels(): Promise<Model<Api>[]> {
   const providers = await getConfiguredProviders();
+  const configured = new Set(providers);
   const result: Model<Api>[] = [];
+  const seen = new Set<string>();
   for (const provider of providers) {
-    result.push(...(getBuiltinModels(provider as never) as Model<Api>[]));
+    for (const m of getBuiltinModels(provider as never) as Model<Api>[]) {
+      result.push(m);
+      seen.add(m.id);
+    }
+  }
+  // Custom models for configured providers, skipping ids the catalog now covers.
+  for (const cm of pruneAbsorbedCustomModels()) {
+    if (!configured.has(cm.provider) || seen.has(cm.id)) continue;
+    const built = buildCustomModel(cm.provider, cm.id, cm.name);
+    if (built) {
+      result.push(built);
+      seen.add(cm.id);
+    } else {
+      aiLog.warn(`custom model ${cm.provider}:${cm.id} has no sibling to clone from; skipping`);
+    }
   }
   return result;
 }
@@ -258,10 +382,17 @@ export function unqualifyModelId(modelId: string): string {
 }
 
 function findModel(modelId: string): Model<Api> | undefined {
-  // Exact match against the built-in catalog
+  // Exact match against the built-in catalog (built-in always wins)
   for (const provider of getBuiltinProviders()) {
     const model = getBuiltinModel(provider as never, modelId as never);
     if (model) return model as Model<Api>;
+  }
+  // Admin-defined custom models
+  for (const cm of getCustomModels()) {
+    if (cm.id === modelId) {
+      const built = buildCustomModel(cm.provider, cm.id, cm.name);
+      if (built) return built;
+    }
   }
   // Prefix match fallback
   for (const provider of getBuiltinProviders()) {

--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -23,9 +23,19 @@ export type AiProviderConfig = {
   };
 };
 
+/**
+ * An admin-defined model on an already-configured provider, for models not yet
+ * in pi-ai's built-in catalog. Only identity (provider + id, plus an optional
+ * display name) is stored; the heavy metadata (api/baseUrl/caps/cost) is cloned
+ * from a sibling built-in model of the same provider at resolution time so it
+ * never goes stale as the catalog evolves.
+ */
+export type CustomModel = { provider: string; id: string; name?: string };
+
 export type AiConfig = {
   providers: Record<string, AiProviderConfig>;
   models?: string[];
+  customModels?: CustomModel[];
   utilityModel?: string;
 };
 

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -13,12 +13,16 @@ import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import {
+  addCustomModel,
+  buildCustomModel,
   getAiConfig,
   getAvailableModels,
   getConfiguredProviders,
+  getCustomModels,
   getEnabledModels,
   getUtilityModel,
   removeAiConfig,
+  removeCustomModel,
   removeProviderConfig,
   resolveApiKey,
   saveProviderConfig,
@@ -339,6 +343,7 @@ const app = new Hono<AuthEnv>()
   .get("/ai/models", requireAdmin, async (c) => {
     const models = await getAvailableModels();
     const enabled = new Set(getEnabledModels());
+    const customIds = new Set(getCustomModels().map((m) => m.id));
     return c.json(
       models.map((m) => ({
         id: m.id,
@@ -347,6 +352,7 @@ const app = new Hono<AuthEnv>()
         contextWindow: m.contextWindow,
         maxTokens: m.maxTokens,
         enabled: enabled.has(m.id),
+        custom: customIds.has(m.id),
       })),
     );
   })
@@ -360,6 +366,44 @@ const app = new Hono<AuthEnv>()
       return c.json({ ok: true });
     },
   )
+  .post(
+    "/ai/models/custom",
+    requireAdmin,
+    zValidator(
+      "json",
+      z.object({ provider: z.string().min(1), id: z.string().min(1), name: z.string().optional() }),
+    ),
+    (c) => {
+      const { provider, id, name } = c.req.valid("json");
+      // Must be a provider we can clone metadata from, or the model would be
+      // stored but never resolve.
+      if (!buildCustomModel(provider, id)) {
+        return c.json(
+          { error: `No built-in model for provider "${provider}" to clone metadata from` },
+          400,
+        );
+      }
+      // The enabled list and resolution are keyed by bare id, so a custom id must
+      // be unique across providers to stay unambiguous.
+      if (getCustomModels().some((m) => m.id === id && m.provider !== provider)) {
+        return c.json(
+          { error: `A custom model "${id}" is already registered under another provider` },
+          400,
+        );
+      }
+      addCustomModel(provider, id, name);
+      // Enable it immediately (dedupe against already-enabled ids).
+      setEnabledModels([...new Set([...getEnabledModels(), id])]);
+      return c.json({ ok: true });
+    },
+  )
+  .delete("/ai/models/custom", requireAdmin, (c) => {
+    const provider = c.req.query("provider");
+    const id = c.req.query("id");
+    if (!provider || !id) return c.json({ error: "provider and id are required" }, 400);
+    removeCustomModel(provider, id);
+    return c.json({ ok: true });
+  })
   .get("/ai/defaults", requireAdmin, (c) => {
     const config = readGlobalConfig();
     return c.json({

--- a/packages/web/src/ui/components/system/AiProviders.svelte
+++ b/packages/web/src/ui/components/system/AiProviders.svelte
@@ -3,6 +3,8 @@ import { Modal } from "@volute/ui";
 import {
   type AiModel,
   type AiProvider,
+  addCustomModel,
+  deleteCustomModel,
   fetchAiModels,
   fetchAiProviders,
   pollAiOAuthStatus,
@@ -97,6 +99,16 @@ let modelSuggestions = $derived(
         )
         .slice(0, 12)
     : aiModels.filter((m) => !m.enabled && m.provider === modelSearchProvider).slice(0, 12),
+);
+
+// Offer a custom-model option when the typed id doesn't already exist for this provider.
+let canAddCustomModel = $derived(
+  modelSearch.trim().length > 0 &&
+    !aiModels.some(
+      (m) =>
+        m.provider === modelSearchProvider &&
+        m.id.toLowerCase() === modelSearch.trim().toLowerCase(),
+    ),
 );
 
 function authMethodLabel(method: string | null): string {
@@ -286,12 +298,37 @@ async function addModel(modelId: string) {
   }
 }
 
-async function removeModel(modelId: string) {
-  const updated = enabledModels.map((m) => m.id).filter((id) => id !== modelId);
+// Register a freeform model id (not in pi-ai's built-in catalog) for an already-configured provider.
+async function addCustom() {
+  const id = modelSearch.trim();
+  if (!id) return;
+  try {
+    await addCustomModel(modelSearchProvider, id);
+    modelSearch = "";
+    showModelSearch = false;
+    await load();
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to add custom model";
+  }
+}
+
+async function removeModel(model: AiModel) {
+  // Custom models are user-created: removing deletes them outright.
+  if (model.custom) {
+    try {
+      await deleteCustomModel(model.provider, model.id);
+      aiModels = aiModels.filter((m) => m.id !== model.id);
+      if (utilityModel === model.id) utilityModel = "";
+    } catch (err) {
+      error = err instanceof Error ? err.message : "Failed to remove custom model";
+    }
+    return;
+  }
+  const updated = enabledModels.map((m) => m.id).filter((id) => id !== model.id);
   try {
     await saveEnabledModels(updated);
-    aiModels = aiModels.map((m) => (m.id === modelId ? { ...m, enabled: false } : m));
-    if (utilityModel === modelId) utilityModel = "";
+    aiModels = aiModels.map((m) => (m.id === model.id ? { ...m, enabled: false } : m));
+    if (utilityModel === model.id) utilityModel = "";
   } catch (err) {
     error = err instanceof Error ? err.message : "Failed to remove model";
   }
@@ -319,16 +356,14 @@ async function removeModel(modelId: string) {
             {#each providerModels as model (model.id)}
               <span class="model-tag">
                 {model.id}
-                <button class="model-tag-remove" onclick={() => removeModel(model.id)}>×</button>
+                <button class="model-tag-remove" onclick={() => removeModel(model)}>×</button>
               </span>
             {/each}
           </div>
         {:else}
           <span class="dim">No models enabled</span>
         {/if}
-        {#if aiModels.some((m) => !m.enabled && m.provider === provider.id)}
-          <button class="add-model-btn" onclick={() => { modelSearchProvider = provider.id; modelSearch = ""; showModelSearch = true; }}>Add model</button>
-        {/if}
+        <button class="add-model-btn" onclick={() => { modelSearchProvider = provider.id; modelSearch = ""; error = ""; showModelSearch = true; }}>Add model</button>
       </div>
     </div>
   {/each}
@@ -471,7 +506,7 @@ async function removeModel(modelId: string) {
       <input
         type="text"
         bind:value={modelSearch}
-        placeholder="Search models..."
+        placeholder="Search or type a model id..."
         class="text-input"
       />
       {#if modelSuggestions.length > 0}
@@ -482,8 +517,17 @@ async function removeModel(modelId: string) {
             </button>
           {/each}
         </div>
-      {:else}
+      {/if}
+      {#if canAddCustomModel}
+        <button class="custom-add-btn" onclick={addCustom}>
+          Add “{modelSearch.trim()}” as a custom model
+        </button>
+        <span class="dim">For a model not yet in the catalog. Settings are inherited from a built-in model of this provider.</span>
+      {:else if modelSuggestions.length === 0}
         <span class="dim">No more models available</span>
+      {/if}
+      {#if error}
+        <div class="error">{error}</div>
       {/if}
     </div>
   </Modal>
@@ -864,6 +908,21 @@ async function removeModel(modelId: string) {
 
   .model-option:last-child { border-bottom: none; }
   .model-option:hover { background: var(--bg-3); }
+
+  .custom-add-btn {
+    width: 100%;
+    padding: 8px 12px;
+    font-family: inherit;
+    font-size: 13px;
+    text-align: left;
+    background: var(--accent-dim);
+    color: var(--accent);
+    border: 1px solid var(--accent-border);
+    border-radius: var(--radius);
+    cursor: pointer;
+  }
+
+  .custom-add-btn:hover { border-color: var(--accent); }
 
   /* --- Model defaults --- */
 

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -505,6 +505,7 @@ export type AiModel = {
   contextWindow: number;
   maxTokens: number;
   enabled: boolean;
+  custom?: boolean;
 };
 
 export function fetchAiProviders(): Promise<AiProvider[]> {
@@ -545,6 +546,14 @@ export function submitAiOAuthCode(flowId: string, code: string): Promise<void> {
 
 export function saveEnabledModels(models: string[]): Promise<void> {
   return put(`${V1}/system/ai/models`, { models });
+}
+
+export function addCustomModel(provider: string, id: string, name?: string): Promise<void> {
+  return post(`${V1}/system/ai/models/custom`, { provider, id, ...(name ? { name } : {}) });
+}
+
+export function deleteCustomModel(provider: string, id: string): Promise<void> {
+  return del(`${V1}/system/ai/models/custom?provider=${enc(provider)}&id=${enc(id)}`);
 }
 
 export type AiDefaults = { spiritModel?: string | null; utilityModel: string | null };

--- a/templates/pi/src/lib/resolve-model.ts
+++ b/templates/pi/src/lib/resolve-model.ts
@@ -1,21 +1,59 @@
 import { getBuiltinModel, getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 
+/** Length of the shared leading prefix of two strings. */
+function sharedPrefixLength(a: string, b: string): number {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+}
+
+/**
+ * Build a usable model for a custom id not in the built-in catalog by cloning a
+ * sibling built-in model of the same provider (inherits api/baseUrl/compat/caps)
+ * and overriding id/name. Picks the sibling sharing the longest id prefix (same
+ * family), breaking ties toward the largest context window. Returns undefined
+ * when the provider has no built-in models at all.
+ *
+ * NOTE: mirrors pickSibling/buildCustomModel in the daemon's
+ * packages/daemon/src/lib/ai-service.ts (kept as a copy since the template can't
+ * import daemon code); keep the two in sync.
+ */
+function buildCustomModel(provider: string, id: string) {
+  const siblings = getBuiltinModels(provider as any);
+  if (siblings.length === 0) return undefined;
+  let best = siblings[0];
+  let bestPrefix = -1;
+  for (const s of siblings) {
+    const prefix = sharedPrefixLength(s.id, id);
+    if (prefix > bestPrefix || (prefix === bestPrefix && s.contextWindow > best.contextWindow)) {
+      bestPrefix = prefix;
+      best = s;
+    }
+  }
+  return { ...best, id, name: id, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } };
+}
+
 export function resolveModel(modelStr: string) {
   const [provider, ...rest] = modelStr.split(":");
   const modelId = rest.join(":");
 
-  // Try exact match first, then prefix match against available models
-  let model = getBuiltinModel(provider as any, modelId as any);
-  if (!model) {
-    const available = getBuiltinModels(provider as any);
-    const found = available.find((m) => m.id.startsWith(modelId));
-    if (found) model = found;
-  }
-  if (!model) {
-    const available = getBuiltinModels(provider as any);
-    throw new Error(
-      `Model not found: ${modelStr}\nAvailable ${provider} models: ${available.map((m) => m.id).join(", ")}`,
+  // Exact catalog match wins.
+  const exact = getBuiltinModel(provider as any, modelId as any);
+  if (exact) return exact;
+
+  // Not in the catalog: treat the id as authoritative and clone a sibling of the
+  // same provider. The daemon only ever writes exact ids here (built-in or an
+  // admin-registered custom id), so we deliberately do NOT prefix-match — doing so
+  // could silently resolve a selected custom id (e.g. "gpt-5") to a different
+  // catalog model that starts with it (e.g. "gpt-5-codex"). Mirrors the daemon's
+  // exact→custom ordering in ai-service.ts findModel().
+  const custom = buildCustomModel(provider, modelId);
+  if (custom) {
+    console.warn(
+      `[resolve-model] "${modelStr}" is not in the built-in catalog; cloning provider defaults from a sibling model. If this id is a typo it will fail at request time.`,
     );
+    return custom;
   }
-  return model;
+
+  throw new Error(`Model not found: ${modelStr}\nUnknown provider: ${provider}`);
 }

--- a/test/ai-service.test.ts
+++ b/test/ai-service.test.ts
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import {
+  addCustomModel,
+  buildCustomModel,
   getAiConfig,
+  getAvailableModels,
+  getCustomModels,
+  getEnabledModels,
+  qualifyModelId,
   removeAiConfig,
+  removeCustomModel,
   removeProviderConfig,
   saveProviderConfig,
+  setEnabledModels,
 } from "../packages/daemon/src/lib/ai-service.js";
 
 describe("ai-service config", () => {
@@ -49,5 +58,122 @@ describe("ai-service config", () => {
     saveProviderConfig("anthropic", { apiKey: "sk-test" });
     removeProviderConfig("anthropic");
     assert.equal(getAiConfig(), null);
+  });
+});
+
+describe("custom models", () => {
+  it("buildCustomModel clones a sibling: correct api, nonzero caps, zeroed cost", () => {
+    const model = buildCustomModel("anthropic", "claude-future-1");
+    assert.ok(model);
+    assert.equal(model.id, "claude-future-1");
+    assert.equal(model.name, "claude-future-1");
+    assert.equal(model.provider, "anthropic");
+    assert.equal(model.api, "anthropic-messages");
+    assert.ok(model.maxTokens > 0);
+    assert.ok(model.contextWindow > 0);
+    assert.equal(model.cost.input, 0);
+    assert.equal(model.cost.output, 0);
+  });
+
+  it("buildCustomModel prefers the family (longest-prefix) sibling", () => {
+    const opus = getBuiltinModels("anthropic").find((m) => m.id.includes("opus"));
+    assert.ok(opus, "expected an anthropic opus model in the catalog");
+    // Sharing opus's full id as a prefix guarantees it's the longest-prefix sibling.
+    const model = buildCustomModel("anthropic", `${opus.id}-next`);
+    assert.ok(model);
+    assert.equal(model.contextWindow, opus.contextWindow);
+  });
+
+  it("buildCustomModel falls back to the largest-context sibling when no family overlaps", () => {
+    const maxCtx = Math.max(...getBuiltinModels("anthropic").map((m) => m.contextWindow));
+    const model = buildCustomModel("anthropic", "zzz-no-overlap");
+    assert.ok(model);
+    assert.equal(model.contextWindow, maxCtx);
+  });
+
+  it("buildCustomModel returns undefined for a provider with no built-in models", () => {
+    assert.equal(buildCustomModel("not-a-real-provider", "whatever"), undefined);
+  });
+
+  it("getAvailableModels includes custom models for configured providers", async () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "claude-future-2");
+    const models = await getAvailableModels();
+    const found = models.find((m) => m.id === "claude-future-2");
+    assert.ok(found);
+    assert.equal(found.provider, "anthropic");
+  });
+
+  it("addCustomModel dedupes", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "claude-future-3");
+    addCustomModel("anthropic", "claude-future-3");
+    assert.equal(getCustomModels().filter((m) => m.id === "claude-future-3").length, 1);
+  });
+
+  it("removeCustomModel drops the record and the enabled id", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "claude-future-4");
+    setEnabledModels(["claude-future-4"]);
+    removeCustomModel("anthropic", "claude-future-4");
+    assert.equal(getCustomModels().length, 0);
+    assert.equal(getEnabledModels().includes("claude-future-4"), false);
+  });
+
+  it("built-in wins: getAvailableModels dedupes and prunes an absorbed custom id", async () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    const builtinId = getBuiltinModels("anthropic")[0].id;
+    addCustomModel("anthropic", builtinId);
+    const models = await getAvailableModels();
+    assert.equal(models.filter((m) => m.id === builtinId).length, 1);
+    // The custom record is pruned once the catalog covers the id.
+    assert.equal(getCustomModels().length, 0);
+  });
+
+  it("buildCustomModel uses an explicit display name when given", () => {
+    const model = buildCustomModel("anthropic", "claude-future-x", "Friendly Name");
+    assert.ok(model);
+    assert.equal(model.name, "Friendly Name");
+    assert.equal(model.id, "claude-future-x");
+  });
+
+  it("addCustomModel persists an explicit name", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "claude-future-named", "My Model");
+    const rec = getCustomModels().find((m) => m.id === "claude-future-named");
+    assert.equal(rec?.name, "My Model");
+  });
+
+  it("qualifyModelId resolves a custom id to its provider (findModel custom path)", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "claude-future-q");
+    assert.equal(qualifyModelId("claude-future-q"), "anthropic:claude-future-q");
+  });
+
+  it("qualifyModelId still resolves a built-in id (built-in wins in findModel)", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    const builtin = getBuiltinModels("anthropic")[0];
+    assert.equal(qualifyModelId(builtin.id), `anthropic:${builtin.id}`);
+  });
+
+  it("removeCustomModel deletes only the target, leaving siblings intact", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "keep-me");
+    addCustomModel("anthropic", "delete-me");
+    setEnabledModels(["keep-me", "delete-me"]);
+    removeCustomModel("anthropic", "delete-me");
+    assert.deepEqual(
+      getCustomModels().map((m) => m.id),
+      ["keep-me"],
+    );
+    assert.deepEqual(getEnabledModels(), ["keep-me"]);
   });
 });

--- a/test/resolve-model.test.ts
+++ b/test/resolve-model.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
+import { resolveModel } from "../templates/pi/src/lib/resolve-model.js";
+
+describe("pi template resolveModel", () => {
+  it("resolves a built-in model to its catalog entry", () => {
+    const builtin = getBuiltinModels("anthropic")[0];
+    const model = resolveModel(`anthropic:${builtin.id}`);
+    assert.equal(model.id, builtin.id);
+    // The real catalog entry has a friendly name, not the bare id.
+    assert.equal(model.name, builtin.name);
+  });
+
+  it("falls back to a cloned sibling for a custom (non-catalog) id", () => {
+    const model = resolveModel("anthropic:claude-future-99");
+    assert.equal(model.id, "claude-future-99");
+    assert.equal(model.name, "claude-future-99");
+    assert.equal(model.api, "anthropic-messages");
+    assert.ok(model.contextWindow > 0);
+    assert.ok(model.maxTokens > 0);
+    assert.equal(model.cost.input, 0);
+  });
+
+  it("prefers the built-in entry over a clone when the id exists", () => {
+    const builtin =
+      getBuiltinModels("anthropic").find((m) => m.id !== m.name) ??
+      getBuiltinModels("anthropic")[0];
+    const model = resolveModel(`anthropic:${builtin.id}`);
+    // A clone would zero the cost and set name === id; the built-in does neither.
+    assert.notEqual(model.name, model.id);
+  });
+
+  it("clones (does not prefix-match) a custom id that is a strict prefix of a built-in id", () => {
+    // Mirrors the daemon's exact→custom ordering: a selected custom id must not be
+    // silently resolved to a longer catalog id that merely starts with it.
+    const anthropic = getBuiltinModels("anthropic");
+    const ids = new Set(anthropic.map((m) => m.id));
+    // A built-in whose one-char-shorter prefix is not itself a catalog id.
+    const target = anthropic.find((m) => m.id.length > 1 && !ids.has(m.id.slice(0, -1)));
+    assert.ok(target, "expected a suitable anthropic model");
+    const prefix = target.id.slice(0, -1);
+    const model = resolveModel(`anthropic:${prefix}`);
+    assert.equal(model.id, prefix); // cloned with the exact typed id, not the longer built-in
+    assert.equal(model.name, prefix); // a clone sets name === id
+  });
+
+  it("throws for an unknown provider", () => {
+    assert.throws(() => resolveModel("not-a-real-provider:some-model"), /Unknown provider/);
+  });
+});


### PR DESCRIPTION
## What & why

When an admin adds an AI provider in system settings, the model picker only offered models from `@earendil-works/pi-ai`'s built-in catalog. When a provider ships a new model that pi-ai hasn't catalogued yet, there was no way to use it — you couldn't start a mind on it, and it wasn't offered to the daemon's system AI. The motivating case: start a mind on a brand-new model before pi-ai adds it.

Now an admin can type a **freeform model id** for an already-configured provider. It works end-to-end: the daemon's system AI, the mind model dropdown, and pi-template mind startup.

## How it works

A custom model's metadata is cloned from a **sibling built-in model of the same provider** — inheriting `api`/`baseUrl`/`compat` and sane context/token caps — with `id`/`name` overridden and `cost` zeroed. Sibling selection prefers the longest shared-id-prefix (same family, e.g. `claude-opus-5-1` → `claude-opus-4-8`), falling back to the largest-context model. So you only type the id.

Only identity (`provider` + `id`, plus optional display name) is persisted; heavy metadata is never stored, so it can't go stale.

## Upgrade safety

The built-in catalog **always wins** over a custom entry at every resolution point (`exact → custom → prefix`). When pi-ai later ships the model for real, minds silently switch to the accurate definition — no reconfiguration — and `getAvailableModels()` dedupes by id and auto-prunes the now-absorbed custom record.

## Changed

- `config/setup.ts` — `CustomModel` type + `customModels` field on `AiConfig`
- `ai-service.ts` — `pickSibling`/`buildCustomModel`, add/remove/get custom helpers, prune-on-read, updated `getAvailableModels` + `findModel`
- `web/api/system.ts` — `custom` flag on `GET /ai/models`; new `POST`/`DELETE /ai/models/custom` (both `requireAdmin`, with validation)
- web `client.ts` + `AiProviders.svelte` — "Add … as a custom model" modal action; custom tags delete on remove
- `templates/pi/src/lib/resolve-model.ts` — clone-sibling fallback instead of throwing on a catalog miss

## Review

Ran a multi-agent PR review (code, tests, silent failures, type design, comments) and addressed all findings: pi-template resolution ordering, UI error surfacing, POST validation + cross-provider id uniqueness, warn-logs for unresolvable customs, comment accuracy, and added test coverage.

## Testing

- 24 unit tests (`test/ai-service.test.ts`, `test/resolve-model.test.ts`)
- daemon + all 3 templates typecheck; Svelte component compiles clean

Note: 3 pre-existing failures in `test/global-config.test.ts` are unrelated to this branch (confirmed failing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
