### PR TITLE
fix: strip provider prefix from codex mind model

### DIFF
--- a/templates/codex/src/server.ts
+++ b/templates/codex/src/server.ts
@@ -15,7 +15,13 @@ import { createVoluteServer } from "./lib/volute-server.js";
 const { port } = parseArgs();
 const config = loadConfig();
 if (config.logLevel) setLevel(config.logLevel);
-if (config.model) log("server", `using model: ${config.model}`);
+// The Codex SDK wants a bare model slug, but config.model may carry a pi-style
+// "provider:model" prefix (e.g. "openai-codex:gpt-5.5") when the spirit's model
+// is provider-qualified. Strip the prefix so the SDK gets just the model.
+const model = config.model?.includes(":")
+  ? config.model.slice(config.model.indexOf(":") + 1)
+  : config.model;
+if (config.model) log("server", `using model: ${model}`);
 if (config.reasoningEffort) log("server", `reasoning effort: ${config.reasoningEffort}`);
 
 const systemPrompt = loadSystemPrompt();
@@ -28,7 +34,7 @@ const mind = createMind({
   systemPrompt,
   cwd,
   mindDir,
-  model: config.model,
+  model,
   reasoningEffort: config.reasoningEffort,
   maxContextTokens: config.compaction?.maxContextTokens,
 });


### PR DESCRIPTION
## Problem

The system spirit could not run on a codex-template model. Its model must be **provider-qualified** (e.g. `openai-codex:gpt-5.5`) so `resolveTemplate()` selects the codex template — a bare model id (`gpt-5.5`) now resolves to the `azure-openai-responses` provider (→ pi template) in the current pi-ai catalog, which isn't configured. But the codex template passes `config.model` **straight to the Codex SDK**, which rejects a `provider:model` string:

```
400 invalid_request_error: The 'openai-codex:gpt-5.5' model is not supported
when using Codex with a ChatGPT account.
```

So the spirit crash-looped on every turn (`Codex Exec exited with code 1`).

## Fix

Strip the `provider:` prefix in `templates/codex/src/server.ts` before passing the model to `createMind()`, so the Codex SDK receives a bare slug (`gpt-5.5`). The pi template intentionally keeps the qualified `provider:model` form (that's pi's native format); only the codex template needs the bare slug.

## Verification

Reproduced and confirmed on a live deployment (Raspberry Pi, volute 0.41.1, codex-sdk 0.142.5, ChatGPT-business account):

- Direct `codex exec -m gpt-5.5` → replies `pong` ✓
- Direct `codex exec -m openai-codex:gpt-5.5` → `400 ... not supported` ✗
- After this fix, the spirit logs `using model: gpt-5.5` and completes turns end-to-end on gpt-5.5 (`turn done`, no error).

Follows the deps fix in #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)