### PR TITLE
fix: gate /api/v1/events activity feed to the calling mind

### DIFF
--- a/packages/daemon/src/lib/events/event-sequencer.ts
+++ b/packages/daemon/src/lib/events/event-sequencer.ts
@@ -33,14 +33,19 @@ export function nextEventId(): number {
 
 /**
  * Replay buffered events after `sinceId` that the caller is entitled to see.
- * The buffer is global, so audience must be enforced here:
+ * The buffer is global, so audience must be enforced here per event type:
  * - Snapshot events are connection-specific and never replayed to anyone.
  * - Conversation events are only replayed to participants of that conversation.
- * - Activity events are broadcast to all connections (matching the live path).
+ * - Activity events (which include another mind's AI-generated turn summaries)
+ *   are gated to the caller's own mind. `allowedActivityMind === undefined`
+ *   means a privileged caller (admin/system) who may see the global feed.
+ * The audience is decided explicitly per event type; unknown event types are
+ * denied so a newly-added type can never leak by default.
  */
 export function getEventsSince(
   sinceId: number,
   allowedConversationIds: Set<string>,
+  allowedActivityMind: string | undefined,
 ): BufferedEvent[] {
   const now = Date.now();
 
@@ -51,9 +56,16 @@ export function getEventsSince(
   return buffer.slice(startIdx).filter((e) => {
     if (now - e.timestamp >= MAX_AGE_MS) return false;
     const data = e.data;
-    if (data.event === "snapshot") return false;
-    if (data.event === "conversation") return allowedConversationIds.has(data.conversationId);
-    return true;
+    switch (data.event) {
+      case "snapshot":
+        return false;
+      case "conversation":
+        return allowedConversationIds.has(data.conversationId);
+      case "activity":
+        return allowedActivityMind === undefined || data.mind === allowedActivityMind;
+      default:
+        return false;
+    }
   });
 }
 

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -1,4 +1,4 @@
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { getDb } from "../../../lib/db.js";
@@ -15,6 +15,7 @@ import {
 } from "../../../lib/events/conversations.js";
 import { bufferEvent, getEventsSince, nextEventId } from "../../../lib/events/event-sequencer.js";
 import { getActiveMinds } from "../../../lib/events/mind-activity-tracker.js";
+import { getBaseName } from "../../../lib/mind/registry.js";
 import { activity } from "../../../lib/schema.js";
 import log from "../../../lib/util/logger.js";
 import { type AuthEnv, authMiddleware } from "../../middleware/auth.js";
@@ -23,6 +24,12 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
   const user = c.get("user");
   const since = c.req.query("since");
   const sinceId = since ? Number(since) : 0;
+
+  // Minds are untrusted: a non-admin/system principal may only see its own
+  // activity (activity.summary is an AI-generated summary of a mind's turn).
+  // `activityMind === undefined` means a privileged caller with the global feed.
+  const privileged = user.role === "admin" || user.role === "system";
+  const activityMind = privileged ? undefined : await getBaseName(user.username);
 
   return streamSSE(c, async (stream) => {
     const cleanups: (() => void)[] = [];
@@ -50,10 +57,11 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
       const allowedConversationIds = new Set<string>(conversations.map((c: any) => c.id));
 
       // If reconnecting with a valid sinceId, replay only the buffered events
-      // the caller is entitled to (their own conversation events + global
-      // activity). Other users' events and per-connect snapshots are filtered out.
+      // the caller is entitled to (their own conversation events + their own
+      // mind's activity, or the global feed for privileged callers). Other
+      // users' events and per-connect snapshots are filtered out.
       if (sinceId > 0) {
-        const missed = getEventsSince(sinceId, allowedConversationIds);
+        const missed = getEventsSince(sinceId, allowedConversationIds, activityMind);
         for (const event of missed) {
           await stream.writeSSE({
             id: String(event.id),
@@ -69,6 +77,7 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         recentActivity = await db
           .select()
           .from(activity)
+          .where(activityMind ? eq(activity.mind, activityMind) : undefined)
           .orderBy(desc(activity.created_at))
           .limit(50);
         recentActivity = recentActivity.map((row) => ({
@@ -97,8 +106,11 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         data: JSON.stringify(snapshotData),
       });
 
-      // Subscribe to activity events
+      // Subscribe to activity events. Non-privileged callers only see their own
+      // mind's activity; the buffer still records every event globally so the
+      // audience filter is re-applied on reconnect replay too.
       const unsubActivity = subscribeActivity((event) => {
+        if (activityMind !== undefined && event.mind !== activityMind) return;
         const data = {
           event: "activity" as const,
           ...event,

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -107,16 +107,19 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
       });
 
       // Subscribe to activity events. Non-privileged callers only see their own
-      // mind's activity; the buffer still records every event globally so the
-      // audience filter is re-applied on reconnect replay too.
+      // mind's activity live; the buffer still records every event globally so
+      // the audience filter is re-applied on reconnect replay too.
       const unsubActivity = subscribeActivity((event) => {
-        if (activityMind !== undefined && event.mind !== activityMind) return;
         const data = {
           event: "activity" as const,
           ...event,
           metadata: event.metadata ?? null,
         };
+        // Buffer every event globally first so the audience filter is re-applied
+        // on reconnect replay (getEventsSince) rather than dropping events that
+        // this connection isn't entitled to see live.
         const eventId = bufferEvent(data);
+        if (activityMind !== undefined && event.mind !== activityMind) return;
         stream
           .writeSSE({
             id: String(eventId),

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1438,6 +1438,72 @@ describe("daemon e2e", { timeout: 120000 }, () => {
         "Admin should still be able to read Bob's turns",
       );
     });
+
+    // Open an SSE connection to /api/v1/events, return the first `snapshot`
+    // event, then abort. The snapshot's `activity` array is the vector at risk
+    // of a cross-tenant leak.
+    async function readEventsSnapshot(
+      authHeader: string,
+    ): Promise<{ activity: Array<{ mind: string }> }> {
+      const controller = new AbortController();
+      const res = await fetch(`${BASE_URL}/api/v1/events`, {
+        headers: { Authorization: authHeader, Origin: BASE_URL },
+        signal: controller.signal,
+      });
+      assert.equal(res.status, 200, "events stream should connect");
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          for (;;) {
+            const sep = buf.indexOf("\n\n");
+            if (sep === -1) break;
+            const frame = buf.slice(0, sep);
+            buf = buf.slice(sep + 2);
+            const dataLine = frame.split("\n").find((l) => l.startsWith("data:"));
+            if (!dataLine) continue;
+            const json = dataLine.slice(dataLine.indexOf(":") + 1).trim();
+            if (!json) continue;
+            const parsed = JSON.parse(json);
+            if (parsed.event === "snapshot") return parsed;
+          }
+        }
+      } finally {
+        controller.abort();
+        try {
+          await reader.cancel();
+        } catch {}
+      }
+      throw new Error("no snapshot event received");
+    }
+
+    it("/api/v1/events snapshot scopes activity to the caller's own mind", async () => {
+      const snap = await readEventsSnapshot(`Bearer ${aliceSession}`);
+      assert.ok(
+        snap.activity.every((a) => a.mind === ALICE),
+        "Alice's snapshot must only contain her own activity",
+      );
+      assert.ok(
+        !JSON.stringify(snap.activity).includes(BOB_SECRET),
+        "Alice's snapshot must not leak Bob's activity",
+      );
+      assert.ok(
+        snap.activity.some((a) => a.mind === ALICE),
+        "Alice should still see her own activity",
+      );
+    });
+
+    it("/api/v1/events snapshot keeps the global feed for admin/system", async () => {
+      const snap = await readEventsSnapshot(`Bearer ${TOKEN}`);
+      assert.ok(
+        snap.activity.some((a) => a.mind !== ALICE),
+        "Admin snapshot should include activity beyond a single mind (global feed)",
+      );
+    });
   });
 
   it("extension command endpoint ignores body.mind for non-admin callers", async () => {

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -1,13 +1,64 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { publish } from "../packages/daemon/src/lib/events/activity-events.js";
 import {
   bufferEvent,
   getEventsSince,
   nextEventId,
   resetSequencer,
 } from "../packages/daemon/src/lib/events/event-sequencer.js";
+import eventsApp from "../packages/daemon/src/web/api/v1/events.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 const NO_CONVS = new Set<string>();
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Open an in-process SSE connection to the events app and collect delivered
+// events in the background until closed. Lets a test publish activity while the
+// live subscription is active and observe exactly what gets delivered.
+async function openEventStream(authHeader: string) {
+  const res = await eventsApp.request("/", { headers: { Authorization: authHeader } });
+  assert.equal(res.status, 200, "events stream should connect");
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let active = true;
+  const events: any[] = [];
+  const loop = (async () => {
+    try {
+      while (active) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        for (;;) {
+          const sep = buf.indexOf("\n\n");
+          if (sep === -1) break;
+          const frame = buf.slice(0, sep);
+          buf = buf.slice(sep + 2);
+          const dataLine = frame.split("\n").find((l) => l.startsWith("data:"));
+          if (!dataLine) continue;
+          const json = dataLine.slice(dataLine.indexOf(":") + 1).trim();
+          if (!json) continue;
+          try {
+            events.push(JSON.parse(json));
+          } catch {}
+        }
+      }
+    } catch {}
+  })();
+  return {
+    events,
+    async close() {
+      active = false;
+      try {
+        await reader.cancel();
+      } catch {}
+      await loop;
+    },
+  };
+}
 
 describe("event sequencer", () => {
   it("assigns monotonically increasing IDs", () => {
@@ -240,5 +291,69 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
     assert.ok(bufId > id);
+  });
+});
+
+describe("v1 events live activity delivery filter", () => {
+  it("does not deliver another mind's activity live to a scoped connection", async () => {
+    resetSequencer();
+    const alice = await getOrCreateMindUser("live-events-alice");
+    const aliceSession = await createSession(alice.id);
+
+    const stream = await openEventStream(`Bearer ${aliceSession}`);
+    // Let the snapshot flush and the live subscription register.
+    await delay(200);
+
+    const before = nextEventId();
+    await publish({ type: "mind_done", mind: "live-events-bob", summary: "bob-live-secret" });
+    await publish({ type: "mind_done", mind: "live-events-alice", summary: "alice-live-visible" });
+    await delay(200);
+    await stream.close();
+
+    const activityEvents = stream.events.filter((e) => e.event === "activity");
+
+    // The scoped connection sees its own mind's activity live.
+    assert.ok(
+      activityEvents.some(
+        (e) => e.mind === "live-events-alice" && e.summary === "alice-live-visible",
+      ),
+      "scoped connection should receive its own mind's activity live",
+    );
+    // But never another mind's activity — this is the live audience gate under test.
+    assert.ok(
+      !activityEvents.some((e) => e.mind === "live-events-bob"),
+      "scoped connection must not receive another mind's activity live",
+    );
+
+    // Buffer coverage: the other mind's event is still recorded globally, so a
+    // privileged reconnect replay (getEventsSince) can deliver it. This is the
+    // regression the buffer-before-gate ordering protects against.
+    const replay = getEventsSince(before, NO_CONVS, undefined);
+    assert.ok(
+      replay.some((e) => e.data.event === "activity" && e.data.mind === "live-events-bob"),
+      "buffer must still record another mind's activity globally for reconnect replay",
+    );
+  });
+
+  it("delivers any mind's activity live to a privileged connection", async () => {
+    resetSequencer();
+    const prevToken = process.env.VOLUTE_DAEMON_TOKEN;
+    process.env.VOLUTE_DAEMON_TOKEN = "live-events-admin-token";
+    try {
+      const stream = await openEventStream("Bearer live-events-admin-token");
+      await delay(200);
+      await publish({ type: "mind_done", mind: "live-events-charlie", summary: "charlie-live" });
+      await delay(200);
+      await stream.close();
+
+      const activityEvents = stream.events.filter((e) => e.event === "activity");
+      assert.ok(
+        activityEvents.some((e) => e.mind === "live-events-charlie"),
+        "privileged connection should receive any mind's activity live",
+      );
+    } finally {
+      if (prevToken === undefined) delete process.env.VOLUTE_DAEMON_TOKEN;
+      else process.env.VOLUTE_DAEMON_TOKEN = prevToken;
+    }
   });
 });

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -63,7 +63,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(id1, NO_CONVS);
+    const events = getEventsSince(id1, NO_CONVS, undefined);
     assert.equal(events.length, 2);
     assert.equal(events[0].id, id2);
     assert.equal(events[1].id, id3);
@@ -81,7 +81,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(id, NO_CONVS);
+    const events = getEventsSince(id, NO_CONVS, undefined);
     assert.equal(events.length, 0);
   });
 
@@ -97,7 +97,7 @@ describe("event sequencer", () => {
       created_at: "2024-01-01",
     });
 
-    const events = getEventsSince(9999, NO_CONVS);
+    const events = getEventsSince(9999, NO_CONVS, undefined);
     assert.equal(events.length, 0);
   });
 
@@ -118,7 +118,7 @@ describe("event sequencer", () => {
 
     // Events with IDs 1-5 should have been trimmed
     // Trying to replay from 0 should only get ~1000 events
-    const events = getEventsSince(0, NO_CONVS);
+    const events = getEventsSince(0, NO_CONVS, undefined);
     assert.ok(events.length <= 1000);
     // First event should have ID > 5
     assert.ok(events[0].id > 5);
@@ -135,7 +135,7 @@ describe("event sequencer", () => {
     });
     assert.ok(id > 0);
 
-    const events = getEventsSince(0, NO_CONVS);
+    const events = getEventsSince(0, NO_CONVS, undefined);
     assert.equal(events.length, 0);
   });
 
@@ -153,11 +153,11 @@ describe("event sequencer", () => {
     });
 
     // A caller who is not a participant sees nothing.
-    assert.equal(getEventsSince(0, NO_CONVS).length, 0);
-    assert.equal(getEventsSince(0, new Set(["other-conv"])).length, 0);
+    assert.equal(getEventsSince(0, NO_CONVS, undefined).length, 0);
+    assert.equal(getEventsSince(0, new Set(["other-conv"]), undefined).length, 0);
 
     // A participant sees the event.
-    const events = getEventsSince(0, new Set(["conv-123"]));
+    const events = getEventsSince(0, new Set(["conv-123"]), undefined);
     assert.equal(events.length, 1);
     assert.equal(events[0].data.event, "conversation");
   });
@@ -185,9 +185,42 @@ describe("event sequencer", () => {
     });
 
     // Outsider gets only the global activity event, never the private message.
-    const events = getEventsSince(0, NO_CONVS);
+    const events = getEventsSince(0, NO_CONVS, undefined);
     assert.equal(events.length, 1);
     assert.equal(events[0].data.event, "activity");
+  });
+
+  it("gates activity events to the caller's own mind for non-privileged callers", () => {
+    resetSequencer();
+    bufferEvent({
+      event: "activity",
+      id: 1,
+      type: "mind_done",
+      mind: "mind-a",
+      summary: "a did a thing",
+      metadata: null,
+      created_at: "2024-01-01",
+    });
+    bufferEvent({
+      event: "activity",
+      id: 2,
+      type: "mind_done",
+      mind: "mind-b",
+      summary: "b did a thing",
+      metadata: null,
+      created_at: "2024-01-01",
+    });
+
+    // A non-privileged caller scoped to mind-a sees only mind-a's activity —
+    // mind-b's turn summary must never be replayed cross-tenant.
+    const scoped = getEventsSince(0, NO_CONVS, "mind-a");
+    assert.equal(scoped.length, 1);
+    assert.equal(scoped[0].data.event, "activity");
+    assert.equal(scoped[0].data.event === "activity" ? scoped[0].data.mind : null, "mind-a");
+
+    // A privileged caller (undefined) sees the global feed.
+    const global = getEventsSince(0, NO_CONVS, undefined);
+    assert.equal(global.length, 2);
   });
 
   it("nextEventId advances the counter without buffering", () => {
@@ -195,7 +228,7 @@ describe("event sequencer", () => {
     const id = nextEventId();
     assert.ok(id > 0);
     // Nothing buffered, so no replay.
-    assert.equal(getEventsSince(0, NO_CONVS).length, 0);
+    assert.equal(getEventsSince(0, NO_CONVS, undefined).length, 0);
     // Subsequent buffered events get higher IDs.
     const bufId = bufferEvent({
       event: "activity",


### PR DESCRIPTION
Closes #343

## Problem

PR #341 closed cross-tenant reads on `/api/v1/history/*` by forcing non-admin/system callers to their own base name via `resolveMindFilter`, but `/api/v1/events` (SSE) still exposed the global activity feed to any authenticated mind. `activity.summary` is an AI-generated summary of another mind's turn — the same data class #341 protected — and it was reachable cross-tenant through three paths:

1. **Snapshot** — `recentActivity` returned the global last-50 `activity` rows, sent unfiltered on connect.
2. **Live** — `subscribeActivity` is a global firehose; every mind's activity event was pushed to every connected client.
3. **Replay** — `getEventsSince` returned every buffered `activity` event via a blanket `return true`, so `?since=` replayed cross-tenant activity too.

This completes the residual vector scoped out of #320 / #341.

## Fix

Mirror the `resolveMindFilter` model from #341. In the `/api/v1/events` handler we compute `privileged = role === "admin" || role === "system"` and, for non-privileged callers, `activityMind = getBaseName(user.username)` (`undefined` for privileged = global feed). That scope is applied to all three paths:

1. **Snapshot** — the `recentActivity` query is filtered by `eq(activity.mind, activityMind)` for non-privileged callers.
2. **Live** — each `subscribeActivity` event is dropped before write when `event.mind !== activityMind`.
3. **Replay** — `getEventsSince` takes an `allowedActivityMind` argument and gates `activity` events to it. The audience is now decided **explicitly per event type** (switch with `default: return false`) instead of a blanket `return true`, so a newly-added event type can never leak by default.

Admin/system callers keep the global feed on all three paths.

## Test plan

- `test/web-v1-events.test.ts`: new case asserts an `activity` event for mind B is **not** replayed to a non-privileged connection scoped to mind A, while a privileged (`undefined`) caller still gets the global feed. Existing sequencer cases updated for the new argument.
- `test/daemon-e2e.test.ts`: new cases open a real `/api/v1/events` SSE connection and assert a non-admin mind's snapshot contains only its own activity (no cross-tenant secret), while an admin/system token still receives the global feed. Reuses the seeded ALICE/BOB fixtures from the #341 cross-tenant block.
- Full unit suite passes (1639/1639); `npm run typecheck` and `svelte-check` clean. Pre-existing daemon-e2e mind-lifecycle failures in this sandbox are environmental (tsx IPC pipe `EINVAL` / missing provider API key) and unrelated; the two new e2e cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)