### PR TITLE
fix: repair daemon e2e tests and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,18 @@ jobs:
           git config --global user.email "ci@test.com"
           git config --global user.name "CI"
       - run: npm test
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@test.com"
+          git config --global user.name "CI"
+      - run: npm run test:e2e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,7 +487,7 @@ Tests run via `npm test` which uses `node --import tsx --import ./test/setup.ts 
 ### Testing
 
 - **Unit tests** (`npm test`): Primary safety net. Run before every PR.
-- **Daemon e2e** (`test/daemon-e2e.test.ts`): Tests daemon API without Docker. Included in `npm test`. Add tests here for new API endpoints or daemon features.
+- **Daemon e2e** (`test/daemon-e2e.test.ts`): Tests daemon API without Docker, spawning a real daemon and mind. Runs via `npm run test:e2e` (also in CI). Add tests here for cross-process daemon behavior: lifecycle, crash recovery, delivery, variants.
 - **Docker e2e** (`test/docker-e2e.sh`): Full Docker lifecycle with user isolation. Run for PRs touching daemon, mind lifecycle, or Docker setup.
 - **Integration testing**: For manual testing with real minds in Docker — see `docs/integration-testing.md` for setup scripts, test mind fixtures, and interaction guidelines. Use `test/integration-setup.sh` to spin up an environment and `test/integration-teardown.sh` to clean up.
 

--- a/test/auto-commit.test.ts
+++ b/test/auto-commit.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 
-const tmpDir = join(tmpdir(), ".volute-autocommit-test");
+const tmpDir = join(tmpdir(), `.volute-autocommit-test-${process.pid}`);
 
 function git(args: string[], cwd: string): string {
   const env: Record<string, string> = { LEFTHOOK: "0" };

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -58,7 +58,7 @@ async function waitForHealth(timeoutMs = 15000): Promise<void> {
   throw new Error(`Daemon did not become healthy within ${timeoutMs}ms`);
 }
 
-describe("daemon e2e", { timeout: 120000 }, () => {
+describe("daemon e2e", { timeout: 420000 }, () => {
   let daemon: ChildProcess;
 
   before(async () => {
@@ -466,6 +466,68 @@ describe("daemon e2e", { timeout: 120000 }, () => {
 
     await waitForMindRunning();
 
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+  });
+
+  it("variants: split creates a worktree variant, merge folds it back into the parent", {
+    timeout: 300000,
+  }, async () => {
+    await ensureTestMind();
+    const parentDir = mindDir(TEST_MIND);
+
+    // Split: create the variant without starting its server.
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "e2e-var", noStart: true }),
+    });
+    assert.equal(createRes.status, 200, `Split: ${await createRes.clone().text()}`);
+    const created = (await createRes.json()) as {
+      ok: boolean;
+      variant: { name: string; branch: string; path: string; port: number };
+    };
+    assert.equal(created.ok, true);
+    assert.ok(existsSync(created.variant.path), "variant worktree should exist");
+
+    // Variant is registered with the parent.
+    const listRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`);
+    assert.equal(listRes.status, 200);
+    const variants = (await listRes.json()) as { name: string }[];
+    assert.ok(
+      variants.some((v) => v.name === "e2e-var"),
+      `expected e2e-var in ${JSON.stringify(variants)}`,
+    );
+
+    // The variant does some work: a new tracked file in src/.
+    // (Merge auto-commits uncommitted worktree changes; src/ is always tracked.)
+    writeFileSync(
+      resolve(created.variant.path, "src", "e2e-merge-marker.ts"),
+      'export const marker = "e2e";\n',
+    );
+
+    // Join: merge the variant back. skipVerify avoids booting a verification server.
+    const mergeRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-var/merge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skipVerify: true, summary: "e2e merge test" }),
+    });
+    assert.equal(mergeRes.status, 200, `Merge: ${await mergeRes.clone().text()}`);
+    const mergeBody = (await mergeRes.json()) as { ok: boolean; warning?: string };
+    assert.equal(mergeBody.ok, true);
+    assert.equal(mergeBody.warning, undefined, `merge reported a warning: ${mergeBody.warning}`);
+
+    // The variant's change landed in the parent working tree.
+    assert.ok(
+      existsSync(resolve(parentDir, "src", "e2e-merge-marker.ts")),
+      "merged file should exist in the parent src/",
+    );
+
+    // The variant is cleaned up: gone from registry and disk.
+    assert.ok(!(await findMind("e2e-var")), "variant should be removed from the registry");
+    assert.ok(!existsSync(created.variant.path), "variant worktree should be removed");
+
+    // Merge restarts the parent — wait for it, then stop it for subsequent tests.
+    await waitForMindRunning(60000);
     await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -439,8 +439,8 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     // List channels — should include the new one
     const listRes = await daemonRequest("/api/v1/channels");
     assert.equal(listRes.status, 200);
