### PR TITLE
fix: pages UI empty-mind dashboard fallthrough and publish resetting all page dates

### DIFF
--- a/packages/extensions/pages/src/commands.ts
+++ b/packages/extensions/pages/src/commands.ts
@@ -6,6 +6,7 @@ import type { ExtensionCommand } from "@volute/extensions";
 import { getPublishedPages, syncPublishedPages, syncSystemPages } from "./db.js";
 import {
   collectHtmlFiles,
+  hashFiles,
   isolationFrom,
   pagesLog,
   pagesPull,
@@ -54,7 +55,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
             if (result.ok && ctx.db) {
               const repoDir = resolve(ctx.dataDir, "repo");
               try {
-                syncSystemPages(ctx.db, collectHtmlFiles(repoDir), mindName);
+                syncSystemPages(ctx.db, hashFiles(repoDir, collectHtmlFiles(repoDir)), mindName);
               } catch (err) {
                 console.error("[pages] failed to sync system pages to DB:", err);
                 syncWarning =
@@ -98,7 +99,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         // Sync DB and get diff
         let diff: { added: string[]; removed: string[]; updated: string[] };
         try {
-          diff = syncPublishedPages(db, mindName, pageFiles);
+          diff = syncPublishedPages(db, mindName, hashFiles(snapshotDir, pageFiles));
         } catch (err) {
           return { error: `Failed to update page database: ${(err as Error).message}` };
         }

--- a/packages/extensions/pages/src/db.ts
+++ b/packages/extensions/pages/src/db.ts
@@ -13,15 +13,20 @@ export function initDb(db: Database): void {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_pp_mind_file ON published_pages(mind, file);
     CREATE INDEX IF NOT EXISTS idx_pp_updated_at ON published_pages(updated_at);
   `);
-  // Migration: add author column if missing
-  try {
-    db.exec("ALTER TABLE published_pages ADD COLUMN author TEXT");
-  } catch (err) {
-    if (!(err instanceof Error) || !err.message.includes("duplicate column")) {
-      throw err;
+  // Migrations: add columns if missing
+  for (const column of ["author TEXT", "hash TEXT"]) {
+    try {
+      db.exec(`ALTER TABLE published_pages ADD COLUMN ${column}`);
+    } catch (err) {
+      if (!(err instanceof Error) || !err.message.includes("duplicate column")) {
+        throw err;
+      }
     }
   }
 }
+
+/** A page file paired with a hash of its content. */
+export type PageInput = { file: string; hash: string };
 
 type PublishedPage = {
   file: string;
@@ -97,37 +102,39 @@ export function getSystemPages(db: Database): SiteEntry | null {
   };
 }
 
-export function syncSystemPages(db: Database, htmlFiles: string[], author?: string): void {
-  const existing = new Set(
+export function syncSystemPages(db: Database, pages: PageInput[], author?: string): void {
+  const existing = new Map(
     (
-      db.prepare("SELECT file FROM published_pages WHERE mind = '_system'").all() as {
+      db.prepare("SELECT file, hash FROM published_pages WHERE mind = '_system'").all() as {
         file: string;
+        hash: string | null;
       }[]
-    ).map((r) => r.file),
+    ).map((r) => [r.file, r.hash]),
   );
-  const newSet = new Set(htmlFiles);
+  const newSet = new Set(pages.map((p) => p.file));
 
   db.exec("BEGIN");
   try {
-    for (const file of htmlFiles) {
-      if (existing.has(file)) {
+    for (const { file, hash } of pages) {
+      if (!existing.has(file)) {
+        db.prepare(
+          "INSERT INTO published_pages (mind, file, hash, author) VALUES ('_system', ?, ?, ?)",
+        ).run(file, hash, author ?? null);
+      } else if (existing.get(file) !== hash) {
+        // Only touch files whose content actually changed — unchanged files
+        // keep their updated_at and author (the publisher didn't author them).
         if (author) {
           db.prepare(
-            "UPDATE published_pages SET updated_at = datetime('now'), author = ? WHERE mind = '_system' AND file = ?",
-          ).run(author, file);
+            "UPDATE published_pages SET updated_at = datetime('now'), hash = ?, author = ? WHERE mind = '_system' AND file = ?",
+          ).run(hash, author, file);
         } else {
           db.prepare(
-            "UPDATE published_pages SET updated_at = datetime('now') WHERE mind = '_system' AND file = ?",
-          ).run(file);
+            "UPDATE published_pages SET updated_at = datetime('now'), hash = ? WHERE mind = '_system' AND file = ?",
+          ).run(hash, file);
         }
-      } else {
-        db.prepare("INSERT INTO published_pages (mind, file, author) VALUES ('_system', ?, ?)").run(
-          file,
-          author ?? null,
-        );
       }
     }
-    for (const file of existing) {
+    for (const file of existing.keys()) {
       if (!newSet.has(file)) {
         db.prepare("DELETE FROM published_pages WHERE mind = '_system' AND file = ?").run(file);
       }
@@ -142,37 +149,42 @@ export function syncSystemPages(db: Database, htmlFiles: string[], author?: stri
 export function syncPublishedPages(
   db: Database,
   mind: string,
-  pageFiles: string[],
+  pages: PageInput[],
 ): { added: string[]; removed: string[]; updated: string[] } {
   const existing = new Map(
     (
-      db.prepare("SELECT file, updated_at FROM published_pages WHERE mind = ?").all(mind) as {
+      db.prepare("SELECT file, hash FROM published_pages WHERE mind = ?").all(mind) as {
         file: string;
-        updated_at: string;
+        hash: string | null;
       }[]
-    ).map((r) => [r.file, r.updated_at]),
+    ).map((r) => [r.file, r.hash]),
   );
 
-  const newSet = new Set(pageFiles);
+  const newSet = new Set(pages.map((p) => p.file));
   const added: string[] = [];
   const updated: string[] = [];
   const removed: string[] = [];
 
   db.exec("BEGIN");
   try {
-    for (const file of pageFiles) {
-      if (existing.has(file)) {
-        db.prepare(
-          "UPDATE published_pages SET updated_at = datetime('now') WHERE mind = ? AND file = ?",
-        ).run(mind, file);
-        updated.push(file);
-      } else {
-        db.prepare("INSERT INTO published_pages (mind, file) VALUES (?, ?)").run(mind, file);
+    for (const { file, hash } of pages) {
+      if (!existing.has(file)) {
+        db.prepare("INSERT INTO published_pages (mind, file, hash) VALUES (?, ?, ?)").run(
+          mind,
+          file,
+          hash,
+        );
         added.push(file);
+      } else if (existing.get(file) !== hash) {
+        // Only bump updated_at when the content actually changed
+        db.prepare(
+          "UPDATE published_pages SET updated_at = datetime('now'), hash = ? WHERE mind = ? AND file = ?",
+        ).run(hash, mind, file);
+        updated.push(file);
       }
     }
 
-    for (const [file] of existing) {
+    for (const file of existing.keys()) {
       if (!newSet.has(file)) {
         db.prepare("DELETE FROM published_pages WHERE mind = ? AND file = ?").run(mind, file);
         removed.push(file);

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -8,6 +8,7 @@ import {
   addPagesWorktree,
   collectHtmlFiles,
   ensurePagesRepo,
+  hashFiles,
   isolationFrom,
 } from "./shared-pages.js";
 
@@ -43,16 +44,14 @@ export default createExtension({
   onDaemonStart(ctx) {
     ensurePagesRepo(ctx.dataDir, isolationFrom(ctx))
       .then(() => {
-        // Sync system pages from the repo to the DB so they appear in the UI
+        // Sync system pages from the repo to the DB so they appear in the UI.
+        // Run even when the repo is empty so stale DB rows are removed.
         if (ctx.db) {
           const repoDir = resolve(ctx.dataDir, "repo");
-          const htmlFiles = collectHtmlFiles(repoDir);
-          if (htmlFiles.length > 0) {
-            try {
-              syncSystemPages(ctx.db, htmlFiles);
-            } catch (err) {
-              console.error("[pages] failed to sync system pages to DB:", err);
-            }
+          try {
+            syncSystemPages(ctx.db, hashFiles(repoDir, collectHtmlFiles(repoDir)));
+          } catch (err) {
+            console.error("[pages] failed to sync system pages to DB:", err);
           }
         }
       })

--- a/packages/extensions/pages/src/shared-pages.ts
+++ b/packages/extensions/pages/src/shared-pages.ts
@@ -5,6 +5,7 @@
  * Each mind gets a worktree at <mindDir>/home/pages/_system/ on a per-mind branch.
  */
 import { execFile as execFileCb } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -517,6 +518,16 @@ export function collectHtmlFiles(dir: string): string[] {
   }
   walk(dir);
   return files.sort();
+}
+
+/** Pair each file (relative to baseDir) with a sha256 hash of its content. */
+export function hashFiles(baseDir: string, files: string[]): { file: string; hash: string }[] {
+  return files.map((file) => ({
+    file,
+    hash: createHash("sha256")
+      .update(readFileSync(resolve(baseDir, file)))
+      .digest("hex"),
+  }));
 }
 
 /** Show files in the mind's shared pages worktree with draft/published status. */

--- a/packages/extensions/pages/ui/src/App.svelte
+++ b/packages/extensions/pages/ui/src/App.svelte
@@ -52,9 +52,11 @@ $effect(() => {
 let allSites = $derived([...(systemSite ? [systemSite] : []), ...sites]);
 
 let selectedSite = $derived.by(() => {
-  if (route.view === "site") return allSites.find((s) => s.name === route.name);
-  if (route.view === "mind") return allSites.find((s) => s.name === route.name);
-  return undefined;
+  if (route.view !== "site" && route.view !== "mind") return undefined;
+  const name = route.name;
+  // Fall back to an empty site so a mind with no pages shows "no pages"
+  // instead of the system-wide dashboard.
+  return allSites.find((s) => s.name === name) ?? { name, label: name, pages: [] };
 });
 
 function navigateParent(path: string) {
@@ -70,7 +72,7 @@ function handleIframeNav(e: Event) {
     const match = path.match(/^\/ext\/pages\/public\/([^/]+)\/(.+)$/);
     if (!match) return;
     const [, mind, file] = match;
-    if (mind === route.name && file === (route as { path?: string }).path) return;
+    if (route.view === "page" && mind === route.name && file === route.path) return;
     if (mind === "_system") {
       navigateParent(`/pages/_system/${file}`);
     } else {

--- a/test/pages-commands.test.ts
+++ b/test/pages-commands.test.ts
@@ -36,6 +36,11 @@ import {
 } from "../packages/extensions/pages/src/db.js";
 import type { Database } from "../packages/extensions/sdk/src/types.js";
 
+/** Build page inputs with a stable content hash derived from the file name. */
+function ph(...files: string[]): { file: string; hash: string }[] {
+  return files.map((file) => ({ file, hash: `h:${file}` }));
+}
+
 async function createTestDb(): Promise<Database> {
   const mod = await import("libsql");
   const Libsql = (mod.default ?? mod) as unknown as new (path: string) => any;
@@ -75,7 +80,7 @@ describe("pages db", () => {
   });
 
   it("syncPublishedPages adds new files", () => {
-    const diff = syncPublishedPages(db, "mind1", ["index.html", "about.html"]);
+    const diff = syncPublishedPages(db, "mind1", ph("index.html", "about.html"));
     assert.deepEqual(diff.added, ["index.html", "about.html"]);
     assert.deepEqual(diff.removed, []);
     assert.deepEqual(diff.updated, []);
@@ -87,22 +92,51 @@ describe("pages db", () => {
   });
 
   it("syncPublishedPages detects removed files", () => {
-    syncPublishedPages(db, "mind1", ["index.html", "about.html"]);
-    const diff = syncPublishedPages(db, "mind1", ["index.html"]);
+    syncPublishedPages(db, "mind1", ph("index.html", "about.html"));
+    const diff = syncPublishedPages(db, "mind1", ph("index.html"));
     assert.deepEqual(diff.added, []);
     assert.deepEqual(diff.removed, ["about.html"]);
-    assert.deepEqual(diff.updated, ["index.html"]);
+    assert.deepEqual(diff.updated, []);
+  });
+
+  it("syncPublishedPages does not bump updated_at for unchanged files", () => {
+    syncPublishedPages(db, "mind1", ph("index.html", "about.html"));
+    db.prepare("UPDATE published_pages SET updated_at = '2020-01-01 00:00:00'").run();
+
+    const diff = syncPublishedPages(db, "mind1", ph("index.html", "about.html"));
+    assert.deepEqual(diff.updated, []);
+
+    const pages = getPublishedPages(db, "mind1");
+    assert.equal(pages[0].updated_at, "2020-01-01 00:00:00");
+    assert.equal(pages[1].updated_at, "2020-01-01 00:00:00");
+  });
+
+  it("syncPublishedPages bumps updated_at only for changed files", () => {
+    syncPublishedPages(db, "mind1", ph("index.html", "about.html"));
+    db.prepare("UPDATE published_pages SET updated_at = '2020-01-01 00:00:00'").run();
+
+    const diff = syncPublishedPages(db, "mind1", [
+      { file: "index.html", hash: "h:index.html" },
+      { file: "about.html", hash: "changed" },
+    ]);
+    assert.deepEqual(diff.updated, ["about.html"]);
+
+    const pages = getPublishedPages(db, "mind1");
+    const about = pages.find((p) => p.file === "about.html");
+    const index = pages.find((p) => p.file === "index.html");
+    assert.notEqual(about?.updated_at, "2020-01-01 00:00:00");
+    assert.equal(index?.updated_at, "2020-01-01 00:00:00");
   });
 
   it("syncPublishedPages handles empty list", () => {
-    syncPublishedPages(db, "mind1", ["index.html"]);
-    const diff = syncPublishedPages(db, "mind1", []);
+    syncPublishedPages(db, "mind1", ph("index.html"));
+    const diff = syncPublishedPages(db, "mind1", ph());
     assert.deepEqual(diff.removed, ["index.html"]);
   });
 
   it("getRecentPages returns pages ordered by updated_at", () => {
-    syncPublishedPages(db, "mind1", ["a.html"]);
-    syncPublishedPages(db, "mind2", ["b.html"]);
+    syncPublishedPages(db, "mind1", ph("a.html"));
+    syncPublishedPages(db, "mind2", ph("b.html"));
 
     const pages = getRecentPages(db);
     assert.equal(pages.length, 2);
@@ -112,8 +146,8 @@ describe("pages db", () => {
   });
 
   it("getRecentPages filters by mind", () => {
-    syncPublishedPages(db, "mind1", ["a.html"]);
-    syncPublishedPages(db, "mind2", ["b.html"]);
+    syncPublishedPages(db, "mind1", ph("a.html"));
+    syncPublishedPages(db, "mind2", ph("b.html"));
 
     const pages = getRecentPages(db, { mind: "mind1" });
     assert.equal(pages.length, 1);
@@ -121,20 +155,20 @@ describe("pages db", () => {
   });
 
   it("syncSystemPages syncs _system entries", () => {
-    syncSystemPages(db, ["index.html", "about.html"]);
+    syncSystemPages(db, ph("index.html", "about.html"));
     const pages = getPublishedPages(db, "_system");
     assert.equal(pages.length, 2);
 
     // Removes deleted files, keeps existing
-    syncSystemPages(db, ["index.html"]);
+    syncSystemPages(db, ph("index.html"));
     const after = getPublishedPages(db, "_system");
     assert.equal(after.length, 1);
     assert.equal(after[0].file, "index.html");
   });
 
   it("getAllSites groups by mind", () => {
-    syncPublishedPages(db, "mind1", ["index.html"]);
-    syncPublishedPages(db, "mind2", ["about.html", "contact.html"]);
+    syncPublishedPages(db, "mind1", ph("index.html"));
+    syncPublishedPages(db, "mind2", ph("about.html", "contact.html"));
 
     const sites = getAllSites(db);
     assert.equal(sites.length, 2);
@@ -145,8 +179,8 @@ describe("pages db", () => {
   });
 
   it("getAllSites excludes _system pages", () => {
-    syncPublishedPages(db, "mind1", ["index.html"]);
-    syncSystemPages(db, ["shared.html"]);
+    syncPublishedPages(db, "mind1", ph("index.html"));
+    syncSystemPages(db, ph("shared.html"));
 
     const sites = getAllSites(db);
     assert.equal(sites.length, 1);
@@ -154,21 +188,44 @@ describe("pages db", () => {
   });
 
   it("syncSystemPages stores author", () => {
-    syncSystemPages(db, ["index.html"], "alice");
+    syncSystemPages(db, ph("index.html"), "alice");
     const pages = getPublishedPages(db, "_system");
     assert.equal(pages[0].author, "alice");
   });
 
-  it("syncSystemPages updates author on re-sync", () => {
-    syncSystemPages(db, ["index.html"], "alice");
-    syncSystemPages(db, ["index.html"], "bob");
+  it("syncSystemPages updates author when content changes", () => {
+    syncSystemPages(db, ph("index.html"), "alice");
+    syncSystemPages(db, [{ file: "index.html", hash: "changed" }], "bob");
     const pages = getPublishedPages(db, "_system");
     assert.equal(pages[0].author, "bob");
   });
 
+  it("syncSystemPages preserves author and updated_at for unchanged files", () => {
+    syncSystemPages(db, ph("index.html", "about.html"), "alice");
+    db.prepare("UPDATE published_pages SET updated_at = '2020-01-01 00:00:00'").run();
+
+    // bob publishes a change to about.html only — index.html is untouched
+    syncSystemPages(
+      db,
+      [
+        { file: "index.html", hash: "h:index.html" },
+        { file: "about.html", hash: "changed" },
+      ],
+      "bob",
+    );
+
+    const pages = getPublishedPages(db, "_system");
+    const index = pages.find((p) => p.file === "index.html");
+    const about = pages.find((p) => p.file === "about.html");
+    assert.equal(index?.author, "alice");
+    assert.equal(index?.updated_at, "2020-01-01 00:00:00");
+    assert.equal(about?.author, "bob");
+    assert.notEqual(about?.updated_at, "2020-01-01 00:00:00");
+  });
+
   it("syncSystemPages preserves author when not provided", () => {
-    syncSystemPages(db, ["index.html"], "alice");
-    syncSystemPages(db, ["index.html"]);
+    syncSystemPages(db, ph("index.html"), "alice");
+    syncSystemPages(db, [{ file: "index.html", hash: "changed" }]);
     const pages = getPublishedPages(db, "_system");
     assert.equal(pages[0].author, "alice");
   });
@@ -178,7 +235,7 @@ describe("pages db", () => {
   });
 
   it("getSystemPages returns system site with author", () => {
-    syncSystemPages(db, ["about.html", "index.html"], "alice");
+    syncSystemPages(db, ph("about.html", "index.html"), "alice");
     const site = getSystemPages(db);
     assert.ok(site);
     assert.equal(site.mind, "_system");
@@ -295,6 +352,28 @@ describe("pages commands", () => {
     assert.equal(removeEvents[0].metadata.file, "about.html");
   });
 
+  it("publish command does not report unchanged files as updated", async () => {
+    writeFileSync(resolve(pagesDir, "index.html"), "<h1>Hello</h1>");
+    writeFileSync(resolve(pagesDir, "about.html"), "<h1>About</h1>");
+    const commands = createCommands();
+    const ctx = makeCtx();
+    await commands.publish.handler(
+      { args: {}, flags: { remote: false, shared: false }, rest: [] },
+      ctx,
+    );
+
+    // Re-publish with only one file changed
+    writeFileSync(resolve(pagesDir, "about.html"), "<h1>About v2</h1>");
+    const result = await commands.publish.handler(
+      { args: {}, flags: { remote: false, shared: false }, rest: [] },
+      ctx,
+    );
+
+    assert.ok("output" in result);
+    assert.ok(result.output.includes("1 updated"), `expected "1 updated" in: ${result.output}`);
+    assert.ok(!result.output.includes("2 updated"), `unchanged file counted: ${result.output}`);
+  });
+
   it("publish command excludes _system/ from snapshot", async () => {
     writeFileSync(resolve(pagesDir, "index.html"), "<h1>Hello</h1>");
     const systemDir = resolve(pagesDir, "_system");
@@ -332,7 +411,7 @@ describe("pages commands", () => {
     // Publish one file
     const commands = createCommands();
     const ctx = makeCtx();
-    syncPublishedPages(db, "test-mind", ["published.html"]);
+    syncPublishedPages(db, "test-mind", ph("published.html"));
 
     const result = await commands.list.handler(
       { args: {}, flags: { all: false, shared: false }, rest: [] },
@@ -368,7 +447,7 @@ describe("pages commands", () => {
   it("list command shows .md files", async () => {
     writeFileSync(resolve(pagesDir, "index.html"), "<h1>Hello</h1>");
     writeFileSync(resolve(pagesDir, "post.md"), "# Post\n");
-    syncPublishedPages(db, "test-mind", ["index.html"]);
+    syncPublishedPages(db, "test-mind", ph("index.html"));
 
     const commands = createCommands();
     const ctx = makeCtx();
@@ -382,8 +461,8 @@ describe("pages commands", () => {
   });
 
   it("list --all queries across minds", async () => {
-    syncPublishedPages(db, "mind-a", ["index.html"]);
-    syncPublishedPages(db, "mind-b", ["about.html"]);
+    syncPublishedPages(db, "mind-a", ph("index.html"));
+    syncPublishedPages(db, "mind-b", ph("about.html"));
 
     const commands = createCommands();
     const ctx = makeCtx();
@@ -397,8 +476,8 @@ describe("pages commands", () => {
   });
 
   it("list --all shows system pages with author", async () => {
-    syncSystemPages(db, ["shared.html"], "alice");
-    syncPublishedPages(db, "mind-a", ["index.html"]);
+    syncSystemPages(db, ph("shared.html"), "alice");
+    syncPublishedPages(db, "mind-a", ph("index.html"));
 
     const commands = createCommands();
     const ctx = makeCtx();
@@ -413,7 +492,7 @@ describe("pages commands", () => {
   });
 
   it("list --all works without a mind name", async () => {
-    syncPublishedPages(db, "mind-a", ["index.html"]);
+    syncPublishedPages(db, "mind-a", ph("index.html"));
 
     const commands = createCommands();
     const ctx = makeCtx();


### PR DESCRIPTION
## Problem

Two bugs visible in the web UI, plus two related ones found while investigating:

1. **Mind pages tab shows the system dashboard when the mind has no pages.** The extension UI only rendered `SiteView` when the mind had a site entry in the fetched data; with zero published pages it fell through to the system-wide `PagesDashboard`. (The same fallthrough caused a dashboard flash on every mind pages tab while data loaded.)
2. **Publishing one page resets every page's updated date.** `volute pages publish` always syncs the whole pages dir, and `syncPublishedPages` bumped `updated_at = datetime('now')` on every existing row whether or not it changed. Worse, `syncSystemPages` did the same and runs on **every daemon start**, so all `_system` page dates reset on each restart.
3. **Author attribution wipe**: shared publish stamped the publishing mind as `author` on *all* system pages, not just the ones it changed.
4. **Stale system pages**: the daemon-start sync was skipped when the repo had no HTML files, so deleting the last system page left DB rows around forever.

## Fix

- `App.svelte`: site/mind routes now always render `SiteView`, falling back to an empty site (shows "No pages in this site.") instead of the dashboard. Also fixed a pre-existing TS hole in the iframe nav handler (unnarrowed `route.name` + cast).
- `published_pages` gains a `hash` column (sha256 of content, migrated like `author`). Sync functions take `{file, hash}` pairs and only bump `updated_at` — and set `author`, for system pages — when the content actually changed.
- Daemon-start system page sync runs even when the repo is empty so removals propagate.

Original dates were destroyed by the bug (not recoverable); dates are stable going forward. Rows without a hash get a one-time bump on first sync after upgrade.

## Testing

- New unit tests: unchanged files keep `updated_at`/`author`, changed files bump; command-level test with real files verifying publish output only counts changed files as updated
- Full suite green (1716/1716), tsc clean, ext UI builds, svelte-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)