### PR TITLE
fix: chown parent pages dir to mind user under isolation

### DIFF
--- a/packages/extensions/pages/src/shared-pages.ts
+++ b/packages/extensions/pages/src/shared-pages.ts
@@ -85,6 +85,20 @@ function worktreePath(mindDir: string): string {
   return resolve(mindDir, "home", "pages", "_system");
 }
 
+/**
+ * Paths that must be owned by the mind user when isolation is enabled.
+ * The daemon runs as root, so the parent home/pages directory it provisions is
+ * created root-owned — chowning only the _system worktree would leave the mind
+ * unable to write its own pages. The parent dir is chowned recursively (covering
+ * the _system worktree too); the worktree git dir lives outside pages/ and is
+ * chowned separately.
+ */
+export function pagesIsolationChownPaths(mindDir: string, wtGitDir: string | null): string[] {
+  const paths = [resolve(mindDir, "home", "pages")];
+  if (wtGitDir) paths.push(wtGitDir);
+  return paths;
+}
+
 /** Idempotently initialize the collaborative pages git repo. */
 export async function ensurePagesRepo(dataDir: string, isolation?: IsolationInfo): Promise<void> {
   const dir = pagesRepoDir(dataDir);
@@ -156,17 +170,12 @@ export async function addPagesWorktree(
 
   if (isolation?.isIsolationEnabled()) {
     const user = isolation.getMindUser(mindName);
-    try {
-      await execAsync("chown", ["-R", `${user}:volute`, wt]);
-    } catch {
-      console.warn(`[pages] failed to chown worktree for ${mindName}`);
-    }
     const wtGitDir = readWorktreeGitDir(wt);
-    if (wtGitDir) {
+    for (const target of pagesIsolationChownPaths(mindDir, wtGitDir)) {
       try {
-        await execAsync("chown", ["-R", `${user}:volute`, wtGitDir]);
+        await execAsync("chown", ["-R", `${user}:volute`, target]);
       } catch {
-        console.warn(`[pages] failed to chown worktree git dir for ${mindName}`);
+        console.warn(`[pages] failed to chown ${target} for ${mindName}`);
       }
     }
   }

--- a/test/pages-commands.test.ts
+++ b/test/pages-commands.test.ts
@@ -193,6 +193,7 @@ describe("pages db", () => {
 // ---------------------------------------------------------------------------
 
 import { createCommands } from "../packages/extensions/pages/src/commands.js";
+import { pagesIsolationChownPaths } from "../packages/extensions/pages/src/shared-pages.js";
 
 describe("pages commands", () => {
   let mindDir: string;
@@ -814,5 +815,28 @@ describe("system API routes", () => {
       });
       assert.equal(res.status, 400);
     });
+  });
+});
+
+describe("pages isolation chown targets", () => {
+  it("includes the parent home/pages directory so the mind can write to it", () => {
+    const mindDir = "/minds/pip";
+    const targets = pagesIsolationChownPaths(mindDir, null);
+    assert.ok(
+      targets.includes(resolve(mindDir, "home", "pages")),
+      "parent pages dir must be chowned to the mind user",
+    );
+  });
+
+  it("includes the worktree git dir when present", () => {
+    const mindDir = "/minds/pip";
+    const wtGitDir = "/data/repo/.git/worktrees/pip";
+    const targets = pagesIsolationChownPaths(mindDir, wtGitDir);
+    assert.ok(targets.includes(wtGitDir), "worktree git dir must be chowned");
+  });
+
+  it("omits the git dir when it cannot be resolved", () => {
+    const targets = pagesIsolationChownPaths("/minds/pip", null);
+    assert.equal(targets.length, 1);
   });
 });


### PR DESCRIPTION
## Problem

A new mind on a `user`-isolation deployment found that `home/pages/` is owned `root:root` while it runs as `mind-<name>`, so its very first `touch pages/test-write` fails with *Permission denied*. The pages skill invites newcomers to create files in a directory they can't write to.

## Root cause

`addPagesWorktree()` (`packages/extensions/pages/src/shared-pages.ts`) runs in the daemon, which is **root** under `user` isolation. It `mkdirSync`s the parent `home/pages/` directory (created `root:root`) and sets up the `_system` git worktree, but the isolation chown block only re-owned the `_system` worktree and its git dir — **never the parent `pages/` directory itself**. So the mind can't write into `pages/`.

## Fix

Chown the parent `home/pages` directory recursively to the mind user (this also covers the `_system` worktree), keeping the separate chown for the worktree git dir that lives outside `pages/`. The chown-target computation is extracted into a small pure, exported `pagesIsolationChownPaths()` helper so it's unit-testable.

## Testing

- Added 3 tests (`pages isolation chown targets`) written TDD-first (red → green).
- Full suite passes: **1708 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)