### PR TITLE
feat: provider-qualified AI model identity

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -102,6 +102,11 @@ export async function startDaemon(opts: {
   // Migrate pre-existing installations (setup field without setupCompleted)
   migrateSetupCompleted();
 
+  // Migrate bare model ids to provider-qualified form before the spirit starts,
+  // so syncSpiritTemplate reads a qualified spiritModel.
+  const { migrateAiModelQualification } = await import("./lib/ai-service.js");
+  migrateAiModelQualification();
+
   // Initialize database (runs drizzle migrations + creates raw connection)
   await (await import("./lib/db.js")).getDb();
 

--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -207,6 +207,63 @@ export function setEnabledModels(modelIds: string[]): void {
   writeGlobalConfig({ ...config, ai });
 }
 
+/**
+ * One-time migration: convert bare model ids in `ai.models`, `spiritModel`, and
+ * `ai.utilityModel` to provider-qualified `provider:model` form. A bare id is
+ * ambiguous (many providers serve the same id), so this pins each to the
+ * explicitly-configured provider(s) that serve it: the enabled list expands to
+ * one entry per configured provider, and the single-value defaults qualify to
+ * the first configured provider that serves them. Idempotent — a no-op once
+ * every stored id already contains a ":".
+ */
+export function migrateAiModelQualification(): void {
+  const config = readGlobalConfig();
+  const ai = config.ai;
+  const isBare = (id?: string): id is string => id != null && !id.includes(":");
+
+  const hasBareInList = (ai?.models ?? []).some(isBare);
+  if (!hasBareInList && !isBare(config.spiritModel) && !isBare(ai?.utilityModel)) return;
+
+  // Only providers the admin explicitly added (with credentials) — not ambient
+  // env/OAuth providers — are candidates, matching what the user configured.
+  const providers = ai ? Object.keys(ai.providers) : [];
+  const customModels = ai?.customModels ?? [];
+  const providersServing = (bareId: string): string[] =>
+    providers.filter(
+      (p) =>
+        getBuiltinModel(p as never, bareId as never) != null ||
+        customModels.some((cm) => cm.provider === p && cm.id === bareId),
+    );
+
+  let changed = false;
+
+  if (ai?.models) {
+    const expanded: string[] = [];
+    for (const id of ai.models) {
+      if (!isBare(id)) {
+        expanded.push(id);
+        continue;
+      }
+      changed = true;
+      for (const p of providersServing(id)) expanded.push(`${p}:${id}`);
+    }
+    ai.models = expanded.length > 0 ? [...new Set(expanded)] : undefined;
+    if (!ai.models) delete ai.models;
+  }
+
+  const qualifyOne = (id: string | undefined): string | undefined => {
+    if (!isBare(id)) return id;
+    const [provider] = providersServing(id);
+    if (!provider) return id; // no configured provider serves it — leave as-is
+    changed = true;
+    return `${provider}:${id}`;
+  };
+  config.spiritModel = qualifyOne(config.spiritModel);
+  if (ai) ai.utilityModel = qualifyOne(ai.utilityModel);
+
+  if (changed) writeGlobalConfig(config);
+}
+
 /** Get the admin-defined custom models (not in pi-ai's built-in catalog). */
 export function getCustomModels(): CustomModel[] {
   return getAiConfig()?.customModels ?? [];
@@ -234,7 +291,9 @@ export function removeCustomModel(provider: string, id: string): void {
   ai.customModels = customModels.length > 0 ? customModels : undefined;
   if (!ai.customModels) delete ai.customModels;
   if (ai.models) {
-    ai.models = ai.models.filter((mid) => mid !== id);
+    // Enabled ids are provider-qualified ("provider:model").
+    const qualified = `${provider}:${id}`;
+    ai.models = ai.models.filter((mid) => mid !== qualified);
     if (ai.models.length === 0) delete ai.models;
   }
   const config = readGlobalConfig();
@@ -381,8 +440,25 @@ export function unqualifyModelId(modelId: string): string {
   return idx >= 0 ? modelId.slice(idx + 1) : modelId;
 }
 
-function findModel(modelId: string): Model<Api> | undefined {
-  // Exact match against the built-in catalog (built-in always wins)
+export function findModel(modelId: string): Model<Api> | undefined {
+  // Provider-qualified id ("provider:model") resolves within that provider only,
+  // so the same bare id under different providers stays unambiguous.
+  const colon = modelId.indexOf(":");
+  if (colon >= 0) {
+    const provider = modelId.slice(0, colon);
+    const bareId = modelId.slice(colon + 1);
+    const built = getBuiltinModel(provider as never, bareId as never);
+    if (built) return built as Model<Api>;
+    for (const cm of getCustomModels()) {
+      if (cm.provider === provider && cm.id === bareId) {
+        const model = buildCustomModel(cm.provider, cm.id, cm.name);
+        if (model) return model;
+      }
+    }
+    return undefined;
+  }
+  // Bare id (legacy / fallback): exact built-in match against the catalog
+  // (built-in always wins).
   for (const provider of getBuiltinProviders()) {
     const model = getBuiltinModel(provider as never, modelId as never);
     if (model) return model as Model<Api>;

--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -1,6 +1,6 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { qualifyModelId, resolveTemplate } from "../ai-service.js";
+import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../ai-service.js";
 import { readGlobalConfig } from "../config/setup.js";
 import { getSharedSkill, installSkill, mindSkillsDir } from "../skills.js";
 import {
@@ -105,7 +105,8 @@ export async function ensureSpiritProject(): Promise<void> {
 
     // Set spirit model in mind config if available
     if (spiritModel) {
-      const modelForConfig = template === "pi" ? qualifyModelId(spiritModel) : spiritModel;
+      const modelForConfig =
+        template === "pi" ? qualifyModelId(spiritModel) : unqualifyModelId(spiritModel);
       const configPath = resolve(dir, "home/.config/config.json");
       const mindConfig = existsSync(configPath)
         ? JSON.parse(readFileSync(configPath, "utf-8"))
@@ -236,7 +237,8 @@ export async function syncSpiritTemplate(): Promise<void> {
   const spiritModel = config.spiritModel;
   if (spiritModel) {
     // Pi template needs provider:model format, claude template needs just the model ID
-    const modelForConfig = template === "pi" ? qualifyModelId(spiritModel) : spiritModel;
+    const modelForConfig =
+      template === "pi" ? qualifyModelId(spiritModel) : unqualifyModelId(spiritModel);
     const mindConfigPath = resolve(dir, "home/.config/config.json");
     const mindConfig = existsSync(mindConfigPath)
       ? JSON.parse(readFileSync(mindConfigPath, "utf-8"))

--- a/packages/daemon/src/web/api/config.ts
+++ b/packages/daemon/src/web/api/config.ts
@@ -15,7 +15,7 @@ config.get("/models", async (c) => {
     id: m.id,
     name: m.name,
     provider: m.provider,
-    enabled: enabled.has(m.id),
+    enabled: enabled.has(`${m.provider}:${m.id}`),
   }));
   return c.json(models);
 });

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -343,17 +343,21 @@ const app = new Hono<AuthEnv>()
   .get("/ai/models", requireAdmin, async (c) => {
     const models = await getAvailableModels();
     const enabled = new Set(getEnabledModels());
-    const customIds = new Set(getCustomModels().map((m) => m.id));
+    const customIds = new Set(getCustomModels().map((m) => `${m.provider}:${m.id}`));
     return c.json(
-      models.map((m) => ({
-        id: m.id,
-        name: m.name,
-        provider: m.provider,
-        contextWindow: m.contextWindow,
-        maxTokens: m.maxTokens,
-        enabled: enabled.has(m.id),
-        custom: customIds.has(m.id),
-      })),
+      models.map((m) => {
+        const qualifiedId = `${m.provider}:${m.id}`;
+        return {
+          id: m.id,
+          qualifiedId,
+          name: m.name,
+          provider: m.provider,
+          contextWindow: m.contextWindow,
+          maxTokens: m.maxTokens,
+          enabled: enabled.has(qualifiedId),
+          custom: customIds.has(qualifiedId),
+        };
+      }),
     );
   })
   .put(
@@ -383,17 +387,9 @@ const app = new Hono<AuthEnv>()
           400,
         );
       }
-      // The enabled list and resolution are keyed by bare id, so a custom id must
-      // be unique across providers to stay unambiguous.
-      if (getCustomModels().some((m) => m.id === id && m.provider !== provider)) {
-        return c.json(
-          { error: `A custom model "${id}" is already registered under another provider` },
-          400,
-        );
-      }
       addCustomModel(provider, id, name);
-      // Enable it immediately (dedupe against already-enabled ids).
-      setEnabledModels([...new Set([...getEnabledModels(), id])]);
+      // Enable it immediately as a provider-qualified id (dedupe against enabled).
+      setEnabledModels([...new Set([...getEnabledModels(), `${provider}:${id}`])]);
       return c.json({ ok: true });
     },
   )

--- a/packages/web/src/ui/components/system/AiProviders.svelte
+++ b/packages/web/src/ui/components/system/AiProviders.svelte
@@ -185,7 +185,8 @@ async function handleProviderRemove(providerId: string) {
     // Clear utility model if it belonged to this provider
     const removedModels = aiModels.filter((m) => m.provider === providerId && m.enabled);
     for (const m of removedModels) {
-      if (utilityModel === m.id) utilityModel = "";
+      if (utilityModel === m.qualifiedId) utilityModel = "";
+      if (spiritModel === m.qualifiedId) spiritModel = "";
     }
     await load();
   } catch (err) {
@@ -286,11 +287,11 @@ function handleOAuthCodeInputChange() {
   }
 }
 
-async function addModel(modelId: string) {
-  const updated = [...enabledModels.map((m) => m.id), modelId];
+async function addModel(qualifiedId: string) {
+  const updated = [...enabledModels.map((m) => m.qualifiedId), qualifiedId];
   try {
     await saveEnabledModels(updated);
-    aiModels = aiModels.map((m) => (m.id === modelId ? { ...m, enabled: true } : m));
+    aiModels = aiModels.map((m) => (m.qualifiedId === qualifiedId ? { ...m, enabled: true } : m));
     modelSearch = "";
     showModelSearch = false;
   } catch (err) {
@@ -317,18 +318,22 @@ async function removeModel(model: AiModel) {
   if (model.custom) {
     try {
       await deleteCustomModel(model.provider, model.id);
-      aiModels = aiModels.filter((m) => m.id !== model.id);
-      if (utilityModel === model.id) utilityModel = "";
+      aiModels = aiModels.filter((m) => m.qualifiedId !== model.qualifiedId);
+      if (utilityModel === model.qualifiedId) utilityModel = "";
+      if (spiritModel === model.qualifiedId) spiritModel = "";
     } catch (err) {
       error = err instanceof Error ? err.message : "Failed to remove custom model";
     }
     return;
   }
-  const updated = enabledModels.map((m) => m.id).filter((id) => id !== model.id);
+  const updated = enabledModels.map((m) => m.qualifiedId).filter((id) => id !== model.qualifiedId);
   try {
     await saveEnabledModels(updated);
-    aiModels = aiModels.map((m) => (m.id === model.id ? { ...m, enabled: false } : m));
-    if (utilityModel === model.id) utilityModel = "";
+    aiModels = aiModels.map((m) =>
+      m.qualifiedId === model.qualifiedId ? { ...m, enabled: false } : m,
+    );
+    if (utilityModel === model.qualifiedId) utilityModel = "";
+    if (spiritModel === model.qualifiedId) spiritModel = "";
   } catch (err) {
     error = err instanceof Error ? err.message : "Failed to remove model";
   }
@@ -353,7 +358,7 @@ async function removeModel(model: AiModel) {
       <div class="provider-models">
         {#if providerModels.length > 0}
           <div class="model-tags">
-            {#each providerModels as model (model.id)}
+            {#each providerModels as model (model.qualifiedId)}
               <span class="model-tag">
                 {model.id}
                 <button class="model-tag-remove" onclick={() => removeModel(model)}>×</button>
@@ -380,7 +385,7 @@ async function removeModel(model: AiModel) {
     <div class="model-defaults">
       <span class="label">Spirit model</span>
       <ModelSelect
-        items={enabledModels.map((m) => ({ id: m.id, label: m.name }))}
+        items={enabledModels.map((m) => ({ id: m.qualifiedId, label: `${m.name} · ${m.provider}` }))}
         bind:value={spiritModel}
         placeholder="Search models..."
       />
@@ -388,7 +393,7 @@ async function removeModel(model: AiModel) {
 
       <span class="label mt">Utility model <span class="optional">(optional)</span></span>
       <ModelSelect
-        items={enabledModels.map((m) => ({ id: m.id, label: m.name }))}
+        items={enabledModels.map((m) => ({ id: m.qualifiedId, label: `${m.name} · ${m.provider}` }))}
         bind:value={utilityModel}
         placeholder="Search models..."
         emptyLabel="None"
@@ -511,8 +516,8 @@ async function removeModel(model: AiModel) {
       />
       {#if modelSuggestions.length > 0}
         <div class="model-list">
-          {#each modelSuggestions as model (model.id)}
-            <button class="model-option" onclick={() => addModel(model.id)}>
+          {#each modelSuggestions as model (model.qualifiedId)}
+            <button class="model-option" onclick={() => addModel(model.qualifiedId)}>
               {model.id}
             </button>
           {/each}

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -500,6 +500,8 @@ export type AiProvider = {
 
 export type AiModel = {
   id: string;
+  /** Provider-qualified id ("provider:model") — the canonical selection/enable key. */
+  qualifiedId: string;
   name: string;
   provider: string;
   contextWindow: number;

--- a/packages/web/src/ui/pages/SetupPage.svelte
+++ b/packages/web/src/ui/pages/SetupPage.svelte
@@ -93,7 +93,7 @@ let utilityModel = $state("");
 let enabledModelIds = $state<string[]>([]);
 
 function handleProviderLoad(enabledModels: AiModel[]) {
-  const newIds = enabledModels.map((m) => m.id);
+  const newIds = enabledModels.map((m) => m.qualifiedId);
   // Skip if nothing changed to avoid reactive loops
   if (
     newIds.length === enabledModelIds.length &&
@@ -107,7 +107,7 @@ function handleProviderLoad(enabledModels: AiModel[]) {
     spiritModel = "";
   }
   if (enabledModels.length > 0 && !spiritModel) {
-    spiritModel = enabledModels[0].id;
+    spiritModel = enabledModels[0].qualifiedId;
   }
 }
 

--- a/templates/codex/src/server.ts
+++ b/templates/codex/src/server.ts
@@ -15,13 +15,7 @@ import { createVoluteServer } from "./lib/volute-server.js";
 const { port } = parseArgs();
 const config = loadConfig();
 if (config.logLevel) setLevel(config.logLevel);
-// The Codex SDK wants a bare model slug, but config.model may carry a pi-style
-// "provider:model" prefix (e.g. "openai-codex:gpt-5.5") when the spirit's model
-// is provider-qualified. Strip the prefix so the SDK gets just the model.
-const model = config.model?.includes(":")
-  ? config.model.slice(config.model.indexOf(":") + 1)
-  : config.model;
-if (config.model) log("server", `using model: ${model}`);
+if (config.model) log("server", `using model: ${config.model}`);
 if (config.reasoningEffort) log("server", `reasoning effort: ${config.reasoningEffort}`);
 
 const systemPrompt = loadSystemPrompt();
@@ -34,7 +28,7 @@ const mind = createMind({
   systemPrompt,
   cwd,
   mindDir,
-  model,
+  model: config.model,
   reasoningEffort: config.reasoningEffort,
   maxContextTokens: config.compaction?.maxContextTokens,
 });

--- a/test/ai-service.test.ts
+++ b/test/ai-service.test.ts
@@ -4,17 +4,23 @@ import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import {
   addCustomModel,
   buildCustomModel,
+  findModel,
   getAiConfig,
   getAvailableModels,
   getCustomModels,
   getEnabledModels,
+  getUtilityModel,
+  migrateAiModelQualification,
   qualifyModelId,
   removeAiConfig,
   removeCustomModel,
   removeProviderConfig,
   saveProviderConfig,
   setEnabledModels,
+  setUtilityModel,
+  unqualifyModelId,
 } from "../packages/daemon/src/lib/ai-service.js";
+import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
 
 describe("ai-service config", () => {
   it("returns null when not configured", () => {
@@ -117,10 +123,10 @@ describe("custom models", () => {
     removeAiConfig();
     saveProviderConfig("anthropic", { apiKey: "sk-test" });
     addCustomModel("anthropic", "claude-future-4");
-    setEnabledModels(["claude-future-4"]);
+    setEnabledModels(["anthropic:claude-future-4"]);
     removeCustomModel("anthropic", "claude-future-4");
     assert.equal(getCustomModels().length, 0);
-    assert.equal(getEnabledModels().includes("claude-future-4"), false);
+    assert.equal(getEnabledModels().includes("anthropic:claude-future-4"), false);
   });
 
   it("built-in wins: getAvailableModels dedupes and prunes an absorbed custom id", async () => {
@@ -168,12 +174,114 @@ describe("custom models", () => {
     saveProviderConfig("anthropic", { apiKey: "sk-test" });
     addCustomModel("anthropic", "keep-me");
     addCustomModel("anthropic", "delete-me");
-    setEnabledModels(["keep-me", "delete-me"]);
+    setEnabledModels(["anthropic:keep-me", "anthropic:delete-me"]);
     removeCustomModel("anthropic", "delete-me");
     assert.deepEqual(
       getCustomModels().map((m) => m.id),
       ["keep-me"],
     );
-    assert.deepEqual(getEnabledModels(), ["keep-me"]);
+    assert.deepEqual(getEnabledModels(), ["anthropic:keep-me"]);
+  });
+});
+
+describe("findModel provider-qualified resolution", () => {
+  it("resolves a provider:model id within that provider only", () => {
+    removeAiConfig();
+    // gpt-5.5 is served by several providers; the prefix disambiguates.
+    const codex = findModel("openai-codex:gpt-5.5");
+    assert.ok(codex, "expected openai-codex:gpt-5.5 to resolve");
+    assert.equal(codex.provider, "openai-codex");
+
+    const copilot = findModel("github-copilot:gpt-5.5");
+    assert.ok(copilot, "expected github-copilot:gpt-5.5 to resolve");
+    assert.equal(copilot.provider, "github-copilot");
+  });
+
+  it("returns undefined when the provider does not serve the model", () => {
+    removeAiConfig();
+    assert.equal(findModel("anthropic:gpt-5.5"), undefined);
+  });
+
+  it("resolves a provider:model custom id within that provider", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-test" });
+    addCustomModel("anthropic", "claude-future-pq");
+    const found = findModel("anthropic:claude-future-pq");
+    assert.ok(found);
+    assert.equal(found.provider, "anthropic");
+    // Wrong provider prefix must not resolve the custom model.
+    assert.equal(findModel("openai:claude-future-pq"), undefined);
+  });
+
+  it("still resolves a bare built-in id (legacy fallback)", () => {
+    removeAiConfig();
+    const builtin = getBuiltinModels("anthropic")[0];
+    const found = findModel(builtin.id);
+    assert.ok(found);
+    assert.equal(found.id, builtin.id);
+  });
+});
+
+describe("migrateAiModelQualification", () => {
+  it("expands a bare enabled id to every configured provider serving it", () => {
+    removeAiConfig();
+    saveProviderConfig("openai-codex", { apiKey: "sk-codex" });
+    saveProviderConfig("github-copilot", { apiKey: "sk-copilot" });
+    setEnabledModels(["gpt-5.5"]);
+
+    migrateAiModelQualification();
+
+    assert.deepEqual(getEnabledModels(), ["openai-codex:gpt-5.5", "github-copilot:gpt-5.5"]);
+  });
+
+  it("qualifies bare spiritModel and utilityModel to the first configured provider", () => {
+    removeAiConfig();
+    saveProviderConfig("openai-codex", { apiKey: "sk-codex" });
+    saveProviderConfig("github-copilot", { apiKey: "sk-copilot" });
+    setUtilityModel("gpt-5.5");
+    const cfg = readGlobalConfig();
+    writeGlobalConfig({ ...cfg, spiritModel: "gpt-5.5" });
+
+    migrateAiModelQualification();
+
+    assert.equal(readGlobalConfig().spiritModel, "openai-codex:gpt-5.5");
+    assert.equal(getUtilityModel(), "openai-codex:gpt-5.5");
+  });
+
+  it("leaves already-qualified values untouched and is idempotent", () => {
+    removeAiConfig();
+    saveProviderConfig("openai-codex", { apiKey: "sk-codex" });
+    setEnabledModels(["openai-codex:gpt-5.5"]);
+    const cfg = readGlobalConfig();
+    writeGlobalConfig({ ...cfg, spiritModel: "openai-codex:gpt-5.5" });
+
+    migrateAiModelQualification();
+    assert.deepEqual(getEnabledModels(), ["openai-codex:gpt-5.5"]);
+
+    // Second run is a no-op.
+    migrateAiModelQualification();
+    assert.deepEqual(getEnabledModels(), ["openai-codex:gpt-5.5"]);
+    assert.equal(readGlobalConfig().spiritModel, "openai-codex:gpt-5.5");
+  });
+
+  it("drops a bare enabled id no configured provider serves", () => {
+    removeAiConfig();
+    saveProviderConfig("anthropic", { apiKey: "sk-ant" });
+    setEnabledModels(["gpt-5.5"]); // anthropic does not serve gpt-5.5
+
+    migrateAiModelQualification();
+
+    assert.deepEqual(getEnabledModels(), []);
+  });
+});
+
+describe("spirit config.model derivation from a qualified spiritModel", () => {
+  // syncSpiritTemplate writes `template === "pi" ? qualifyModelId(m) : unqualifyModelId(m)`.
+  // With a provider-qualified spiritModel, pi keeps the qualified form and codex/claude
+  // get a bare slug — this covers that branch without a full sync harness.
+  it("pi keeps the qualified id; codex/claude get the bare slug", () => {
+    const qualified = "openai-codex:gpt-5.5";
+    assert.equal(qualifyModelId(qualified), "openai-codex:gpt-5.5");
+    assert.equal(unqualifyModelId(qualified), "gpt-5.5");
   });
 });


### PR DESCRIPTION
## Problem

Model ids are stored, resolved, and selected as **bare** strings (`gpt-5.5`), but a bare id is ambiguous — `gpt-5.5` is served by `azure-openai-responses`, `openai-codex`, `github-copilot`, `openai`, etc. `findModel` picks the *first provider in catalog order* (`azure-openai-responses`), which:

- silently sent the system spirit to the unconfigured `azure` provider (→ pi template, **offline**), and
- crashes the settings UI with `each_key_duplicate` when two configured providers expose the same model id.

Provider is not cosmetic — it selects both the **template** (`openai-codex:gpt-5.5` → codex + ChatGPT; `github-copilot:gpt-5.5` → pi + Copilot) and the **billing account**. So model identity should be provider-qualified (`provider:model`) end to end.

## Changes

- **`ai-service.ts`**: `findModel` parses a `provider:` prefix and resolves within that provider only (bare fallback kept for legacy). The enabled list / `spiritModel` / `utilityModel` are qualified; `removeCustomModel` filters by qualified id. New `migrateAiModelQualification()` (run at daemon start, before the spirit) expands existing bare config to the explicitly-configured `provider:model` combos — idempotent.
- **`spirit.ts`**: write `config.model` via `unqualifyModelId` for codex/claude (bare slug) and `qualifyModelId` for pi, matching the non-spirit path in `minds.ts`.
- **`templates/codex/src/server.ts`**: **revert the #348 prefix-strip** — with the spirit change, `config.model` is always bare for codex, so the daemon is the single source of truth.
- **API (`system.ts`, `config.ts`)**: `/ai/models` exposes `qualifiedId` and computes `enabled`/`custom` against qualified sets; the cross-provider custom-id restriction is dropped (qualified ids disambiguate).
- **UI (`AiProviders.svelte`, `SetupPage.svelte`, `client.ts`)**: pickers and enable/disable key on qualified id — **fixes `each_key_duplicate`** — with options labeled `model · provider`. (`Settings.svelte` needed no change.)

## Migration

`ai.models` bare ids expand to one `provider:model` per explicitly-configured provider that serves them; bare `spiritModel`/`utilityModel` qualify to their first configured provider; already-qualified values are untouched. Bare ids no configured provider serves are dropped.

## Tests

`test/ai-service.test.ts` gains: qualified `findModel` resolution (openai-codex vs github-copilot vs a wrong provider), the migration (expand / qualify defaults / idempotent / drop-unserved), the custom-id enabled-list qualification, and the spirit `config.model` derivation. Updated the existing `removeCustomModel` tests to qualified ids.

Verified: `test/ai-service.test.ts`, `setup`, `template-compose`, `web-setup`, `system-chat`, `summarizer`, `web-minds`, `authz-coverage`, `global-config`, `imagegen` all pass; daemon `tsc`, template typecheck, and `svelte-check` are clean. (The full `npm test` run hangs in the 100+ file parallel pool on `--test-timeout=0` unrelated to this change — `sandbox.test.ts` passes in isolation.)

## Follow-ups (out of scope)

- Per-mind model picker (`minds.ts` already qualify/unqualifies) could get the same treatment.
- `imagegen` model namespace is separate (already `provider:owner/model`) and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)