### PR TITLE
fix: optimize web image serving (avatar resize, caching, lightbox)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -135,6 +135,14 @@ export async function startDaemon(opts: {
     log.warn("failed to migrate system user role", log.errorData(err));
   }
 
+  // Downscale oversized avatars uploaded before resize-on-upload existed (non-fatal)
+  try {
+    const { migrateAvatarSizes } = await import("./lib/util/avatar-image.js");
+    await migrateAvatarSizes();
+  } catch (err) {
+    log.warn("avatar size migration failed", log.errorData(err));
+  }
+
   // Initialize sandbox runtime for mind process isolation
   const { initSandbox } = await import("./lib/mind/sandbox.js");
   await initSandbox();

--- a/packages/daemon/src/lib/util/avatar-image.ts
+++ b/packages/daemon/src/lib/util/avatar-image.ts
@@ -1,0 +1,107 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { mindDir, readAllMinds, voluteHome } from "../mind/registry.js";
+import { readVoluteConfig } from "../mind/volute-config.js";
+import log from "./logger.js";
+import { safeResolveWithinBase } from "./paths.js";
+
+const alog = log.child("avatar-image");
+
+/** Max avatar dimension — covers the largest display size (96px) at retina density. */
+export const AVATAR_DIM = 256;
+
+async function loadSharp(): Promise<any | null> {
+  try {
+    const mod = await import("sharp");
+    return mod.default ?? mod;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
+      alog.debug("sharp not available, keeping original avatars");
+    } else {
+      alog.warn("sharp import failed, keeping original avatars", log.errorData(err));
+    }
+    return null;
+  }
+}
+
+/**
+ * Downscale an uploaded avatar to AVATAR_DIM and re-encode as webp.
+ * Returns null when sharp is unavailable or processing fails — the caller
+ * should fall back to storing the original bytes.
+ */
+export async function normalizeAvatar(
+  buffer: Buffer,
+): Promise<{ buffer: Buffer; ext: ".webp"; mime: "image/webp" } | null> {
+  const sharp = await loadSharp();
+  if (!sharp) return null;
+  try {
+    const out = await sharp(buffer, { animated: true })
+      .resize(AVATAR_DIM, AVATAR_DIM, { fit: "cover", withoutEnlargement: true })
+      .webp({ quality: 85 })
+      .toBuffer();
+    return { buffer: out, ext: ".webp", mime: "image/webp" };
+  } catch (err) {
+    alog.warn("avatar normalize failed, keeping original", log.errorData(err));
+    return null;
+  }
+}
+
+/** Re-encode a single avatar file in place (same format) if it exceeds AVATAR_DIM. */
+async function downscaleFile(sharp: any, filePath: string): Promise<boolean> {
+  const data = await readFile(filePath);
+  const image = sharp(data, { animated: true });
+  const meta = await image.metadata();
+  if (!meta.format || ((meta.width ?? 0) <= AVATAR_DIM && (meta.height ?? 0) <= AVATAR_DIM)) {
+    return false;
+  }
+  const out = await image
+    .resize(AVATAR_DIM, AVATAR_DIM, { fit: "cover" })
+    .toFormat(meta.format)
+    .toBuffer();
+  await writeFile(filePath, out);
+  return true;
+}
+
+/**
+ * One-time daemon-startup migration: downscale oversized avatars uploaded
+ * before resize-on-upload existed. Re-encodes in place, preserving format and
+ * filename so no DB or volute.json references change. Idempotent.
+ */
+export async function migrateAvatarSizes(): Promise<void> {
+  const sharp = await loadSharp();
+  if (!sharp) return;
+
+  const userAvatarsDir = resolve(voluteHome(), "avatars");
+  let userAvatars: string[] = [];
+  try {
+    userAvatars = (await readdir(userAvatarsDir)).map((f) => resolve(userAvatarsDir, f));
+  } catch {
+    // no avatars dir yet
+  }
+
+  const mindAvatars: string[] = [];
+  try {
+    for (const mind of await readAllMinds()) {
+      const dir = mind.dir ?? mindDir(mind.name);
+      const avatar = readVoluteConfig(dir)?.profile?.avatar;
+      if (!avatar) continue;
+      const path = safeResolveWithinBase(resolve(dir, "home"), avatar);
+      if (path) mindAvatars.push(path);
+    }
+  } catch (err) {
+    alog.warn("failed to enumerate mind avatars for migration", log.errorData(err));
+  }
+
+  for (const filePath of [...userAvatars, ...mindAvatars]) {
+    try {
+      if (await downscaleFile(sharp, filePath)) {
+        alog.info(`downscaled oversized avatar ${filePath}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        alog.warn(`failed to downscale avatar ${filePath}`, log.errorData(err));
+      }
+    }
+  }
+}

--- a/packages/daemon/src/lib/util/http-cache.ts
+++ b/packages/daemon/src/lib/util/http-cache.ts
@@ -1,0 +1,14 @@
+import type { Stats } from "node:fs";
+import type { Context } from "hono";
+
+/** Weak ETag derived from file mtime + size. */
+export function fileEtag(stat: Stats): string {
+  return `W/"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+}
+
+/** True when the request's If-None-Match matches the given ETag. */
+export function isNotModified(c: Context, etag: string): boolean {
+  const inm = c.req.header("if-none-match");
+  if (!inm) return false;
+  return inm.split(",").some((t) => t.trim() === etag);
+}

--- a/packages/daemon/src/web/api/auth.ts
+++ b/packages/daemon/src/web/api/auth.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { extname, resolve } from "node:path";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -23,6 +23,8 @@ import {
 import { joinSystemChannel } from "../../lib/chat/system-channel.js";
 import { broadcast } from "../../lib/events/activity-events.js";
 import { readRegistry, voluteHome } from "../../lib/mind/registry.js";
+import { normalizeAvatar } from "../../lib/util/avatar-image.js";
+import { fileEtag, isNotModified } from "../../lib/util/http-cache.js";
 
 /** Only join system channel when running inside the daemon (not in tests). */
 function tryJoinSystem(userId: number): void {
@@ -114,11 +116,19 @@ const authenticated = new Hono<AuthEnv>()
       return c.json({ error: "Invalid file type (png, jpg, gif, webp only)" }, 400);
     }
 
+    // Downscale + re-encode as webp; fall back to original bytes if sharp is unavailable
+    let buffer: Buffer = Buffer.from(await file.arrayBuffer());
+    let finalExt = ext;
+    const normalized = await normalizeAvatar(buffer);
+    if (normalized) {
+      buffer = normalized.buffer;
+      finalExt = normalized.ext;
+    }
+
     const dir = avatarsDir();
     mkdirSync(dir, { recursive: true });
 
-    const filename = `avatar-${user.id}${ext}`;
-    const buffer = Buffer.from(await file.arrayBuffer());
+    const filename = `avatar-${user.id}${finalExt}`;
     writeFileSync(resolve(dir, filename), buffer);
 
     // Delete old avatar after writing new one (safe if same filename)
@@ -341,12 +351,17 @@ const app = new Hono()
     const mime = AVATAR_MIME[ext];
     if (!mime) return c.json({ error: "Invalid file type" }, 400);
 
-    const data = readFileSync(filePath);
-    return c.body(data, 200, {
+    const fileStat = statSync(filePath);
+    const etag = fileEtag(fileStat);
+    const headers = {
       "Content-Type": mime,
       "Cache-Control": "public, max-age=3600",
       "X-Content-Type-Options": "nosniff",
-    });
+      ETag: etag,
+    };
+    if (isNotModified(c, etag)) return c.body(null, 304, headers);
+    const data = readFileSync(filePath);
+    return c.body(data, 200, headers);
   })
   .route("/", admin)
   .route("/", authenticated);

--- a/packages/daemon/src/web/api/files.ts
+++ b/packages/daemon/src/web/api/files.ts
@@ -7,6 +7,8 @@ import { syncMindProfile } from "../../lib/auth.js";
 import { broadcast } from "../../lib/events/activity-events.js";
 import { findMind, mindDir } from "../../lib/mind/registry.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
+import { normalizeAvatar } from "../../lib/util/avatar-image.js";
+import { fileEtag, isNotModified } from "../../lib/util/http-cache.js";
 import { safeResolveWithinBase } from "../../lib/util/paths.js";
 import { type AuthEnv, requireAdmin, requireSelf } from "../middleware/auth.js";
 
@@ -59,9 +61,18 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Invalid file type (png, jpg, gif, webp only)" }, 400);
     }
 
+    // Downscale + re-encode as webp; fall back to original bytes if sharp is unavailable
+    let buffer: Buffer = Buffer.from(await file.arrayBuffer());
+    let finalExt = ext;
+    const normalized = await normalizeAvatar(buffer);
+    if (normalized) {
+      buffer = normalized.buffer;
+      finalExt = normalized.ext;
+    }
+
     const dir = entry.dir ?? mindDir(name);
     const homeDir = resolve(dir, "home");
-    const filename = `avatar${ext}`;
+    const filename = `avatar${finalExt}`;
     const avatarPath = resolve(homeDir, filename);
 
     // Delete old avatar if different extension. The stored avatar value is
@@ -74,7 +85,6 @@ const app = new Hono<AuthEnv>()
       if (oldAvatarPath) rmSync(oldAvatarPath, { force: true });
     }
 
-    const buffer = Buffer.from(await file.arrayBuffer());
     mkdirSync(homeDir, { recursive: true });
     writeFileSync(avatarPath, buffer);
 
@@ -124,11 +134,15 @@ const app = new Hono<AuthEnv>()
     try {
       const fileStat = await stat(realAvatarPath);
       if (fileStat.size > MAX_AVATAR_SIZE) return c.json({ error: "Avatar file too large" }, 400);
-      const body = await readFile(realAvatarPath);
-      return c.body(body, 200, {
+      const etag = fileEtag(fileStat);
+      const headers = {
         "Content-Type": mime,
         "Cache-Control": "public, max-age=300",
-      });
+        ETag: etag,
+      };
+      if (isNotModified(c, etag)) return c.body(null, 304, headers);
+      const body = await readFile(realAvatarPath);
+      return c.body(body, 200, headers);
     } catch {
       return c.json({ error: "Failed to read avatar file" }, 500);
     }
@@ -203,9 +217,12 @@ const app = new Hono<AuthEnv>()
 
     if (fileStat.size > MAX_FILE_SIZE) return c.text("File too large", 413);
 
-    const body = await readFile(resolvedPath);
     const mime = MIME_TYPES[extname(resolvedPath).toLowerCase()] || "application/octet-stream";
-    return c.body(body, 200, { "Content-Type": mime });
+    const etag = fileEtag(fileStat);
+    const headers = { "Content-Type": mime, "Cache-Control": "no-cache", ETag: etag };
+    if (isNotModified(c, etag)) return c.body(null, 304, headers);
+    const body = await readFile(resolvedPath);
+    return c.body(body, 200, headers);
   });
 
 export default app;

