### PR TITLE
feat: last-known-good restart protection for self-modifying minds

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -16,6 +16,7 @@ import {
 } from "../mind/registry.js";
 import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
 import { getPrompt } from "../prompts.js";
+import { checkHealth } from "../util/health.js";
 import { clearJsonMap, loadJsonMap, saveJsonMap } from "../util/json-state.js";
 import log from "../util/logger.js";
 import { RotatingLog } from "../util/rotating-log.js";
@@ -91,6 +92,21 @@ type TrackedMind = {
   child: ChildProcess;
   port: number;
 };
+
+/**
+ * Thrown when a mind process fails to become ready during startup. Carries the
+ * child's recent stderr so callers (e.g. the restart route's last-known-good
+ * recovery) can surface the actual failure to the mind.
+ */
+export class MindStartupError extends Error {
+  constructor(
+    message: string,
+    readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "MindStartupError";
+  }
+}
 
 function mindPidPath(name: string): string {
   return resolve(stateDir(name), "mind.pid");
@@ -441,37 +457,62 @@ export class MindManager {
       while (recentStderr.length > 20) recentStderr.shift();
     });
 
-    // Wait for "listening on :PORT" or timeout
+    // Poll /health until the server is ready, or reject on a startup budget timeout
+    // or an early child exit/error (e.g. a `tsx` syntax error from a self-edit). Polling
+    // /health is more robust than scraping stdout for "listening on :PORT".
     try {
       await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error(`Mind ${name} did not start within 30s`));
-        }, 30000);
+        let settled = false;
+        const deadline = Date.now() + 30000;
 
