### PR TITLE
fix: make delivery_queue the source of truth for message delivery

### DIFF
--- a/drizzle/0010_delivery_queue_redrive.sql
+++ b/drizzle/0010_delivery_queue_redrive.sql
@@ -1,0 +1,6 @@
+-- Make delivery_queue an at-least-once queue: track attempts and a backoff
+-- window so a redrive loop can re-deliver stranded rows without hot-looping.
+
+ALTER TABLE `delivery_queue` ADD `attempts` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `delivery_queue` ADD `next_attempt_at` text;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_delivery_queue_status_next` ON `delivery_queue` (`status`, `next_attempt_at`);

--- a/drizzle/0010_delivery_queue_redrive.sql
+++ b/drizzle/0010_delivery_queue_redrive.sql
@@ -3,4 +3,8 @@
 
 ALTER TABLE `delivery_queue` ADD `attempts` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
 ALTER TABLE `delivery_queue` ADD `next_attempt_at` text;--> statement-breakpoint
+-- Original delivery target (may be a variant name); redrive resolves the port from
+-- this so a variant's stranded row is re-delivered to the variant, not the parent.
+-- Nullable: legacy rows fall back to `mind` (the base name) at read time.
+ALTER TABLE `delivery_queue` ADD `target_mind` text;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS `idx_delivery_queue_status_next` ON `delivery_queue` (`status`, `next_attempt_at`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1775400000000,
       "tag": "0009_mind_notices",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1775500000000,
+      "tag": "0010_delivery_queue_redrive",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -333,10 +333,12 @@ export async function startDaemon(opts: {
     log.warn("failed to initialize version notifications", log.errorData(err));
   }
 
-  // Restore delivery queue from DB (non-blocking)
+  // Restore delivery queue from DB (non-blocking) and start the periodic redrive
+  // sweep so stranded/failed deliveries are retried at-least-once.
   delivery.restoreFromDb().catch((err) => {
     log.warn("failed to restore delivery queue", log.errorData(err));
   });
+  delivery.startRedrive();
 
   // Clean up expired sessions and old log entries (non-blocking)
   cleanExpiredSessions().catch((err) => {

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -748,3 +748,8 @@ export function getMindManager(): MindManager {
   if (!instance) throw new Error("MindManager not initialized — call initMindManager() first");
   return instance;
 }
+
+/** Like getMindManager but returns null instead of throwing when uninitialized. */
+export function tryGetMindManager(): MindManager | null {
+  return instance;
+}

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -147,7 +147,7 @@ export class DeliveryManager {
         await this.enqueueBatch(mindName, sessionName, payload, sessionConfig);
         return { routed: true, session: sessionName, destination: "mind", mode: "batch" };
       }
-      const queueId = await this.persistToQueue(baseName, sessionName, payload);
+      const queueId = await this.persistToQueue(mindName, sessionName, payload);
       await this.deliverToMind(mindName, sessionName, payload, sessionConfig, queueId);
       return { routed: true, session: sessionName, destination: "mind", mode: "immediate" };
     }
@@ -216,7 +216,7 @@ export class DeliveryManager {
 
     // Immediate delivery — persist to the queue BEFORE the POST so a crash or a
     // failed POST leaves an at-least-once record the redrive loop can re-deliver.
-    const queueId = await this.persistToQueue(baseName, sessionName, payload);
+    const queueId = await this.persistToQueue(mindName, sessionName, payload);
     await this.deliverToMind(mindName, sessionName, payload, sessionConfig, queueId);
     return { routed: true, session: sessionName, destination: "mind", mode: "immediate" };
   }
@@ -307,9 +307,14 @@ export class DeliveryManager {
       const config = getRoutingConfig(row.mind);
       const sessionConfig = resolveDeliveryMode(config, row.session);
 
+      // Resolve delivery from the original target (may be a variant) — the `mind`
+      // column is the base name, used only for keying/cleanup. Falls back to `mind`
+      // for legacy rows with no recorded target.
+      const target = row.target_mind ?? row.mind;
+
       if (sessionConfig.delivery.mode === "batch") {
         this.inFlight.add(row.id);
-        this.addToBatchBuffer(row.mind, row.session, sessionConfig, {
+        this.addToBatchBuffer(target, row.session, sessionConfig, {
           payload,
           channel: payload.channel,
           sender: payload.sender ?? null,
@@ -317,8 +322,8 @@ export class DeliveryManager {
           queueId: row.id,
         });
       } else {
-        this.deliverToMind(row.mind, row.session, payload, sessionConfig, row.id).catch((err) => {
-          dlog.warn(`failed to redrive delivery for ${row.mind}`, log.errorData(err));
+        this.deliverToMind(target, row.session, payload, sessionConfig, row.id).catch((err) => {
+          dlog.warn(`failed to redrive delivery for ${target}`, log.errorData(err));
         });
       }
       redriven++;
@@ -781,7 +786,7 @@ export class DeliveryManager {
     // the in-memory buffer is a fast path reconciled against these rows on ack/redrive.
     // The row is "owned" (inFlight) while buffered so the redrive sweep won't double-send.
     const baseName = await getBaseName(mindName);
-    const queueId = await this.persistToQueue(baseName, session, payload);
+    const queueId = await this.persistToQueue(mindName, session, payload);
     if (queueId != null) this.inFlight.add(queueId);
     const msg: QueuedMessage = {
       payload,
@@ -921,7 +926,7 @@ export class DeliveryManager {
     payload: DeliveryPayload,
   ): Promise<void> {
     const baseName = await getBaseName(mindName);
-    await this.persistToQueue(baseName, session, payload, "gated");
+    await this.persistToQueue(mindName, session, payload, "gated");
 
     // Check if this is the first gated message for this channel — send invite
     try {
@@ -970,9 +975,12 @@ export class DeliveryManager {
   }
 
   /**
-   * Insert a delivery_queue row and return its id. Always keyed by `baseName` so that
-   * inserts under a variant name and the id-scoped cleanup use the same key (fixes the
-   * variant mismatch where variant-keyed rows were never matched by the base cleanup).
+   * Insert a delivery_queue row and return its id. The `mind` column is always keyed by
+   * `baseName` so inserts under a variant name and the id-scoped cleanup use the same key
+   * (fixes the variant mismatch where variant-keyed rows were never matched by the base
+   * cleanup). `target_mind` records the original delivery target (`mindName`, which may be a
+   * variant) so redrive resolves the port from it — a variant's stranded row is re-delivered
+   * to the variant, not the parent.
    */
   private async persistToQueue(
     mindName: string,
@@ -987,6 +995,7 @@ export class DeliveryManager {
         .insert(deliveryQueue)
         .values({
           mind: baseName,
+          target_mind: mindName,
           session,
           channel: payload.channel ?? null,
           sender: payload.sender ?? null,

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -1,7 +1,8 @@
 import { readFile, realpath } from "node:fs/promises";
 import { extname, resolve } from "node:path";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
+import { tryGetMindManager } from "../daemon/mind-manager.js";
 import { getDb } from "../db.js";
 import { getParticipants } from "../events/conversations.js";
 import { onMindEvent } from "../events/mind-activity-tracker.js";
@@ -19,12 +20,19 @@ import {
   type ResolvedSessionConfig,
   resolveDeliveryMode,
   resolveRoute,
+  setRoutesChangeListener,
 } from "./delivery-router.js";
 import { tagRecentInbound } from "./message-delivery.js";
 
 const dlog = log.child("delivery-manager");
 
 const MAX_BATCH_SIZE = 50;
+
+// --- Redrive / retry tuning ---
+const REDRIVE_INTERVAL_MS = 15_000;
+const RETRY_BASE_MS = 5_000;
+const RETRY_MAX_MS = 5 * 60_000;
+const REDRIVE_BATCH_LIMIT = 200;
 
 const mentionRegexCache = new Map<string, RegExp>();
 
@@ -60,6 +68,8 @@ type QueuedMessage = {
   channel: string;
   sender: string | null;
   createdAt: number;
+  /** delivery_queue row id backing this message (source of truth). */
+  queueId?: number;
 };
 
 // --- Delivery Manager ---
@@ -67,6 +77,39 @@ type QueuedMessage = {
 export class DeliveryManager {
   private sessionStates = new Map<string, Map<string, SessionState>>();
   private batchBuffers = new Map<string, BatchBuffer>();
+
+  /**
+   * delivery_queue row ids currently owned in-memory — either buffered in a batch
+   * buffer or actively being POSTed. The redrive sweep skips these so it never
+   * double-delivers a row that the normal path is already handling.
+   */
+  private inFlight = new Set<number>();
+
+  /**
+   * Per-`(baseName:session)` promise chain that serializes POSTs so two rapid
+   * messages to the same session can't be reordered by resolvePort/enrichment latency.
+   */
+  private drainChains = new Map<string, Promise<unknown>>();
+
+  private redriveTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Predicate for whether a mind is up; overridable in tests. */
+  private isMindRunning: (baseName: string) => boolean = (name) =>
+    tryGetMindManager()?.isRunning(name) ?? false;
+
+  constructor() {
+    // Release gated messages when a mind's routes.json changes.
+    setRoutesChangeListener((mind) => {
+      this.releaseGated(mind).catch((err) =>
+        dlog.warn(`failed to release gated messages for ${mind}`, log.errorData(err)),
+      );
+    });
+  }
+
+  /** Test seam: override the mind-running predicate. */
+  setRunningCheck(fn: (baseName: string) => boolean): void {
+    this.isMindRunning = fn;
+  }
 
   // --- Public API ---
 
@@ -104,7 +147,8 @@ export class DeliveryManager {
         await this.enqueueBatch(mindName, sessionName, payload, sessionConfig);
         return { routed: true, session: sessionName, destination: "mind", mode: "batch" };
       }
-      await this.deliverToMind(mindName, sessionName, payload, sessionConfig);
+      const queueId = await this.persistToQueue(baseName, sessionName, payload);
+      await this.deliverToMind(mindName, sessionName, payload, sessionConfig, queueId);
       return { routed: true, session: sessionName, destination: "mind", mode: "immediate" };
     }
 
@@ -170,8 +214,10 @@ export class DeliveryManager {
       return { routed: true, session: sessionName, destination: "mind", mode: "batch" };
     }
 
-    // Immediate delivery
-    await this.deliverToMind(mindName, sessionName, payload, sessionConfig);
+    // Immediate delivery — persist to the queue BEFORE the POST so a crash or a
+    // failed POST leaves an at-least-once record the redrive loop can re-deliver.
+    const queueId = await this.persistToQueue(baseName, sessionName, payload);
+    await this.deliverToMind(mindName, sessionName, payload, sessionConfig, queueId);
     return { routed: true, session: sessionName, destination: "mind", mode: "immediate" };
   }
 
@@ -199,49 +245,142 @@ export class DeliveryManager {
   }
 
   /**
-   * Restore queued messages from DB on daemon restart.
+   * Restore queued messages from DB on daemon restart — a single redrive pass.
+   * All accepted deliveries are persisted to delivery_queue before their POST and
+   * only deleted on mind-ack, so pending rows are exactly the undelivered messages.
    */
   async restoreFromDb(): Promise<void> {
+    await this.redrive();
+  }
+
+  /** Start the periodic redrive sweep (idempotent). */
+  startRedrive(): void {
+    if (this.redriveTimer) return;
+    this.redriveTimer = setInterval(() => {
+      this.redrive().catch((err) => dlog.warn("redrive sweep failed", log.errorData(err)));
+    }, REDRIVE_INTERVAL_MS);
+    this.redriveTimer.unref();
+  }
+
+  /**
+   * Re-read pending delivery_queue rows that are eligible (past their backoff window)
+   * and re-deliver them through the normal path. Rows already owned in-memory
+   * (`inFlight`) and minds that are down are skipped so we never hot-loop or double-send.
+   */
+  async redrive(): Promise<void> {
+    let rows: (typeof deliveryQueue.$inferSelect)[];
     try {
       const db = await getDb();
-      const rows = await db.select().from(deliveryQueue).where(eq(deliveryQueue.status, "pending"));
-
-      for (const row of rows) {
-        let payload: DeliveryPayload;
-        try {
-          payload = JSON.parse(row.payload) as DeliveryPayload;
-        } catch (parseErr) {
-          dlog.warn(
-            `corrupt payload in delivery queue row ${row.id}, skipping`,
-            log.errorData(parseErr),
-          );
-          continue;
-        }
-        const config = getRoutingConfig(row.mind);
-        const sessionConfig = resolveDeliveryMode(config, row.session);
-
-        if (sessionConfig.delivery.mode === "batch") {
-          this.addToBatchBuffer(row.mind, row.session, payload, sessionConfig);
-        } else {
-          // Immediate messages that were queued but not delivered — delete first
-          // to prevent re-delivery on daemon crash during replay
-          try {
-            await db.delete(deliveryQueue).where(eq(deliveryQueue.id, row.id));
-          } catch (err) {
-            dlog.warn(`failed to delete queue row ${row.id} for ${row.mind}`, log.errorData(err));
-          }
-          this.deliverToMind(row.mind, row.session, payload, sessionConfig).catch((err) => {
-            dlog.warn(`failed to restore delivery for ${row.mind}`, log.errorData(err));
-          });
-        }
-      }
-
-      if (rows.length > 0) {
-        dlog.info(`restored ${rows.length} queued messages from DB`);
-      }
+      rows = await db
+        .select()
+        .from(deliveryQueue)
+        .where(
+          and(
+            eq(deliveryQueue.status, "pending"),
+            sql`(${deliveryQueue.next_attempt_at} IS NULL OR ${deliveryQueue.next_attempt_at} <= datetime('now'))`,
+          ),
+        )
+        .orderBy(deliveryQueue.id)
+        .limit(REDRIVE_BATCH_LIMIT);
     } catch (err) {
-      dlog.warn("failed to restore delivery queue from DB", log.errorData(err));
+      dlog.warn("failed to read delivery queue for redrive", log.errorData(err));
+      return;
     }
+
+    let redriven = 0;
+    for (const row of rows) {
+      if (this.inFlight.has(row.id)) continue;
+      if (!this.isMindRunning(row.mind)) continue;
+
+      let payload: DeliveryPayload;
+      try {
+        payload = JSON.parse(row.payload) as DeliveryPayload;
+      } catch (parseErr) {
+        dlog.warn(
+          `corrupt payload in delivery queue row ${row.id}, dropping`,
+          log.errorData(parseErr),
+        );
+        await this.deleteQueueRows([row.id]);
+        continue;
+      }
+
+      const config = getRoutingConfig(row.mind);
+      const sessionConfig = resolveDeliveryMode(config, row.session);
+
+      if (sessionConfig.delivery.mode === "batch") {
+        this.inFlight.add(row.id);
+        this.addToBatchBuffer(row.mind, row.session, sessionConfig, {
+          payload,
+          channel: payload.channel,
+          sender: payload.sender ?? null,
+          createdAt: Date.now(),
+          queueId: row.id,
+        });
+      } else {
+        this.deliverToMind(row.mind, row.session, payload, sessionConfig, row.id).catch((err) => {
+          dlog.warn(`failed to redrive delivery for ${row.mind}`, log.errorData(err));
+        });
+      }
+      redriven++;
+    }
+
+    if (redriven > 0) dlog.info(`redrove ${redriven} pending delivery queue rows`);
+  }
+
+  /**
+   * Re-evaluate a mind's `gated` rows against its current routes.json and promote any
+   * that now match to `pending` (delivered by the next redrive sweep). Called when the
+   * routing config changes.
+   */
+  async releaseGated(mindName: string): Promise<void> {
+    const baseName = await getBaseName(mindName);
+    const config = getRoutingConfig(baseName);
+    let rows: (typeof deliveryQueue.$inferSelect)[];
+    try {
+      const db = await getDb();
+      rows = await db
+        .select()
+        .from(deliveryQueue)
+        .where(and(eq(deliveryQueue.mind, baseName), eq(deliveryQueue.status, "gated")));
+    } catch (err) {
+      dlog.warn(`failed to read gated rows for ${baseName}`, log.errorData(err));
+      return;
+    }
+
+    const promote: number[] = [];
+    for (const row of rows) {
+      let payload: DeliveryPayload;
+      try {
+        payload = JSON.parse(row.payload) as DeliveryPayload;
+      } catch {
+        continue;
+      }
+      const meta: MatchMeta = {
+        channel: payload.channel,
+        sender: payload.sender ?? undefined,
+        isDM: payload.isDM,
+        participantCount: payload.participantCount,
+      };
+      const route = resolveRoute(config, meta);
+      if (route.matched && route.destination === "mind") {
+        promote.push(row.id);
+      }
+    }
+
+    if (promote.length === 0) return;
+    try {
+      const db = await getDb();
+      await db
+        .update(deliveryQueue)
+        .set({ status: "pending", attempts: 0, next_attempt_at: null })
+        .where(inArray(deliveryQueue.id, promote));
+      dlog.info(`released ${promote.length} gated message(s) for ${baseName} after route change`);
+    } catch (err) {
+      dlog.warn(`failed to promote gated rows for ${baseName}`, log.errorData(err));
+      return;
+    }
+    // Deliver immediately rather than waiting for the next sweep.
+    await this.redrive();
   }
 
   /**
@@ -317,6 +456,11 @@ export class DeliveryManager {
       if (bufferKey.startsWith(`${mindName}:`)) {
         if (buffer.debounceTimer) clearTimeout(buffer.debounceTimer);
         if (buffer.maxWaitTimer) clearTimeout(buffer.maxWaitTimer);
+        // Release ownership of the buffered rows: their persisted queue rows remain
+        // pending, so the redrive loop can re-deliver them once the mind is back.
+        for (const msg of buffer.messages) {
+          if (msg.queueId != null) this.inFlight.delete(msg.queueId);
+        }
         toDelete.push(bufferKey);
       }
     }
@@ -355,6 +499,13 @@ export class DeliveryManager {
     }
     this.batchBuffers.clear();
     this.sessionStates.clear();
+    this.inFlight.clear();
+    this.drainChains.clear();
+    if (this.redriveTimer) {
+      clearInterval(this.redriveTimer);
+      this.redriveTimer = null;
+    }
+    setRoutesChangeListener(undefined);
     if (instance === this) instance = undefined;
   }
 
@@ -389,59 +540,131 @@ export class DeliveryManager {
     }
   }
 
+  /**
+   * Serialize `fn` on a per-key promise chain so calls for the same key run one at a
+   * time in submission order. Used to drain a `(mind, session)` sequentially.
+   */
+  private runSequential<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.drainChains.get(key) ?? Promise.resolve();
+    const run = prev.then(fn, fn);
+    const tail = run.then(
+      () => {},
+      () => {},
+    );
+    this.drainChains.set(key, tail);
+    tail.then(() => {
+      if (this.drainChains.get(key) === tail) this.drainChains.delete(key);
+    });
+    return run;
+  }
+
+  /** Delete delivered queue rows by their specific ids. */
+  private async deleteQueueRows(ids: (number | undefined)[]): Promise<void> {
+    const valid = [...new Set(ids.filter((id): id is number => typeof id === "number"))];
+    if (valid.length === 0) return;
+    try {
+      const db = await getDb();
+      await db.delete(deliveryQueue).where(inArray(deliveryQueue.id, valid));
+    } catch (err) {
+      dlog.warn("failed to delete delivered delivery queue rows", log.errorData(err));
+    }
+  }
+
+  /** Bump attempt counters and set a backoff window so a down mind isn't hot-looped. */
+  private async scheduleRetry(ids: (number | undefined)[]): Promise<void> {
+    const valid = [...new Set(ids.filter((id): id is number => typeof id === "number"))];
+    if (valid.length === 0) return;
+    try {
+      const db = await getDb();
+      const rows = await db
+        .select({ id: deliveryQueue.id, attempts: deliveryQueue.attempts })
+        .from(deliveryQueue)
+        .where(inArray(deliveryQueue.id, valid));
+      for (const row of rows) {
+        const attempts = row.attempts + 1;
+        const backoffSec = Math.round(
+          Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.min(attempts, 20)) / 1000,
+        );
+        await db
+          .update(deliveryQueue)
+          .set({ attempts, next_attempt_at: sql`datetime('now', ${`+${backoffSec} seconds`})` })
+          .where(eq(deliveryQueue.id, row.id));
+      }
+    } catch (err) {
+      dlog.warn("failed to schedule delivery retry", log.errorData(err));
+    }
+  }
+
   private async deliverToMind(
     mindName: string,
     session: string,
     payload: DeliveryPayload,
     sessionConfig: ResolvedSessionConfig,
+    queueId?: number,
   ): Promise<void> {
-    const resolved = await this.resolvePort(mindName);
-    if (!resolved) {
-      dlog.warn(`cannot deliver to ${mindName}: mind not found`);
-      return;
-    }
-    const { baseName, port } = resolved;
+    if (queueId != null) this.inFlight.add(queueId);
 
-    // Increment active count before delivery with sender/channel metadata
-    const senders = new Set<string>();
-    if (payload.sender) senders.add(payload.sender);
-    const channels = new Set<string>();
-    if (payload.channel) channels.add(payload.channel);
-    this.incrementActive(baseName, session, senders, channels);
+    // Serialize the ENTIRE delivery (resolvePort + enrichment + POST) per
+    // (mind, session) so resolvePort/enrichment latency can't reorder two rapid
+    // messages — they POST in submission order.
+    await this.runSequential(`${mindName}:${session}`, async () => {
+      const resolved = await this.resolvePort(mindName);
+      if (!resolved) {
+        // Mind not found/running — leave the persisted row pending for the redrive loop.
+        dlog.warn(`cannot deliver to ${mindName}: mind not found`);
+        if (queueId != null) this.inFlight.delete(queueId);
+        return;
+      }
+      const { baseName, port } = resolved;
 
-    // Set typing indicator on both slug and conversationId keys
-    const typingMap = getTypingMap();
-    if (payload.channel) {
-      typingMap.set(payload.channel, baseName, { persistent: true });
-    }
-    if (payload.conversationId) {
-      typingMap.set(payload.conversationId, baseName, { persistent: true });
-    }
+      // Increment active count before delivery with sender/channel metadata
+      const senders = new Set<string>();
+      if (payload.sender) senders.add(payload.sender);
+      const channels = new Set<string>();
+      if (payload.channel) channels.add(payload.channel);
+      this.incrementActive(baseName, session, senders, channels);
 
-    // Mark mind as active immediately at delivery time (before it emits events)
-    onMindEvent(baseName, "delivery", payload.channel);
+      // Set typing indicator on both slug and conversationId keys
+      const typingMap = getTypingMap();
+      if (payload.channel) {
+        typingMap.set(payload.channel, baseName, { persistent: true });
+      }
+      if (payload.conversationId) {
+        typingMap.set(payload.conversationId, baseName, { persistent: true });
+      }
 
-    // Enrich with participant profiles on first encounter per channel
-    const enrichedPayload = await this.enrichWithProfiles(baseName, session, payload);
+      // Mark mind as active immediately at delivery time (before it emits events)
+      onMindEvent(baseName, "delivery", payload.channel);
 
-    const body = JSON.stringify({
-      ...enrichedPayload,
-      session,
-      interrupt: sessionConfig.interrupt,
-      instructions: sessionConfig.instructions,
-    });
+      // Enrich with participant profiles on first encounter per channel
+      const enrichedPayload = await this.enrichWithProfiles(baseName, session, payload);
 
-    try {
-      const ok = await this.postToMind(port, body);
-      if (!ok) {
+      const body = JSON.stringify({
+        ...enrichedPayload,
+        session,
+        interrupt: sessionConfig.interrupt,
+        instructions: sessionConfig.instructions,
+      });
+
+      try {
+        const ok = await this.postToMind(port, body);
+        if (!ok) {
+          this.decrementActive(baseName, session);
+          publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
+          await this.scheduleRetry([queueId]);
+        } else {
+          // Mark delivered ONLY on ack, by specific row id — never a broad DELETE.
+          await this.deleteQueueRows([queueId]);
+        }
+      } catch (err) {
+        dlog.warn(`failed to deliver to ${mindName}`, log.errorData(err));
         this.decrementActive(baseName, session);
         publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
+        await this.scheduleRetry([queueId]);
+      } finally {
+        if (queueId != null) this.inFlight.delete(queueId);
       }
-    } catch (err) {
-      dlog.warn(`failed to deliver to ${mindName}`, log.errorData(err));
-      this.decrementActive(baseName, session);
-      publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-    }
+    });
   }
 
   private async deliverBatchToMind(
@@ -451,99 +674,99 @@ export class DeliveryManager {
     sessionConfig: ResolvedSessionConfig,
     interruptOverride?: boolean,
   ): Promise<void> {
-    const resolved = await this.resolvePort(mindName);
-    if (!resolved) {
-      dlog.warn(`cannot deliver batch to ${mindName}: mind not found`);
-      return;
-    }
-    const { baseName, port } = resolved;
+    const queueIds = messages
+      .map((m) => m.queueId)
+      .filter((id): id is number => typeof id === "number");
 
-    // Enrich first message per new channel with participant profiles
-    const firstPerChannel = new Set<string>();
-    const isFirstForChannel: boolean[] = [];
-    for (const msg of messages) {
-      const ch = msg.channel ?? "unknown";
-      isFirstForChannel.push(!firstPerChannel.has(ch));
-      firstPerChannel.add(ch);
-    }
-    const enrichedMessages = await Promise.all(
-      messages.map(async (msg, i) => {
-        if (!isFirstForChannel[i]) return msg;
-        const enrichedPayload = await this.enrichWithProfiles(baseName, session, msg.payload);
-        return { ...msg, payload: enrichedPayload };
-      }),
-    );
-
-    // Group messages by channel
-    const channels: Record<string, DeliveryPayload[]> = {};
-    for (const msg of enrichedMessages) {
-      const ch = msg.channel ?? "unknown";
-      if (!channels[ch]) channels[ch] = [];
-      channels[ch].push(msg.payload);
-    }
-
-    // Collect sender/channel metadata from messages
-    const senders = new Set<string>();
-    const channelSet = new Set<string>();
-    for (const msg of messages) {
-      if (msg.sender) senders.add(msg.sender);
-      if (msg.channel) channelSet.add(msg.channel);
-    }
-
-    // Increment active count with metadata
-    this.incrementActive(baseName, session, senders, channelSet);
-
-    // Set typing indicators for all real channels in the batch
-    const typingMap = getTypingMap();
-    for (const ch of Object.keys(channels)) {
-      if (ch !== "unknown") typingMap.set(ch, baseName, { persistent: true });
-    }
-    // Also set on conversationId keys for web UI typing
-    const seenConvIds = new Set<string>();
-    for (const msg of messages) {
-      if (msg.payload.conversationId && !seenConvIds.has(msg.payload.conversationId)) {
-        seenConvIds.add(msg.payload.conversationId);
-        typingMap.set(msg.payload.conversationId, baseName, { persistent: true });
+    // Serialize the whole batch delivery per (mind, session) so it can't be
+    // reordered against interleaving immediate deliveries to the same session.
+    await this.runSequential(`${mindName}:${session}`, async () => {
+      const resolved = await this.resolvePort(mindName);
+      if (!resolved) {
+        dlog.warn(`cannot deliver batch to ${mindName}: mind not found`);
+        // Leave rows pending for redrive; release ownership so the sweep can retry.
+        for (const id of queueIds) this.inFlight.delete(id);
+        return;
       }
-    }
+      const { baseName, port } = resolved;
 
-    const body = JSON.stringify({
-      session,
-      batch: { channels },
-      interrupt: interruptOverride ?? sessionConfig.interrupt,
-      instructions: sessionConfig.instructions,
-    });
+      // Enrich first message per new channel with participant profiles
+      const firstPerChannel = new Set<string>();
+      const isFirstForChannel: boolean[] = [];
+      for (const msg of messages) {
+        const ch = msg.channel ?? "unknown";
+        isFirstForChannel.push(!firstPerChannel.has(ch));
+        firstPerChannel.add(ch);
+      }
+      const enrichedMessages = await Promise.all(
+        messages.map(async (msg, i) => {
+          if (!isFirstForChannel[i]) return msg;
+          const enrichedPayload = await this.enrichWithProfiles(baseName, session, msg.payload);
+          return { ...msg, payload: enrichedPayload };
+        }),
+      );
 
-    try {
-      const ok = await this.postToMind(port, body);
-      if (!ok) {
-        this.decrementActive(baseName, session);
-        publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-      } else {
-        // Clean up DB entries only after successful delivery
-        try {
-          const db = await getDb();
-          await db
-            .delete(deliveryQueue)
-            .where(
-              and(
-                eq(deliveryQueue.mind, baseName),
-                eq(deliveryQueue.session, session),
-                eq(deliveryQueue.status, "pending"),
-              ),
-            );
-        } catch (err) {
-          dlog.warn(
-            `failed to clean delivery queue for ${baseName}/${session}`,
-            log.errorData(err),
-          );
+      // Group messages by channel
+      const channels: Record<string, DeliveryPayload[]> = {};
+      for (const msg of enrichedMessages) {
+        const ch = msg.channel ?? "unknown";
+        if (!channels[ch]) channels[ch] = [];
+        channels[ch].push(msg.payload);
+      }
+
+      // Collect sender/channel metadata from messages
+      const senders = new Set<string>();
+      const channelSet = new Set<string>();
+      for (const msg of messages) {
+        if (msg.sender) senders.add(msg.sender);
+        if (msg.channel) channelSet.add(msg.channel);
+      }
+
+      // Increment active count with metadata
+      this.incrementActive(baseName, session, senders, channelSet);
+
+      // Set typing indicators for all real channels in the batch
+      const typingMap = getTypingMap();
+      for (const ch of Object.keys(channels)) {
+        if (ch !== "unknown") typingMap.set(ch, baseName, { persistent: true });
+      }
+      // Also set on conversationId keys for web UI typing
+      const seenConvIds = new Set<string>();
+      for (const msg of messages) {
+        if (msg.payload.conversationId && !seenConvIds.has(msg.payload.conversationId)) {
+          seenConvIds.add(msg.payload.conversationId);
+          typingMap.set(msg.payload.conversationId, baseName, { persistent: true });
         }
       }
-    } catch (err) {
-      dlog.warn(`failed to deliver batch to ${mindName}`, log.errorData(err));
-      this.decrementActive(baseName, session);
-      publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-    }
+
+      const body = JSON.stringify({
+        session,
+        batch: { channels },
+        interrupt: interruptOverride ?? sessionConfig.interrupt,
+        instructions: sessionConfig.instructions,
+      });
+
+      try {
+        const ok = await this.postToMind(port, body);
+        if (!ok) {
+          this.decrementActive(baseName, session);
+          publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
+          await this.scheduleRetry(queueIds);
+        } else {
+          // Mark delivered ONLY on ack, and ONLY the specific rows in this batch —
+          // a broad (mind, session, pending) DELETE would race with rows enqueued
+          // concurrently during the flush.
+          await this.deleteQueueRows(queueIds);
+        }
+      } catch (err) {
+        dlog.warn(`failed to deliver batch to ${mindName}`, log.errorData(err));
+        this.decrementActive(baseName, session);
+        publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
+        await this.scheduleRetry(queueIds);
+      } finally {
+        for (const id of queueIds) this.inFlight.delete(id);
+      }
+    });
   }
 
   private async enqueueBatch(
@@ -554,20 +777,27 @@ export class DeliveryManager {
   ): Promise<void> {
     const delivery = sessionConfig.delivery as Extract<ResolvedDeliveryMode, { mode: "batch" }>;
 
+    // Persist to the queue FIRST (keyed by baseName) — the row is the source of truth;
+    // the in-memory buffer is a fast path reconciled against these rows on ack/redrive.
+    // The row is "owned" (inFlight) while buffered so the redrive sweep won't double-send.
+    const baseName = await getBaseName(mindName);
+    const queueId = await this.persistToQueue(baseName, session, payload);
+    if (queueId != null) this.inFlight.add(queueId);
+    const msg: QueuedMessage = {
+      payload,
+      channel: payload.channel,
+      sender: payload.sender ?? null,
+      createdAt: Date.now(),
+      queueId,
+    };
+
     // Check triggers — immediate flush if matched
     if (delivery.triggers?.length) {
       const text = extractTextContent(payload.content);
       const lower = text.toLowerCase();
       if (delivery.triggers.some((t) => lower.includes(t.toLowerCase()))) {
         // Flush existing buffer + this message immediately
-        await this.flushBatch(mindName, session, [
-          {
-            payload,
-            channel: payload.channel,
-            sender: payload.sender ?? null,
-            createdAt: Date.now(),
-          },
-        ]);
+        await this.flushBatch(mindName, session, [msg]);
         return;
       }
     }
@@ -575,7 +805,6 @@ export class DeliveryManager {
     // New-speaker interrupt: if mind is active on this channel and a different sender
     // arrives (within the maxWait window and past the debounce cooldown), force-flush
     // with interrupt so the mind can incorporate the new voice
-    const baseName = await getBaseName(mindName);
     const state = this.sessionStates.get(baseName)?.get(session);
     if (
       state &&
@@ -588,33 +817,18 @@ export class DeliveryManager {
       Date.now() - state.lastInterruptAt > delivery.debounce * 1000
     ) {
       state.lastInterruptAt = Date.now();
-      // Persist to DB (fire-and-forget) and flush immediately with interrupt override
-      this.persistToQueue(mindName, session, payload).catch((err) => {
-        dlog.warn(`failed to persist batch message for ${mindName}/${session}`, log.errorData(err));
-      });
-      await this.flushBatch(
-        mindName,
-        session,
-        [{ payload, channel: payload.channel, sender: payload.sender, createdAt: Date.now() }],
-        true,
-      );
+      await this.flushBatch(mindName, session, [msg], true);
       return;
     }
 
-    // Persist to DB (fire-and-forget): the in-memory buffer is primary for batches,
-    // DB persistence is for crash recovery only. Gated messages await because DB is their only store.
-    this.persistToQueue(mindName, session, payload).catch((err) => {
-      dlog.warn(`failed to persist batch message for ${mindName}/${session}`, log.errorData(err));
-    });
-
-    this.addToBatchBuffer(mindName, session, payload, sessionConfig);
+    this.addToBatchBuffer(mindName, session, sessionConfig, msg);
   }
 
   private addToBatchBuffer(
     mindName: string,
     session: string,
-    payload: DeliveryPayload,
     sessionConfig: ResolvedSessionConfig,
+    msg: QueuedMessage,
   ): void {
     const delivery = sessionConfig.delivery as Extract<ResolvedDeliveryMode, { mode: "batch" }>;
     const bufferKey = `${mindName}:${session}`;
@@ -630,12 +844,7 @@ export class DeliveryManager {
       this.batchBuffers.set(bufferKey, buffer);
     }
 
-    buffer.messages.push({
-      payload,
-      channel: payload.channel,
-      sender: payload.sender ?? null,
-      createdAt: Date.now(),
-    });
+    buffer.messages.push(msg);
 
     // Max batch size — force flush
     if (buffer.messages.length >= MAX_BATCH_SIZE) {
@@ -760,27 +969,38 @@ export class DeliveryManager {
     await sendSystemMessage(mindName, notification);
   }
 
+  /**
+   * Insert a delivery_queue row and return its id. Always keyed by `baseName` so that
+   * inserts under a variant name and the id-scoped cleanup use the same key (fixes the
+   * variant mismatch where variant-keyed rows were never matched by the base cleanup).
+   */
   private async persistToQueue(
     mindName: string,
     session: string,
     payload: DeliveryPayload,
     status: "pending" | "gated" = "pending",
-  ): Promise<void> {
+  ): Promise<number | undefined> {
     try {
+      const baseName = await getBaseName(mindName);
       const db = await getDb();
-      await db.insert(deliveryQueue).values({
-        mind: mindName,
-        session,
-        channel: payload.channel ?? null,
-        sender: payload.sender ?? null,
-        status,
-        payload: JSON.stringify(payload),
-      });
+      const result = await db
+        .insert(deliveryQueue)
+        .values({
+          mind: baseName,
+          session,
+          channel: payload.channel ?? null,
+          sender: payload.sender ?? null,
+          status,
+          payload: JSON.stringify(payload),
+        })
+        .returning({ id: deliveryQueue.id });
+      return result[0]?.id;
     } catch (err) {
       dlog.warn(
         `failed to persist to delivery queue for ${mindName}/${session}`,
         log.errorData(err),
       );
+      return undefined;
     }
   }
 

--- a/packages/daemon/src/lib/delivery/delivery-router.ts
+++ b/packages/daemon/src/lib/delivery/delivery-router.ts
@@ -107,6 +107,23 @@ const STAT_TTL_MS = 5_000;
 
 const dlog = log.child("delivery-router");
 
+// Notified when a mind's routes.json changes (explicit cache clear or detected mtime
+// change), so held (gated) messages can be re-evaluated against the new rules.
+let routesChangeListener: ((mind: string) => void) | undefined;
+
+export function setRoutesChangeListener(fn: ((mind: string) => void) | undefined): void {
+  routesChangeListener = fn;
+}
+
+function notifyRoutesChanged(mind: string): void {
+  if (!routesChangeListener) return;
+  try {
+    routesChangeListener(mind);
+  } catch (err) {
+    dlog.warn(`routes change listener failed for ${mind}`, log.errorData(err));
+  }
+}
+
 // Cache of mind name → directory overrides (e.g. spirits with custom dirs)
 const dirOverrides = new Map<string, string>();
 
@@ -149,7 +166,11 @@ export function getRoutingConfig(mindName: string): RoutingConfig {
 
   try {
     const config: RoutingConfig = JSON.parse(readFileSync(path, "utf-8"));
+    const changed = cached != null && cached.mtime !== mtime;
     configCache.set(mindName, { config, mtime });
+    // A pre-existing cached config with a different mtime means routes.json actually
+    // changed — release any gated messages that the new rules now match.
+    if (changed) notifyRoutesChanged(mindName);
     return config;
   } catch (err) {
     dlog.warn(`failed to load routes.json for ${mindName}`, log.errorData(err));
@@ -166,6 +187,9 @@ export function clearConfigCache(mindName?: string): void {
   if (mindName) {
     configCache.delete(mindName);
     statCheckCache.delete(mindName);
+    // An explicit invalidation typically follows a routes.json write — re-evaluate
+    // gated messages against the (about to be reloaded) rules.
+    notifyRoutesChanged(mindName);
   } else {
     configCache.clear();
     statCheckCache.clear();

--- a/packages/daemon/src/lib/delivery/echo-text.ts
+++ b/packages/daemon/src/lib/delivery/echo-text.ts
@@ -72,6 +72,15 @@ async function resolveConversationId(mind: string, channel: string): Promise<str
 /**
  * If echoText is enabled for this mind, send the text content as an outbound
  * message to the channel. Returns the outbound history ID if sent.
+ *
+ * Fan-out decision (echoText vs. chat-send asymmetry): echoText intentionally does
+ * NOT fan out to peer mind participants. It fires on every raw `text` event a mind
+ * streams, so it is a real-time mirror to the human-facing conversation and external
+ * bridges (`routeOutboundBridge`) — display surfaces, not interactive principals.
+ * The authoritative mind→mind delivery path is the explicit chat send
+ * (`/chat` → `fanOutToMinds`), which owns fan-out AND loop protection. Echoing raw
+ * streamed text to peer minds would double-deliver every deliberate send and amplify
+ * mind→mind loops, so peer-mind fan-out stays exclusively on the explicit send path.
  */
 export async function echoTextToChannel(
   mind: string,

--- a/packages/daemon/src/lib/delivery/fan-out.ts
+++ b/packages/daemon/src/lib/delivery/fan-out.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared fan-out: deliver one conversation message to every mind participant.
+ *
+ * This is the single fan-out path used by both the chat API (`/chat`) and the
+ * bridge inbound path. It also holds mind→mind loop protection: after too many
+ * consecutive automated (mind-authored) turns without human input, fan-out to
+ * minds is paused and a one-time notice is posted, so two minds can't ping-pong
+ * unbounded.
+ */
+import { getOrCreateSystemUser } from "../auth.js";
+import { getTypingMap } from "../chat/typing.js";
+import { getMindManager } from "../daemon/mind-manager.js";
+import { getSleepManagerIfReady } from "../daemon/sleep-manager.js";
+import { addMessage, type ContentBlock, getParticipants } from "../events/conversations.js";
+import log from "../util/logger.js";
+import { buildVoluteSlug } from "../util/slugify.js";
+import { deliverMessage } from "./message-delivery.js";
+
+type Participant = Awaited<ReturnType<typeof getParticipants>>[number];
+type SlugOpts = Parameters<typeof buildVoluteSlug>[0];
+
+export interface FanOutOpts {
+  conversationId: string;
+  contentBlocks: ContentBlock[];
+  senderName: string;
+  /** Whether the sender is itself a mind — drives loop protection (increment vs. reset). */
+  senderIsMind?: boolean;
+  /** Participants; fetched from the conversation if not provided. */
+  participants?: Participant[];
+  /** Override isDM (defaults to participants.length === 2). */
+  isDM?: boolean;
+  /** Extra fields passed to buildVoluteSlug (e.g. convType, convName). */
+  slugExtra?: Partial<SlugOpts>;
+  /** Maps a mind username to its delivery target name (variant-aware targeting). */
+  targetName?: (username: string) => string;
+}
+
+/**
+ * Max consecutive mind-authored turns in a conversation before fan-out to minds is
+ * paused. A non-mind (human/bridge) message resets the counter.
+ */
+export const MAX_CONSECUTIVE_MIND_TURNS = 6;
+
+const consecutiveMindTurns = new Map<string, number>();
+
+/** Reset the loop-protection counter for a conversation (e.g. on human input). */
+export function resetLoopCounter(conversationId: string): void {
+  consecutiveMindTurns.delete(conversationId);
+}
+
+async function emitLoopNotice(conversationId: string): Promise<void> {
+  const systemUser = await getOrCreateSystemUser();
+  await addMessage(conversationId, "user", systemUser.username, [
+    {
+      type: "text",
+      text: `[System] This exchange has continued for ${MAX_CONSECUTIVE_MIND_TURNS} consecutive automated turns without human input, so automatic delivery between minds has been paused. Send a message to resume.`,
+    },
+  ]);
+}
+
+export async function fanOutToMinds(opts: FanOutOpts): Promise<void> {
+  const participants = opts.participants ?? (await getParticipants(opts.conversationId));
+  const mindParticipants = participants.filter(
+    (p) => p.userType === "mind" || p.userType === "system",
+  );
+  const participantNames = participants.map((p) => p.username);
+  const isDM = opts.isDM ?? participants.length === 2;
+
+  // --- Loop protection ---
+  if (opts.senderIsMind) {
+    const count = (consecutiveMindTurns.get(opts.conversationId) ?? 0) + 1;
+    consecutiveMindTurns.set(opts.conversationId, count);
+    if (count > MAX_CONSECUTIVE_MIND_TURNS) {
+      // Emit the notice once as we cross the threshold, then pause fan-out until a
+      // non-mind message resets the counter.
+      if (count === MAX_CONSECUTIVE_MIND_TURNS + 1) {
+        await emitLoopNotice(opts.conversationId).catch((err) =>
+          log.warn(`failed to emit loop notice for ${opts.conversationId}`, log.errorData(err)),
+        );
+      }
+      log.warn(
+        `loop protection: paused mind fan-out for ${opts.conversationId} after ${count} consecutive mind turns`,
+      );
+      return;
+    }
+  } else {
+    // A human/bridge message breaks the chain.
+    consecutiveMindTurns.delete(opts.conversationId);
+  }
+
+  const manager = getMindManager();
+  const sm = getSleepManagerIfReady();
+
+  // Include running minds AND sleeping minds (sleeping ones route through the sleep queue).
+  const targetMinds = mindParticipants
+    .map((ap) => {
+      const key = opts.targetName ? opts.targetName(ap.username) : ap.username;
+      if (manager.isRunning(key) || sm?.isSleeping(ap.username)) return ap.username;
+      return null;
+    })
+    .filter((n): n is string => n !== null && n !== opts.senderName);
+
+  // Fire-and-forget: deliver to all target minds (running or sleeping)
+  for (const mindName of targetMinds) {
+    const target = opts.targetName ? opts.targetName(mindName) : mindName;
+    const channel = buildVoluteSlug({
+      participants,
+      mindUsername: mindName,
+      conversationId: opts.conversationId,
+      ...opts.slugExtra,
+    });
+    const typingMap = getTypingMap();
+    // Filter typing to only participants of this conversation (slugs are shared across DMs).
+    const currentlyTyping = typingMap
+      .get(channel)
+      .filter((name) => participantNames.includes(name));
+    deliverMessage(target, {
+      content: opts.contentBlocks,
+      channel,
+      conversationId: opts.conversationId,
+      sender: opts.senderName,
+      participants: participantNames,
+      participantCount: participants.length,
+      isDM,
+      ...(currentlyTyping.length > 0 ? { typing: currentlyTyping } : {}),
+    }).catch((err) => {
+      log.warn(`fan-out delivery failed for ${target}`, log.errorData(err));
+    });
+  }
+}

--- a/packages/daemon/src/lib/delivery/fan-out.ts
+++ b/packages/daemon/src/lib/delivery/fan-out.ts
@@ -67,25 +67,31 @@ export async function fanOutToMinds(opts: FanOutOpts): Promise<void> {
   const isDM = opts.isDM ?? participants.length === 2;
 
   // --- Loop protection ---
-  if (opts.senderIsMind) {
-    const count = (consecutiveMindTurns.get(opts.conversationId) ?? 0) + 1;
-    consecutiveMindTurns.set(opts.conversationId, count);
-    if (count > MAX_CONSECUTIVE_MIND_TURNS) {
-      // Emit the notice once as we cross the threshold, then pause fan-out until a
-      // non-mind message resets the counter.
-      if (count === MAX_CONSECUTIVE_MIND_TURNS + 1) {
-        await emitLoopNotice(opts.conversationId).catch((err) =>
-          log.warn(`failed to emit loop notice for ${opts.conversationId}`, log.errorData(err)),
+  // Only meaningful when there's more than one mind in the conversation. fanOutToMinds
+  // runs for EVERY posted message, so a mind posting into a DM/channel where it's the
+  // only mind has no peer to loop with — it must not trip the counter or inject the
+  // "delivery paused" notice into a conversation with zero mind→mind delivery.
+  if (mindParticipants.length > 1) {
+    if (opts.senderIsMind) {
+      const count = (consecutiveMindTurns.get(opts.conversationId) ?? 0) + 1;
+      consecutiveMindTurns.set(opts.conversationId, count);
+      if (count > MAX_CONSECUTIVE_MIND_TURNS) {
+        // Emit the notice once as we cross the threshold, then pause fan-out until a
+        // non-mind message resets the counter.
+        if (count === MAX_CONSECUTIVE_MIND_TURNS + 1) {
+          await emitLoopNotice(opts.conversationId).catch((err) =>
+            log.warn(`failed to emit loop notice for ${opts.conversationId}`, log.errorData(err)),
+          );
+        }
+        log.warn(
+          `loop protection: paused mind fan-out for ${opts.conversationId} after ${count} consecutive mind turns`,
         );
+        return;
       }
-      log.warn(
-        `loop protection: paused mind fan-out for ${opts.conversationId} after ${count} consecutive mind turns`,
-      );
-      return;
+    } else {
+      // A human/bridge message breaks the chain.
+      consecutiveMindTurns.delete(opts.conversationId);
     }
-  } else {
-    // A human/bridge message breaks the chain.
-    consecutiveMindTurns.delete(opts.conversationId);
   }
 
   const manager = getMindManager();

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -141,7 +141,13 @@ export const deliveryQueue = sqliteTable(
   "delivery_queue",
   {
     id: integer("id").primaryKey({ autoIncrement: true }),
+    // Keying/cleanup/dedup key: always the base (parent) name, so an insert under a
+    // variant name and the id-scoped cleanup share a key.
     mind: text("mind").notNull(),
+    // Original delivery target — may be a variant name. Used to resolve the port on
+    // redrive so a variant's stranded message is re-delivered to the variant, not the
+    // parent. Null on legacy rows → callers fall back to `mind`.
+    target_mind: text("target_mind"),
     session: text("session").notNull(),
     channel: text("channel"),
     sender: text("sender"),

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -147,12 +147,17 @@ export const deliveryQueue = sqliteTable(
     sender: text("sender"),
     status: text("status").notNull().default("pending"),
     payload: text("payload").notNull(),
+    // Redrive bookkeeping: how many delivery attempts have been made, and the
+    // earliest time the row is eligible for a retry (null = deliver ASAP).
+    attempts: integer("attempts").notNull().default(0),
+    next_attempt_at: text("next_attempt_at"),
     created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
   },
   (table) => [
     index("idx_delivery_queue_mind_session").on(table.mind, table.session),
     index("idx_delivery_queue_mind_status").on(table.mind, table.status),
     index("idx_delivery_queue_status").on(table.status),
+    index("idx_delivery_queue_status_next").on(table.status, table.next_attempt_at),
   ],
 );
 

--- a/packages/daemon/src/web/api/bridges.ts
+++ b/packages/daemon/src/web/api/bridges.ts
@@ -14,7 +14,7 @@ import {
 } from "../../lib/bridges/bridges.js";
 import { findOrCreatePuppet } from "../../lib/chat/puppets.js";
 import { getBridgeManager } from "../../lib/daemon/bridge-manager.js";
-import { deliverMessage } from "../../lib/delivery/message-delivery.js";
+import { fanOutToMinds } from "../../lib/delivery/fan-out.js";
 import {
   addMessage,
   type ContentBlock,
@@ -25,7 +25,6 @@ import {
 } from "../../lib/events/conversations.js";
 import { findMind } from "../../lib/mind/registry.js";
 import log from "../../lib/util/logger.js";
-import { buildVoluteSlug } from "../../lib/util/slugify.js";
 import type { AuthEnv } from "../middleware/auth.js";
 import { requireAdmin } from "../middleware/auth.js";
 
@@ -249,7 +248,8 @@ const app = new Hono<AuthEnv>()
 
 /**
  * Fan out a message from a bridged conversation to all mind participants.
- * Reuses the existing delivery infrastructure.
+ * Bridge senders are external humans, so this is not a mind→mind turn (loop
+ * protection counter resets). Delegates to the shared fan-out path.
  */
 async function fanOutToBridgedMinds(opts: {
   conversationId: string;
@@ -258,43 +258,13 @@ async function fanOutToBridgedMinds(opts: {
   platform: string;
   isDM: boolean;
 }): Promise<void> {
-  const participants = await getParticipants(opts.conversationId);
-  const mindParticipants = participants.filter((p) => p.userType === "mind");
-  const participantNames = participants.map((p) => p.username);
-
-  const { getMindManager } = await import("../../lib/daemon/mind-manager.js");
-  const { getSleepManagerIfReady } = await import("../../lib/daemon/sleep-manager.js");
-  const manager = getMindManager();
-  const sm = getSleepManagerIfReady();
-
-  const targetMinds = mindParticipants
-    .filter((ap) => {
-      return (
-        (manager.isRunning(ap.username) || sm?.isSleeping(ap.username)) &&
-        ap.username !== opts.senderName
-      );
-    })
-    .map((ap) => ap.username);
-
-  for (const mindName of targetMinds) {
-    const channel = buildVoluteSlug({
-      participants,
-      mindUsername: mindName,
-      conversationId: opts.conversationId,
-    });
-
-    deliverMessage(mindName, {
-      content: opts.contentBlocks,
-      channel,
-      conversationId: opts.conversationId,
-      sender: opts.senderName,
-      participants: participantNames,
-      participantCount: participants.length,
-      isDM: opts.isDM,
-    }).catch((err) => {
-      log.warn(`bridge fan-out delivery failed for ${mindName}`, log.errorData(err));
-    });
-  }
+  await fanOutToMinds({
+    conversationId: opts.conversationId,
+    contentBlocks: opts.contentBlocks,
+    senderName: opts.senderName,
+    senderIsMind: false,
+    isDM: opts.isDM,
+  });
 }
 
 export default app;

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -6,11 +6,9 @@ import { getOrCreateMindUser, getOrCreateSystemUser } from "../../../lib/auth.js
 import { routeOutboundBridge } from "../../../lib/bridges/bridge-outbound.js";
 import { formatFileSize, stageFile, validateFilePath } from "../../../lib/chat/file-sharing.js";
 import { generateSystemReply } from "../../../lib/chat/system-chat.js";
-import { getTypingMap } from "../../../lib/chat/typing.js";
-import { getMindManager } from "../../../lib/daemon/mind-manager.js";
-import { getSleepManagerIfReady } from "../../../lib/daemon/sleep-manager.js";
 import { extractTextContent } from "../../../lib/delivery/delivery-router.js";
-import { deliverMessage, recordOutbound } from "../../../lib/delivery/message-delivery.js";
+import { fanOutToMinds } from "../../../lib/delivery/fan-out.js";
+import { recordOutbound } from "../../../lib/delivery/message-delivery.js";
 import { subscribe } from "../../../lib/events/conversation-events.js";
 import {
   addMessage,
@@ -29,72 +27,6 @@ import { fixModelEscapes } from "../../../lib/util/fix-model-escapes.js";
 import log from "../../../lib/util/logger.js";
 import { buildVoluteSlug } from "../../../lib/util/slugify.js";
 import type { AuthEnv } from "../../middleware/auth.js";
-
-type SlugOpts = Parameters<typeof buildVoluteSlug>[0];
-
-async function fanOutToMinds(opts: {
-  conversationId: string;
-  contentBlocks: ContentBlock[];
-  senderName: string;
-  participants: Awaited<ReturnType<typeof getParticipants>>;
-  /** Override isDM (defaults to participants.length === 2) */
-  isDM?: boolean;
-  /** Extra fields passed to buildVoluteSlug (e.g. convType, convName) */
-  slugExtra?: Partial<SlugOpts>;
-  /** Maps mind username to delivery target name (for variant-aware targeting) */
-  targetName?: (username: string) => string;
-}): Promise<void> {
-  const participants = opts.participants;
-  const mindParticipants = participants.filter(
-    (p) => p.userType === "mind" || p.userType === "system",
-  );
-  const participantNames = participants.map((p) => p.username);
-  const isDM = opts.isDM ?? participants.length === 2;
-
-  const manager = getMindManager();
-  const sm = getSleepManagerIfReady();
-
-  // Include running minds AND sleeping minds (sleeping ones get routed through sleep queue)
-  const targetMinds = mindParticipants
-    .map((ap) => {
-      const key = opts.targetName ? opts.targetName(ap.username) : ap.username;
-      if (manager.isRunning(key) || sm?.isSleeping(ap.username)) return ap.username;
-      return null;
-    })
-    .filter((n): n is string => n !== null && n !== opts.senderName);
-
-  function slugForMind(mindUsername: string): string {
-    return buildVoluteSlug({
-      participants,
-      mindUsername,
-      conversationId: opts.conversationId,
-      ...opts.slugExtra,
-    });
-  }
-
-  // Fire-and-forget: deliver to all target minds (running or sleeping)
-  for (const mindName of targetMinds) {
-    const target = opts.targetName ? opts.targetName(mindName) : mindName;
-    const channel = slugForMind(mindName);
-    const typingMap = getTypingMap();
-    // Filter typing to only participants of this conversation (slugs are shared across DMs)
-    const currentlyTyping = typingMap
-      .get(channel)
-      .filter((name) => participantNames.includes(name));
-    deliverMessage(target, {
-      content: opts.contentBlocks,
-      channel,
-      conversationId: opts.conversationId,
-      sender: opts.senderName,
-      participants: participantNames,
-      participantCount: participants.length,
-      isDM,
-      ...(currentlyTyping.length > 0 ? { typing: currentlyTyping } : {}),
-    }).catch((err) => {
-      log.warn(`fan-out delivery failed for ${target}`, log.errorData(err));
-    });
-  }
-}
 
 const fileSchema = z.object({
   filename: z.string(),
@@ -336,6 +268,7 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
       conversationId: conversationId!,
       contentBlocks,
       senderName,
+      senderIsMind: !!senderIsMind,
       participants,
       isDM,
       slugExtra: { convType: conv.type as "dm" | "channel", convName },

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -12,7 +12,13 @@ import {
   removeMind,
   voluteSystemDir,
 } from "../packages/daemon/src/lib/mind/registry.js";
-import { activity, mindHistory, summaries, turns } from "../packages/daemon/src/lib/schema.js";
+import {
+  activity,
+  deliveryQueue,
+  mindHistory,
+  summaries,
+  turns,
+} from "../packages/daemon/src/lib/schema.js";
 import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 // Strip GIT_* env vars that hook runners (e.g. pre-push) inject, so that
@@ -222,6 +228,59 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.equal(stoppedRes.status, 200);
     const stoppedStatus = (await stoppedRes.json()) as { status: string };
     assert.equal(stoppedStatus.status, "stopped");
+  });
+
+  it("GET /:name/delivery/pending previews gated messages and clears once released", async () => {
+    const db = await getDb();
+    // The daemon and this test share volute.db, so directly seeding gated rows is a
+    // deterministic way to exercise the pending-preview API without a real gating race.
+    await db.insert(deliveryQueue).values([
+      {
+        mind: TEST_MIND,
+        session: "main",
+        channel: "slack:random",
+        sender: "zoe",
+        status: "gated",
+        payload: JSON.stringify({
+          channel: "slack:random",
+          sender: "zoe",
+          content: "first held message",
+        }),
+      },
+      {
+        mind: TEST_MIND,
+        session: "main",
+        channel: "slack:random",
+        sender: "amp",
+        status: "gated",
+        payload: JSON.stringify({
+          channel: "slack:random",
+          sender: "amp",
+          content: "second held message",
+        }),
+      },
+    ]);
+
+    const res = await daemonRequest(`/api/minds/${TEST_MIND}/delivery/pending`);
+    assert.equal(res.status, 200);
+    const pending = (await res.json()) as Array<{
+      channel: string;
+      count: number;
+      preview: string;
+    }>;
+    const entry = pending.find((p) => p.channel === "slack:random");
+    assert.ok(entry, "gated channel should appear in pending preview");
+    assert.equal(entry.count, 2);
+    assert.match(entry.preview, /held message/);
+
+    // Releasing (delivering) the gated rows clears them from the preview.
+    await db.delete(deliveryQueue).where(eq(deliveryQueue.mind, TEST_MIND));
+    const res2 = await daemonRequest(`/api/minds/${TEST_MIND}/delivery/pending`);
+    const pending2 = (await res2.json()) as Array<{ channel: string }>;
+    assert.ok(
+      !pending2.find((p) => p.channel === "slack:random"),
+      "released messages should no longer be pending",
+    );
   });
 
   it("minds persist running state across daemon restart", async () => {

--- a/test/delivery-durability.test.ts
+++ b/test/delivery-durability.test.ts
@@ -190,13 +190,15 @@ describe("DeliveryManager durability", () => {
     removeMind(name);
   });
 
-  it("keys queue rows by baseName for variants and cleans them by id (no restart replay)", async () => {
-    // Variant delivery goes to the variant's port (here: failing); redrive re-resolves
-    // the baseName and delivers to the parent's port.
+  it("keys variant rows by baseName but redrives to the variant's own port (no restart replay)", async () => {
+    // The live path delivers to the variant's port; if that POST transiently fails, the row
+    // is keyed by baseName (so id-scoped cleanup matches) but records target_mind=variant, so
+    // redrive re-delivers to the VARIANT — never the parent. The variant must durably receive
+    // its own stranded message.
     const parentSrv = await startMindServer();
     const variantSrv = await startMindServer();
     servers.push(parentSrv.server, variantSrv.server);
-    variantSrv.fail();
+    variantSrv.fail(); // first delivery to the variant fails → leaves a pending row
 
     const parent = `dur-parent-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const variant = `${parent}-v1`;