-    const channels = (await listRes.json()) as { name: string; id: string }[];
-    assert.ok(channels.some((ch) => ch.name === "test-bridge-channel"));
+    const channels = (await listRes.json()) as { channel_name: string; id: string }[];
+    assert.ok(channels.some((ch) => ch.channel_name === "test-bridge-channel"));
 
     // Invite the test mind to the channel
     const inviteRes = await daemonRequest("/api/v1/channels/test-bridge-channel/invite", {
@@ -542,10 +542,9 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       `/api/minds/${TEST_MIND}/conversations/${conv.id}/messages`,
     );
     assert.equal(msgsRes.status, 200);
-    const messages = (await msgsRes.json()) as {
-      content: { type: string; text?: string }[];
-      sender_name: string;
-    }[];
+    const { items: messages } = (await msgsRes.json()) as {
+      items: { content: { type: string; text?: string }[]; sender_name: string }[];
+    };
     assert.ok(messages.length >= 1);
     const lastMsg = messages[messages.length - 1];
     const text = lastMsg.content
@@ -601,7 +600,9 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       `/api/minds/${TEST_MIND}/conversations/${conv.id}/messages`,
     );
     assert.equal(msgsRes.status, 200);
-    const messages = (await msgsRes.json()) as { content: { type: string; text?: string }[] }[];
+    const { items: messages } = (await msgsRes.json()) as {
+      items: { content: { type: string; text?: string }[] }[];
+    };
     assert.ok(messages.length >= 1);
   });
 
@@ -788,10 +789,9 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       `/api/minds/${TEST_MIND}/conversations/${inboundBody.conversationId}/messages`,
     );
     assert.equal(msgsRes.status, 200);
-    const messages = (await msgsRes.json()) as {
-      content: { type: string; text?: string }[];
-      sender_name: string;
-    }[];
+    const { items: messages } = (await msgsRes.json()) as {
+      items: { content: { type: string; text?: string }[]; sender_name: string }[];
+    };
     const bridgedMsg = messages.find((m) => m.sender_name === "Alice");
     assert.ok(bridgedMsg, `Expected message from Alice, got: ${JSON.stringify(messages)}`);
 
@@ -849,7 +849,9 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       `/api/minds/${TEST_MIND}/conversations/${body1.conversationId}/messages`,
     );
     assert.equal(msgsRes.status, 200);
-    const messages = (await msgsRes.json()) as { sender_name: string }[];
+    const { items: messages } = (await msgsRes.json()) as {
+      items: { sender_name: string }[];
+    };
     const bobMsgs = messages.filter((m) => m.sender_name === "Bob");
     assert.ok(bobMsgs.length >= 2, `Expected 2+ messages from Bob, got ${bobMsgs.length}`);
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1432,61 +1432,49 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.equal(((await cleared.json()) as { notices: unknown[] }).notices.length, 0);
   });
 