-        function checkOutput(data: Buffer) {
-          if (data.toString().match(/listening on :\d+/)) {
-            clearTimeout(timeout);
-            resolve();
-          }
+        const onExit = (code: number | null) => {
+          // Extract the most useful error line from stderr
+          const errorLine = recentStderr.find((l) => l.includes("Error:"));
+          const detail = errorLine ? `: ${errorLine.trim()}` : "";
+          finish(() =>
+            reject(
+              new MindStartupError(
+                `Mind ${name} exited with code ${code} during startup${detail}`,
+                recentStderr.join("\n"),
+              ),
+            ),
+          );
+        };
+        const onError = (err: Error) => finish(() => reject(err));
+
+        function finish(action: () => void) {
+          if (settled) return;
+          settled = true;
+          child.off("exit", onExit);
+          child.off("error", onError);
+          action();
         }
 
-        child.stdout?.on("data", checkOutput);
-        child.stderr?.on("data", checkOutput);
+        child.on("exit", onExit);
+        child.on("error", onError);
 
-        child.on("error", (err) => {
-          clearTimeout(timeout);
-          reject(err);
-        });
-
-        child.on("exit", (code) => {
-          clearTimeout(timeout);
-          // Extract the most useful error line from stderr
-          const errorLine = recentStderr.find(
-            (l) => l.startsWith("Error:") || l.includes("Error:"),
-          );
-          const detail = errorLine ? `: ${errorLine.trim()}` : "";
-          reject(new Error(`Mind ${name} exited with code ${code} during startup${detail}`));
-        });
+        const poll = async () => {
+          if (settled) return;
+          const { ok } = await checkHealth(port);
+          if (settled) return;
+          if (ok) {
+            finish(() => resolve());
+            return;
+          }
+          if (Date.now() >= deadline) {
+            finish(() =>
+              reject(
+                new MindStartupError(
+                  `Mind ${name} did not become healthy within 30s`,
+                  recentStderr.join("\n"),
+                ),
+              ),
+            );
+            return;
+          }
+          setTimeout(poll, 250);
+        };
+        void poll();
       });
     } catch (err) {
       this.minds.delete(name);

--- a/packages/daemon/src/lib/daemon/notices.ts
+++ b/packages/daemon/src/lib/daemon/notices.ts
@@ -6,10 +6,10 @@ import type { ErrorReason } from "./error-classify.js";
 
 const nlog = log.child("notices");
 
-export type NoticeKind = "turn_error" | "crash" | "budget";
+export type NoticeKind = "turn_error" | "crash" | "budget" | "startup";
 
 /** The full closed set of reasons; each kind constrains which reasons are legal. */
-export type NoticeReason = ErrorReason | "process_crash" | "token_budget";
+export type NoticeReason = ErrorReason | "process_crash" | "token_budget" | "startup_failed";
 
 /**
  * A notice to record. The union ties `kind` to its legal `reason`(s), so e.g.
@@ -24,6 +24,7 @@ export type RecordNoticeInput = {
   | { kind: "turn_error"; reason: ErrorReason }
   | { kind: "crash"; reason: "process_crash" }
   | { kind: "budget"; reason: "token_budget" }
+  | { kind: "startup"; reason: "startup_failed" }
 );
 
 /** A persisted notice row (kind/reason narrowed via the schema column $type). */

--- a/packages/daemon/src/lib/mind/last-known-good.ts
+++ b/packages/daemon/src/lib/mind/last-known-good.ts
@@ -1,16 +1,19 @@
+import { randomBytes } from "node:crypto";
 import { gitExec } from "../util/exec.js";
 import log from "../util/logger.js";
 
 const glog = log.child("last-known-good");
 
 /** Are there uncommitted changes (tracked or untracked) under the repo's src/ dir? */
-async function hasSrcChanges(dir: string): Promise<boolean> {
-  const status = (await gitExec(["status", "--porcelain", "--", "src"], { cwd: dir })).trim();
+async function hasSrcChanges(dir: string, mindName?: string): Promise<boolean> {
+  const status = (
+    await gitExec(["status", "--porcelain", "--", "src"], { cwd: dir, mindName })
+  ).trim();
   return status.length > 0;
 }
 
 /**
- * Park uncommitted changes under `src/` on a `broken/<timestamp>` branch, then revert
+ * Park uncommitted changes under `src/` on a `broken/<timestamp>-<rand>` branch, then revert
  * the working tree's `src/` back to HEAD (the last known-good state). Changes elsewhere
  * (e.g. the mind's `home/` directory) are left untouched.
  *
@@ -18,26 +21,45 @@ async function hasSrcChanges(dir: string): Promise<boolean> {
  * server source and the edit breaks startup, this preserves the broken change for the
  * mind to inspect while restoring a bootable src/.
  *
+ * Under user-isolation, `mindName` makes git run as the mind's OS user so it doesn't
+ * leave root-owned objects/refs in the mind's `.git` (which would break the mind's own
+ * auto-commit with EACCES).
+ *
  * Never uses `git stash` — the daemon shares one git object store across worktrees, so a
  * stash entry here could collide with concurrent work. We commit-then-rewind instead.
+ *
+ * The rewind (`reset --mixed HEAD~1`) happens BEFORE the fragile branch step so that if
+ * branch creation ever fails, HEAD is already back at the good state and the broken src/
+ * is still in the working tree — leaving the mind recoverable on the next restart rather
+ * than permanently stuck on committed-but-broken src/.
  *
  * Returns whether anything was parked and, if so, the branch it was parked on.
  */
 export async function rollbackSrcChanges(
   dir: string,
+  mindName?: string,
 ): Promise<{ parked: boolean; branch?: string }> {
-  if (!(await hasSrcChanges(dir))) return { parked: false };
+  if (!(await hasSrcChanges(dir, mindName))) return { parked: false };
 
+  // Collision-proof branch name: two variants sharing the object store can roll back in
+  // the same second, so a second-resolution timestamp alone isn't unique.
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const branch = `broken/${ts}`;
-  const opts = { cwd: dir };
+  const branch = `broken/${ts}-${randomBytes(4).toString("hex")}`;
+  const opts = { cwd: dir, mindName };
 
-  // Stage only src/ (home/ stays unstaged and untouched), commit it, mark the commit with
-  // a branch, then move the working branch back one commit so HEAD is the good state again.
+  // Stage only src/ (home/ stays unstaged and untouched) and commit ONLY src/ — `--only`
+  // ignores any pre-staged non-src content so it can't be swept into the parked commit.
   await gitExec(["add", "--", "src"], opts);
-  await gitExec(["commit", "-m", `Parked broken src changes (${branch})`], opts);
-  await gitExec(["branch", branch], opts);
+  await gitExec(
+    ["commit", "--only", "-m", `Parked broken src changes (${branch})`, "--", "src"],
+    opts,
+  );
+  // Capture the broken commit, rewind HEAD to the good state, THEN park the broken commit
+  // on a branch (created from the captured hash, not from HEAD). Rewinding first keeps the
+  // repo recoverable if `git branch` fails.
+  const brokenHash = (await gitExec(["rev-parse", "HEAD"], opts)).trim();
   await gitExec(["reset", "--mixed", "HEAD~1"], opts);
+  await gitExec(["branch", branch, brokenHash], opts);
   // Restore tracked src/ files to HEAD and drop any newly-added (untracked) src/ files, so
   // an added-but-broken file can't linger and re-break startup.
   await gitExec(["checkout", "--", "src"], opts);
@@ -53,10 +75,15 @@ export async function rollbackSrcChanges(
  * giving {@link rollbackSrcChanges} a clean point to revert to next time. The mind's
  * auto-commit hook only tracks `home/`, so without this src/ edits would never be
  * committed and every rollback would discard prior good work. No-op if src/ is clean.
+ *
+ * Under user-isolation, `mindName` makes git run as the mind's OS user (see
+ * {@link rollbackSrcChanges}).
  */
-export async function commitSrcChanges(dir: string): Promise<void> {
-  if (!(await hasSrcChanges(dir))) return;
-  await gitExec(["add", "--", "src"], { cwd: dir });
-  await gitExec(["commit", "-m", "Update src (self-edit)"], { cwd: dir });
+export async function commitSrcChanges(dir: string, mindName?: string): Promise<void> {
+  if (!(await hasSrcChanges(dir, mindName))) return;
+  const opts = { cwd: dir, mindName };
+  // Commit ONLY src/ so pre-staged non-src content isn't swept into the baseline commit.
+  await gitExec(["add", "--", "src"], opts);
+  await gitExec(["commit", "--only", "-m", "Update src (self-edit)", "--", "src"], opts);
   glog.info(`committed known-good src changes (${dir})`);
 }

--- a/packages/daemon/src/lib/mind/last-known-good.ts
+++ b/packages/daemon/src/lib/mind/last-known-good.ts
@@ -1,0 +1,62 @@
+import { gitExec } from "../util/exec.js";
+import log from "../util/logger.js";
+
+const glog = log.child("last-known-good");
+
+/** Are there uncommitted changes (tracked or untracked) under the repo's src/ dir? */
+async function hasSrcChanges(dir: string): Promise<boolean> {
+  const status = (await gitExec(["status", "--porcelain", "--", "src"], { cwd: dir })).trim();
+  return status.length > 0;
+}
+
+/**
+ * Park uncommitted changes under `src/` on a `broken/<timestamp>` branch, then revert
+ * the working tree's `src/` back to HEAD (the last known-good state). Changes elsewhere
+ * (e.g. the mind's `home/` directory) are left untouched.
+ *
+ * Used by the restart route's last-known-good recovery: when a mind edits its own
+ * server source and the edit breaks startup, this preserves the broken change for the
+ * mind to inspect while restoring a bootable src/.
+ *
+ * Never uses `git stash` — the daemon shares one git object store across worktrees, so a
+ * stash entry here could collide with concurrent work. We commit-then-rewind instead.
+ *
+ * Returns whether anything was parked and, if so, the branch it was parked on.
+ */
+export async function rollbackSrcChanges(
+  dir: string,
+): Promise<{ parked: boolean; branch?: string }> {
+  if (!(await hasSrcChanges(dir))) return { parked: false };
+
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const branch = `broken/${ts}`;
+  const opts = { cwd: dir };
+
+  // Stage only src/ (home/ stays unstaged and untouched), commit it, mark the commit with
+  // a branch, then move the working branch back one commit so HEAD is the good state again.
+  await gitExec(["add", "--", "src"], opts);
+  await gitExec(["commit", "-m", `Parked broken src changes (${branch})`], opts);
+  await gitExec(["branch", branch], opts);
+  await gitExec(["reset", "--mixed", "HEAD~1"], opts);
+  // Restore tracked src/ files to HEAD and drop any newly-added (untracked) src/ files, so
+  // an added-but-broken file can't linger and re-break startup.
+  await gitExec(["checkout", "--", "src"], opts);
+  await gitExec(["clean", "-fdq", "--", "src"], opts);
+
+  glog.info(`parked broken src changes on ${branch} (${dir})`);
+  return { parked: true, branch };
+}
+
+/**
+ * Commit uncommitted `src/` changes as the new known-good baseline. Called after a
+ * successful (re)start so HEAD always reflects the last src/ that actually booted —
+ * giving {@link rollbackSrcChanges} a clean point to revert to next time. The mind's
+ * auto-commit hook only tracks `home/`, so without this src/ edits would never be
+ * committed and every rollback would discard prior good work. No-op if src/ is clean.
+ */
+export async function commitSrcChanges(dir: string): Promise<void> {
+  if (!(await hasSrcChanges(dir))) return;
+  await gitExec(["add", "--", "src"], { cwd: dir });
+  await gitExec(["commit", "-m", "Update src (self-edit)"], { cwd: dir });
+  glog.info(`committed known-good src changes (${dir})`);
+}

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -267,7 +267,7 @@ export const mindNotices = sqliteTable(
     id: integer("id").primaryKey({ autoIncrement: true }),
     mind: text("mind").notNull(),
     session: text("session").notNull(),
-    kind: text("kind").$type<"turn_error" | "crash" | "budget">().notNull(),
+    kind: text("kind").$type<"turn_error" | "crash" | "budget" | "startup">().notNull(),
     reason: text("reason")
       .$type<
         | "auth_error"
@@ -277,6 +277,7 @@ export const mindNotices = sqliteTable(
         | "unknown"
         | "process_crash"
         | "token_budget"
+        | "startup_failed"
       >()
       .notNull(),
     detail: text("detail").notNull(),

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -18,7 +18,7 @@ import { announceToSystem } from "../../lib/chat/system-channel.js";
 import { getTypingMap, publishTypingForChannels } from "../../lib/chat/typing.js";
 import { readSystemsConfig } from "../../lib/config/systems-config.js";
 import { classify } from "../../lib/daemon/error-classify.js";
-import { getMindManager } from "../../lib/daemon/mind-manager.js";
+import { getMindManager, MindStartupError } from "../../lib/daemon/mind-manager.js";
 // Lifecycle functions from mind-service.ts
 import {
   startMindFull as startMindFullService,
@@ -77,6 +77,7 @@ import {
   isIsolationEnabled,
   wrapForIsolation,
 } from "../../lib/mind/isolation.js";
+import { commitSrcChanges, rollbackSrcChanges } from "../../lib/mind/last-known-good.js";
 import {
   addMind,
   ensureVoluteHome,
@@ -1484,7 +1485,58 @@ const app = new Hono<AuthEnv>()
         }
       }
 
-      await startMindFullService(name);
+      // Resolve the mind's git repo dir (variant worktree or the base mind dir) so
+      // last-known-good recovery can operate on the right working tree.
+      const repoDir = entry.parent ? entry.dir! : mindDir(name);
+
+      try {
+        await startMindFullService(name);
+      } catch (startErr) {
+        // A mind can break its own startup by editing src/ (e.g. src/server.ts) then
+        // calling daemonRestart(). The auto-commit hook only tracks home/, so the bad
+        // src/ change is usually uncommitted. Park it on a broken/<ts> branch, revert
+        // src/ to the last known-good HEAD, and retry — turning a fatal self-edit into
+        // a recoverable one. If nothing was under src/, there's nothing to roll back.
+        const stderr = startErr instanceof MindStartupError ? startErr.stderr : undefined;
+        let rollback: { parked: boolean; branch?: string } = { parked: false };
+        try {
+          rollback = await rollbackSrcChanges(repoDir);
+        } catch (rbErr) {
+          log.error(`failed to roll back src changes for ${name}`, log.errorData(rbErr));
+        }
+
+        if (!rollback.parked) throw startErr;
+
+        // Retry on the restored (known-good) src/. If this also fails, give up.
+        await startMindFullService(name);
+
+        const startMsg = startErr instanceof Error ? startErr.message : String(startErr);
+        const errLine = (stderr ?? startMsg).trim().split("\n").filter(Boolean).pop() ?? "";
+        await recordNotice({
+          mind: baseName,
+          session: "main",
+          kind: "startup",
+          reason: "startup_failed",
+          detail:
+            `Your last change to src/ broke startup, so it was rolled back and your previous ` +
+            `working code was restored. The broken change is preserved on branch ` +
+            `\`${rollback.branch}\` — check it out to inspect and fix it. Error: ${errLine}`,
+          raw: stderr ?? null,
+        });
+
+        return c.json({
+          ok: true,
+          recovered: true,
+          brokenBranch: rollback.branch,
+          port: targetPort,
+        });
+      }
+
+      // Startup succeeded — commit any src/ changes as the new known-good baseline so a
+      // future bad edit has a clean point to roll back to.
+      await commitSrcChanges(repoDir).catch((e) =>
+        log.error(`failed to commit known-good src for ${name}`, log.errorData(e)),
+      );
       return c.json({ ok: true, port: targetPort });
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : "Failed to restart mind" }, 500);

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1500,7 +1500,7 @@ const app = new Hono<AuthEnv>()
         const stderr = startErr instanceof MindStartupError ? startErr.stderr : undefined;
         let rollback: { parked: boolean; branch?: string } = { parked: false };
         try {
-          rollback = await rollbackSrcChanges(repoDir);
+          rollback = await rollbackSrcChanges(repoDir, name);
         } catch (rbErr) {
           log.error(`failed to roll back src changes for ${name}`, log.errorData(rbErr));
         }
@@ -1512,8 +1512,11 @@ const app = new Hono<AuthEnv>()
 
         const startMsg = startErr instanceof Error ? startErr.message : String(startErr);
         const errLine = (stderr ?? startMsg).trim().split("\n").filter(Boolean).pop() ?? "";
+        // Attribute the notice to the mind/session that was actually restarted. For a
+        // variant restart `baseName` is the parent, so recording against it would notify
+        // the parent about code it didn't touch while the variant never sees it.
         await recordNotice({
-          mind: baseName,
+          mind: name,
           session: "main",
           kind: "startup",
           reason: "startup_failed",
@@ -1534,7 +1537,7 @@ const app = new Hono<AuthEnv>()
 
       // Startup succeeded — commit any src/ changes as the new known-good baseline so a
       // future bad edit has a clean point to roll back to.
-      await commitSrcChanges(repoDir).catch((e) =>
+      await commitSrcChanges(repoDir, name).catch((e) =>
         log.error(`failed to commit known-good src for ${name}`, log.errorData(e)),
       );
       return c.json({ ok: true, port: targetPort });

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -16,6 +16,7 @@ import {
   activity,
   deliveryQueue,
   mindHistory,
+  mindNotices,
   summaries,
   turns,
 } from "../packages/daemon/src/lib/schema.js";
@@ -602,6 +603,87 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.equal(msgsRes.status, 200);
     const messages = (await msgsRes.json()) as { content: { type: string; text?: string }[] }[];
     assert.ok(messages.length >= 1);
+  });
+
+  it("last-known-good: recovers when a self-edit to src/ breaks startup", {
+    timeout: 90000,
+  }, async () => {
+    await ensureTestMind();
+    const dir = mindDir(TEST_MIND);
+
+    // Deps are installed by the "mind lifecycle" test; install as a fallback if missing.
+    if (!existsSync(resolve(dir, "node_modules"))) {
+      execFileSync("npm", ["install"], { cwd: dir, stdio: "pipe", timeout: 60000, env: cleanEnv });
+      await waitForHealth();
+    }
+
+    // Make sure the mind is running on good code.
+    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    assert.ok(
+      startRes.status === 200 || startRes.status === 409,
+      `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
+    );
+
+    const serverPath = resolve(dir, "src", "server.ts");
+    const goodSource = readFileSync(serverPath, "utf-8");
+
+    // The mind edits its own server source and breaks it (uncommitted, as a real self-edit
+    // would be — the auto-commit hook only tracks home/).
+    writeFileSync(serverPath, `${goodSource}\nthis is not valid typescript !!! (((\n`);
+
+    // Restart: the daemon should detect the broken startup, park the change, restore the
+    // last known-good src/, and come back up rather than dying.
+    const restartRes = await daemonRequest(`/api/minds/${TEST_MIND}/restart`, { method: "POST" });
+    assert.equal(
+      restartRes.status,
+      200,
+      `Restart: ${restartRes.status} ${await restartRes.clone().text()}`,
+    );
+    const body = (await restartRes.json()) as { recovered?: boolean; brokenBranch?: string };
+    assert.equal(body.recovered, true, "restart should report last-known-good recovery");
+    assert.ok(
+      body.brokenBranch?.startsWith("broken/"),
+      `expected a broken/* branch, got ${body.brokenBranch}`,
+    );
+
+    // The working tree src/ is restored to the previous good code.
+    assert.equal(
+      readFileSync(serverPath, "utf-8"),
+      goodSource,
+      "src/server.ts should be restored to the good version",
+    );
+
+    // The mind is back up.
+    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const status = (await statusRes.json()) as { status: string };
+    assert.ok(
+      status.status === "running" || status.status === "starting",
+      `Expected running/starting after recovery, got ${status.status}`,
+    );
+
+    // The broken change is preserved on a broken/* branch.
+    const branches = execFileSync("git", ["branch", "--list", "broken/*"], {
+      cwd: dir,
+      encoding: "utf-8",
+      env: cleanEnv,
+    });
+    assert.ok(branches.includes("broken/"), `expected a broken/* branch, got: ${branches}`);
+
+    // A startup notice was recorded, carrying the failed child's stderr.
+    const db = await getDb();
+    const rows = await db.select().from(mindNotices).where(eq(mindNotices.mind, TEST_MIND));
+    const startupNotice = rows.find((r) => r.kind === "startup");
+    assert.ok(startupNotice, "a startup notice should be recorded");
+    assert.ok(
+      startupNotice.raw != null && startupNotice.raw.length > 0,
+      "startup notice should carry the failed process stderr",
+    );
+    assert.ok(
+      startupNotice.detail.includes(body.brokenBranch ?? "broken/"),
+      "notice should name the broken branch",
+    );
+
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("bridge config: set, mappings CRUD, remove", async () => {

--- a/test/last-known-good.test.ts
+++ b/test/last-known-good.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, beforeEach, describe, it } from "node:test";
+import {
+  commitSrcChanges,
+  rollbackSrcChanges,
+} from "../packages/daemon/src/lib/mind/last-known-good.js";
+
+const tmpDir = join(tmpdir(), ".volute-lkg-test");
+const repoDir = join(tmpDir, "mind-repo");
+
+function git(args: string[]): string {
+  const env: Record<string, string> = { LEFTHOOK: "0" };
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
+  }
+  return execFileSync("git", args, { cwd: repoDir, encoding: "utf-8", env }).trim();
+}
+
+const GOOD_SERVER = "console.log('good server');\n";
+
+function seedRepo() {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  mkdirSync(join(repoDir, "src"), { recursive: true });
+  mkdirSync(join(repoDir, "home"), { recursive: true });
+  git(["init", "-b", "main"]);
+  git(["config", "user.email", "mind@volute"]);
+  git(["config", "user.name", "mind"]);
+  writeFileSync(join(repoDir, "src", "server.ts"), GOOD_SERVER);
+  writeFileSync(join(repoDir, "home", "SOUL.md"), "soul\n");
+  git(["add", "-A"]);
+  git(["commit", "-m", "initial commit"]);
+}
+
+describe("last-known-good rollback", () => {
+  beforeEach(() => {
+    seedRepo();
+  });
+
+  after(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  it("reverts a broken src/ change and preserves it on a broken/* branch", async () => {
+    // Mind edits its server source, breaking it (uncommitted, as auto-commit ignores src/)
+    writeFileSync(join(repoDir, "src", "server.ts"), "this is broken !@#$\n");
+
+    const result = await rollbackSrcChanges(repoDir);
+
+    assert.equal(result.parked, true, "should report a parked change");
+    assert.ok(
+      result.branch?.startsWith("broken/"),
+      `expected broken/* branch, got ${result.branch}`,
+    );
+
+    // Working tree src/ restored to the last known-good HEAD version
+    assert.equal(
+      readFileSync(join(repoDir, "src", "server.ts"), "utf-8"),
+      GOOD_SERVER,
+      "working tree src/server.ts should be restored to HEAD",
+    );
+
+    // Working tree is clean under src/ (nothing uncommitted after rollback)
+    assert.equal(git(["status", "--porcelain", "--", "src"]), "", "src/ should be clean");
+
+    // The broken change is preserved on the broken/* branch
+    const branch = result.branch!;
+    const brokenContent = git(["show", `${branch}:src/server.ts`]);
+    assert.ok(brokenContent.includes("this is broken"), "broken branch should hold the bad change");
+
+    // HEAD (main) still has the good version — the branch pointer wasn't advanced
+    assert.equal(git(["show", "HEAD:src/server.ts"]), GOOD_SERVER.trim());
+  });
+
+  it("preserves uncommitted home/ changes when rolling back src/", async () => {
+    // A concurrent (mid-turn) edit to home/ must survive the src/ rollback
+    writeFileSync(join(repoDir, "home", "SOUL.md"), "new identity\n");
+    writeFileSync(join(repoDir, "src", "server.ts"), "broken\n");
+
+    const result = await rollbackSrcChanges(repoDir);
+    assert.equal(result.parked, true);
+
+    assert.equal(
+      readFileSync(join(repoDir, "home", "SOUL.md"), "utf-8"),
+      "new identity\n",
+      "uncommitted home/ change should be preserved",
+    );
+    assert.equal(readFileSync(join(repoDir, "src", "server.ts"), "utf-8"), GOOD_SERVER);
+  });
+
+  it("drops a newly-added broken src/ file on rollback", async () => {
+    writeFileSync(join(repoDir, "src", "extra.ts"), "syntax ??? error\n");
+
+    const result = await rollbackSrcChanges(repoDir);
+    assert.equal(result.parked, true);
+
+    assert.equal(
+      existsSync(join(repoDir, "src", "extra.ts")),
+      false,
+      "newly-added broken file should be removed from the working tree",
+    );
+    // ...but preserved on the broken branch
+    assert.ok(git(["show", `${result.branch}:src/extra.ts`]).includes("syntax"));
+  });
+
+  it("is a no-op when src/ is clean", async () => {
+    const result = await rollbackSrcChanges(repoDir);
+    assert.equal(result.parked, false);
+    assert.equal(result.branch, undefined);
+    // No broken/* branches created
+    assert.equal(git(["branch", "--list", "broken/*"]), "");
+  });
+
+  it("commitSrcChanges advances HEAD so the next rollback restores the new baseline", async () => {
+    // Mind makes a good src/ edit and restarts successfully — commit it as new baseline
+    const NEW_GOOD = "console.log('v2');\n";
+    writeFileSync(join(repoDir, "src", "server.ts"), NEW_GOOD);
+    await commitSrcChanges(repoDir);
+    assert.equal(git(["show", "HEAD:src/server.ts"]), NEW_GOOD.trim());
+    assert.equal(
+      git(["status", "--porcelain", "--", "src"]),
+      "",
+      "src/ should be clean after commit",
+    );
+
+    // Now a later bad edit rolls back to the v2 baseline, not the original
+    writeFileSync(join(repoDir, "src", "server.ts"), "broken again\n");
+    const result = await rollbackSrcChanges(repoDir);
+    assert.equal(result.parked, true);
+    assert.equal(readFileSync(join(repoDir, "src", "server.ts"), "utf-8"), NEW_GOOD);
+  });
+
+  it("commitSrcChanges is a no-op when src/ is clean", async () => {
+    const before = git(["rev-parse", "HEAD"]);
+    await commitSrcChanges(repoDir);
+    assert.equal(git(["rev-parse", "HEAD"]), before, "no commit should be created");
+  });
+});

--- a/test/last-known-good.test.ts
+++ b/test/last-known-good.test.ts
@@ -138,4 +138,70 @@ describe("last-known-good rollback", () => {
     await commitSrcChanges(repoDir);
     assert.equal(git(["rev-parse", "HEAD"]), before, "no commit should be created");
   });
+
+  it("parks on a collision-proof branch name (timestamp + random suffix)", async () => {
+    writeFileSync(join(repoDir, "src", "server.ts"), "broken\n");
+    const result = await rollbackSrcChanges(repoDir);
+    assert.equal(result.parked, true);
+    // A second-resolution timestamp alone can collide across concurrent variants, so the
+    // name must carry a random suffix (8 hex chars).
+    assert.match(
+      result.branch!,
+      /^broken\/.+-[0-9a-f]{8}$/,
+      `expected a random suffix, got ${result.branch}`,
+    );
+  });
+
+  it("rewinds HEAD before parking so a failed branch step stays recoverable", async () => {
+    // Occupy the `broken` ref name so `git branch broken/<...>` hits a D/F conflict and
+    // fails — simulating any transient failure of the fragile branch-creation step.
+    git(["branch", "broken"]);
+    const goodHead = git(["rev-parse", "HEAD"]);
+    writeFileSync(join(repoDir, "src", "server.ts"), "broken change\n");
+
+    await assert.rejects(rollbackSrcChanges(repoDir), "branch creation should fail");
+
+    // HEAD must be rewound to the good state — NOT left advanced on the broken commit,
+    // which would make hasSrcChanges() see a clean tree and skip rollback forever.
+    assert.equal(git(["rev-parse", "HEAD"]), goodHead, "HEAD should be back at the good commit");
+    assert.equal(git(["show", "HEAD:src/server.ts"]), GOOD_SERVER.trim());
+    // The broken change is still in the working tree, so the next restart retries rollback.
+    assert.equal(readFileSync(join(repoDir, "src", "server.ts"), "utf-8"), "broken change\n");
+  });
+
+  it("commitSrcChanges does not sweep in pre-staged non-src content", async () => {
+    // Something non-src is already staged in the index (e.g. a mid-turn home/ edit)
+    writeFileSync(join(repoDir, "home", "SOUL.md"), "staged identity\n");
+    git(["add", "--", "home/SOUL.md"]);
+    // A good src/ edit to commit as the new baseline
+    const NEW_GOOD = "console.log('v2');\n";
+    writeFileSync(join(repoDir, "src", "server.ts"), NEW_GOOD);
+
+    await commitSrcChanges(repoDir);
+
+    // The baseline commit captures src/ ...
+    assert.equal(git(["show", "HEAD:src/server.ts"]), NEW_GOOD.trim());
+    // ... but NOT the pre-staged home/ content
+    assert.equal(git(["show", "HEAD:home/SOUL.md"]), "soul", "home/ change must not be committed");
+    // ... which remains staged/uncommitted for the mind's own auto-commit to handle
+    assert.notEqual(
+      git(["status", "--porcelain", "--", "home/SOUL.md"]),
+      "",
+      "home/ change should still be pending",
+    );
+  });
+
+  it("rollbackSrcChanges does not sweep in pre-staged non-src content", async () => {
+    writeFileSync(join(repoDir, "home", "SOUL.md"), "staged identity\n");
+    git(["add", "--", "home/SOUL.md"]);
+    writeFileSync(join(repoDir, "src", "server.ts"), "broken\n");
+
+    const result = await rollbackSrcChanges(repoDir);
+    assert.equal(result.parked, true);
+
+    // The parked (broken) commit holds src/ but not the pre-staged home/ content
+    assert.equal(git(["show", `${result.branch}:home/SOUL.md`]), "soul");
+    // The home/ change survives untouched in the working tree
+    assert.equal(readFileSync(join(repoDir, "home", "SOUL.md"), "utf-8"), "staged identity\n");
+  });
 });


### PR DESCRIPTION
Closes #329

> **Stacked on #328 (PR #349).** Base branch is `fix/mind-manager-races`, not `main` — this builds on #328's MindManager lifecycle mutex, `/health`/`/message` timeout budgets, and child-identity crash guard. **Merge after #349.**

## Problem
A mind can edit its own server source (e.g. `src/server.ts`) and call `daemonRestart()`. If the edit has a startup error, `tsx` fails, the new process never becomes ready, and the mind ends up dead with no rollback — auto-commit only tracks `home/`, so the breaking `src/` change is usually uncommitted and lost. This makes the lightweight self-edit-then-restart path fatal. This PR makes it recoverable.

## Changes
1. **Detect start failure in the restart route** (`web/api/minds.ts`). When `startMindFullService` throws, enter a last-known-good recovery branch instead of returning 500.
2. **Roll back uncommitted `src/` changes** (`lib/mind/last-known-good.ts`, new). `rollbackSrcChanges()` parks the broken change on a `broken/<timestamp>` branch and restores `src/` to HEAD, then the route retries the start. **Never uses `git stash`** (shared object store across worktrees) — it commits-then-rewinds, touching only `src/` so uncommitted `home/` edits survive.
3. **Surface the failure to the mind.** `MindStartupError` (new, in `mind-manager.ts`) carries the failed child's buffered stderr up through the `startMind` rejection. The route `recordNotice(...)`s a new `startup` / `startup_failed` notice naming the `broken/<ts>` branch and the error, with the stderr as `raw`. Added the `startup` kind to `RecordNoticeInput` and the `mind_notices` schema `$type`.
4. **Always have a rollback point.** `commitSrcChanges()` commits proven-good `src/` after a *successful* (re)start, so HEAD always reflects the last src that actually booted — giving step 2 a clean revert target. (Chose the "commit in the restart route" option, but on success rather than before stop, so we never commit an untested/broken change into HEAD.)
5. **Switch readiness from stdout-regex to `/health` polling** (`mind-manager.ts`). Replaced the `listening on :PORT` stdout scrape with a poll of `checkHealth(port)` under the same 30s budget, still rejecting promptly on child `exit`/`error` (so a `tsx` syntax-error exit is caught immediately, not after 30s). Composes with #328's timeout work.

## Test plan
- **Unit** (`test/last-known-good.test.ts`, new, 6 tests): rollback reverts a broken `src/` change and preserves it on a `broken/*` branch; uncommitted `home/` changes survive rollback; newly-added broken `src/` files are dropped from the worktree but kept on the branch; no-op when `src/` is clean; `commitSrcChanges` advances HEAD so the next rollback restores the new baseline; `commitSrcChanges` no-op when clean.
- **Daemon e2e** (`test/daemon-e2e.test.ts`): create + start the test mind, write a syntax error into `src/server.ts`, POST `/restart`; asserts the response reports `recovered: true` + a `broken/*` branch, `src/server.ts` is restored to the good version, the mind is running again, the broken change is on a `broken/*` branch, and a `startup` notice was recorded carrying the stderr.
- Full `npm test` suite passes: **1655/1655**. New e2e recovery test passes. (5 pre-existing daemon-e2e failures around channels/conversations/bridges are unchanged from the base branch and are not run by the pre-push hook.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