@@ -216,8 +218,10 @@ describe("DeliveryManager durability", () => {
     const pending = await queueRows(parent, "pending");
     assert.equal(pending.length, 1, "row is keyed by the base name, not the variant");
     assert.equal((await queueRows(variant)).length, 0, "nothing is keyed under the variant name");
+    assert.equal(pending[0].target_mind, variant, "row records the variant as the delivery target");
 
-    // Restore-from-db (redrive): the row delivers (to the parent) and is cleaned, not replayed.
+    // The variant recovers. Redrive must deliver to the VARIANT's port, not the parent's.
+    variantSrv.ok();
     const db = await getDb();
     await db
       .update(deliveryQueue)
@@ -225,13 +229,14 @@ describe("DeliveryManager durability", () => {
       .where(eq(deliveryQueue.id, pending[0].id));
     await manager.restoreFromDb();
     await waitFor(async () => (await queueRows(parent)).length === 0);
-    assert.equal(parentSrv.received.length, 1);
+    assert.equal(variantSrv.received.length, 1, "redrive delivered to the variant's own port");
+    assert.equal(parentSrv.received.length, 0, "the parent never received the variant's message");
 
     // A second restore must NOT replay it.
-    parentSrv.received.length = 0;
+    variantSrv.received.length = 0;
     await manager.restoreFromDb();
     await new Promise((r) => setTimeout(r, 100));
-    assert.equal(parentSrv.received.length, 0, "cleaned row is not replayed on restart");
+    assert.equal(variantSrv.received.length, 0, "cleaned row is not replayed on restart");
 
     removeMind(variant);
     removeMind(parent);

--- a/test/delivery-durability.test.ts
+++ b/test/delivery-durability.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { DeliveryManager } from "../packages/daemon/src/lib/delivery/delivery-manager.js";
+import {
+  clearConfigCache,
+  type RoutingConfig,
+} from "../packages/daemon/src/lib/delivery/delivery-router.js";
+import { addMind, addVariant, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import { deliveryQueue } from "../packages/daemon/src/lib/schema.js";
+
+// --- Helpers ---
+
+/** A mind HTTP server that records received message bodies. Optional response delay. */
+async function startMindServer(delayMs = 0): Promise<{
+  server: Server;
+  port: number;
+  received: unknown[];
+  fail: () => void;
+  ok: () => void;
+}> {
+  const received: unknown[] = [];
+  let shouldFail = false;
+  const server = createServer((req, res) => {
+    if (req.method !== "POST") {
+      res.writeHead(404).end();
+      return;
+    }
+    let raw = "";
+    req.on("data", (c) => {
+      raw += c;
+    });
+    req.on("end", () => {
+      const respond = () => {
+        if (shouldFail) {
+          res.writeHead(500).end("nope");
+          return;
+        }
+        try {
+          received.push(JSON.parse(raw));
+        } catch {
+          received.push(raw);
+        }
+        res.writeHead(200, { "Content-Type": "application/json" }).end("{}");
+      };
+      if (delayMs > 0) setTimeout(respond, delayMs);
+      else respond();
+    });
+  });
+  const port: number = await new Promise((res) => {
+    server.listen(0, "127.0.0.1", () => res((server.address() as { port: number }).port));
+  });
+  return {
+    server,
+    port,
+    received,
+    fail: () => {
+      shouldFail = true;
+    },
+    ok: () => {
+      shouldFail = false;
+    },
+  };
+}
+
+async function registerMind(port: number, config: RoutingConfig | object): Promise<string> {
+  const name = `dur-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  await addMind(name, port);
+  const configDir = resolve(process.env.VOLUTE_HOME!, "minds", name, "home/.config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(resolve(configDir, "routes.json"), JSON.stringify(config));
+  return name;
+}
+
+async function queueRows(mind: string, status?: string) {
+  const db = await getDb();
+  const where = status
+    ? and(eq(deliveryQueue.mind, mind), eq(deliveryQueue.status, status))
+    : eq(deliveryQueue.mind, mind);
+  return db.select().from(deliveryQueue).where(where);
+}
+
+async function waitFor(cond: () => Promise<boolean> | boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await cond()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error("waitFor timed out");
+}
+
+const IMMEDIATE: RoutingConfig = {
+  rules: [{ channel: "*", session: "main" }],
+  gateUnmatched: false,
+};
+
+describe("DeliveryManager durability", () => {
+  let manager: DeliveryManager;
+  const servers: Server[] = [];
+
+  afterEach(() => {
+    manager?.dispose();
+    clearConfigCache();
+    for (const s of servers.splice(0)) s.close();
+  });
+
+  it("persists to the queue before POST and marks done by row id on ack", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+
+    await manager.routeAndDeliver(name, { channel: "test:ch", sender: "alice", content: "hi" });
+
+    // Ack received → row deleted by its specific id, and the mind got exactly one POST.
+    assert.equal(srv.received.length, 1);
+    assert.equal((await queueRows(name)).length, 0, "row should be deleted after ack");
+    removeMind(name);
+  });
+
+  it("leaves a pending row when the POST fails, then the redrive loop delivers it", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.fail(); // mind responds 500 → delivery fails
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+
+    await manager.routeAndDeliver(name, { channel: "test:ch", sender: "alice", content: "hi" });
+
+    // Persist-before-POST: the row survives a failed delivery, with a bumped attempt count.
+    let rows = await queueRows(name, "pending");
+    assert.equal(rows.length, 1, "failed delivery must leave a pending row");
+    assert.ok(rows[0].attempts >= 1, "attempt counter should be bumped on failure");
+
+    // Now the mind recovers. Clear the backoff window and redrive.
+    srv.ok();
+    const db = await getDb();
+    await db
+      .update(deliveryQueue)
+      .set({ next_attempt_at: null })
+      .where(eq(deliveryQueue.id, rows[0].id));
+
+    await manager.redrive();
+    await waitFor(async () => (await queueRows(name)).length === 0);
+    assert.equal(srv.received.length, 1, "redrive delivered the stranded message");
+
+    rows = await queueRows(name);
+    assert.equal(rows.length, 0, "row cleaned after successful redrive");
+    removeMind(name);
+  });
+
+  it("marks only the batch's own rows done — no broad DELETE races concurrent inserts", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+
+    // Two independently-persisted rows for the same (mind, session).
+    const anyMgr = manager as unknown as {
+      persistToQueue: (m: string, s: string, p: unknown) => Promise<number | undefined>;
+      deliverBatchToMind: (m: string, s: string, msgs: unknown[], cfg: unknown) => Promise<void>;
+    };
+    const p1 = { channel: "test:ch", sender: "a", content: "one" };
+    const p2 = { channel: "test:ch", sender: "b", content: "two" };
+    const id1 = await anyMgr.persistToQueue(name, "main", p1);
+    const id2 = await anyMgr.persistToQueue(name, "main", p2);
+    assert.ok(id1 && id2);
+
+    // Deliver a batch containing ONLY row 1.
+    await anyMgr.deliverBatchToMind(
+      name,
+      "main",
+      [{ payload: p1, channel: "test:ch", sender: "a", createdAt: Date.now(), queueId: id1 }],
+      { delivery: { mode: "immediate" }, interrupt: true },
+    );
+
+    const remaining = await queueRows(name);
+    assert.equal(remaining.length, 1, "the concurrently-enqueued row must survive");
+    assert.equal(remaining[0].id, id2, "only the batch's own row was deleted");
+    removeMind(name);
+  });
+
+  it("keys queue rows by baseName for variants and cleans them by id (no restart replay)", async () => {
+    // Variant delivery goes to the variant's port (here: failing); redrive re-resolves
+    // the baseName and delivers to the parent's port.
+    const parentSrv = await startMindServer();
+    const variantSrv = await startMindServer();
+    servers.push(parentSrv.server, variantSrv.server);
+    variantSrv.fail();
+
+    const parent = `dur-parent-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const variant = `${parent}-v1`;
+    await addMind(parent, parentSrv.port);
+    await addVariant(variant, parent, variantSrv.port, "/tmp/variant-dir", "branch");
+    // routes live under the parent's mind dir
+    const configDir = resolve(process.env.VOLUTE_HOME!, "minds", parent, "home/.config");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(resolve(configDir, "routes.json"), JSON.stringify(IMMEDIATE));
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+
+    // Deliver to the VARIANT name — the failing POST leaves a pending row keyed by baseName.
+    await manager.routeAndDeliver(variant, { channel: "test:ch", sender: "a", content: "hi" });
+
+    const pending = await queueRows(parent, "pending");
+    assert.equal(pending.length, 1, "row is keyed by the base name, not the variant");
+    assert.equal((await queueRows(variant)).length, 0, "nothing is keyed under the variant name");
+
+    // Restore-from-db (redrive): the row delivers (to the parent) and is cleaned, not replayed.
+    const db = await getDb();
+    await db
+      .update(deliveryQueue)
+      .set({ next_attempt_at: null })
+      .where(eq(deliveryQueue.id, pending[0].id));
+    await manager.restoreFromDb();
+    await waitFor(async () => (await queueRows(parent)).length === 0);
+    assert.equal(parentSrv.received.length, 1);
+
+    // A second restore must NOT replay it.
+    parentSrv.received.length = 0;
+    await manager.restoreFromDb();
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(parentSrv.received.length, 0, "cleaned row is not replayed on restart");
+
+    removeMind(variant);
+    removeMind(parent);
+  });
+
+  it("releases gated messages when a matching route is added — no daemon restart", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    // gateUnmatched defaults on; only discord is routed initially.
+    const name = await registerMind(srv.port, { rules: [{ channel: "discord:*", session: "d" }] });
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+
+    const res = await manager.routeAndDeliver(name, {
+      channel: "slack:random",
+      sender: "z",
+      content: "held",
+    });
+    assert.equal(res.routed && res.mode, "gated");
+    assert.equal((await queueRows(name, "gated")).length, 1);
+
+    // Add a matching route and invalidate the config cache (as a routes.json write would).
+    const configDir = resolve(process.env.VOLUTE_HOME!, "minds", name, "home/.config");
+    writeFileSync(
+      resolve(configDir, "routes.json"),
+      JSON.stringify({ rules: [{ channel: "slack:*", session: "s" }] }),
+    );
+    clearConfigCache(name); // triggers releaseGated → redrive
+
+    await waitFor(async () => (await queueRows(name)).length === 0);
+    assert.equal(srv.received.length, 1, "gated message delivered after the route was added");
+    removeMind(name);
+  });
+
+  it("drains two rapid immediate messages to one session in order", async () => {
+    const srv = await startMindServer(80); // slow enough that a reorder would surface
+    servers.push(srv.server);
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+
+    const p1 = manager.routeAndDeliver(name, { channel: "test:ch", sender: "a", content: "one" });
+    // Let the first delivery enter the per-session chain and begin its (slow) POST.
+    await new Promise((r) => setTimeout(r, 20));
+    const p2 = manager.routeAndDeliver(name, { channel: "test:ch", sender: "b", content: "two" });
+    await Promise.all([p1, p2]);
+
+    const texts = srv.received.map((b) => {
+      const body = b as { content?: string };
+      return body.content;
+    });
+    assert.deepEqual(texts, ["one", "two"], "messages delivered in submission order");
+    removeMind(name);
+  });
+});

--- a/test/fan-out.test.ts
+++ b/test/fan-out.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { and, eq, like } from "drizzle-orm";
-import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { initMindManager } from "../packages/daemon/src/lib/daemon/mind-manager.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
@@ -23,6 +23,14 @@ async function makeMindDM(a: string, b: string): Promise<string> {
   const ua = await getOrCreateMindUser(a);
   const ub = await getOrCreateMindUser(b);
   const conv = await createConversation({ participantIds: [ua.id, ub.id] });
+  return conv.id;
+}
+
+/** A DM between one mind and one human (brain) user. */
+async function makeMindHumanDM(mind: string, human: string): Promise<string> {
+  const um = await getOrCreateMindUser(mind);
+  const uh = await createUser(human, "pw");
+  const conv = await createConversation({ participantIds: [um.id, uh.id] });
   return conv.id;
 }
 
@@ -65,6 +73,21 @@ describe("fan-out loop protection", () => {
     // Still paused — further mind turns don't spam additional notices.
     await mindTurn(conv, "loopB");
     assert.equal(await noticeCount(conv), 1, "no duplicate notices while paused");
+  });
+
+  it("never pauses or emits a notice when only one mind is in the conversation", async () => {
+    // A mind posting into a DM with a human (its only peer is non-mind) can't loop with
+    // anyone — the counter must not trip even well past the threshold.
+    const conv = await makeMindHumanDM("soloMind", "soloHuman");
+
+    for (let i = 0; i < MAX_CONSECUTIVE_MIND_TURNS + 5; i++) {
+      await mindTurn(conv, "soloMind");
+    }
+    assert.equal(
+      await noticeCount(conv),
+      0,
+      "no loop notice when the mind is the only mind present",
+    );
   });
 
   it("resets the loop counter on human (non-mind) input", async () => {

--- a/test/fan-out.test.ts
+++ b/test/fan-out.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { and, eq, like } from "drizzle-orm";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { initMindManager } from "../packages/daemon/src/lib/daemon/mind-manager.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  fanOutToMinds,
+  MAX_CONSECUTIVE_MIND_TURNS,
+  resetLoopCounter,
+} from "../packages/daemon/src/lib/delivery/fan-out.js";
+import { createConversation } from "../packages/daemon/src/lib/events/conversations.js";
+import { messages } from "../packages/daemon/src/lib/schema.js";
+
+// A fresh test-runner process per file, so this singleton is isolated.
+try {
+  initMindManager();
+} catch {
+  // already initialized in this process
+}
+
+async function makeMindDM(a: string, b: string): Promise<string> {
+  const ua = await getOrCreateMindUser(a);
+  const ub = await getOrCreateMindUser(b);
+  const conv = await createConversation({ participantIds: [ua.id, ub.id] });
+  return conv.id;
+}
+
+async function noticeCount(conversationId: string): Promise<number> {
+  const db = await getDb();
+  const rows = await db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversation_id, conversationId),
+        like(messages.content, "%automated turns%"),
+      ),
+    );
+  return rows.length;
+}
+
+async function mindTurn(conversationId: string, sender: string): Promise<void> {
+  await fanOutToMinds({
+    conversationId,
+    contentBlocks: [{ type: "text", text: "ping" }],
+    senderName: sender,
+    senderIsMind: true,
+  });
+}
+
+describe("fan-out loop protection", () => {
+  it("pauses mind→mind fan-out and emits a notice after N consecutive mind turns", async () => {
+    const conv = await makeMindDM("loopA", "loopB");
+
+    // N allowed exchanges, then the (N+1)th pauses and posts a single notice.
+    for (let i = 0; i < MAX_CONSECUTIVE_MIND_TURNS; i++) {
+      await mindTurn(conv, i % 2 === 0 ? "loopA" : "loopB");
+    }
+    assert.equal(await noticeCount(conv), 0, "no notice while under the limit");
+
+    await mindTurn(conv, "loopA"); // crosses the threshold
+    assert.equal(await noticeCount(conv), 1, "one pause notice emitted at the threshold");
+
+    // Still paused — further mind turns don't spam additional notices.
+    await mindTurn(conv, "loopB");
+    assert.equal(await noticeCount(conv), 1, "no duplicate notices while paused");
+  });
+
+  it("resets the loop counter on human (non-mind) input", async () => {
+    const conv = await makeMindDM("loopC", "loopD");
+
+    for (let i = 0; i <= MAX_CONSECUTIVE_MIND_TURNS; i++) {
+      await mindTurn(conv, i % 2 === 0 ? "loopC" : "loopD");
+    }
+    assert.equal(await noticeCount(conv), 1, "paused after the limit");
+
+    // A human message resets the chain...
+    await fanOutToMinds({
+      conversationId: conv,
+      contentBlocks: [{ type: "text", text: "hello minds" }],
+      senderName: "human",
+      senderIsMind: false,
+    });
+
+    // ...so the next batch of mind turns runs again without immediately re-pausing.
+    for (let i = 0; i < MAX_CONSECUTIVE_MIND_TURNS; i++) {
+      await mindTurn(conv, i % 2 === 0 ? "loopC" : "loopD");
+    }
+    assert.equal(await noticeCount(conv), 1, "counter reset — no second notice yet");
+  });
+
+  it("resetLoopCounter clears a conversation's counter", async () => {
+    const conv = await makeMindDM("loopE", "loopF");
+    for (let i = 0; i <= MAX_CONSECUTIVE_MIND_TURNS; i++) {
+      await mindTurn(conv, "loopE");
+    }
+    assert.equal(await noticeCount(conv), 1);
+
+    resetLoopCounter(conv);
+    for (let i = 0; i < MAX_CONSECUTIVE_MIND_TURNS; i++) {
+      await mindTurn(conv, "loopE");
+    }
+    assert.equal(await noticeCount(conv), 1, "explicit reset prevented a new pause notice");
+  });
+});