-  it("message proxy returns JSON response", async () => {
-    if (!process.env.ANTHROPIC_API_KEY) {
-      console.log("Skipping message test: ANTHROPIC_API_KEY not set");
-      return;
-    }
+  it("chat delivery: message reaches a running mind and lands in history", {
+    timeout: 60000,
+  }, async () => {
+    await ensureTestMind();
 
-    // Start mind
     const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
-    // May already be running from previous test or 409 if so
-    const startBody = (await startRes.json()) as { ok?: boolean; port?: number; error?: string };
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
-      `Start: expected 200 or 409, got ${startRes.status}: ${JSON.stringify(startBody)}`,
+      `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
     );
-    if (startRes.status === 200) {
-      assert.equal(typeof startBody.port, "number", "Start response should include port");
-    }
+    await waitForMindRunning();
 
-    // Wait for health
-    const healthDeadline = Date.now() + 30000;
-    let mindHealthy = false;
-    while (Date.now() < healthDeadline) {
-      const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
-      const status = (await statusRes.json()) as { status: string };
-      if (status.status === "running") {
-        mindHealthy = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-    assert.ok(mindHealthy, "Mind should become healthy");
-
-    // Send message
-    const msgRes = await daemonRequest(`/api/minds/${TEST_MIND}/message`, {
+    // Send through the unified chat endpoint (the real CLI/web send path).
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        content: [{ type: "text", text: "Reply with just the word 'hello'" }],
-        channel: "cli",
-        sender: "e2e-test",
-      }),
+      body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND] }),
     });
+    assert.equal(createRes.status, 201, `Create conv: ${await createRes.clone().text()}`);
+    const conv = (await createRes.json()) as { id: string };
 
-    assert.equal(msgRes.status, 200, `Message failed: ${msgRes.status}`);
+    const probe = `delivery round-trip probe ${Date.now()}`;
+    const chatRes = await daemonRequest("/api/v1/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId: conv.id, message: probe, targetMind: TEST_MIND }),
+    });
+    assert.equal(chatRes.status, 200, `Chat: ${await chatRes.clone().text()}`);
 
-    const body = (await msgRes.json()) as { ok: boolean };
-    assert.equal(body.ok, true, "Response should have ok: true");
+    // Delivery is async (queue → HTTP POST to the mind → recordInbound). Inbound
+    // recording happens at delivery time, before the mind's model turn, so this
+    // works without ANTHROPIC_API_KEY. Poll history for the probe.
+    const deadline = Date.now() + 30000;
+    let delivered = false;
+    while (Date.now() < deadline && !delivered) {
+      const res = await daemonRequest(`/api/minds/${TEST_MIND}/history?full=true&limit=100`);
+      assert.equal(res.status, 200);
+      const rows = (await res.json()) as { type: string; content: string | null }[];
+      delivered = rows.some((r) => r.type === "inbound" && (r.content ?? "").includes(probe));
+      if (!delivered) await new Promise((r) => setTimeout(r, 500));
+    }
+    assert.ok(delivered, "inbound message should be recorded in mind_history after delivery");
 
-    // Check history
-    const historyRes = await daemonRequest(`/api/minds/${TEST_MIND}/history`);
-    assert.equal(historyRes.status, 200);
-    const history = (await historyRes.json()) as Array<Record<string, unknown>>;
-    assert.ok(history.length > 0, "History should have messages");
-
-    // Stop mind
     await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -137,6 +137,46 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     } catch {}
   }
 
+  /** Poll `lsof` until a process (optionally different from `notPid`) listens on `port`. */
+  async function waitForListeningPid(
+    port: number,
+    timeoutMs: number,
+    notPid?: number,
+  ): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const out = execFileSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], {
+          encoding: "utf-8",
+        }).trim();
+        const pid = out
+          .split("\n")
+          .filter(Boolean)
+          .map((p) => parseInt(p, 10))
+          .find((p) => p !== notPid);
+        if (pid) return pid;
+      } catch {
+        // lsof exits non-zero when nothing is listening — keep polling
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    throw new Error(
+      `No${notPid ? " new" : ""} process listening on :${port} within ${timeoutMs}ms`,
+    );
+  }
+
+  /** Poll the daemon API until the test mind reports status "running". */
+  async function waitForMindRunning(timeoutMs = 30000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const res = await daemonRequest(`/api/minds/${TEST_MIND}`);
+      const s = (await res.json()) as { status: string };
+      if (s.status === "running") return;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    throw new Error(`Mind did not reach running within ${timeoutMs}ms`);
+  }
+
   it("health endpoint returns ok", async () => {
     const res = await fetch(`${BASE_URL}/api/health`);
     assert.equal(res.status, 200);
@@ -403,6 +443,30 @@ describe("daemon e2e", { timeout: 120000 }, () => {
       "stopped",
       "Stopped mind should not be auto-started after daemon restart",
     );
+  });
+
+  it("crash recovery: daemon restarts a mind whose process dies", { timeout: 60000 }, async () => {
+    const entry = await findMind(TEST_MIND);
+    assert.ok(entry, "test mind should be registered");
+
+    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    assert.ok(
+      startRes.status === 200 || startRes.status === 409,
+      `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
+    );
+    await waitForMindRunning();
+
+    // Kill the mind's server process out from under the daemon.
+    const oldPid = await waitForListeningPid(entry.port, 15000);
+    process.kill(oldPid, "SIGKILL");
+
+    // Crash recovery has a 3s first-attempt backoff, then respawns via tsx.
+    const newPid = await waitForListeningPid(entry.port, 30000, oldPid);
+    assert.notEqual(newPid, oldPid, "a new process should be listening after crash recovery");
+
+    await waitForMindRunning();
+
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   // ── Bridge & Chat Integration Tests ──

--- a/test/last-known-good.test.ts
+++ b/test/last-known-good.test.ts
@@ -9,7 +9,7 @@ import {
   rollbackSrcChanges,
 } from "../packages/daemon/src/lib/mind/last-known-good.js";
 
-const tmpDir = join(tmpdir(), ".volute-lkg-test");
+const tmpDir = join(tmpdir(), `.volute-lkg-test-${process.pid}`);
 const repoDir = join(tmpDir, "mind-repo");
 
 function git(args: string[]): string {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,7 +11,11 @@ for (const key of Object.keys(process.env)) {
 
 // Redirect all volute state to a temp directory so tests never touch
 // the live ~/.volute (registry, variants, database, env, etc.)
-const testHome = resolve(tmpdir(), `volute-test-${process.pid}`);
+// On macOS use /tmp rather than os.tmpdir()'s long /var/folders/... path:
+// minds get TMPDIR=<mindDir>/.mind/tmp, and tsx creates a unix socket there
+// whose path must stay under the 104-byte sun_path limit.
+const tmpRoot = process.platform === "darwin" ? "/tmp" : tmpdir();
+const testHome = resolve(tmpRoot, `volute-test-${process.pid}`);
 // Remove stale test dir from a prior run with the same PID to ensure
 // a clean database (avoids migration issues with leftover DB files)
 if (existsSync(testHome)) rmSync(testHome, { recursive: true, force: true });

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -13,7 +13,7 @@ import {
   listFiles,
 } from "../packages/daemon/src/lib/template/template.js";
 
-const tmpDir = join(tmpdir(), ".volute-upgrade-test");
+const tmpDir = join(tmpdir(), `.volute-upgrade-test-${process.pid}`);
 
 function git(args: string[], cwd: string): string {
   // Strip ALL GIT_* env vars set by hooks (e.g. pre-push) that override cwd-based repo discovery


### PR DESCRIPTION
## Summary
- **Fix the broken daemon e2e suite**: test setup now uses `/tmp` on macOS so the mind's TMPDIR-based tsx IPC socket stays under the 104-byte `sun_path` limit, and tests were updated for API drift (`{ items, hasMore }` messages envelope from #274, `channel_name` field in channel lists)
- **Run `npm run test:e2e` in CI** — the suite is excluded from `npm test` and was never exercised in CI, which is how it drifted silently
- **New e2e coverage**:
  - crash recovery: SIGKILL the mind's process, assert the daemon respawns it
  - chat delivery round-trip: `/api/v1/chat` → delivery queue → mind → `mind_history` inbound row, runs without `ANTHROPIC_API_KEY`
  - variant split/merge: worktree creation, registry, merge-back with cleanup and parent restart
- **Replace a dead test**: `"message proxy returns JSON response"` posted to `POST /api/minds/:name/message`, which no longer exists — it never failed because it self-skipped without an API key
- **De-flake unit tests**: pid-suffix the fixed tmp dir names in `upgrade`/`last-known-good`/`auto-commit` tests so concurrent `npm test` runs on one machine don't delete each other's working directories

## Test plan
- `npm test` (1712 tests) and `npm run test:e2e` (46 tests) both green locally on macOS
- e2e suite runs ~47s locally; expect a few minutes in CI (cold npm cache for the two mind installs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)