### PR TITLE
fix: restore recordNotice import and drop dead classify import in minds.ts

### DIFF
--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -16,14 +16,13 @@ import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../../lib/ai-
 import { deleteMindUser } from "../../lib/auth.js";
 import { announceToSystem } from "../../lib/chat/system-channel.js";
 import { readSystemsConfig } from "../../lib/config/systems-config.js";
-import { classify } from "../../lib/daemon/error-classify.js";
 import { getMindManager, MindStartupError } from "../../lib/daemon/mind-manager.js";
 // Lifecycle functions from mind-service.ts
 import {
   startMindFull as startMindFullService,
   stopMindFull as stopMindFullService,
 } from "../../lib/daemon/mind-service.js";
-import { drainNotices, formatNotices } from "../../lib/daemon/notices.js";
+import { drainNotices, formatNotices, recordNotice } from "../../lib/daemon/notices.js";
 import { getTokenBudget } from "../../lib/daemon/token-budget.js";
 import { handleMindEvent, setNoticeDrainWatermark } from "../../lib/daemon/turn-lifecycle.js";
 import { getActiveTurnId } from "../../lib/daemon/turn-tracker.js";


### PR DESCRIPTION
## Problem

`main` fails `tsc --noEmit` after #352 and #353 merged:

```
packages/daemon/src/web/api/minds.ts(1464,15): error TS2304: Cannot find name 'recordNotice'.
```

Two **semantic merge conflicts** that git could not detect, both from #352 and #353 editing `minds.ts` imports independently:

1. **#352** added a `recordNotice(...)` call in the last-known-good restart route. **#353** (branched before #352) removed the then-unused `recordNotice` import when it extracted the `/events` handler into `turn-lifecycle.ts`. Squash-merged independently → the call lost its import.
2. Symmetrically, the `classify` import became **dead** in `minds.ts` — its only usage moved into `turn-lifecycle.ts` with the extracted handler — but #352's side kept the import line.

`npm test` (the pre-push gate) doesn't run `tsc`, so neither was caught until a full typecheck on merged `main`.

## Fix

- Add `recordNotice` to the existing `notices.js` import.
- Remove the now-unused `classify` import (still correctly used in `turn-lifecycle.ts`).

`tsc --noEmit` clean, lint clean, full unit suite green (1705/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)