--- a/packages/extensions/notes/ui/src/components/CommentSection.svelte
+++ b/packages/extensions/notes/ui/src/components/CommentSection.svelte
@@ -76,7 +76,7 @@ function initial(name: string): string {
   <div class="compose">
     <div class="compose-avatar">
       {#if userAvatarUrl}
-        <img src={userAvatarUrl} alt="" class="avatar-img" />
+        <img src={userAvatarUrl} alt="" class="avatar-img" loading="lazy" decoding="async" />
       {:else}
         <div class="avatar-fallback">{initial(currentUsername)}</div>
       {/if}

--- a/packages/ui/src/base.css
+++ b/packages/ui/src/base.css
@@ -167,6 +167,11 @@ a:focus-visible {
   border-top: 1px solid var(--border);
   margin: 12px 0;
 }
+.markdown-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+}
 
 /* Tooltip (portaled to body by use:tooltip action) */
 .volute-tooltip {

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -766,7 +766,7 @@ function handleGlobalClick(e: MouseEvent) {
               <div class="user-menu-anchor">
                 <button class="user-avatar-btn" onclick={() => { showUserMenu = !showUserMenu; }} title={auth.user?.username}>
                   {#if userAvatar}
-                    <img src={userAvatar} alt="" class="user-avatar-img" />
+                    <img src={userAvatar} alt="" class="user-avatar-img" loading="lazy" decoding="async" />
                   {:else}
                     <Icon kind="brain" />
                   {/if}

--- a/packages/web/src/ui/components/ProfileHoverCard.svelte
+++ b/packages/web/src/ui/components/ProfileHoverCard.svelte
@@ -100,6 +100,8 @@ function handleMouseLeave() {
         src={profile.avatarUrl}
         alt=""
         class="avatar"
+        loading="lazy"
+        decoding="async"
       />
     {/if}
     <div class="info">

--- a/packages/web/src/ui/components/chat/ImageLightbox.svelte
+++ b/packages/web/src/ui/components/chat/ImageLightbox.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+let {
+  src,
+  onClose,
+}: {
+  src: string;
+  onClose: () => void;
+} = $props();
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape" && !e.defaultPrevented) {
+    e.preventDefault();
+    onClose();
+  }
+}
+
+function portal(node: HTMLElement) {
+  document.body.appendChild(node);
+  return {
+    destroy() {
+      node.remove();
+    },
+  };
+}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+  use:portal
+  class="lightbox-overlay"
+  role="button"
+  tabindex="-1"
+  onclick={onClose}
+  onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") onClose(); }}
+>
+  <img {src} alt="" class="lightbox-image" />
+</div>
+
+<style>
+  .lightbox-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    z-index: var(--z-modal);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.15s ease;
+  }
+
+  .lightbox-image {
+    max-width: 92vw;
+    max-height: 92vh;
+    object-fit: contain;
+    border-radius: var(--radius);
+  }
+</style>

--- a/packages/web/src/ui/components/chat/MessageEntry.svelte
+++ b/packages/web/src/ui/components/chat/MessageEntry.svelte
@@ -3,6 +3,7 @@ import type { ContentBlock, Mind, Participant } from "@volute/api";
 import { renderMarkdown } from "@volute/ui/markdown";
 import { normalizeTimestamp } from "../../lib/format";
 import ProfileHoverCard, { type HoverProfile } from "../ProfileHoverCard.svelte";
+import ImageLightbox from "./ImageLightbox.svelte";
 import ToolBlock from "./ToolBlock.svelte";
 
 type ToolInfo = {
@@ -41,6 +42,8 @@ let {
   participants?: Participant[];
   onOpenMind?: (mind: Mind) => void;
 } = $props();
+
+let lightboxSrc = $state<string | null>(null);
 
 function profileForSender(name: string): HoverProfile | null {
   const mind = mindsByName.get(name);
@@ -153,7 +156,10 @@ function buildAssistantItems(
         {#if block.type === "text"}
           <div class="user-text">{block.text}</div>
         {:else if block.type === "image"}
-          <img src={`data:${block.media_type};base64,${block.data}`} alt="" class="chat-image" />
+          {@const imgSrc = `data:${block.media_type};base64,${block.data}`}
+          <button type="button" class="chat-image-btn" onclick={() => (lightboxSrc = imgSrc)}>
+            <img src={imgSrc} alt="" class="chat-image" loading="lazy" decoding="async" />
+          </button>
         {/if}
       {/each}
     {:else}
@@ -172,12 +178,19 @@ function buildAssistantItems(
             onToggle={() => onToggleTool(toolKey)}
           />
         {:else if item.kind === "image"}
-          <img src={`data:${item.media_type};base64,${item.data}`} alt="" class="chat-image" />
+          {@const imgSrc = `data:${item.media_type};base64,${item.data}`}
+          <button type="button" class="chat-image-btn" onclick={() => (lightboxSrc = imgSrc)}>
+            <img src={imgSrc} alt="" class="chat-image" loading="lazy" decoding="async" />
+          </button>
         {/if}
       {/each}
     {/if}
   </div>
 </div>
+
+{#if lightboxSrc}
+  <ImageLightbox src={lightboxSrc} onClose={() => (lightboxSrc = null)} />
+{/if}
 
 <style>
   .entry {
@@ -234,6 +247,14 @@ function buildAssistantItems(
   .user-text {
     color: var(--text-0);
     white-space: pre-wrap;
+  }
+
+  .chat-image-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: zoom-in;
+    display: block;
   }
 
   .chat-image {

--- a/packages/web/src/ui/components/mind/MindCard.svelte
+++ b/packages/web/src/ui/components/mind/MindCard.svelte
@@ -13,6 +13,8 @@ let { mind }: { mind: Mind } = $props();
           src={`/api/minds/${encodeURIComponent(mind.name)}/avatar`}
           alt=""
           class="card-avatar"
+          loading="lazy"
+          decoding="async"
         />
       {/if}
       <span class="name">{mind.displayName ?? mind.name}</span>

--- a/packages/web/src/ui/components/mind/MindRightPanel.svelte
+++ b/packages/web/src/ui/components/mind/MindRightPanel.svelte
@@ -42,6 +42,8 @@ let isActive = $derived(activeMinds.has(mind.name));
           src={`/api/minds/${encodeURIComponent(mind.name)}/avatar`}
           alt=""
           class="profile-avatar"
+          loading="lazy"
+          decoding="async"
         />
       {/if}
       <span class="profile-name">

--- a/packages/web/src/ui/components/mind/MindSettingsProfile.svelte
+++ b/packages/web/src/ui/components/mind/MindSettingsProfile.svelte
@@ -63,6 +63,8 @@ async function saveDescription() {
             src={`/api/minds/${encodeURIComponent(mind.name)}/avatar`}
             alt=""
             class="avatar-img"
+            loading="lazy"
+            decoding="async"
           />
         {:else}
           <div class="avatar-placeholder">?</div>

--- a/packages/web/src/ui/components/modals/UserSettingsModal.svelte
+++ b/packages/web/src/ui/components/modals/UserSettingsModal.svelte
@@ -139,9 +139,9 @@ async function handleChangePassword(e: Event) {
       <div class="avatar-section">
         <div class="avatar-preview">
           {#if avatarPreview}
-            <img src={avatarPreview} alt="Avatar preview" class="avatar-img" />
+            <img src={avatarPreview} alt="Avatar preview" class="avatar-img" loading="lazy" decoding="async" />
           {:else if avatarUrl}
-            <img src={avatarUrl} alt="Avatar" class="avatar-img" />
+            <img src={avatarUrl} alt="Avatar" class="avatar-img" loading="lazy" decoding="async" />
           {:else}
             <div class="avatar-placeholder">?</div>
           {/if}

--- a/test/avatar-image.test.ts
+++ b/test/avatar-image.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import sharp from "sharp";
+import { voluteHome } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  AVATAR_DIM,
+  migrateAvatarSizes,
+  normalizeAvatar,
+} from "../packages/daemon/src/lib/util/avatar-image.js";
+import { fileEtag, isNotModified } from "../packages/daemon/src/lib/util/http-cache.js";
+
+function makePng(size: number): Promise<Buffer> {
+  return sharp({
+    create: { width: size, height: size, channels: 3, background: { r: 200, g: 40, b: 40 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe("normalizeAvatar", () => {
+  it("downscales an oversized image to AVATAR_DIM webp", async () => {
+    const input = await makePng(512);
+    const result = await normalizeAvatar(input);
+    assert.ok(result);
+    assert.equal(result.ext, ".webp");
+    assert.equal(result.mime, "image/webp");
+    const meta = await sharp(result.buffer).metadata();
+    assert.equal(meta.format, "webp");
+    assert.equal(meta.width, AVATAR_DIM);
+    assert.equal(meta.height, AVATAR_DIM);
+  });
+
+  it("does not enlarge a small image but still converts to webp", async () => {
+    const input = await makePng(64);
+    const result = await normalizeAvatar(input);
+    assert.ok(result);
+    const meta = await sharp(result.buffer).metadata();
+    assert.equal(meta.format, "webp");
+    assert.equal(meta.width, 64);
+    assert.equal(meta.height, 64);
+  });
+
+  it("returns null for non-image input", async () => {
+    const result = await normalizeAvatar(Buffer.from("not an image"));
+    assert.equal(result, null);
+  });
+});
+
+describe("migrateAvatarSizes", () => {
+  it("re-encodes oversized avatars in place, preserving format, and skips small ones", async () => {
+    const dir = resolve(voluteHome(), "avatars");
+    mkdirSync(dir, { recursive: true });
+    const bigPath = resolve(dir, "avatar-big.png");
+    const smallPath = resolve(dir, "avatar-small.png");
+    writeFileSync(bigPath, await makePng(600));
+    writeFileSync(smallPath, await makePng(100));
+    const smallMtimeBefore = statSync(smallPath).mtimeMs;
+
+    await migrateAvatarSizes();
+
+    const bigMeta = await sharp(bigPath).metadata();
+    assert.equal(bigMeta.format, "png");
+    assert.equal(bigMeta.width, AVATAR_DIM);
+    assert.equal(bigMeta.height, AVATAR_DIM);
+    assert.equal(statSync(smallPath).mtimeMs, smallMtimeBefore);
+
+    // Idempotent: second run leaves the migrated file untouched
+    const bigMtime = statSync(bigPath).mtimeMs;
+    await migrateAvatarSizes();
+    assert.equal(statSync(bigPath).mtimeMs, bigMtime);
+  });
+});
+
+describe("http-cache", () => {
+  it("fileEtag is stable for a file and changes when the file changes", async () => {
+    const dir = resolve(voluteHome(), "avatars");
+    mkdirSync(dir, { recursive: true });
+    const path = resolve(dir, "etag-test.png");
+    writeFileSync(path, await makePng(10));
+    const a = fileEtag(statSync(path));
+    assert.equal(a, fileEtag(statSync(path)));
+    assert.match(a, /^W\/".+"$/);
+    await new Promise((r) => setTimeout(r, 10));
+    writeFileSync(path, await makePng(20));
+    assert.notEqual(a, fileEtag(statSync(path)));
+  });
+
+  it("isNotModified matches If-None-Match lists", () => {
+    const ctx = (value: string | undefined) =>
+      ({ req: { header: () => value } }) as unknown as Parameters<typeof isNotModified>[0];
+    assert.equal(isNotModified(ctx('W/"abc"'), 'W/"abc"'), true);
+    assert.equal(isNotModified(ctx('W/"x", W/"abc"'), 'W/"abc"'), true);
+    assert.equal(isNotModified(ctx('W/"other"'), 'W/"abc"'), false);
+    assert.equal(isNotModified(ctx(undefined), 'W/"abc"'), false);
+  });
+});

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -231,6 +231,42 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.equal(stoppedStatus.status, "stopped");
   });
 
+  it("avatar upload: resized to webp, served with ETag, revalidates with 304", async () => {
+    const sharp = (await import("sharp")).default;
+    const bigPng = await sharp({
+      create: { width: 512, height: 512, channels: 3, background: { r: 40, g: 40, b: 200 } },
+    })
+      .png()
+      .toBuffer();
+
+    const form = new FormData();
+    form.append("file", new File([new Uint8Array(bigPng)], "big.png", { type: "image/png" }));
+    const uploadRes = await daemonRequest(`/api/minds/${TEST_MIND}/avatar`, {
+      method: "POST",
+      body: form,
+    });
+    const uploadText = await uploadRes.text();
+    assert.equal(uploadRes.status, 200, `Upload failed: ${uploadText}`);
+    const uploaded = JSON.parse(uploadText) as { avatar: string };
+    assert.equal(uploaded.avatar, "avatar.webp");
+
+    const getRes = await daemonRequest(`/api/minds/${TEST_MIND}/avatar`);
+    assert.equal(getRes.status, 200);
+    assert.equal(getRes.headers.get("content-type"), "image/webp");
+    const etag = getRes.headers.get("etag");
+    assert.ok(etag, "avatar response should carry an ETag");
+    const body = new Uint8Array(await getRes.arrayBuffer());
+    const meta = await sharp(Buffer.from(body)).metadata();
+    assert.equal(meta.format, "webp");
+    assert.equal(meta.width, 256);
+    assert.equal(meta.height, 256);
+
+    const revalidateRes = await daemonRequest(`/api/minds/${TEST_MIND}/avatar`, {
+      headers: { "If-None-Match": etag },
+    });
+    assert.equal(revalidateRes.status, 304);
+  });
+
   it("GET /:name/delivery/pending previews gated messages and clears once released", async () => {
     const db = await getDb();
     // The daemon and this test share volute.db, so directly seeding gated rows is a


### PR DESCRIPTION
Quick wins from the image-serving investigation (larger follow-ups tracked in #364 and #365).

## Changes

- **Avatar resize on upload** — both user and mind avatar uploads are downscaled to 256×256 and re-encoded as webp via `sharp` (already a dependency; lazy import with graceful fallback to original bytes, matching the delivery-manager pattern). A one-time daemon-startup migration (`migrateAvatarSizes`) downscales existing oversized avatar files in place, preserving format and filename so no DB/volute.json references change.
- **ETag + 304 revalidation** — `GET /api/minds/:name/avatar`, `GET /api/auth/avatars/:filename`, and `GET /api/minds/:name/files/*` now send a weak ETag (mtime+size) and answer `If-None-Match` with a byte-free 304. The mind-files route previously had no cache headers at all.
- **Chat image lightbox** — chat images are now click-to-expand: a minimal fullscreen overlay (portaled to `<body>` to escape the chat pane's stacking context), closed by Escape or click.
- **Markdown image constraint** — `.markdown-body img { max-width: 100% }` in `@volute/ui` base.css (previously completely unconstrained; extensions pick it up via the generated ext-theme.css).
- **Lazy loading** — `loading="lazy" decoding="async"` on chat images and all seven avatar `<img>` sites.

## Verification

- New unit tests (`test/avatar-image.test.ts`): resize, no-enlarge, non-image fallback, in-place migration idempotency, ETag helpers.
- New e2e test: upload a 512px PNG → stored as `avatar.webp`, served as 256×256 `image/webp` with ETag, revalidates with 304.
- Manual end-to-end against a scratch daemon: a 1.4MB PNG avatar upload is served as a 30KB webp with working 304 revalidation; lightbox open/close verified in a real browser (Playwright), including full-viewport overlay coverage.
- `npm test` (1718 pass), `npm run typecheck`, biome, web + notes extension builds all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)