### PR DESCRIPTION
Closes #326

## Problem
The delivery path treated in-memory buffers as primary and the `delivery_queue` table as best-effort scratch, so there was no at-least-once guarantee. Messages could be dropped silently (immediate mode, no retry), stranded in the DB until a daemon restart (batch flush failure), re-delivered every restart (variant key mismatch), or held forever (gated channels) — plus no mind→mind loop protection, an undocumented echoText/chat-send asymmetry, and two near-duplicate fan-out helpers.

## Changes
1. **`delivery_queue` is the real queue.** `routeAndDeliver` now persists every accepted delivery (immediate AND trigger-flush AND batch) to `delivery_queue` via `persistToQueue` **before** any POST, returning the row id(s).
2. **Mark delivered on mind-ack, by id.** `deliverToMind`/`deliverBatchToMind` delete rows by their **specific** row ids only after a successful `postToMind`, replacing the broad `and(mind, session, status=pending)` DELETE that raced concurrently-enqueued rows. On failure the row stays pending.
3. **Key everything by `baseName`.** `persistToQueue`/`gateMessage`/`enqueueBatch` resolve `baseName` up front, so inserts under a variant name and the id-scoped cleanup share a key — fixing the variant mismatch that replayed every restart.
4. **Redrive loop.** A periodic sweep (`startRedrive`, sibling to `restoreFromDb`) re-reads `pending` rows past their backoff window and re-delivers via the normal path. New `attempts`/`next_attempt_at` columns (migration `0010`) provide exponential backoff; `MindManager.isRunning` skips minds that are down, and an in-memory `inFlight` set skips rows the normal path already owns.
5. **Release gated messages on route change.** A routes-change listener (hooked into `clearConfigCache` and the mtime/stat check in `delivery-router.ts`) re-evaluates a mind's `gated` rows against the new rules and promotes newly-matched ones to `pending` for the redrive loop.
6. **Sequential per-`(mind, session)` drain.** The whole delivery (resolvePort + enrichment + POST) runs on a per-key promise chain, so resolvePort/enrichment latency can't reorder two rapid messages.
7. **Unified fan-out.** `fanOutToMinds` (chat) and `fanOutToBridgedMinds` (bridges) are merged into one shared helper in `packages/daemon/src/lib/delivery/fan-out.ts`.
8. **Loop protection.** A per-conversation consecutive-mind-turn counter pauses fan-out to minds and posts a one-time notice after N automated turns without human input; a non-mind (human/bridge) message resets it.

