### PR TITLE
fix: split daemon.json admin token into a 0600 file so the operator CLI can read it

### DIFF
--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -105,6 +105,11 @@ export function resolveDaemonUrl(): string {
   return buildUrl(readDaemonConfig());
 }
 
+/** The bearer token daemonFetch would use: mind token (in a mind) or CLI session (operator). */
+export function getAuthToken(): string | undefined {
+  return process.env.VOLUTE_MIND_TOKEN ?? readCliSession()?.sessionId;
+}
+
 export async function daemonFetch(path: string, options?: RequestInit): Promise<Response> {
   const url = resolveDaemonUrl();
   const headers = new Headers(options?.headers);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -55,13 +55,24 @@ if (process.env.VOLUTE_TIMEZONE && !process.env.TZ) {
 }
 
 /**
- * Write daemon.json (holds the daemon admin token) owner-only. The chmodSync
- * enforces 0600 even when the file pre-existed with looser perms (writeFileSync's
- * `mode` only applies on creation).
+ * Persist daemon connection info, splitting the secret from the non-secret part:
+ * daemon.json (port/hostname) stays operator-readable at 0644 so a non-root CLI
+ * on a system install can find the daemon, while the admin token goes to a
+ * separate 0600 owner-only file. chmodSync enforces the mode even when a file
+ * pre-existed with looser/tighter perms (writeFileSync's `mode` only applies on
+ * creation) — this also relaxes a daemon.json left at 0600 by v0.41.1.
  */
-export function writeDaemonConfig(path: string, config: Record<string, unknown>): void {
-  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
-  chmodSync(path, 0o600);
+export function writeDaemonConfig(
+  systemDir: string,
+  config: Record<string, unknown>,
+  token: string,
+): void {
+  const configPath = resolve(systemDir, "daemon.json");
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o644 });
+  chmodSync(configPath, 0o644);
+  const tokenPath = resolve(systemDir, "daemon-token");
+  writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
+  chmodSync(tokenPath, 0o600);
 }
 
 export async function startDaemon(opts: {
@@ -90,6 +101,7 @@ export async function startDaemon(opts: {
   }
   const DAEMON_PID_PATH = resolve(systemDir, "daemon.pid");
   const DAEMON_JSON_PATH = resolve(systemDir, "daemon.json");
+  const DAEMON_TOKEN_PATH = resolve(systemDir, "daemon-token");
 
   mkdirSync(home, { recursive: true });
   ensureSystemDir();
@@ -213,11 +225,11 @@ export async function startDaemon(opts: {
 
   // Server is listening — safe to write PID and config
   writeFileSync(DAEMON_PID_PATH, myPid, { mode: 0o644 });
-  const daemonConfig: Record<string, unknown> = { port, hostname, token };
+  const daemonConfig: Record<string, unknown> = { port, hostname };
   if (internalPort) daemonConfig.internalPort = internalPort;
   if (tls) daemonConfig.tls = true;
-  // 0600 — daemon.json holds the daemon admin token; owner-only (matches env.json/volute.db).
-  writeDaemonConfig(DAEMON_JSON_PATH, daemonConfig);
+  // daemon.json is operator-readable (0644); the admin token is written separately at 0600.
+  writeDaemonConfig(systemDir, daemonConfig, token);
 
   // Start delivery manager, mind manager, bridge manager, and scheduler
   const delivery = initDeliveryManager();
@@ -358,13 +370,18 @@ export async function startDaemon(opts: {
       // PID file may not exist or belong to another process — ignore
     }
     try {
-      // Only delete daemon.json if it belongs to this process
-      const data = JSON.parse(readFileSync(DAEMON_JSON_PATH, "utf-8"));
-      if (data.token === token) {
-        unlinkSync(DAEMON_JSON_PATH);
+      // Only delete daemon.json/token if they still belong to this process
+      // (the token file, 0600, is the ownership marker now that daemon.json is public).
+      if (readFileSync(DAEMON_TOKEN_PATH, "utf-8").trim() === token) {
+        unlinkSync(DAEMON_TOKEN_PATH);
+        try {
+          unlinkSync(DAEMON_JSON_PATH);
+        } catch {
+          // daemon.json may already be gone — ignore
+        }
       }
     } catch {
-      // Config file may not exist — ignore
+      // Token file may not exist or belong to another process — ignore
     }
   }
 

--- a/packages/daemon/src/lib/config/service-mode.ts
+++ b/packages/daemon/src/lib/config/service-mode.ts
@@ -211,14 +211,38 @@ export async function restartService(mode: ManagedServiceMode): Promise<void> {
   }
 }
 
-/** Read daemon.json for hostname, port, and token. Returns defaults if missing or corrupt. */
+export function daemonConfigPath(): string {
+  return resolve(voluteSystemDir(), "daemon.json");
+}
+
+/**
+ * The daemon admin token lives in its own owner-only file, split out from
+ * daemon.json so the latter (port/hostname) can stay operator-readable (0644)
+ * on a system install where the daemon runs as root. Only daemon-side code (also
+ * root) needs the token; the operator CLI authenticates via cli-session.json.
+ */
+export function daemonTokenPath(): string {
+  return resolve(voluteSystemDir(), "daemon-token");
+}
+
+/** Read the daemon admin token; undefined when missing or unreadable (e.g. a non-root caller). */
+export function readDaemonToken(): string | undefined {
+  const path = daemonTokenPath();
+  if (!existsSync(path)) return undefined;
+  try {
+    return readFileSync(path, "utf-8").trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read daemon.json for hostname and port. Returns defaults if missing or corrupt. */
 export function readDaemonConfig(): {
   hostname: string;
   port: number;
   internalPort?: number;
-  token?: string;
 } {
-  const configPath = resolve(voluteSystemDir(), "daemon.json");
+  const configPath = daemonConfigPath();
   if (!existsSync(configPath)) return { hostname: "127.0.0.1", port: 1618 };
   try {
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
@@ -226,7 +250,6 @@ export function readDaemonConfig(): {
       hostname: config.hostname || "127.0.0.1",
       port: config.port ?? 1618,
       internalPort: config.internalPort,
-      token: config.token,
     };
   } catch {
     console.error("Warning: could not read daemon config, using defaults.");

--- a/packages/daemon/src/lib/platforms/volute.ts
+++ b/packages/daemon/src/lib/platforms/volute.ts
@@ -21,11 +21,11 @@ function readSessionFile(mindDir: string): string | undefined {
   return undefined;
 }
 
-import { voluteSystemDir } from "../mind/registry.js";
+import { daemonConfigPath, readDaemonToken } from "../config/service-mode.js";
 import { buildVoluteSlug } from "../util/slugify.js";
 
 function getDaemonConfig(): { url: string; token?: string } {
-  const configPath = resolve(voluteSystemDir(), "daemon.json");
+  const configPath = daemonConfigPath();
   if (!existsSync(configPath)) {
     throw new Error("Volute daemon is not running");
   }
@@ -41,7 +41,9 @@ function getDaemonConfig(): { url: string; token?: string } {
   const url = new URL("http://localhost");
   url.hostname = (config.hostname as string) || "localhost";
   url.port = String(config.port);
-  return { url: url.origin, token: config.token as string | undefined };
+  // The admin token lives in a separate 0600 file (daemon-token), readable by
+  // this daemon-side driver which runs as root.
+  return { url: url.origin, token: readDaemonToken() };
 }
 
 export async function read(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "node:util";
 import { command } from "@volute/cli/lib/command.js";
+import { getAuthToken } from "@volute/cli/lib/daemon-client.js";
 import {
   getDaemonUrl,
   getServiceMode,
@@ -25,7 +26,7 @@ const cmd = command({
     const mode = getServiceMode();
     console.log(`Mode: ${modeLabel(mode)}`);
 
-    const { hostname, port, internalPort, token } = readDaemonConfig();
+    const { hostname, port, internalPort } = readDaemonConfig();
     // Use internal HTTP port for API calls, user-facing port for display
     const apiPort = internalPort ?? port;
     const baseUrl = getDaemonUrl("127.0.0.1", apiPort);
@@ -68,8 +69,9 @@ const cmd = command({
       }
     }
 
-    // List minds
+    // List minds (best-effort — authenticate as the operator via CLI session)
     const headers: Record<string, string> = {};
+    const token = getAuthToken();
     if (token) headers.Authorization = `Bearer ${token}`;
     headers.Origin = baseUrl;
 

--- a/test/daemon-config.test.ts
+++ b/test/daemon-config.test.ts
@@ -1,20 +1,36 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import { writeDaemonConfig } from "../packages/daemon/src/daemon.js";
 
 describe("writeDaemonConfig", () => {
-  it("locks daemon.json to owner-only (0600), even when pre-existing 0644", () => {
-    // daemon.json holds the daemon admin token — must never be world-readable.
+  it("keeps daemon.json operator-readable (0644) and puts the token in a 0600 file", () => {
+    // daemon.json (port/hostname) must be readable by a non-root operator CLI on a
+    // system install; the admin token must never be world-readable.
     const dir = mkdtempSync(resolve(tmpdir(), "volute-daemon-cfg-"));
-    const path = resolve(dir, "daemon.json");
-    // Pre-create with loose perms to prove the chmod tightens them (writeFileSync's
-    // `mode` only applies on creation).
-    writeFileSync(path, "{}", { mode: 0o644 });
-    writeDaemonConfig(path, { port: 1618, hostname: "127.0.0.1", token: "secret" });
-    const mode = statSync(path).mode & 0o777;
-    assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+    const configPath = resolve(dir, "daemon.json");
+    const tokenPath = resolve(dir, "daemon-token");
+    // Pre-create daemon.json at 0600 (as v0.41.1 left it) to prove the write relaxes it.
+    writeFileSync(configPath, "{}", { mode: 0o600 });
+
+    writeDaemonConfig(dir, { port: 1618, hostname: "127.0.0.1" }, "super-secret");
+
+    assert.equal(statSync(configPath).mode & 0o777, 0o644, "daemon.json should be 0644");
+    const config = readFileSync(configPath, "utf-8");
+    assert.ok(!config.includes("super-secret"), "daemon.json must not contain the token");
+    assert.ok(config.includes("1618"), "daemon.json keeps port/hostname");
+
+    assert.equal(statSync(tokenPath).mode & 0o777, 0o600, "daemon-token should be 0600");
+    assert.equal(readFileSync(tokenPath, "utf-8").trim(), "super-secret");
+  });
+
+  it("tightens a pre-existing token file left at loose perms", () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "volute-daemon-cfg-"));
+    const tokenPath = resolve(dir, "daemon-token");
+    writeFileSync(tokenPath, "old", { mode: 0o644 });
+    writeDaemonConfig(dir, { port: 1618, hostname: "127.0.0.1" }, "new-token");
+    assert.equal(statSync(tokenPath).mode & 0o777, 0o600);
   });
 });

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { existsSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
@@ -137,11 +137,20 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.equal(body.ok, true);
   });
 
-  it("daemon.json (holds admin token) is written owner-only (0600)", () => {
+  it("daemon.json is operator-readable (0644) and the admin token is owner-only (0600)", () => {
+    // daemon.json (port/hostname) must be readable by a non-root operator CLI on a
+    // system install; the token lives in a separate 0600 file.
     const daemonJson = resolve(voluteSystemDir(), "daemon.json");
     assert.ok(existsSync(daemonJson), "daemon.json should exist");
-    const mode = statSync(daemonJson).mode & 0o777;
-    assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+    assert.equal(statSync(daemonJson).mode & 0o777, 0o644, "daemon.json should be 0644");
+    assert.ok(
+      !readFileSync(daemonJson, "utf-8").includes("token"),
+      "daemon.json must not hold the token",
+    );
+
+    const tokenFile = resolve(voluteSystemDir(), "daemon-token");
+    assert.ok(existsSync(tokenFile), "daemon-token should exist");
+    assert.equal(statSync(tokenFile).mode & 0o777, 0o600, "daemon-token should be 0600");
   });
 
   it("unauthenticated request returns 401", async () => {


### PR DESCRIPTION
Follow-up to #350, which fixed the `config.json` half of the same regression. This fixes the `daemon.json` half.

## Problem

`v0.41.1` (#340) also locked `daemon.json` to `0600` because it held the daemon admin token. On a `--system` install the daemon runs as **root**, so the file became root-only — but the operator's non-root CLI reads `daemon.json` on **every** command to find the daemon's port/hostname:

```
Permission denied reading /var/lib/volute/system/daemon.json. Try: sudo volute ...
```

## Fix — split the token out (same pattern as #350)

`daemon.json` keeps `port`/`hostname`/`internalPort`/`tls` at `0644` (operator-readable). The admin token moves to a separate root-only **`daemon-token`** file (`0600`).

No operator command needs the token — the CLI authenticates via `cli-session.json` (or `VOLUTE_MIND_TOKEN` for minds), and `status`/`down`/`restart`/`update` read only the port. The token is consumed solely by daemon-side code (the volute platform driver and the shutdown ownership check), which runs as root and reads it via `readDaemonToken()`.

`daemon.json` is rewritten on every daemon start, so an existing `0600` file is relaxed to `0644` on the next restart — no migration needed. The shutdown ownership check now uses the token file as its marker and cleans up both files. `volute status` lists minds via cli-session auth (`getAuthToken`) instead of the admin token, so a logged-in operator still sees them.

Secrets stay protected identically: the sandbox denies all of `$HOME` on local installs, and `0600` root-only covers system installs where minds run as separate users.

## Audit

This completes the audit from #350: `daemon.json` and `config.json` were the only two files the non-root operator CLI reads directly. Everything else (`env.json`, `systems.json`, bridges, `volute.db`) is reached through the authenticated daemon API, so `0600` doesn't affect the operator.

## Deploying

Upgrade and **restart the daemon** — it rewrites `daemon.json` at `0644` on startup and the operator CLI works without `sudo`.

## Testing

- `test/daemon-config.test.ts`: daemon.json 0644 without token; token in `daemon-token` at 0600; tightens a loose pre-existing token file.
- `test/daemon-e2e.test.ts`: updated the daemon.json perms assertion (0644 + separate 0600 token file).
- Full suite passes; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
