### PR TITLE
fix: recover in-flight messages dropped by compaction abort

### DIFF
--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -292,6 +292,9 @@ export function createMind(options: {
         },
         broadcast: (event: VoluteEvent) => broadcastToSession(session, event),
         onTurnEnd: async () => {
+          // This turn's message is fully processed — drop it from the channel's
+          // in-flight set so a later compaction abort won't re-feed it.
+          session.channel.ack();
           await autoCommit.flushFileChanges();
           const wasCompacting = compactionTriggered.get(session.name);
           compactionTriggered.set(session.name, false);
@@ -422,7 +425,11 @@ export function createMind(options: {
                 break;
               }
               streamAbort = new AbortController();
-              const pending = session.channel.drain();
+              // Recover input the aborted stream had already pulled but not
+              // finished (the compaction wrap-up plus any messages that arrived
+              // mid-turn) alongside anything queued during /compact, so nothing
+              // is dropped when the killed subprocess takes its buffer with it.
+              const pending = session.channel.recover();
               session.channel = createMessageChannel();
               for (const msg of pending) session.channel.push(msg);
               continue; // restart the stream loop

--- a/templates/claude/src/lib/message-channel.ts
+++ b/templates/claude/src/lib/message-channel.ts
@@ -2,40 +2,62 @@ import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 
 export type MessageChannel = {
   push: (msg: SDKUserMessage) => void;
-  drain: () => SDKUserMessage[];
+  /** Acknowledge that the oldest in-flight message's turn has completed. */
+  ack: () => void;
+  /**
+   * Return every message that has not been fully processed — those delivered to
+   * the consumer but not yet acked (their turn never finished) followed by those
+   * still queued — and reset the channel. Used to re-feed the stream after a
+   * compaction abort so in-flight input is never lost.
+   */
+  recover: () => SDKUserMessage[];
   iterable: AsyncIterable<SDKUserMessage>;
 };
 
 export function createMessageChannel(): MessageChannel {
   const queue: SDKUserMessage[] = [];
+  // Messages handed to the consumer (the SDK's read-ahead) whose turn has not yet
+  // completed. The SDK's streamInput loop pulls messages eagerly and writes them
+  // to the CLI subprocess, so once delivered they no longer live in `queue`. We
+  // retain them here so a compaction abort — which kills that subprocess — can
+  // re-feed the unprocessed ones instead of dropping them.
+  const inFlight: SDKUserMessage[] = [];
   let resolve: ((value: IteratorResult<SDKUserMessage>) => void) | null = null;
+
+  function deliver(msg: SDKUserMessage): IteratorResult<SDKUserMessage> {
+    inFlight.push(msg);
+    return { value: msg, done: false };
+  }
 
   return {
     push(msg: SDKUserMessage) {
       if (resolve) {
         const r = resolve;
         resolve = null;
-        r({ value: msg, done: false });
+        r(deliver(msg));
       } else {
         queue.push(msg);
       }
     },
-    drain() {
+    ack() {
+      inFlight.shift();
+    },
+    recover() {
       // Resolve any pending iterator wait with done:true so it doesn't
-      // leak as an orphaned promise (the old iterator is discarded after drain)
+      // leak as an orphaned promise (the old iterator is discarded after recover)
       if (resolve) {
         const r = resolve;
         resolve = null;
         r({ value: undefined as any, done: true });
       }
-      return queue.splice(0);
+      return [...inFlight.splice(0), ...queue.splice(0)];
     },
     iterable: {
       [Symbol.asyncIterator]() {
         return {
           next(): Promise<IteratorResult<SDKUserMessage>> {
             if (queue.length > 0) {
-              return Promise.resolve({ value: queue.shift()!, done: false });
+              return Promise.resolve(deliver(queue.shift()!));
             }
             return new Promise((r) => {
               resolve = r;

--- a/test/message-channel.test.ts
+++ b/test/message-channel.test.ts
@@ -11,6 +11,10 @@ function msg(text: string) {
   };
 }
 
+function text(m: { message: { content: unknown[] } }): string {
+  return (m.message.content[0] as { text: string }).text;
+}
+
 describe("createMessageChannel", () => {
   it("push then iterate yields messages in order", async () => {
     const ch = createMessageChannel();
@@ -41,18 +45,15 @@ describe("createMessageChannel", () => {
     assert.equal((result.value.message.content[0] as any).text, "delayed");
   });
 
-  describe("drain()", () => {
+  describe("recover()", () => {
     it("returns all queued messages and empties the queue", async () => {
       const ch = createMessageChannel();
       ch.push(msg("x"));
       ch.push(msg("y"));
       ch.push(msg("z"));
 
-      const drained = ch.drain();
-      assert.equal(drained.length, 3);
-      assert.equal((drained[0].message.content[0] as any).text, "x");
-      assert.equal((drained[1].message.content[0] as any).text, "y");
-      assert.equal((drained[2].message.content[0] as any).text, "z");
+      const recovered = ch.recover();
+      assert.deepEqual(recovered.map(text), ["x", "y", "z"]);
 
       // Queue should now be empty — next push goes to a fresh queue
       ch.push(msg("after"));
@@ -61,63 +62,113 @@ describe("createMessageChannel", () => {
       assert.equal((r.value.message.content[0] as any).text, "after");
     });
 
-    it("returns empty array when queue is empty", () => {
+    it("returns empty array when nothing is queued or in flight", () => {
       const ch = createMessageChannel();
-      const drained = ch.drain();
-      assert.deepEqual(drained, []);
+      assert.deepEqual(ch.recover(), []);
     });
 
-    it("messages pushed after drain are not affected", async () => {
+    it("messages pushed after recover are not affected", async () => {
       const ch = createMessageChannel();
       ch.push(msg("before"));
-      ch.drain();
+      ch.recover();
 
       ch.push(msg("after1"));
       ch.push(msg("after2"));
-      const drained2 = ch.drain();
-      assert.equal(drained2.length, 2);
-      assert.equal((drained2[0].message.content[0] as any).text, "after1");
-      assert.equal((drained2[1].message.content[0] as any).text, "after2");
+      const recovered2 = ch.recover();
+      assert.deepEqual(recovered2.map(text), ["after1", "after2"]);
     });
 
-    it("clears pending resolve so iterator does not steal drained messages", async () => {
+    it("recovers a message consumed via the read-ahead fast-path (not lost)", async () => {
       const ch = createMessageChannel();
       const iter = ch.iterable[Symbol.asyncIterator]();
 
-      // Start a consumer waiting for a message (sets resolve)
+      // A waiting consumer (the SDK's streamInput read-ahead) is handed the
+      // message immediately — it never sits in the queue.
       const pending = iter.next();
-
-      // Push a message — this goes to the pending resolve, not the queue
       ch.push(msg("consumed"));
       const consumed = await pending;
       assert.equal((consumed.value.message.content[0] as any).text, "consumed");
 
-      // Now push more and drain
-      ch.push(msg("queued1"));
-      ch.push(msg("queued2"));
-      const drained = ch.drain();
-      assert.equal(drained.length, 2);
+      // Its turn never completed (no ack), so recovery must return it.
+      const recovered = ch.recover();
+      assert.deepEqual(recovered.map(text), ["consumed"]);
     });
 
-    it("drain while iterator is waiting terminates the pending iterator", async () => {
+    it("returns delivered-unacked messages before still-queued ones, in order", async () => {
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+
+      // m1 delivered to a waiting consumer (out of the queue)
+      const p1 = iter.next();
+      ch.push(msg("m1"));
+      await p1;
+
+      // m2, m3 pushed with no waiting consumer — they sit in the queue
+      ch.push(msg("m2"));
+      ch.push(msg("m3"));
+
+      assert.deepEqual(ch.recover().map(text), ["m1", "m2", "m3"]);
+    });
+
+    it("recover while iterator is waiting terminates the pending iterator", async () => {
       const ch = createMessageChannel();
       const iter = ch.iterable[Symbol.asyncIterator]();
 
       // Start waiting (sets resolve)
       const waiting = iter.next();
 
-      // Drain should resolve the pending iterator with done:true
-      const drained = ch.drain();
-      assert.deepEqual(drained, []);
+      // Recover should resolve the pending iterator with done:true
+      const recovered = ch.recover();
+      assert.deepEqual(recovered, []);
 
       const result = await waiting;
-      assert.equal(result.done, true, "drain should terminate pending iterator");
+      assert.equal(result.done, true, "recover should terminate pending iterator");
 
-      // Push to new channel — goes to the queue (not the old resolve)
+      // Push to the same channel — goes to the queue (not the old resolve)
       ch.push(msg("new"));
-      const newDrained = ch.drain();
-      assert.equal(newDrained.length, 1);
-      assert.equal((newDrained[0].message.content[0] as any).text, "new");
+      assert.deepEqual(ch.recover().map(text), ["new"]);
+    });
+  });
+
+  describe("ack()", () => {
+    it("excludes an acknowledged message from recovery", async () => {
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+
+      const pending = iter.next();
+      ch.push(msg("done"));
+      await pending;
+
+      // The turn completed — acknowledge it.
+      ch.ack();
+      assert.deepEqual(ch.recover(), []);
+    });
+
+    it("acks the oldest delivered message (FIFO), recovering the rest", async () => {
+      // Mirrors the compaction race: m1 is mid-turn when m2 and m3 are
+      // read-ahead-delivered; m1's turn completes, then compaction recovers.
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+
+      const p1 = iter.next();
+      ch.push(msg("m1"));
+      await p1;
+      const p2 = iter.next();
+      ch.push(msg("m2"));
+      await p2;
+      const p3 = iter.next();
+      ch.push(msg("m3"));
+      await p3;
+
+      ch.ack(); // m1's turn finished
+
+      assert.deepEqual(ch.recover().map(text), ["m2", "m3"]);
+    });
+
+    it("is a no-op when nothing is in flight", () => {
+      const ch = createMessageChannel();
+      assert.doesNotThrow(() => ch.ack());
+      assert.deepEqual(ch.recover(), []);
     });
   });
 });


### PR DESCRIPTION
## Problem

When a mind's context crossed the token limit, the stream was aborted to run `/compact`, then resumed by draining and re-feeding the message channel. But the SDK's `streamInput` loop reads the channel **eagerly** — it writes each message straight to the CLI subprocess the instant it's pushed, independent of turn boundaries. So any message that arrived during the aborted turn (the compaction wrap-up, plus user messages that landed mid-turn) had already left the channel's internal queue. `drain()` only saw the queue, so those messages were **silently lost** when the aborted subprocess was killed.

With nothing left to process, the resumed stream emitted `session_start` and sat idle — the mind never replied, leaving a turn wedged `active` until the daemon's sweep reaped it ~15 min later. Observed in production on a mind that was handed a URL, then sent a follow-up mid-turn while compaction was pending: both messages vanished and the mind went silent.

## Fix

The channel now retains delivered-but-unacknowledged messages:

- **`ack()`** drops the oldest in-flight message when a turn completes — wired into `onTurnEnd`, which only fires at a `result` boundary.
- **`recover()`** replaces `drain()` in the compaction-resume path, returning in-flight (delivered-but-unacked) messages **plus** anything still queued.

Because the compaction abort is only ever issued from `onTurnEnd` (always at a turn boundary), `recover()` yields exactly the not-yet-processed input to re-feed. The completed turn is acked away first; the wrap-up message and any mid-turn arrivals survive. `inFlight` stays in lockstep with the existing `messageIds` queue.

## Tests

TDD: added channel-contract tests first (including one reproducing the exact read-ahead loss and the FIFO ack race), watched them fail, then implemented. Full suite green (1709 pass), all three templates typecheck, lint clean.

## Review findings (high-effort multi-agent review) — known limitations, not regressions

- **[confirmed] Compaction-*failure* branch still drops input** (`agent.ts` `catch (compactErr)`): the "custom compaction failed, starting fresh" path replaces the channel without `recover()`. This is entangled with a pre-existing behavior — that branch `break`s and the stream consumer terminates — so a correct fix (recover + `break`→`continue`, guarded against a pathological retry loop) belongs in its own change with test coverage for the SDK-failure path. Not a regression: identical in the current release.
- **[plausible] Duplicate side-effects on re-feed:** if a read-ahead message's turn was fully processed by the CLI (side-effecting tools ran) but its `result` was lost to the abort race, `recover()` re-feeds it and those tool side-effects re-run. The channel *reply* itself does not double (an unread result means `consumeStream` never emitted it). This is the accepted tradeoff vs. the confirmed silent-drop.
- **[plausible] `messageIds` not restored in lockstep with `recover()`:** in a narrow abort-timing race a re-fed message can lose its reply correlation (mis-routed reply). The re-push-without-`messageIds` surface is pre-existing (old `drain()` did the same for queued messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)