## echoText fan-out decision
**echoText intentionally does NOT fan out to peer mind participants** (documented in `echo-text.ts`). `echoTextToChannel` fires on every raw `text` event a mind streams, so it is a real-time mirror to the human-facing conversation and external bridges (display surfaces). The authoritative mind→mind delivery path is the explicit chat send (`/chat` → `fanOutToMinds`), which owns fan-out **and** loop protection. Echoing raw streamed text to peer minds would double-deliver every deliberate send and amplify mind→mind loops, so peer-mind fan-out stays exclusively on the explicit send path.

## Test plan
- **Unit (`test/delivery-durability.test.ts`)**: persist-before-POST + mark-done-by-id; failed POST leaves a pending row that the redrive loop delivers; batch marks only its own rows (no broad-DELETE race); variant rows keyed by baseName + cleaned by id (no restart replay); gated release after a route is added without a daemon restart; two rapid immediate messages drain in order.
- **Unit (`test/fan-out.test.ts`)**: loop protection pauses + emits one notice after N mind turns; human input resets the counter; `resetLoopCounter` clears it.
- **E2E (`test/daemon-e2e.test.ts`)**: `GET /:name/delivery/pending` previews gated messages and clears once released.
- Full `npm test` suite (pre-push): **1647/1647 pass**. svelte-check + biome + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)