### PR TITLE
refactor: extract turn lifecycle service and replace marker-based turn correlation

### DIFF
--- a/packages/daemon/src/lib/daemon/turn-lifecycle.ts
+++ b/packages/daemon/src/lib/daemon/turn-lifecycle.ts
@@ -1,0 +1,311 @@
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
+import { getDb } from "../db.js";
+import { getDeliveryManager } from "../delivery/delivery-manager.js";
+import { echoTextToChannel } from "../delivery/echo-text.js";
+import { linkToolResultToTurn } from "../delivery/message-delivery.js";
+import { broadcast } from "../events/activity-events.js";
+import { onMindEvent } from "../events/mind-activity-tracker.js";
+import { publish as publishMindEvent } from "../events/mind-events.js";
+import { mindHistory, turns } from "../schema.js";
+import log from "../util/logger.js";
+import { classify } from "./error-classify.js";
+import { clearDeliveredNotices, recordNotice } from "./notices.js";
+import { summarizeTurn } from "./summarizer.js";
+import { getTokenBudget } from "./token-budget.js";
+import {
+  assignSession,
+  completeTurn,
+  createTurn,
+  getActiveTurnId,
+  getLastToolUseEventId,
+  markErrored,
+  takeErrored,
+  trackToolUse,
+} from "./turn-tracker.js";
+
+const llog = log.child("turn-lifecycle");
+
+/** Event types that trigger turn creation (hoisted for perf — avoid per-request allocation). */
+const SUBSTANTIVE_TYPES = new Set(["thinking", "text", "tool_use", "tool_result", "outbound"]);
+
+/** Strip correlation markers from tool_result content before persisting/publishing. */
+const MARKER_RE = /\[volute:(?:outbound|activity):\d+\]/g;
+
+/**
+ * A single event streamed from a mind's server to the daemon. Mirrors the JSON body
+ * accepted by `POST /:name/events`; the HTTP route is a thin adapter over
+ * {@link handleMindEvent}.
+ */
+export type MindEvent = {
+  type: string;
+  session?: string;
+  channel?: string;
+  messageId?: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Highest notice id drained by the pre-prompt hook per `mind:session`. A clean turn
+ * only marks notices delivered up to this id, so a notice created mid-turn isn't lost
+ * before the mind reads it.
+ */
+const noticeDrainWatermarks = new Map<string, number>();
+
+/** Record the high-water notice id drained for a `mind:session` (set by the pre-prompt hook). */
+export function setNoticeDrainWatermark(mind: string, session: string, id: number): void {
+  noticeDrainWatermarks.set(`${mind}:${session}`, id);
+}
+
+/**
+ * On a turn that completed without an error event, mark the notices the mind actually
+ * drained this turn as delivered. If the turn errored, leave them queued so they reach
+ * the mind on its next genuinely successful turn. `takeErrored` both reads and clears
+ * the flag, so call it exactly once per completed turn.
+ */
+function markDeliveredOnCleanTurn(mind: string, session?: string | null): void {
+  if (!session) return;
+  const wmKey = `${mind}:${session}`;
+  const watermark = noticeDrainWatermarks.get(wmKey);
+  noticeDrainWatermarks.delete(wmKey);
+  const errored = takeErrored(mind, session);
+  if (!errored && watermark != null) {
+    clearDeliveredNotices(mind, session, watermark).catch((err) =>
+      llog.warn(`failed to clear delivered notices for ${mind}:${session}`, log.errorData(err)),
+    );
+  }
+}
+
+/**
+ * Link the inbound message(s) that triggered a turn to that turn, and set the turn's
+ * `trigger_event_id`. Session-scoped replacement for the removed time-window heuristic:
+ * a turn is per-session and this only tags inbound events on the turn's own channel that
+ * are still untagged, so it's deterministic (no 60s window, no id-range guessing).
+ */
+async function linkPendingInbound(mind: string, turnId: string, channel?: string): Promise<void> {
+  // Channel is required to prevent cross-session tagging: without it a turn on one
+  // session could steal inbound events meant for a different session/channel.
+  if (!channel) return;
+  const db = await getDb();
+  const recent = await db
+    .select({ id: mindHistory.id })
+    .from(mindHistory)
+    .where(
+      and(
+        eq(mindHistory.mind, mind),
+        eq(mindHistory.type, "inbound"),
+        sql`${mindHistory.turn_id} IS NULL`,
+        eq(mindHistory.channel, channel),
+      ),
+    )
+    .orderBy(desc(mindHistory.id))
+    .limit(5);
+  if (recent.length === 0) return;
+  const ids = recent.map((r) => r.id);
+  await db.update(mindHistory).set({ turn_id: turnId }).where(inArray(mindHistory.id, ids));
+  await db.update(turns).set({ trigger_event_id: recent[0].id }).where(eq(turns.id, turnId));
+}
+
+/**
+ * Drive the delivery/turn state machine for a single mind event.
+ *
+ * Owns the full lifecycle previously inlined in the `POST /:name/events` handler:
+ * turn create/assign/complete, trigger linking, marker fallback linking, typing clears,
+ * failure/budget notices, the summarization trigger, and budget accounting. Extracted
+ * here so the state machine is unit-testable without a live HTTP server.
+ *
+ * Returns the resolved `turnId` (if any) and the persisted mind_history `insertedId`.
+ */
+export async function handleMindEvent(
+  mind: string,
+  event: MindEvent,
+): Promise<{ turnId?: string; insertedId?: number }> {
+  // Assign session to a sessionless turn on first session_start.
+  if (event.type === "session_start" && event.session) {
+    const activeTurnId = getActiveTurnId(mind);
+    if (activeTurnId) await assignSession(mind, activeTurnId, event.session);
+  }
+
+  // Look up active turn for this event; create one if missing for substantive events.
+  // Turns are created per-session when the mind starts processing, not when inbound arrives.
+  let turnId = getActiveTurnId(mind, event.session);
+  if (!turnId && SUBSTANTIVE_TYPES.has(event.type)) {
+    turnId = await createTurn(mind);
+    if (!turnId) {
+      llog.warn(`skipping turn tracking for ${mind}: createTurn failed`);
+    } else {
+      publishMindEvent(mind, { mind, type: "turn_created", turnId });
+      if (event.session) await assignSession(mind, turnId, event.session);
+      // Link the triggering inbound(s) and set the turn's trigger_event_id.
+      try {
+        await linkPendingInbound(mind, turnId, event.channel);
+      } catch (err) {
+        llog.warn(
+          `failed to link trigger inbound for turn ${turnId} (mind: ${mind})`,
+          log.errorData(err),
+        );
+      }
+    }
+  }
+
+  const cleanContent =
+    event.type === "tool_result" && event.content
+      ? event.content.replace(MARKER_RE, "").trimEnd()
+      : event.content;
+
+  // Persist to mind_history.
+  const db = await getDb();
+  let insertedId: number | undefined;
+  try {
+    const result = await db
+      .insert(mindHistory)
+      .values({
+        mind,
+        type: event.type,
+        session: event.session ?? null,
+        channel: event.channel ?? null,
+        message_id: event.messageId ?? null,
+        content: cleanContent ?? null,
+        metadata: event.metadata ? JSON.stringify(event.metadata) : null,
+        turn_id: turnId ?? null,
+      })
+      .returning({ id: mindHistory.id });
+    insertedId = result[0]?.id;
+  } catch (err) {
+    llog.error(`failed to persist event for ${mind}`, log.errorData(err));
+    // Continue — persistence is best-effort, don't block real-time streaming.
+  }
+
+  // Track tool_use events for source_event_id linking.
+  if (event.type === "tool_use" && insertedId != null) {
+    trackToolUse(mind, event.session, insertedId);
+  }
+
+  // Fallback/activity linking via correlation markers. Outbound turn attribution is now
+  // primary via the session header at send time (see volute/chat.ts); linkToolResultToTurn
+  // is idempotent (won't re-publish an already-attributed outbound) and still links
+  // extension activities and any outbound the direct path couldn't attribute.
+  if (event.type === "tool_result" && turnId && event.content) {
+    const toolUseEventId = getLastToolUseEventId(mind, event.session);
+    try {
+      await linkToolResultToTurn(mind, turnId, event.content, toolUseEventId);
+    } catch (err) {
+      llog.error("failed to link tool_result to turn", log.errorData(err));
+    }
+  }
+
+  // Publish to in-process pub-sub.
+  publishMindEvent(mind, {
+    mind,
+    type: event.type,
+    session: event.session,
+    channel: event.channel,
+    messageId: event.messageId,
+    content: cleanContent,
+    metadata: event.metadata,
+    turnId: turnId ?? undefined,
+  });
+
+  if (event.type === "text" && event.channel && cleanContent) {
+    echoTextToChannel(mind, event.channel, cleanContent, turnId ?? undefined, insertedId).catch(
+      (err) => llog.error(`echo-text failed for ${mind} on ${event.channel}`, log.errorData(err)),
+    );
+  }
+
+  // Track mind activity for the dashboard timeline.
+  onMindEvent(mind, event.type, event.channel);
+
+  // Clear typing on first outbound event for a channel.
+  if ((event.type === "text" || event.type === "outbound") && event.channel) {
+    const map = getTypingMap();
+    publishTypingForChannels(map.deleteSender(mind), map);
+  }
+
+  // Turn failure: record a notice and flag the session as errored so the upcoming `done`
+  // does NOT mark notices delivered (failures accumulate until a clean turn).
+  if (event.type === "error" && event.session) {
+    markErrored(mind, event.session);
+    const { reason, detail } = classify(event.content ?? "");
+    await recordNotice({
+      mind,
+      session: event.session,
+      kind: "turn_error",
+      reason,
+      detail,
+      raw: event.content ?? null,
+    });
+  }
+
+  if (event.type === "done") {
+    const map = getTypingMap();
+    publishTypingForChannels(map.deleteSender(mind), map);
+    broadcast({ type: "mind_done", mind, summary: "Finished processing" });
+    // Notify delivery manager of session completion (synchronous — decrement must happen
+    // atomically before the busy check to avoid interleaving with a concurrent delivery).
+    try {
+      getDeliveryManager().sessionDone(mind, event.session);
+    } catch (err) {
+      if (!(err instanceof Error && err.message.includes("not initialized"))) {
+        llog.error(`delivery manager sessionDone failed for ${mind}`, log.errorData(err));
+      }
+    }
+    await completeTurnAndSummarize(mind, event, insertedId);
+  }
+
+  // Record usage against budget.
+  if (event.type === "usage" && event.metadata) {
+    const inputTokens = (event.metadata.input_tokens as number) ?? 0;
+    const outputTokens = (event.metadata.output_tokens as number) ?? 0;
+    const tb = getTokenBudget();
+    tb.recordUsage(mind, inputTokens, outputTokens);
+    if (event.session && tb.noteExceeded(mind)) {
+      void recordNotice({
+        mind,
+        session: event.session,
+        kind: "budget",
+        reason: "token_budget",
+        detail:
+          "You've reached your token budget for this period. Further activity may be paused until the budget resets — wrap up or prioritize accordingly.",
+      });
+    }
+  }
+
+  return { turnId: turnId ?? undefined, insertedId };
+}
+
+/**
+ * Complete the turn on a `done` event if the session has no more pending deliveries,
+ * then mark drained notices delivered and fire summarization.
+ */
+async function completeTurnAndSummarize(
+  mind: string,
+  event: MindEvent,
+  insertedId: number | undefined,
+): Promise<void> {
+  const finish = async () => {
+    const completedTurnId = await completeTurn(mind, event.session);
+    markDeliveredOnCleanTurn(mind, event.session);
+    if (insertedId != null) {
+      summarizeTurn(mind, event.session, event.channel, insertedId, completedTurnId).catch((err) =>
+        llog.error("turn summarization failed", log.errorData(err)),
+      );
+    }
+  };
+
+  try {
+    // Only gate on delivery busy state when we have a session. Sessionless done events
+    // (background/system work) complete immediately to avoid being blocked by unrelated
+    // active sessions. When messages arrive mid-turn their incrementActive() keeps the
+    // count > 0, so we skip here; the subsequent done will re-check.
+    const dm = getDeliveryManager();
+    const busy = event.session ? dm.isSessionBusy(mind, event.session) : false;
+    if (!busy) await finish();
+  } catch (err) {
+    if (!(err instanceof Error && err.message.includes("not initialized"))) {
+      llog.error("turn completion check failed", log.errorData(err));
+    }
+    // DM unavailable — complete immediately as fallback.
+    await finish();
+  }
+}

--- a/packages/daemon/src/lib/daemon/turn-tracker.ts
+++ b/packages/daemon/src/lib/daemon/turn-tracker.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
 import { mindHistory, turns } from "../schema.js";
 import log from "../util/logger.js";
@@ -71,6 +71,43 @@ export async function createTurn(mind: string): Promise<string | undefined> {
 /** Get the active turn ID for a mind+session, falling back to the sessionless `mind:*` key. */
 export function getActiveTurnId(mind: string, session?: string | null): string | undefined {
   return (activeTurns.get(key(mind, session)) ?? activeTurns.get(key(mind)))?.turnId;
+}
+
+/**
+ * Attribute an inbound that arrives mid-turn to the turn already in progress.
+ *
+ * `TurnLifecycle.linkPendingInbound` only runs at turn CREATION and sweeps a bounded set of
+ * the most-recent untagged inbounds. An inbound delivered while a turn is already active for
+ * the session would otherwise wait for the NEXT same-channel turn to sweep it — and be left
+ * `turn_id = NULL` forever if more than that bound accumulate or no later turn runs. Called
+ * per-delivery: when the mind has an active turn for (mind, session), every still-untagged
+ * inbound on that channel is attributed to it immediately.
+ *
+ * No-op when no turn is active yet — the turn-creation path (`linkPendingInbound`) tags the
+ * triggering inbound then. Only `turn_id` is set here: the turn's `trigger_event_id` stays
+ * the original triggering inbound, since a mid-turn message did not trigger the turn.
+ */
+export async function linkInboundToActiveTurn(
+  mind: string,
+  session: string | null | undefined,
+  channel?: string,
+): Promise<void> {
+  // Channel is required to prevent cross-session tagging (mirrors linkPendingInbound).
+  if (!channel) return;
+  const turnId = getActiveTurnId(mind, session);
+  if (!turnId) return;
+  const db = await getDb();
+  await db
+    .update(mindHistory)
+    .set({ turn_id: turnId })
+    .where(
+      and(
+        eq(mindHistory.mind, mind),
+        eq(mindHistory.type, "inbound"),
+        sql`${mindHistory.turn_id} IS NULL`,
+        eq(mindHistory.channel, channel),
+      ),
+    );
 }
 
 /** Record the last tool_use event ID for a mind+session. */

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -22,7 +22,6 @@ import {
   resolveRoute,
   setRoutesChangeListener,
 } from "./delivery-router.js";
-import { tagRecentInbound } from "./message-delivery.js";
 
 const dlog = log.child("delivery-manager");
 
@@ -198,12 +197,9 @@ export class DeliveryManager {
       sessionName = `new-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     }
 
-    // Tag the most recent untagged inbound with the active turn for this session.
-    // This links incoming messages to the current turn immediately so live streams
-    // can group them correctly, and handles interrupts (message arriving mid-turn).
-    tagRecentInbound(baseName, sessionName, payload.channel).catch((err) => {
-      dlog.warn(`tagRecentInbound failed for ${baseName}`, log.errorData(err));
-    });
+    // Inbound-to-turn linking happens deterministically at turn creation (see
+    // TurnLifecycle.linkPendingInbound), scoped by the turn's session and channel, so
+    // no proactive time-window tagging is needed here.
 
     // Resolve delivery mode for this session (pass matched rule for rule-level batch config)
     const sessionConfig = resolveDeliveryMode(config, sessionName, route.rule);

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -3,6 +3,7 @@ import { extname, resolve } from "node:path";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
 import { tryGetMindManager } from "../daemon/mind-manager.js";
+import { linkInboundToActiveTurn } from "../daemon/turn-tracker.js";
 import { getDb } from "../db.js";
 import { getParticipants } from "../events/conversations.js";
 import { onMindEvent } from "../events/mind-activity-tracker.js";
@@ -625,6 +626,14 @@ export class DeliveryManager {
       if (payload.channel) channels.add(payload.channel);
       this.incrementActive(baseName, session, senders, channels);
 
+      // If a turn is already in progress for this session, attribute this mid-turn inbound to
+      // it now. linkPendingInbound only tags at turn creation (bounded sweep), so without this
+      // an interrupt/batched message arriving mid-turn — or a >5 backlog — would stay untagged.
+      // No-op when no turn is active yet; the turn-creation path tags the trigger then.
+      linkInboundToActiveTurn(baseName, session, payload.channel).catch((err) =>
+        dlog.warn(`failed to link mid-turn inbound for ${baseName}`, log.errorData(err)),
+      );
+
       // Set typing indicator on both slug and conversationId keys
       const typingMap = getTypingMap();
       if (payload.channel) {
@@ -725,6 +734,13 @@ export class DeliveryManager {
 
       // Increment active count with metadata
       this.incrementActive(baseName, session, senders, channelSet);
+
+      // Attribute any mid-turn inbounds in this batch to an in-progress turn (see deliverToMind).
+      for (const ch of channelSet) {
+        linkInboundToActiveTurn(baseName, session, ch).catch((err) =>
+          dlog.warn(`failed to link mid-turn inbound for ${baseName}`, log.errorData(err)),
+        );
+      }
 
       // Set typing indicators for all real channels in the batch
       const typingMap = getTypingMap();

--- a/packages/daemon/src/lib/delivery/message-delivery.ts
+++ b/packages/daemon/src/lib/delivery/message-delivery.ts
@@ -1,17 +1,9 @@
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { getSleepManagerIfReady } from "../daemon/sleep-manager.js";
-import { getActiveTurnId } from "../daemon/turn-tracker.js";
 import { getDb } from "../db.js";
 import { publish as publishMindEvent } from "../events/mind-events.js";
 import { findMind, getBaseName } from "../mind/registry.js";
-import {
-  activity,
-  conversationParticipants,
-  messages,
-  mindHistory,
-  turns,
-  users,
-} from "../schema.js";
+import { activity, messages, mindHistory } from "../schema.js";
 import log from "../util/logger.js";
 import { getDeliveryManager } from "./delivery-manager.js";
 import { type DeliveryPayload, extractTextContent } from "./delivery-router.js";
@@ -29,8 +21,8 @@ export async function recordInbound(
   sender: string | null,
   content: string | null,
 ): Promise<number | undefined> {
-  // Record without turn_id initially. The turn will be linked either by
-  // tagRecentInbound (when session is known) or retroactively at turn creation.
+  // Record without turn_id initially. The inbound is linked to its turn when the turn is
+  // created (TurnLifecycle.linkPendingInbound), scoped by the turn's session and channel.
   // This avoids merging unrelated inbounds from different channels into one turn.
   let insertedId: number | undefined;
   try {
@@ -62,17 +54,14 @@ export async function recordInbound(
 }
 
 /**
- * Record an outbound message: persist to mind_history WITHOUT a turn_id.
+ * Record an outbound message: persist to mind_history.
  *
- * The turn association is deferred — concurrent sessions share a single process-level
- * env var (VOLUTE_SESSION) which races, so we don't attempt session-based turn lookup
- * here. Instead, the outbound record is linked to its turn when the corresponding
- * tool_result event arrives at the events endpoint (via `linkToolResultToTurn`).
- *
- * The outbound event is NOT published to SSE here; it is published by
- * `linkToolResultToTurn` once the correct turn_id is known, ensuring the stream
- * always contains correctly-tagged events. Any orphans are caught by
- * `tagUntaggedOutbound` on turn completion as a safety net.
+ * When the caller knows the sending mind's active turn (resolved from the per-request
+ * `X-Volute-Session` header — the primary attribution path), it passes `turnId` and is
+ * responsible for publishing the SSE event itself. When `turnId` is omitted (e.g. a
+ * sessionless path), the record is left untagged and its turn is resolved later when the
+ * corresponding tool_result event arrives with a `[volute:outbound:NNN]` marker (via
+ * `linkToolResultToTurn`), which also publishes the SSE event then.
  *
  * Returns the inserted mind_history record ID (used as a correlation key in tool output).
  */
@@ -139,6 +128,7 @@ export async function linkToolResultToTurn(
           channel: mindHistory.channel,
           content: mindHistory.content,
           message_id: mindHistory.message_id,
+          turn_id: mindHistory.turn_id,
         })
         .from(mindHistory)
         .where(and(eq(mindHistory.id, outboundId), eq(mindHistory.mind, mind)))
@@ -150,7 +140,13 @@ export async function linkToolResultToTurn(
         continue;
       }
 
-      await db.update(mindHistory).set({ turn_id: turnId }).where(eq(mindHistory.id, outboundId));
+      // Direct attribution (session header at send time) is the primary path: if the
+      // outbound already carries a turn_id, the sender already tagged and published it.
+      // Only fill in source_event_id on the linked message; don't re-tag or re-publish.
+      const alreadyTagged = row.turn_id != null;
+      if (!alreadyTagged) {
+        await db.update(mindHistory).set({ turn_id: turnId }).where(eq(mindHistory.id, outboundId));
+      }
 
       if (row.message_id) {
         await db
@@ -162,14 +158,17 @@ export async function linkToolResultToTurn(
           .where(eq(messages.id, Number(row.message_id)));
       }
 
-      // Publish the outbound event to SSE — correctly tagged
-      publishMindEvent(mind, {
-        mind,
-        type: "outbound",
-        channel: row.channel ?? undefined,
-        content: row.content ?? undefined,
-        turnId,
-      });
+      // Publish the outbound event to SSE — correctly tagged. Skipped when the sender
+      // already published it via direct attribution to avoid a duplicate stream event.
+      if (!alreadyTagged) {
+        publishMindEvent(mind, {
+          mind,
+          type: "outbound",
+          channel: row.channel ?? undefined,
+          content: row.content ?? undefined,
+          turnId,
+        });
+      }
     } catch (err) {
       dlog.warn(`failed to link outbound ${outboundId} to turn ${turnId}`, log.errorData(err));
     }
@@ -207,201 +206,6 @@ export async function linkToolResultToTurn(
     } catch (err) {
       dlog.warn(`failed to link activities to turn ${turnId}`, log.errorData(err));
     }
-  }
-}
-
-/**
- * Retroactively tag orphaned outbound records (and their linked messages) with the
- * correct turn_id. Called on turn completion, analogous to `tagUntaggedInbound`.
- *
- * Finds outbound records for this mind that have no turn_id and whose IDs fall within
- * the range of events already tagged with this turn. Also fixes the corresponding
- * messages in the conversations table (turn_id and source_event_id).
- */
-export async function tagUntaggedOutbound(mind: string, turnId: string): Promise<void> {
-  const db = await getDb();
-
-  // Find the event ID range for this turn
-  const range = await db
-    .select({
-      minId: sql<number>`MIN(${mindHistory.id})`,
-      maxId: sql<number>`MAX(${mindHistory.id})`,
-    })
-    .from(mindHistory)
-    .where(and(eq(mindHistory.mind, mind), eq(mindHistory.turn_id, turnId)));
-
-  const minId = range[0]?.minId;
-  const maxId = range[0]?.maxId;
-  if (minId == null || maxId == null) return;
-
-  // Find orphaned outbound records within this turn's event range
-  const orphans = await db
-    .select({ id: mindHistory.id, message_id: mindHistory.message_id })
-    .from(mindHistory)
-    .where(
-      and(
-        eq(mindHistory.mind, mind),
-        eq(mindHistory.type, "outbound"),
-        sql`${mindHistory.turn_id} IS NULL`,
-        sql`${mindHistory.id} >= ${minId}`,
-        sql`${mindHistory.id} <= ${maxId}`,
-      ),
-    );
-
-  if (orphans.length === 0) return;
-
-  // Tag the outbound records
-  const orphanIds = orphans.map((r) => r.id);
-  await db.update(mindHistory).set({ turn_id: turnId }).where(inArray(mindHistory.id, orphanIds));
-
-  // Fix linked messages: set turn_id and source_event_id
-  // Fetch all tool_use events for this turn in one query, then find nearest preceding in-memory
-  const orphansWithMessages = orphans.filter((o) => o.message_id);
-  if (orphansWithMessages.length > 0) {
-    const toolUseEvents = await db
-      .select({ id: mindHistory.id })
-      .from(mindHistory)
-      .where(
-        and(
-          eq(mindHistory.mind, mind),
-          eq(mindHistory.turn_id, turnId),
-          eq(mindHistory.type, "tool_use"),
-        ),
-      )
-      .orderBy(mindHistory.id);
-
-    for (const orphan of orphansWithMessages) {
-      // Find the nearest preceding tool_use from the in-memory array
-      let sourceEventId: number | null = null;
-      for (let i = toolUseEvents.length - 1; i >= 0; i--) {
-        if (toolUseEvents[i].id < orphan.id) {
-          sourceEventId = toolUseEvents[i].id;
-          break;
-        }
-      }
-      await db
-        .update(messages)
-        .set({
-          turn_id: turnId,
-          ...(sourceEventId != null ? { source_event_id: sourceEventId } : {}),
-        })
-        .where(eq(messages.id, Number(orphan.message_id)));
-    }
-  }
-
-  dlog.info(`tagged ${orphans.length} orphaned outbound record(s) for ${mind} with turn ${turnId}`);
-}
-
-/**
- * Tag recent untagged inbound events and messages for a mind with the given turn ID.
- * Used both proactively (on message delivery) and retroactively (on turn creation).
- * When `setTrigger` is true, also sets the turn's `trigger_event_id` to the most recent inbound.
- * When `channel` is provided, only tags inbounds on that channel (prevents cross-session leaks).
- */
-export async function tagUntaggedInbound(
-  mind: string,
-  turnId: string,
-  {
-    limit = 5,
-    setTrigger = false,
-    channel,
-  }: { limit?: number; setTrigger?: boolean; channel?: string } = {},
-): Promise<void> {
-  const db = await getDb();
-
-  // Run history inbound tagging and mind user lookup in parallel — they're independent
-  const tagHistoryPromise = (async () => {
-    // Tag recent untagged inbound events in mind_history.
-    // Channel is required to prevent cross-session tagging: without it, a turn on
-    // one session can steal inbound events meant for a different session/channel.
-    if (!channel) return;
-    const historyConditions = [
-      eq(mindHistory.mind, mind),
-      eq(mindHistory.type, "inbound"),
-      sql`${mindHistory.turn_id} IS NULL`,
-      sql`${mindHistory.created_at} > datetime('now', '-60 seconds')`,
-      eq(mindHistory.channel, channel),
-    ];
-    const recentInbounds = await db
-      .select({ id: mindHistory.id })
-      .from(mindHistory)
-      .where(and(...historyConditions))
-      .orderBy(desc(mindHistory.id))
-      .limit(limit);
-    if (recentInbounds.length > 0) {
-      const ids = recentInbounds.map((r) => r.id);
-      await db.update(mindHistory).set({ turn_id: turnId }).where(inArray(mindHistory.id, ids));
-      if (setTrigger) {
-        await db
-          .update(turns)
-          .set({ trigger_event_id: recentInbounds[0].id })
-          .where(eq(turns.id, turnId));
-      }
-    }
-  })();
-
-  const mindUserPromise = db
-    .select({ id: users.id })
-    .from(users)
-    .where(and(eq(users.username, mind), eq(users.user_type, "mind")))
-    .get();
-
-  // Tag recent untagged conversation messages (only inbound, i.e. not sent by the mind itself)
-  const [tagResult, mindUserResult] = await Promise.allSettled([
-    tagHistoryPromise,
-    mindUserPromise,
-  ]);
-  if (tagResult.status === "rejected") {
-    dlog.error("failed to tag history inbound", log.errorData(tagResult.reason));
-  }
-  const mindUser = mindUserResult.status === "fulfilled" ? mindUserResult.value : undefined;
-  const mindConvIds = mindUser
-    ? (
-        await db
-          .select({ conversation_id: conversationParticipants.conversation_id })
-          .from(conversationParticipants)
-          .where(eq(conversationParticipants.user_id, mindUser.id))
-      ).map((r) => r.conversation_id)
-    : [];
-  const recentMsgs =
-    mindConvIds.length > 0
-      ? await db
-          .select({ id: messages.id })
-          .from(messages)
-          .where(
-            and(
-              inArray(messages.conversation_id, mindConvIds),
-              sql`${messages.turn_id} IS NULL`,
-              sql`${messages.sender_name} != ${mind}`,
-              sql`${messages.created_at} > datetime('now', '-60 seconds')`,
-            ),
-          )
-          .orderBy(desc(messages.id))
-          .limit(limit)
-      : [];
-  if (recentMsgs.length > 0) {
-    const ids = recentMsgs.map((r) => r.id);
-    await db.update(messages).set({ turn_id: turnId }).where(inArray(messages.id, ids));
-  }
-}
-
-/**
- * Tag the most recent untagged inbound for a mind with the active turn for a session.
- * Called from the delivery manager after routing resolves the session, so incoming
- * messages are linked to the current turn immediately (enabling correct live streaming).
- * The channel parameter scopes the tagging to avoid cross-session leaks.
- */
-export async function tagRecentInbound(
-  mind: string,
-  session: string,
-  channel?: string,
-): Promise<void> {
-  const turnId = getActiveTurnId(mind, session);
-  if (!turnId) return;
-  try {
-    await tagUntaggedInbound(mind, turnId, { limit: 1, channel });
-  } catch (err) {
-    dlog.warn(`failed to tag recent inbound for ${mind} with turn ${turnId}`, log.errorData(err));
   }
 }
 

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -15,7 +15,6 @@ import { z } from "zod";
 import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../../lib/ai-service.js";
 import { deleteMindUser } from "../../lib/auth.js";
 import { announceToSystem } from "../../lib/chat/system-channel.js";
-import { getTypingMap, publishTypingForChannels } from "../../lib/chat/typing.js";
 import { readSystemsConfig } from "../../lib/config/systems-config.js";
 import { classify } from "../../lib/daemon/error-classify.js";
 import { getMindManager, MindStartupError } from "../../lib/daemon/mind-manager.js";
@@ -24,33 +23,13 @@ import {
   startMindFull as startMindFullService,
   stopMindFull as stopMindFullService,
 } from "../../lib/daemon/mind-service.js";
-import {
-  clearDeliveredNotices,
-  drainNotices,
-  formatNotices,
-  recordNotice,
-} from "../../lib/daemon/notices.js";
-import { summarizeTurn } from "../../lib/daemon/summarizer.js";
+import { drainNotices, formatNotices } from "../../lib/daemon/notices.js";
 import { getTokenBudget } from "../../lib/daemon/token-budget.js";
-import {
-  assignSession,
-  completeTurn,
-  createTurn,
-  getActiveTurnId,
-  getLastToolUseEventId,
-  markErrored,
-  takeErrored,
-  trackToolUse,
-} from "../../lib/daemon/turn-tracker.js";
+import { handleMindEvent, setNoticeDrainWatermark } from "../../lib/daemon/turn-lifecycle.js";
+import { getActiveTurnId } from "../../lib/daemon/turn-tracker.js";
 import { getDb } from "../../lib/db.js";
 import { getDeliveryManager } from "../../lib/delivery/delivery-manager.js";
-import { echoTextToChannel } from "../../lib/delivery/echo-text.js";
-import {
-  linkToolResultToTurn,
-  recordInbound,
-  tagUntaggedInbound,
-  tagUntaggedOutbound,
-} from "../../lib/delivery/message-delivery.js";
+import { recordInbound } from "../../lib/delivery/message-delivery.js";
 import { broadcast } from "../../lib/events/activity-events.js";
 import {
   addMessage,
@@ -61,11 +40,7 @@ import {
   isParticipant,
   listConversationsForMind,
 } from "../../lib/events/conversations.js";
-import { onMindEvent } from "../../lib/events/mind-activity-tracker.js";
-import {
-  publish as publishMindEvent,
-  subscribe as subscribeMindEvent,
-} from "../../lib/events/mind-events.js";
+import { subscribe as subscribeMindEvent } from "../../lib/events/mind-events.js";
 import { type ExportManifest, isHomeOnlyArchive } from "../../lib/mind/archive.js";
 import { consolidateMemory } from "../../lib/mind/consolidate.js";
 import { generateIdentity, publishPublicKey } from "../../lib/mind/identity.js";
@@ -135,35 +110,6 @@ import {
   requireAdminOrSystem,
   requireSelf,
 } from "../middleware/auth.js";
-
-/** Event types that trigger turn creation (hoisted for perf — avoid per-request allocation). */
-const SUBSTANTIVE_TYPES = new Set(["thinking", "text", "tool_use", "tool_result", "outbound"]);
-
-/**
- * Highest notice id drained by the pre-prompt hook per `mind:session`. A clean turn
- * only marks notices delivered up to this id, so a notice created mid-turn isn't lost
- * before the mind reads it.
- */
-const noticeDrainWatermarks = new Map<string, number>();
-
-/**
- * On a turn that completed without an error event, mark the notices the mind actually
- * drained this turn as delivered. If the turn errored, leave them queued so they reach
- * the mind on its next genuinely successful turn. `takeErrored` both reads and clears
- * the flag, so call it exactly once per completed turn.
- */
-function markDeliveredOnCleanTurn(mind: string, session?: string | null): void {
-  if (!session) return;
-  const wmKey = `${mind}:${session}`;
-  const watermark = noticeDrainWatermarks.get(wmKey);
-  noticeDrainWatermarks.delete(wmKey);
-  const errored = takeErrored(mind, session);
-  if (!errored && watermark != null) {
-    clearDeliveredNotices(mind, session, watermark).catch((err) =>
-      log.warn(`failed to clear delivered notices for ${mind}:${session}`, log.errorData(err)),
-    );
-  }
-}
 
 const _lastActiveCache: { map: Map<string, string>; ts: number } = { map: new Map(), ts: 0 };
 const _LAST_ACTIVE_TTL = 60_000;
@@ -2530,219 +2476,7 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "type required" }, 400);
     }
 
-    // Assign session to sessionless turn on first session_start
-    if (body.type === "session_start" && body.session) {
-      const activeTurnId = getActiveTurnId(baseName);
-      if (activeTurnId) {
-        await assignSession(baseName, activeTurnId, body.session);
-      }
-    }
-
-    // Look up active turn for this event; create one if missing for substantive events.
-    // Turns are created per-session when the mind starts processing, not when inbound arrives.
-    let turnId = getActiveTurnId(baseName, body.session);
-    if (!turnId && SUBSTANTIVE_TYPES.has(body.type)) {
-      turnId = await createTurn(baseName);
-      if (!turnId) {
-        // DB failure — skip turn tracking for this event
-        log.warn(`skipping turn tracking for ${baseName}: createTurn failed`);
-      } else {
-        publishMindEvent(baseName, { mind: baseName, type: "turn_created", turnId });
-        if (body.session) {
-          await assignSession(baseName, turnId, body.session);
-        }
-        // Link trigger and retroactively tag recent untagged inbound events/messages
-        try {
-          await tagUntaggedInbound(baseName, turnId, {
-            setTrigger: true,
-            channel: body.channel,
-          });
-        } catch (err) {
-          log.warn(
-            `failed to link trigger/tag inbounds for turn ${turnId} (mind: ${baseName})`,
-            log.errorData(err),
-          );
-        }
-      } // end if (turnId) after createTurn
-    }
-
-    // Strip correlation markers from tool_result content before persisting/publishing
-    const MARKER_RE = /\[volute:(?:outbound|activity):\d+\]/g;
-    const cleanContent =
-      body.type === "tool_result" && body.content
-        ? body.content.replace(MARKER_RE, "").trimEnd()
-        : body.content;
-
-    // Persist to mind_history
-    const db = await getDb();
-    let insertedId: number | undefined;
-    try {
-      const result = await db
-        .insert(mindHistory)
-        .values({
-          mind: baseName,
-          type: body.type,
-          session: body.session ?? null,
-          channel: body.channel ?? null,
-          message_id: body.messageId ?? null,
-          content: cleanContent ?? null,
-          metadata: body.metadata ? JSON.stringify(body.metadata) : null,
-          turn_id: turnId ?? null,
-        })
-        .returning({ id: mindHistory.id });
-      insertedId = result[0]?.id;
-    } catch (err) {
-      log.error(`failed to persist event for ${baseName}`, log.errorData(err));
-      // Continue — persistence is best-effort, don't block real-time streaming
-    }
-
-    // Track tool_use events for source_event_id linking
-    if (body.type === "tool_use" && insertedId != null) {
-      trackToolUse(baseName, body.session, insertedId);
-    }
-
-    // Link outbound records and extension activities to this turn via correlation markers.
-    // This runs BEFORE publishing to SSE so the outbound events are correctly tagged
-    // by the time they enter the stream.
-    if (body.type === "tool_result" && turnId && body.content) {
-      const toolUseEventId = getLastToolUseEventId(baseName, body.session);
-      try {
-        await linkToolResultToTurn(baseName, turnId, body.content, toolUseEventId);
-      } catch (err) {
-        log.error("failed to link outbound to turn", log.errorData(err));
-      }
-    }
-
-    // Publish to in-process pub-sub
-    publishMindEvent(baseName, {
-      mind: baseName,
-      type: body.type,
-      session: body.session,
-      channel: body.channel,
-      messageId: body.messageId,
-      content: cleanContent,
-      metadata: body.metadata,
-      turnId: turnId ?? undefined,
-    });
-
-    if (body.type === "text" && body.channel && cleanContent) {
-      echoTextToChannel(
-        baseName,
-        body.channel,
-        cleanContent,
-        turnId ?? undefined,
-        insertedId,
-      ).catch((err) =>
-        log.error(`echo-text failed for ${baseName} on ${body.channel}`, log.errorData(err)),
-      );
-    }
-
-    // Track mind activity for dashboard timeline
-    onMindEvent(baseName, body.type, body.channel);
-
-    // Clear typing on first outbound event for a channel (text, outbound)
-    // Use deleteSender to clear both slug and conversationId-based keys
-    if ((body.type === "text" || body.type === "outbound") && body.channel) {
-      const map = getTypingMap();
-      const affected = map.deleteSender(baseName);
-      publishTypingForChannels(affected, map);
-    }
-
-    // Turn failure: record a notice so the mind learns what went wrong on its
-    // next successful turn in this session, and flag the session as errored so the
-    // upcoming `done` does NOT mark notices delivered (failures accumulate until a
-    // clean turn, conveying the full scope of an outage).
-    if (body.type === "error" && body.session) {
-      markErrored(baseName, body.session);
-      const { reason, detail } = classify(body.content ?? "");
-      await recordNotice({
-        mind: baseName,
-        session: body.session,
-        kind: "turn_error",
-        reason,
-        detail,
-        raw: body.content ?? null,
-      });
-    }
-
-    // Clear all typing + notify delivery manager when mind finishes processing
-    if (body.type === "done") {
-      const map = getTypingMap();
-      const affected = map.deleteSender(baseName);
-      publishTypingForChannels(affected, map);
-      // Broadcast mind_done to SSE subscribers (ephemeral — not persisted to DB)
-      broadcast({ type: "mind_done", mind: baseName, summary: "Finished processing" });
-      // Notify delivery manager of session completion (synchronous — decrement
-      // must happen atomically before the busy check to avoid race conditions
-      // where a concurrent delivery's incrementActive interleaves)
-      try {
-        getDeliveryManager().sessionDone(baseName, body.session);
-      } catch (err) {
-        if (!(err instanceof Error && err.message.includes("not initialized"))) {
-          log.error(`delivery manager sessionDone failed for ${baseName}`, log.errorData(err));
-        }
-      }
-      // Complete the turn if the session has no more pending deliveries.
-      // When messages arrive mid-turn, their incrementActive() keeps the
-      // count > 0, so we skip here. The subsequent done will re-check.
-      try {
-        // Only gate on delivery busy state when we have a session to check.
-        // Sessionless done events (e.g., background/system work) complete immediately
-        // to avoid being blocked by unrelated active sessions.
-        const dm = getDeliveryManager();
-        const busy = body.session ? dm.isSessionBusy(baseName, body.session) : false;
-        if (!busy) {
-          const completedTurnId = await completeTurn(baseName, body.session);
-          if (completedTurnId) {
-            tagUntaggedOutbound(baseName, completedTurnId).catch((err) =>
-              log.warn("failed to tag orphaned outbound records", log.errorData(err)),
-            );
-          }
-          markDeliveredOnCleanTurn(baseName, body.session);
-          if (insertedId != null) {
-            summarizeTurn(baseName, body.session, body.channel, insertedId, completedTurnId).catch(
-              (err) => log.error("turn summarization failed", log.errorData(err)),
-            );
-          }
-        }
-      } catch (err) {
-        if (!(err instanceof Error && err.message.includes("not initialized"))) {
-          log.error("turn completion check failed", log.errorData(err));
-        }
-        // DM unavailable — complete immediately as fallback
-        const completedTurnId = await completeTurn(baseName, body.session);
-        if (completedTurnId) {
-          tagUntaggedOutbound(baseName, completedTurnId).catch((err) =>
-            log.warn("failed to tag orphaned outbound records", log.errorData(err)),
-          );
-        }
-        markDeliveredOnCleanTurn(baseName, body.session);
-        if (insertedId != null) {
-          summarizeTurn(baseName, body.session, body.channel, insertedId, completedTurnId).catch(
-            (err) => log.error("turn summarization failed", log.errorData(err)),
-          );
-        }
-      }
-    }
-
-    // Record usage against budget
-    if (body.type === "usage" && body.metadata) {
-      const inputTokens = (body.metadata.input_tokens as number) ?? 0;
-      const outputTokens = (body.metadata.output_tokens as number) ?? 0;
-      const tb = getTokenBudget();
-      tb.recordUsage(baseName, inputTokens, outputTokens);
-      // First time the mind crosses its budget this period, tell it on its next turn.
-      if (body.session && tb.noteExceeded(baseName)) {
-        void recordNotice({
-          mind: baseName,
-          session: body.session,
-          kind: "budget",
-          reason: "token_budget",
-          detail:
-            "You've reached your token budget for this period. Further activity may be paused until the budget resets — wrap up or prioritize accordingly.",
-        });
-      }
-    }
+    await handleMindEvent(baseName, body);
 
     return c.json({ ok: true });
   })
@@ -3012,8 +2746,8 @@ const app = new Hono<AuthEnv>()
   })
   // Drain undelivered failure notices for a session. The pre-prompt hook calls this to
   // whisper prior failures into the mind's next turn. Does not delete them (the DB rows
-  // are only removed once a turn completes cleanly, see markDeliveredOnCleanTurn); it
-  // does record an in-memory drain watermark so that clean turn clears exactly these.
+  // are only removed once a turn completes cleanly, see TurnLifecycle); it records an
+  // in-memory drain watermark (setNoticeDrainWatermark) so that clean turn clears these.
   .get("/:name/history/notices", requireSelf(), async (c) => {
     const name = c.req.param("name");
     const baseName = await getBaseName(name);
@@ -3025,7 +2759,7 @@ const app = new Hono<AuthEnv>()
 
     // Remember the high-water id so a clean turn clears exactly these.
     const maxId = notices.reduce((m, n) => Math.max(m, n.id), 0);
-    noticeDrainWatermarks.set(`${baseName}:${session}`, maxId);
+    setNoticeDrainWatermark(baseName, session, maxId);
 
     return c.json({ context: formatNotices(notices), notices });
   })

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -6,6 +6,7 @@ import { getOrCreateMindUser, getOrCreateSystemUser } from "../../../lib/auth.js
 import { routeOutboundBridge } from "../../../lib/bridges/bridge-outbound.js";
 import { formatFileSize, stageFile, validateFilePath } from "../../../lib/chat/file-sharing.js";
 import { generateSystemReply } from "../../../lib/chat/system-chat.js";
+import { getActiveTurnId } from "../../../lib/daemon/turn-tracker.js";
 import { extractTextContent } from "../../../lib/delivery/delivery-router.js";
 import { fanOutToMinds } from "../../../lib/delivery/fan-out.js";
 import { recordOutbound } from "../../../lib/delivery/message-delivery.js";
@@ -21,6 +22,7 @@ import {
   getParticipants,
   isParticipantOrOwner,
 } from "../../../lib/events/conversations.js";
+import { publish as publishMindEvent } from "../../../lib/events/mind-events.js";
 import { findMind, getBaseName, mindDir } from "../../../lib/mind/registry.js";
 import { readVoluteConfig } from "../../../lib/mind/volute-config.js";
 import { fixModelEscapes } from "../../../lib/util/fix-model-escapes.js";
@@ -236,16 +238,28 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
       }
     }
 
-    // Save message (turn_id and source_event_id are set to null for mind senders —
-    // they'll be linked when the tool_result event arrives with the outbound correlation ID)
-    const message = await addMessage(conversationId!, "user", senderName, contentBlocks);
+    // Resolve the sending mind's active turn from the per-request X-Volute-Session header
+    // (captured into context as `mindSession`). This is the primary turn-attribution path:
+    // it records turn_id directly on send, replacing the racy process-global VOLUTE_SESSION
+    // lookup and the marker-only correlation that ran after the fact.
+    let outboundTurnId: string | undefined;
+    let senderBase: string | undefined;
+    if (senderIsMind) {
+      senderBase = await getBaseName(senderName);
+      outboundTurnId = getActiveTurnId(senderBase, c.get("mindSession"));
+    }
+
+    // Save message. turn_id is attributed directly for mind senders (see above); when the
+    // turn can't be resolved it stays null and is linked later via the tool_result marker.
+    const message = await addMessage(conversationId!, "user", senderName, contentBlocks, {
+      turnId: outboundTurnId,
+    });
 
     let outboundId: number | undefined;
     if (senderIsMind) {
       routeOutboundBridge(conversationId!, senderName, contentBlocks).catch((err) => {
         log.warn("outbound bridge routing failed", log.errorData(err));
       });
-      // Record outbound event in mind_history (without turn_id — linked later via tool_result)
       const channel = buildVoluteSlug({
         participants,
         mindUsername: senderName,
@@ -253,10 +267,24 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
         convType: conv.type as "dm" | "channel",
         convName,
       });
+      const text = extractTextContent(contentBlocks);
       try {
-        outboundId = await recordOutbound(senderName, channel, extractTextContent(contentBlocks), {
+        outboundId = await recordOutbound(senderName, channel, text, {
           messageId: message?.id != null ? String(message.id) : undefined,
+          turnId: outboundTurnId,
         });
+        // When the turn is known, publish the outbound to SSE now (correctly tagged).
+        // Otherwise linkToolResultToTurn publishes it when the marker arrives.
+        if (outboundTurnId) {
+          const mindKey = senderBase ?? senderName;
+          publishMindEvent(mindKey, {
+            mind: mindKey,
+            type: "outbound",
+            channel,
+            content: text,
+            turnId: outboundTurnId,
+          });
+        }
       } catch (err) {
         log.warn(`recordOutbound failed for ${senderName}`, log.errorData(err));
       }

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
-import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { extractTextContent } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import {
@@ -9,14 +8,11 @@ import {
   recordInbound,
   recordOutbound,
   resolveSleepAction,
-  tagUntaggedInbound,
-  tagUntaggedOutbound,
 } from "../packages/daemon/src/lib/delivery/message-delivery.js";
 import { publish as publishActivity } from "../packages/daemon/src/lib/events/activity-events.js";
 import { type MindEvent, subscribe } from "../packages/daemon/src/lib/events/mind-events.js";
 import {
   activity,
-  conversationParticipants,
   conversations,
   messages,
   mindHistory,
@@ -343,341 +339,26 @@ describe("linkToolResultToTurn", () => {
       unsub();
     }
   });
-});
 
-const TAG_MIND = "test-tag";
-const TAG_TURN_ID = "turn-tag-001";
-
-const TAG_CONV_IDS = ["conv-tag-test"];
-async function cleanupTagData() {
-  const db = await getDb();
-  await db.delete(mindHistory).where(eq(mindHistory.mind, TAG_MIND));
-  await db.delete(turns).where(eq(turns.mind, TAG_MIND));
-  for (const id of TAG_CONV_IDS) {
-    await db.delete(messages).where(eq(messages.conversation_id, id));
-    await db.delete(conversations).where(eq(conversations.id, id));
-  }
-}
-
-describe("tagUntaggedOutbound", () => {
-  afterEach(cleanupTagData);
-
-  it("tags orphaned outbound records within turn range", async () => {
-    const db = await getDb();
-
-    // Insert a turn
-    await db.insert(turns).values({ id: TAG_TURN_ID, mind: TAG_MIND, session: "main" });
-
-    // Insert events with turn_id to establish the range
-    await db
-      .insert(mindHistory)
-      .values({ mind: TAG_MIND, type: "inbound", channel: "dm:x", turn_id: TAG_TURN_ID });
-
-    // Insert an orphan outbound (no turn_id)
-    const orphanResult = await db
-      .insert(mindHistory)
-      .values({
-        mind: TAG_MIND,
-        type: "outbound",
-        channel: "dm:x",
-        content: "orphan",
-        turn_id: null,
-      })
-      .returning({ id: mindHistory.id });
-    const orphanId = orphanResult[0].id;
-
-    // Insert another tagged event to set the upper bound
-    await db
-      .insert(mindHistory)
-      .values({ mind: TAG_MIND, type: "tool_use", channel: "dm:x", turn_id: TAG_TURN_ID });
-
-    await tagUntaggedOutbound(TAG_MIND, TAG_TURN_ID);
-
-    const rows = await db.select().from(mindHistory).where(eq(mindHistory.id, orphanId));
-    assert.equal(rows[0].turn_id, TAG_TURN_ID);
-  });
-
-  it("fixes linked message turn_id and source_event_id", async () => {
-    const db = await getDb();
-
-    await db.insert(turns).values({ id: TAG_TURN_ID, mind: TAG_MIND, session: "main" });
-
-    // Create conversation and message
-    const convId = "conv-tag-test";
-    await db.insert(conversations).values({
-      id: convId,
-      type: "dm",
+  it("is idempotent: skips re-tag and re-publish when the outbound is already attributed", async () => {
+    // Direct attribution (session header at send time) already set the turn_id and published.
+    const outId = await recordOutbound(LINK_MIND, "dm:alice", "already tagged", {
+      turnId: LINK_TURN_ID,
     });
-    const msgResult = await db
-      .insert(messages)
-      .values({
-        conversation_id: convId,
-        role: "assistant",
-        sender_name: TAG_MIND,
-        content: "orphan msg",
-      })
-      .returning({ id: messages.id });
-    const msgId = msgResult[0].id;
+    assert.ok(outId != null);
 
-    // Insert a tool_use event with turn_id (establishes range start)
-    await db
-      .insert(mindHistory)
-      .values({ mind: TAG_MIND, type: "tool_use", channel: "dm:x", turn_id: TAG_TURN_ID });
-
-    // Insert an orphan outbound with a message_id
-    await db.insert(mindHistory).values({
-      mind: TAG_MIND,
-      type: "outbound",
-      channel: "dm:x",
-      content: "orphan",
-      turn_id: null,
-      message_id: String(msgId),
-    });
-
-    // Insert another tagged event (upper bound)
-    await db
-      .insert(mindHistory)
-      .values({ mind: TAG_MIND, type: "inbound", channel: "dm:x", turn_id: TAG_TURN_ID });
-
-    await tagUntaggedOutbound(TAG_MIND, TAG_TURN_ID);
-
-    const msgRows = await db.select().from(messages).where(eq(messages.id, msgId));
-    assert.equal(msgRows[0].turn_id, TAG_TURN_ID);
-    // source_event_id should be the tool_use event preceding the orphan
-    assert.ok(msgRows[0].source_event_id != null);
-  });
-
-  it("no-ops when no orphans exist", async () => {
-    const db = await getDb();
-
-    await db.insert(turns).values({ id: TAG_TURN_ID, mind: TAG_MIND, session: "main" });
-
-    // All outbound records already have turn_ids
-    await db.insert(mindHistory).values({
-      mind: TAG_MIND,
-      type: "outbound",
-      channel: "dm:x",
-      content: "tagged",
-      turn_id: TAG_TURN_ID,
-    });
-    await db.insert(mindHistory).values({
-      mind: TAG_MIND,
-      type: "inbound",
-      channel: "dm:x",
-      turn_id: TAG_TURN_ID,
-    });
-
-    // Should not throw or modify anything
-    await assert.doesNotReject(() => tagUntaggedOutbound(TAG_MIND, TAG_TURN_ID));
-  });
-
-  it("no-ops when turn has no events", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: TAG_TURN_ID, mind: TAG_MIND, session: "main" });
-
-    // No events in mind_history for this turn at all
-    await assert.doesNotReject(() => tagUntaggedOutbound(TAG_MIND, TAG_TURN_ID));
-  });
-});
-
-const INBOUND_MIND = "test-inbound-tag";
-const INBOUND_TURN_ID = "turn-inbound-001";
-
-const INBOUND_CONV_IDS = ["conv-inbound-test", "conv-no-channel-test"];
-async function cleanupInboundData() {
-  const db = await getDb();
-  await db.delete(mindHistory).where(eq(mindHistory.mind, INBOUND_MIND));
-  await db.delete(turns).where(eq(turns.mind, INBOUND_MIND));
-  for (const id of INBOUND_CONV_IDS) {
-    await db
-      .delete(conversationParticipants)
-      .where(eq(conversationParticipants.conversation_id, id));
-    await db.delete(messages).where(eq(messages.conversation_id, id));
-    await db.delete(conversations).where(eq(conversations.id, id));
-  }
-}
-
-describe("tagUntaggedInbound", () => {
-  afterEach(cleanupInboundData);
-
-  it("tags recent untagged inbound records with a turn id", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    // Insert an untagged inbound
-    const result = await db
-      .insert(mindHistory)
-      .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:bob", sender: "bob" })
-      .returning({ id: mindHistory.id });
-    const inboundId = result[0].id;
-
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID, { channel: "dm:bob" });
-
-    const rows = await db.select().from(mindHistory).where(eq(mindHistory.id, inboundId));
-    assert.equal(rows[0].turn_id, INBOUND_TURN_ID);
-  });
-
-  it("scopes tagging to a specific channel when provided", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    // Insert inbounds on two different channels
-    const r1 = await db
-      .insert(mindHistory)
-      .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:alice", sender: "alice" })
-      .returning({ id: mindHistory.id });
-    const r2 = await db
-      .insert(mindHistory)
-      .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:bob", sender: "bob" })
-      .returning({ id: mindHistory.id });
-
-    // Only tag dm:bob
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID, { channel: "dm:bob" });
-
-    const aliceRow = await db.select().from(mindHistory).where(eq(mindHistory.id, r1[0].id));
-    const bobRow = await db.select().from(mindHistory).where(eq(mindHistory.id, r2[0].id));
-    assert.equal(aliceRow[0].turn_id, null);
-    assert.equal(bobRow[0].turn_id, INBOUND_TURN_ID);
-  });
-
-  it("sets trigger_event_id when setTrigger is true", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    const r = await db
-      .insert(mindHistory)
-      .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:bob", sender: "bob" })
-      .returning({ id: mindHistory.id });
-
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID, {
-      setTrigger: true,
-      channel: "dm:bob",
-    });
-
-    const turnRows = await db.select().from(turns).where(eq(turns.id, INBOUND_TURN_ID));
-    assert.equal(turnRows[0].trigger_event_id, r[0].id);
-  });
-
-  it("respects the limit parameter", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    // Insert 3 inbounds
-    for (let i = 0; i < 3; i++) {
-      await db
-        .insert(mindHistory)
-        .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:bob", sender: "bob" });
+    const events: MindEvent[] = [];
+    const unsub = subscribe(LINK_MIND, (e) => events.push(e));
+    try {
+      // A stray marker referencing a DIFFERENT turn must not steal or re-publish it.
+      await linkToolResultToTurn(LINK_MIND, "turn-other-999", `[volute:outbound:${outId}]`, 7);
+      assert.equal(events.length, 0, "should not re-publish an already-attributed outbound");
+    } finally {
+      unsub();
     }
 
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID, { limit: 2, channel: "dm:bob" });
-
-    const tagged = await db.select().from(mindHistory).where(eq(mindHistory.mind, INBOUND_MIND));
-    const withTurn = tagged.filter((r) => r.turn_id === INBOUND_TURN_ID);
-    assert.equal(withTurn.length, 2);
-  });
-
-  it("also tags untagged conversation messages", async () => {
     const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    // Create a conversation with the mind as a participant
-    const convId = "conv-inbound-test";
-    const mindUser = await getOrCreateMindUser(INBOUND_MIND);
-    await db.insert(conversations).values({
-      id: convId,
-      type: "dm",
-    });
-    await db.insert(conversationParticipants).values({
-      conversation_id: convId,
-      user_id: mindUser.id,
-      role: "member",
-    });
-    const msgResult = await db
-      .insert(messages)
-      .values({
-        conversation_id: convId,
-        role: "user",
-        sender_name: "bob",
-        content: "hello",
-      })
-      .returning({ id: messages.id });
-
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID, { channel: "dm:bob" });
-
-    const msgRows = await db.select().from(messages).where(eq(messages.id, msgResult[0].id));
-    assert.equal(msgRows[0].turn_id, INBOUND_TURN_ID);
-  });
-
-  it("no-ops when no untagged inbounds exist", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    await assert.doesNotReject(() =>
-      tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID, { channel: "dm:bob" }),
-    );
-  });
-
-  it("skips mind_history tagging when no channel is provided", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    // Insert an untagged inbound on a specific channel
-    const result = await db
-      .insert(mindHistory)
-      .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:bob", sender: "bob" })
-      .returning({ id: mindHistory.id });
-
-    // Call without channel — should NOT tag the inbound (prevents cross-session leaks)
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID);
-
-    const rows = await db.select().from(mindHistory).where(eq(mindHistory.id, result[0].id));
-    assert.equal(rows[0].turn_id, null);
-  });
-
-  it("still tags conversation messages when no channel is provided", async () => {
-    const db = await getDb();
-    await db.insert(turns).values({ id: INBOUND_TURN_ID, mind: INBOUND_MIND, session: "main" });
-
-    // Insert an untagged inbound in mind_history (should NOT be tagged)
-    const historyResult = await db
-      .insert(mindHistory)
-      .values({ mind: INBOUND_MIND, type: "inbound", channel: "dm:bob", sender: "bob" })
-      .returning({ id: mindHistory.id });
-
-    // Insert a conversation message (should still be tagged)
-    const convId = "conv-no-channel-test";
-    const mindUser = await getOrCreateMindUser(INBOUND_MIND);
-    await db.insert(conversations).values({
-      id: convId,
-      type: "dm",
-    });
-    await db.insert(conversationParticipants).values({
-      conversation_id: convId,
-      user_id: mindUser.id,
-      role: "member",
-    });
-    const msgResult = await db
-      .insert(messages)
-      .values({
-        conversation_id: convId,
-        role: "user",
-        sender_name: "bob",
-        content: "hello",
-      })
-      .returning({ id: messages.id });
-
-    // Call without channel
-    await tagUntaggedInbound(INBOUND_MIND, INBOUND_TURN_ID);
-
-    // mind_history should NOT be tagged (no channel = skip)
-    const historyRows = await db
-      .select()
-      .from(mindHistory)
-      .where(eq(mindHistory.id, historyResult[0].id));
-    assert.equal(historyRows[0].turn_id, null);
-
-    // conversation messages SHOULD still be tagged
-    const msgRows = await db.select().from(messages).where(eq(messages.id, msgResult[0].id));
-    assert.equal(msgRows[0].turn_id, INBOUND_TURN_ID);
+    const row = await db.select().from(mindHistory).where(eq(mindHistory.id, outId!)).get();
+    assert.equal(row!.turn_id, LINK_TURN_ID, "existing turn_id must be preserved");
   });
 });

--- a/test/turn-lifecycle.test.ts
+++ b/test/turn-lifecycle.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { afterEach, before, describe, it } from "node:test";
+import { and, eq } from "drizzle-orm";
+import { drainNotices } from "../packages/daemon/src/lib/daemon/notices.js";
+import { initTokenBudget } from "../packages/daemon/src/lib/daemon/token-budget.js";
+import { handleMindEvent } from "../packages/daemon/src/lib/daemon/turn-lifecycle.js";
+import { clearMind, getActiveTurnId } from "../packages/daemon/src/lib/daemon/turn-tracker.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  recordInbound,
+  recordOutbound,
+} from "../packages/daemon/src/lib/delivery/message-delivery.js";
+import { mindHistory, turns } from "../packages/daemon/src/lib/schema.js";
+
+async function cleanup(mind: string): Promise<void> {
+  await clearMind(mind);
+  const db = await getDb();
+  await db.delete(mindHistory).where(eq(mindHistory.mind, mind));
+  await db.delete(turns).where(eq(turns.mind, mind));
+}
+
+describe("turn-lifecycle: handleMindEvent", () => {
+  before(() => {
+    // usage events accrue against the token budget singleton.
+    try {
+      initTokenBudget();
+    } catch {
+      // already initialized by another test in this process
+    }
+  });
+
+  it("session_start assigns a session to an existing sessionless turn", async () => {
+    const mind = "tl-session-start";
+    // A sessionless turn opens on the first substantive event without a session.
+    await handleMindEvent(mind, { type: "tool_use", content: "x" });
+    assert.ok(getActiveTurnId(mind), "sessionless turn should exist");
+
+    await handleMindEvent(mind, { type: "session_start", session: "s1" });
+    const turnId = getActiveTurnId(mind, "s1");
+    assert.ok(turnId, "turn should now be keyed by session s1");
+
+    const db = await getDb();
+    const row = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(row!.session, "s1");
+    await cleanup(mind);
+  });
+
+  it("tool_use creates a turn and persists the event tagged with it", async () => {
+    const mind = "tl-tool-use";
+    const { turnId, insertedId } = await handleMindEvent(mind, {
+      type: "tool_use",
+      session: "s1",
+      content: "bash ls",
+    });
+    assert.ok(turnId, "tool_use should create a turn");
+    assert.equal(getActiveTurnId(mind, "s1"), turnId);
+
+    const db = await getDb();
+    const row = await db.select().from(mindHistory).where(eq(mindHistory.id, insertedId!)).get();
+    assert.equal(row!.type, "tool_use");
+    assert.equal(row!.turn_id, turnId);
+    assert.equal(row!.session, "s1");
+    await cleanup(mind);
+  });
+
+  it("text creates a turn and links the pending inbound as the trigger", async () => {
+    const mind = "tl-text-trigger";
+    // Inbound arrives first (no turn yet), then the mind starts a turn on the same channel.
+    const inboundId = await recordInbound(mind, "@alice", "alice", "hello");
+    const { turnId } = await handleMindEvent(mind, {
+      type: "text",
+      session: "s1",
+      channel: "@alice",
+      content: "hi back",
+    });
+    assert.ok(turnId);
+
+    const db = await getDb();
+    const inbound = await db.select().from(mindHistory).where(eq(mindHistory.id, inboundId!)).get();
+    assert.equal(inbound!.turn_id, turnId, "inbound should be tagged with the new turn");
+    const turn = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(turn!.trigger_event_id, inboundId, "turn trigger should point at the inbound");
+    await cleanup(mind);
+  });
+
+  it("done completes the active turn", async () => {
+    const mind = "tl-done";
+    const { turnId } = await handleMindEvent(mind, {
+      type: "tool_use",
+      session: "s1",
+      content: "x",
+    });
+    assert.ok(getActiveTurnId(mind, "s1"));
+
+    await handleMindEvent(mind, { type: "done", session: "s1" });
+    assert.equal(getActiveTurnId(mind, "s1"), undefined, "turn should be cleared after done");
+
+    const db = await getDb();
+    const row = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(row!.status, "complete");
+    await cleanup(mind);
+  });
+
+  it("error records a turn_error notice for the session", async () => {
+    const mind = "tl-error";
+    await handleMindEvent(mind, { type: "tool_use", session: "s1", content: "x" });
+    await handleMindEvent(mind, {
+      type: "error",
+      session: "s1",
+      content: "boom: something failed",
+    });
+
+    const notices = await drainNotices(mind, "s1");
+    assert.ok(
+      notices.some((n) => n.kind === "turn_error"),
+      "a turn_error notice should be recorded",
+    );
+    await cleanup(mind);
+  });
+
+  it("usage accrues against the token budget", async () => {
+    const mind = "tl-usage";
+    await handleMindEvent(mind, {
+      type: "usage",
+      session: "s1",
+      metadata: { input_tokens: 100, output_tokens: 50 },
+    });
+    // No throw is the primary assertion; the budget singleton recorded the usage.
+    await cleanup(mind);
+  });
+
+  it("tool_result marker links an outbound when no session attribution happened (fallback)", async () => {
+    const mind = "tl-marker-fallback";
+    // Outbound recorded with no turn_id (no session header path).
+    const outboundId = await recordOutbound(mind, "@bob", "sent via CLI");
+    // Turn opens sessionless, then the tool_result carries the correlation marker.
+    await handleMindEvent(mind, { type: "tool_use", content: "volute chat send" });
+    const turnId = getActiveTurnId(mind);
+    await handleMindEvent(mind, {
+      type: "tool_result",
+      content: `Message sent.\n[volute:outbound:${outboundId}]`,
+    });
+
+    const db = await getDb();
+    const row = await db.select().from(mindHistory).where(eq(mindHistory.id, outboundId!)).get();
+    assert.equal(row!.turn_id, turnId, "marker fallback should attribute the outbound to the turn");
+    await cleanup(mind);
+  });
+});
+
+describe("turn-lifecycle: concurrent sessions", () => {
+  const mind = "tl-concurrent";
+  afterEach(() => cleanup(mind));
+
+  it("attributes outbound records to the correct turn per session via the header path", async () => {
+    // Two sessions for one mind, interleaved — this used to race under the process-global
+    // VOLUTE_SESSION. Each substantive event carries its own session, so turns stay distinct.
+    await handleMindEvent(mind, { type: "tool_use", session: "sA", channel: "@a", content: "a1" });
+    await handleMindEvent(mind, { type: "tool_use", session: "sB", channel: "@b", content: "b1" });
+
+    const turnA = getActiveTurnId(mind, "sA");
+    const turnB = getActiveTurnId(mind, "sB");
+    assert.ok(turnA && turnB, "both sessions should have active turns");
+    assert.notEqual(turnA, turnB, "each session must have its own distinct turn");
+
+    // Simulate the direct attribution path (volute/chat.ts): the send resolves the sending
+    // mind's active turn from its session header and records the outbound tagged with it.
+    const outA = await recordOutbound(mind, "@a", "from A", {
+      turnId: getActiveTurnId(mind, "sA"),
+    });
+    const outB = await recordOutbound(mind, "@b", "from B", {
+      turnId: getActiveTurnId(mind, "sB"),
+    });
+
+    const db = await getDb();
+    const rowA = await db.select().from(mindHistory).where(eq(mindHistory.id, outA!)).get();
+    const rowB = await db.select().from(mindHistory).where(eq(mindHistory.id, outB!)).get();
+    assert.equal(rowA!.turn_id, turnA, "session A outbound should be tagged with turn A");
+    assert.equal(rowB!.turn_id, turnB, "session B outbound should be tagged with turn B");
+
+    // Completing one session's turn must not disturb the other.
+    await handleMindEvent(mind, { type: "done", session: "sA" });
+    assert.equal(getActiveTurnId(mind, "sA"), undefined);
+    assert.equal(getActiveTurnId(mind, "sB"), turnB, "session B turn must remain active");
+
+    const stillActive = await db
+      .select()
+      .from(turns)
+      .where(and(eq(turns.id, turnB!), eq(turns.status, "active")))
+      .get();
+    assert.ok(stillActive, "turn B should still be active in the DB");
+  });
+});

--- a/test/turn-lifecycle.test.ts
+++ b/test/turn-lifecycle.test.ts
@@ -4,7 +4,11 @@ import { and, eq } from "drizzle-orm";
 import { drainNotices } from "../packages/daemon/src/lib/daemon/notices.js";
 import { initTokenBudget } from "../packages/daemon/src/lib/daemon/token-budget.js";
 import { handleMindEvent } from "../packages/daemon/src/lib/daemon/turn-lifecycle.js";
-import { clearMind, getActiveTurnId } from "../packages/daemon/src/lib/daemon/turn-tracker.js";
+import {
+  clearMind,
+  getActiveTurnId,
+  linkInboundToActiveTurn,
+} from "../packages/daemon/src/lib/daemon/turn-tracker.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   recordInbound,
@@ -144,6 +148,116 @@ describe("turn-lifecycle: handleMindEvent", () => {
     const db = await getDb();
     const row = await db.select().from(mindHistory).where(eq(mindHistory.id, outboundId!)).get();
     assert.equal(row!.turn_id, turnId, "marker fallback should attribute the outbound to the turn");
+    await cleanup(mind);
+  });
+});
+
+describe("turn-lifecycle: mid-turn inbound tagging", () => {
+  it("tags an inbound arriving mid-turn to the in-progress turn, without touching the trigger", async () => {
+    const mind = "tl-midturn";
+    // A turn is already active for (mind, s1, @alice), triggered by an earlier inbound.
+    const triggerId = await recordInbound(mind, "@alice", "alice", "first");
+    const { turnId } = await handleMindEvent(mind, {
+      type: "text",
+      session: "s1",
+      channel: "@alice",
+      content: "on it",
+    });
+    assert.ok(turnId);
+    assert.equal(getActiveTurnId(mind, "s1"), turnId, "turn should be active");
+
+    // A new inbound arrives on the same channel WHILE the turn is still active.
+    const interruptId = await recordInbound(mind, "@alice", "alice", "actually, wait");
+    const db = await getDb();
+    const before = await db
+      .select()
+      .from(mindHistory)
+      .where(eq(mindHistory.id, interruptId!))
+      .get();
+    assert.equal(before!.turn_id, null, "interrupt starts untagged");
+
+    // Delivery attributes it to the in-progress turn immediately.
+    await linkInboundToActiveTurn(mind, "s1", "@alice");
+
+    const after = await db.select().from(mindHistory).where(eq(mindHistory.id, interruptId!)).get();
+    assert.equal(after!.turn_id, turnId, "mid-turn inbound must be tagged to the active turn now");
+
+    // The turn's trigger stays the original triggering inbound — a mid-turn message is not a trigger.
+    const turn = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(turn!.trigger_event_id, triggerId, "trigger_event_id must not be overwritten");
+    await cleanup(mind);
+  });
+
+  it("tags ALL mid-turn inbounds even when more than 5 accumulate (next-turn sweep would miss them)", async () => {
+    const mind = "tl-midturn-backlog";
+    // Open a turn on the channel.
+    const { turnId } = await handleMindEvent(mind, {
+      type: "text",
+      session: "s1",
+      channel: "@alice",
+      content: "working",
+    });
+    assert.ok(turnId);
+
+    // 7 inbounds pile up mid-turn — more than linkPendingInbound's bounded sweep of 5.
+    const ids: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      const id = await recordInbound(mind, "@alice", "alice", `msg ${i}`);
+      ids.push(id!);
+    }
+
+    await linkInboundToActiveTurn(mind, "s1", "@alice");
+
+    const db = await getDb();
+    for (const id of ids) {
+      const row = await db.select().from(mindHistory).where(eq(mindHistory.id, id)).get();
+      assert.equal(row!.turn_id, turnId, `inbound ${id} must be tagged (not left NULL)`);
+    }
+    await cleanup(mind);
+  });
+
+  it("is a no-op when no turn is active — the turn-creation path tags it instead", async () => {
+    const mind = "tl-midturn-noturn";
+    // No active turn for this session yet.
+    const inboundId = await recordInbound(mind, "@alice", "alice", "hello");
+    await linkInboundToActiveTurn(mind, "s1", "@alice");
+
+    const db = await getDb();
+    const row = await db.select().from(mindHistory).where(eq(mindHistory.id, inboundId!)).get();
+    assert.equal(
+      row!.turn_id,
+      null,
+      "no active turn → inbound stays untagged for the creation path",
+    );
+
+    // The turn-creation path then tags it as the trigger.
+    const { turnId } = await handleMindEvent(mind, {
+      type: "text",
+      session: "s1",
+      channel: "@alice",
+      content: "hi",
+    });
+    const tagged = await db.select().from(mindHistory).where(eq(mindHistory.id, inboundId!)).get();
+    assert.equal(tagged!.turn_id, turnId, "creation path tags the pending inbound");
+    await cleanup(mind);
+  });
+
+  it("does not tag inbounds on a different channel", async () => {
+    const mind = "tl-midturn-otherchannel";
+    const { turnId } = await handleMindEvent(mind, {
+      type: "text",
+      session: "s1",
+      channel: "@alice",
+      content: "hi",
+    });
+    assert.ok(turnId);
+    // Inbound on a different channel must not be swept into this turn.
+    const otherId = await recordInbound(mind, "@bob", "bob", "unrelated");
+    await linkInboundToActiveTurn(mind, "s1", "@alice");
+
+    const db = await getDb();
+    const row = await db.select().from(mindHistory).where(eq(mindHistory.id, otherId!)).get();
+    assert.equal(row!.turn_id, null, "a different channel's inbound must stay untagged");
     await cleanup(mind);
   });
 });


### PR DESCRIPTION
Closes #327

> **Stacked on #326 (PR #351, base `fix/delivery-queue-durability`).** This should merge **after** #326. The diff shown against `main` will be noisy until #326 lands; review against the `fix/delivery-queue-durability` base.

## What & why

The real delivery/turn state machine lived inside a ~240-line `POST /:name/events` HTTP handler, and turn↔message correlation relied on text markers (`[volute:outbound:NNN]`) plus two 60s time-window heuristics and an id-range heuristic as safety nets. Session attribution leaned on the process-global `VOLUTE_SESSION`, which races across concurrent sessions.

## The four changes

1. **Extract a `TurnLifecycle` service** (`packages/daemon/src/lib/daemon/turn-lifecycle.ts`, sibling to `turn-tracker.ts`). It owns the whole state machine — turn create/assign/complete, trigger linking, marker fallback linking, typing clears, failure/budget notices, the summarization trigger, and budget accounting. The `/events` route is now a thin adapter that parses the body and calls `handleMindEvent()`, so the state machine is unit-testable without HTTP. The `noticeDrainWatermarks` map + clean-turn notice bookkeeping moved here too (`setNoticeDrainWatermark()` is called by the pre-prompt notices route).

2. **Record `turn_id` directly on send.** `volute/chat.ts` `POST /chat` now reads `c.get("mindSession")` (the `X-Volute-Session` header captured in `middleware/auth.ts`), resolves the sending mind's active turn via `getActiveTurnId(senderBase, mindSession)`, and passes it into `addMessage` and `recordOutbound`, publishing the outbound SSE event itself when the turn is known. Session-scoped attribution is now the primary mechanism. This mirrors the existing bridge/external-send path and does not touch #326's fan-out / loop-protection.

3. **Demote markers to a fallback.** `linkToolResultToTurn` is now **idempotent** — it skips re-tagging and re-publishing an outbound that already carries a `turn_id` (i.e. one the direct path already attributed), while still linking extension `[volute:activity:NNN]` records and any outbound the direct path couldn't attribute (e.g. a sessionless send or a tool_use/subprocess race). Removed the time-window heuristics `tagUntaggedInbound` / `tagRecentInbound` (60s windows) and the id-range heuristic `tagUntaggedOutbound`. Inbound→turn linking is now deterministic and session/channel-scoped at turn creation via a small `linkPendingInbound` (tags untagged inbounds on the turn's channel, sets `trigger_event_id`) — no time window.

4. **Fix the session race.** Turn attribution is now scoped per-request through the `X-Volute-Session` header end-to-end (`mindSession`) rather than the racy process-global lookup. The template still writes `VOLUTE_SESSION` / `.mind/current-session` purely as the transport that lets a mind-spawned subprocess forward its session as the header (the "subprocess genuinely can't receive the header" case), so no template change was needed.

## Lines removed

~195 lines of heuristic functions deleted from `message-delivery.ts` (`tagUntaggedInbound` ~86, `tagUntaggedOutbound` ~72, `tagRecentInbound` ~13, plus doc comments), their call sites in `minds.ts`/`delivery-manager.ts`, and ~335 lines of their tests. Net for the PR: **+595 / −849**.

## Deviations from the issue

- The issue says keep marker linking "only for paths without a session header." Implemented as an **idempotent** `linkToolResultToTurn` that no-ops when the outbound is already attributed, rather than gating the call on header presence. This is strictly safer: it preserves `source_event_id` linking and activity-marker handling, and it still correctly attributes an outbound when direct attribution couldn't (tool_use/subprocess timing race) — without double-publishing. Markers are genuinely demoted to a fallback; they just self-limit instead of being skipped by the caller.
- `tagUntaggedInbound` also tagged conversation-`messages` rows; the timeline reads inbound/outbound from `mind_history` (not the `messages` table — see `history.ts`), so that half was dropped as dead work rather than reimplemented.

## Test plan

- New `test/turn-lifecycle.test.ts`: drives `handleMindEvent` for `session_start`, `tool_use`, `text` (trigger linking), `error` (notice), `usage` (budget), `done` (completion), and the marker **fallback** path — all without a live HTTP server.
- Concurrency test: two interleaved sessions for one mind get **distinct** turns and their outbounds are attributed to the correct turn via the header path (previously racy under `VOLUTE_SESSION`); completing one session's turn leaves the other active.
- `test/message-delivery.test.ts`: dropped the removed-function tests; added an **idempotency** test proving `linkToolResultToTurn` won't steal/re-publish an already-attributed outbound. The existing marker-linking tests still prove the no-session fallback works.
- Full suite green: **1644 passed / 0 failed** (`npm test`), plus `svelte-check` 0 errors — both enforced by the pre-push hook, which passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)