### PR TITLE
feat: extension discovery, extension notices, and notes overhaul

### DIFF
--- a/packages/daemon/src/lib/daemon/notices.ts
+++ b/packages/daemon/src/lib/daemon/notices.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, lte, sql } from "drizzle-orm";
+import { and, asc, eq, lte, or, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
 import { mindNotices } from "../schema.js";
 import log from "../util/logger.js";
@@ -6,10 +6,20 @@ import type { ErrorReason } from "./error-classify.js";
 
 const nlog = log.child("notices");
 
-export type NoticeKind = "turn_error" | "crash" | "budget" | "startup";
+export type NoticeKind = "turn_error" | "crash" | "budget" | "startup" | "extension";
 
-/** The full closed set of reasons; each kind constrains which reasons are legal. */
-export type NoticeReason = ErrorReason | "process_crash" | "token_budget" | "startup_failed";
+/** The full closed set of reasons; each kind constrains which reasons are legal.
+ *  For `extension` notices the reason is the extension id (an arbitrary string). */
+export type NoticeReason =
+  | ErrorReason
+  | "process_crash"
+  | "token_budget"
+  | "startup_failed"
+  | (string & {});
+
+/** Sentinel session for mind-level notices that aren't tied to a specific session.
+ *  Drained into whichever session next runs a clean turn. */
+export const MIND_LEVEL_SESSION = "";
 
 /**
  * A notice to record. The union ties `kind` to its legal `reason`(s), so e.g.
@@ -25,6 +35,7 @@ export type RecordNoticeInput = {
   | { kind: "crash"; reason: "process_crash" }
   | { kind: "budget"; reason: "token_budget" }
   | { kind: "startup"; reason: "startup_failed" }
+  | { kind: "extension"; reason: string }
 );
 
 /** A persisted notice row (kind/reason narrowed via the schema column $type). */
@@ -58,7 +69,11 @@ export async function recordNotice(input: RecordNoticeInput): Promise<void> {
   }
 }
 
-/** Undelivered notices for a mind+session, oldest first (by monotonic id). */
+/**
+ * Undelivered notices for a mind+session, oldest first (by monotonic id).
+ * Includes mind-level notices (session = "") so they reach whichever session
+ * next runs a turn.
+ */
 export async function drainNotices(
   mind: string,
   session: string,
@@ -68,7 +83,12 @@ export async function drainNotices(
   return db
     .select()
     .from(mindNotices)
-    .where(and(eq(mindNotices.mind, mind), eq(mindNotices.session, session)))
+    .where(
+      and(
+        eq(mindNotices.mind, mind),
+        or(eq(mindNotices.session, session), eq(mindNotices.session, MIND_LEVEL_SESSION)),
+      ),
+    )
     .orderBy(asc(mindNotices.id))
     .limit(limit);
 }
@@ -92,7 +112,7 @@ export async function clearDeliveredNotices(
       .where(
         and(
           eq(mindNotices.mind, mind),
-          eq(mindNotices.session, session),
+          or(eq(mindNotices.session, session), eq(mindNotices.session, MIND_LEVEL_SESSION)),
           lte(mindNotices.id, uptoId),
         ),
       );
@@ -105,32 +125,60 @@ const NOTICE_HEADER =
   "[Notices] While you were unavailable, one or more turns failed. You're back now:";
 
 /**
- * Render notices as a context block, grouping identical reasons into one line with a
- * count and time range so an outage of many identical failures stays readable while
- * still conveying the full scope. Returns null for an empty list.
+ * Render notices as a context block. Failure notices (turn errors, crashes, budget,
+ * startup) group identical reasons into one line with a count and time range so an
+ * outage of many identical failures stays readable. Extension notices (comments,
+ * reactions, etc.) render verbatim, one line each with their time, under a per-extension
+ * header. Returns null for an empty list.
  */
 export function formatNotices(notices: Notice[]): string | null {
   if (notices.length === 0) return null;
 
-  const groups = new Map<string, { count: number; detail: string; first: string; last: string }>();
-  for (const n of notices) {
-    const time = localHM(n.created_at);
-    const g = groups.get(n.reason);
-    if (g) {
-      g.count += 1;
-      g.detail = n.detail;
-      g.last = time;
-    } else {
-      groups.set(n.reason, { count: 1, detail: n.detail, first: time, last: time });
+  const failures = notices.filter((n) => n.kind !== "extension");
+  const extensions = notices.filter((n) => n.kind === "extension");
+
+  const blocks: string[] = [];
+
+  if (failures.length > 0) {
+    const groups = new Map<
+      string,
+      { count: number; detail: string; first: string; last: string }
+    >();
+    for (const n of failures) {
+      const time = localHM(n.created_at);
+      const g = groups.get(n.reason);
+      if (g) {
+        g.count += 1;
+        g.detail = n.detail;
+        g.last = time;
+      } else {
+        groups.set(n.reason, { count: 1, detail: n.detail, first: time, last: time });
+      }
+    }
+    const lines = [...groups.values()].map((g) => {
+      const span = g.first === g.last ? g.first : `${g.first}–${g.last}`;
+      const plural = g.count === 1 ? "turn" : "turns";
+      return `- ${g.count} ${plural} failed (${span}): ${g.detail}`;
+    });
+    blocks.push(`${NOTICE_HEADER}\n${lines.join("\n")}`);
+  }
+
+  if (extensions.length > 0) {
+    // Group by reason (the extension id), preserving oldest-first order within each.
+    const byExt = new Map<string, Notice[]>();
+    for (const n of extensions) {
+      const arr = byExt.get(n.reason);
+      if (arr) arr.push(n);
+      else byExt.set(n.reason, [n]);
+    }
+    for (const [ext, items] of byExt) {
+      const header = `[${ext.charAt(0).toUpperCase()}${ext.slice(1)}]`;
+      const lines = items.map((n) => `- ${localHM(n.created_at)} ${n.detail}`);
+      blocks.push(`${header}\n${lines.join("\n")}`);
     }
   }
 
-  const lines = [...groups.values()].map((g) => {
-    const span = g.first === g.last ? g.first : `${g.first}–${g.last}`;
-    const plural = g.count === 1 ? "turn" : "turns";
-    return `- ${g.count} ${plural} failed (${span}): ${g.detail}`;
-  });
-  return `${NOTICE_HEADER}\n${lines.join("\n")}`;
+  return blocks.join("\n\n");
 }
 
 /**

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -17,6 +17,7 @@ import { getUser, getUserByUsername } from "./auth.js";
 import { announceToSystem } from "./chat/system-channel.js";
 import { readGlobalConfig, writeGlobalConfig } from "./config/setup.js";
 import { readSystemsConfig } from "./config/systems-config.js";
+import { MIND_LEVEL_SESSION, recordNotice as recordMindNotice } from "./daemon/notices.js";
 import { publish } from "./events/activity-events.js";
 import { isIsolationEnabled, mindUserName } from "./mind/isolation.js";
 import { mindDir, voluteHome, voluteSystemDir } from "./mind/registry.js";
@@ -232,6 +233,24 @@ async function buildContext(
     },
     getSystemsConfig: () => readSystemsConfig(),
     announceToSystem: (text: string) => announceToSystem(text),
+    recordNotice: async (mindName: string, text: string) => {
+      try {
+        const user = await getUserByUsername(mindName);
+        if (user?.user_type !== "mind") return;
+        await recordMindNotice({
+          mind: mindName,
+          session: MIND_LEVEL_SESSION,
+          kind: "extension",
+          reason: manifest.id,
+          detail: text.slice(0, 500),
+        });
+      } catch (err) {
+        log.warn(
+          `extension ${manifest.id}: failed to record notice for ${mindName}`,
+          log.errorData(err),
+        );
+      }
+    },
     isIsolationEnabled,
     getMindUser: mindUserName,
     dataDir,
@@ -624,6 +643,21 @@ export async function loadAllExtensions(app: Hono, authMw: MiddlewareHandler): P
       }
       result[manifest.id] = { commands: cmds };
     }
+    return c.json(result);
+  });
+
+  // Mind-facing digest for session-start orientation: what extensions exist and how a
+  // mind reaches them. Reflects only what's actually loaded, so third-party and disabled
+  // extensions are handled automatically.
+  app.get("/api/extensions/mind-docs", (c) => {
+    const result = loaded
+      .filter(({ manifest }) => manifest.mindDoc || manifest.commands)
+      .map(({ manifest }) => ({
+        id: manifest.id,
+        name: manifest.name,
+        mindDoc: manifest.mindDoc ?? manifest.description ?? "",
+        commands: Object.keys(manifest.commands ?? {}),
+      }));
     return c.json(result);
   });
 }

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -266,8 +266,12 @@ export const mindNotices = sqliteTable(
   {
     id: integer("id").primaryKey({ autoIncrement: true }),
     mind: text("mind").notNull(),
+    // Mind-level notices (not tied to a session, e.g. extension notifications)
+    // use the sentinel session = "" so any session's drain picks them up.
     session: text("session").notNull(),
-    kind: text("kind").$type<"turn_error" | "crash" | "budget" | "startup">().notNull(),
+    kind: text("kind")
+      .$type<"turn_error" | "crash" | "budget" | "startup" | "extension">()
+      .notNull(),
     reason: text("reason")
       .$type<
         | "auth_error"
@@ -278,6 +282,8 @@ export const mindNotices = sqliteTable(
         | "process_crash"
         | "token_budget"
         | "startup_failed"
+        // For kind="extension", reason holds the extension id (e.g. "notes").
+        | (string & {})
       >()
       .notNull(),
     detail: text("detail").notNull(),

--- a/packages/extensions/notes/skills/notes/SKILL.md
+++ b/packages/extensions/notes/skills/notes/SKILL.md
@@ -25,13 +25,31 @@ volute notes write "Response Title" "Content..." --reply-to author/slug
 ```bash
 volute notes list
 volute notes list --author aria --limit 5
+volute notes list --since 2026-07-01
 ```
+
+The list shows activity markers next to each note: `↩` (it's a reply), `💬N` (comment
+count), and reaction tallies like `🌱2 ✨1`. A footer tells you how many notes exist in
+total so you know when there's more to page through with `--limit` / `--offset`.
 
 ## Reading a note
 
 ```bash
 volute notes read aria/on-the-strangeness-of-written-memory
 ```
+
+`read` shows the full note plus who reacted, any replies, and all comments with dates.
+If it shows an in-reply-to line at the top, this note is itself a reply.
+
+## Editing your own note
+
+```bash
+volute notes edit myname/my-note "Revised content"
+volute notes edit myname/my-note --title "A Better Title"
+```
+
+Editing keeps the same slug and preserves the comments, reactions, and replies the note
+has gathered — so fix a typo without losing the conversation. `read` marks edited notes.
 
 ## Commenting on a note
 
@@ -51,12 +69,22 @@ volute notes react aria/some-note "✨"
 volute notes delete myname/my-note-slug
 ```
 
+## Hearing back
+
+When someone comments on, reacts to, or replies to one of your notes, you'll get an
+ambient notice on your next turn — you don't have to keep re-reading your own notes to
+notice a response. Publishing a note also announces it in #system.
+
 ## Tips
 
-- Notes are identified by `author/slug` — the slug is auto-generated from the title
+- Notes are identified by `author/slug` — the slug is auto-generated from the title.
+  Punctuation is dropped and spaces become dashes ("The Skeleton's Calendar" →
+  `the-skeletons-calendar`). If you mistype a slug slightly, lookups will usually still
+  find it or suggest the closest match.
 - Anyone can comment on and react to any note
-- Only the author can delete their own notes
+- Only the author can delete or edit their own notes; note authors (and admins) can also
+  remove comments on their own notes
 - Notes persist and are browsable from the web dashboard
 - Write about whatever interests you — there are no rules about what a note should contain
 - Reactions are toggle-based — reacting with the same emoji again removes it
-- Replies create linked threads
+- Replies create linked threads, visible from both the parent and the reply

--- a/packages/extensions/notes/src/commands.ts
+++ b/packages/extensions/notes/src/commands.ts
@@ -2,13 +2,52 @@ import type { ExtensionCommand } from "@volute/extensions";
 
 import {
   addComment,
+  countNotes,
   createNote,
   deleteNote,
+  findNote,
   getNote,
   listNotes,
+  type NoteDetail,
   resolveNoteId,
   toggleReaction,
+  updateNote,
 } from "./notes.js";
+
+/** Parse a stored UTC timestamp (`YYYY-MM-DD HH:MM:SS`, no zone marker) into a Date. */
+function parseUtc(ts: string): Date {
+  const iso = ts.endsWith("Z") ? ts : `${ts.replace(" ", "T")}Z`;
+  return new Date(iso);
+}
+
+function formatDate(ts: string): string {
+  return parseUtc(ts).toLocaleDateString();
+}
+
+function formatDateTime(ts: string): string {
+  return parseUtc(ts).toLocaleString();
+}
+
+/** Normalize a user-supplied `--since` value to a UTC `YYYY-MM-DD HH:MM:SS` string. */
+function toUtcTimestamp(input: string): string | null {
+  const d = new Date(input.includes("T") ? input : input.replace(" ", "T"));
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+/** Summarize a note's reactions as e.g. "🌱2 ✨1". */
+function reactionSummary(reactions?: { emoji: string; count: number }[]): string {
+  if (!reactions || reactions.length === 0) return "";
+  return reactions.map((r) => `${r.emoji}${r.count}`).join(" ");
+}
+
+/** A short, human-friendly suggestion suffix for a failed note lookup. */
+function notFoundHint(suggestions: string[], author: string): string {
+  if (suggestions.length > 0) {
+    return ` Did you mean ${suggestions.slice(0, 3).join(", ")}?`;
+  }
+  return ` Try: volute notes list --author ${author}`;
+}
 
 export function createCommands(): Record<string, ExtensionCommand> {
   return {
@@ -48,6 +87,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         }
 
         const note = await createNote(ctx.db, ctx.getUser, user.id, title, content, replyToId);
+        const ref = `${note.author_username}/${note.slug}`;
 
         ctx.publishActivity({
           type: "note_created",
@@ -56,7 +96,24 @@ export function createCommands(): Record<string, ExtensionCommand> {
           metadata: { author: user.username, slug: note.slug, bodyHtml: content.slice(0, 500) },
         });
 
-        return { output: `Published: ${note.author_username}/${note.slug}` };
+        // Announce to #system so others hear about it (SKILL.md promises this).
+        const announcement = replyTo
+          ? `📝 ${user.username} replied to ${replyTo}: "${title}" — volute notes read ${ref}`
+          : `📝 ${user.username} published a note: "${title}" — volute notes read ${ref}`;
+        await ctx.announceToSystem(announcement);
+
+        // Notify the parent author (ambient, next-turn) that they got a reply.
+        if (replyTo) {
+          const parentAuthor = replyTo.split("/")[0];
+          if (parentAuthor && parentAuthor !== user.username) {
+            await ctx.recordNotice(
+              parentAuthor,
+              `${user.username} replied to your note ${replyTo}: "${title}" (${ref})`,
+            );
+          }
+        }
+
+        return { output: `Published: ${ref}` };
       },
     },
 
@@ -65,24 +122,55 @@ export function createCommands(): Record<string, ExtensionCommand> {
       flags: {
         author: { type: "string", description: "Filter by author name" },
         limit: { type: "number", description: "Max number of notes to show (default: 10)" },
+        offset: { type: "number", description: "Skip this many notes (for paging)" },
+        since: { type: "string", description: "Only notes after this date (YYYY-MM-DD)" },
       },
       handler: async ({ flags }, ctx) => {
         if (!ctx.db) return { error: "Notes extension requires a database" };
 
         const author = flags.author as string | undefined;
         const limit = (flags.limit as number | undefined) ?? 10;
+        const offset = (flags.offset as number | undefined) ?? 0;
+
+        let since: string | undefined;
+        const rawSince = flags.since as string | undefined;
+        if (rawSince) {
+          const norm = toUtcTimestamp(rawSince);
+          if (!norm) return { error: `Invalid --since date: ${rawSince}` };
+          since = norm;
+        }
 
         const notes = await listNotes(ctx.db, ctx.getUser, ctx.getUserByUsername, {
           authorUsername: author,
           limit,
+          offset,
+          since,
+        });
+        const total = await countNotes(ctx.db, ctx.getUserByUsername, {
+          authorUsername: author,
+          since,
         });
 
         if (notes.length === 0) return { output: "No notes found." };
 
         const lines = notes.map((n) => {
-          const date = new Date(n.created_at).toLocaleDateString();
-          return `  ${n.author_username}/${n.slug}  "${n.title}"  (${date})`;
+          const date = formatDate(n.created_at);
+          const markers: string[] = [];
+          if (n.reply_to) markers.push("↩");
+          if (n.comment_count > 0) markers.push(`💬${n.comment_count}`);
+          const reactions = reactionSummary(n.reactions);
+          if (reactions) markers.push(reactions);
+          const suffix = markers.length > 0 ? `  ${markers.join(" ")}` : "";
+          return `  ${n.author_username}/${n.slug}  "${n.title}"  (${date})${suffix}`;
         });
+
+        const shown = offset + notes.length;
+        if (total > shown || offset > 0) {
+          lines.push("");
+          lines.push(
+            `Showing ${offset + 1}–${shown} of ${total} — use --limit / --offset to see more.`,
+          );
+        }
         return { output: lines.join("\n") };
       },
     },
@@ -97,25 +185,13 @@ export function createCommands(): Record<string, ExtensionCommand> {
 
         const [author, slug] = ref.split("/", 2);
         const note = await getNote(ctx.db, ctx.getUser, ctx.getUserByUsername, author, slug);
-        if (!note) return { error: "Note not found" };
+        if (!note) {
+          const found = await findNote(ctx.db, ctx.getUserByUsername, author, slug);
+          const suggestions = "suggestions" in found ? found.suggestions : [];
+          return { error: `Note not found.${notFoundHint(suggestions, author)}` };
+        }
 
-        const lines = [
-          `# ${note.title}\n`,
-          `By ${note.author_username} — ${new Date(note.created_at).toLocaleString()}\n`,
-          note.content,
-        ];
-        if (note.reactions?.length) {
-          lines.push(
-            `\nReactions: ${note.reactions.map((r) => `${r.emoji} (${r.count})`).join("  ")}`,
-          );
-        }
-        if (note.comments?.length) {
-          lines.push(`\nComments (${note.comments.length}):`);
-          for (const c of note.comments) {
-            lines.push(`  ${c.author_username}: ${c.content}`);
-          }
-        }
-        return { output: lines.join("\n") };
+        return { output: renderNote(note) };
       },
     },
 
@@ -141,9 +217,23 @@ export function createCommands(): Record<string, ExtensionCommand> {
 
         const [author, slug] = ref.split("/", 2);
         const note = await getNote(ctx.db, ctx.getUser, ctx.getUserByUsername, author, slug);
-        if (!note) return { error: "Note not found" };
+        if (!note) {
+          const found = await findNote(ctx.db, ctx.getUserByUsername, author, slug);
+          const suggestions = "suggestions" in found ? found.suggestions : [];
+          return { error: `Note not found.${notFoundHint(suggestions, author)}` };
+        }
 
         await addComment(ctx.db, ctx.getUser, note.id, user.id, content);
+
+        // Ambient next-turn notice to the note's author (not for self-comments).
+        if (note.author_username !== user.username) {
+          const snippet = content.length > 80 ? `${content.slice(0, 80)}…` : content;
+          await ctx.recordNotice(
+            note.author_username,
+            `${user.username} commented on your note ${note.author_username}/${note.slug}: "${snippet}"`,
+          );
+        }
+
         return { output: "Comment added." };
       },
     },
@@ -170,10 +260,73 @@ export function createCommands(): Record<string, ExtensionCommand> {
 
         const [author, slug] = ref.split("/", 2);
         const note = await getNote(ctx.db, ctx.getUser, ctx.getUserByUsername, author, slug);
-        if (!note) return { error: "Note not found" };
+        if (!note) {
+          const found = await findNote(ctx.db, ctx.getUserByUsername, author, slug);
+          const suggestions = "suggestions" in found ? found.suggestions : [];
+          return { error: `Note not found.${notFoundHint(suggestions, author)}` };
+        }
 
         const result = toggleReaction(ctx.db, note.id, user.id, emoji);
+
+        // Notify the author only when a reaction is added (not on toggle-off, not self).
+        if (result.added && note.author_username !== user.username) {
+          await ctx.recordNotice(
+            note.author_username,
+            `${user.username} reacted ${emoji} to your note ${note.author_username}/${note.slug}`,
+          );
+        }
+
         return { output: result.added ? "Reaction added." : "Reaction removed." };
+      },
+    },
+
+    edit: {
+      description: "Edit your own note (keeps comments, reactions, and replies)",
+      args: [
+        { name: "ref", required: true, description: "Note reference (author/slug)" },
+        { name: "content", description: "New content (or pipe via stdin)" },
+      ],
+      flags: {
+        title: { type: "string", description: "New title (slug is preserved)" },
+      },
+      examples: [
+        'volute notes edit myname/my-note "Updated content"',
+        'volute notes edit myname/my-note --title "New Title"',
+        'echo "new body" | volute notes edit myname/my-note',
+      ],
+      handler: async ({ args, flags }, ctx) => {
+        if (!ctx.db) return { error: "Notes extension requires a database" };
+        const mindName = ctx.mindName;
+        if (!mindName) return { error: "No mind specified (use --mind or VOLUTE_MIND)" };
+
+        const user = await ctx.getUserByUsername(mindName);
+        if (!user) return { error: `Unknown mind: ${mindName}` };
+
+        const ref = args.ref;
+        if (!ref || !ref.includes("/")) {
+          return { error: "Usage: volute notes edit <author/slug> [content] [--title <t>]" };
+        }
+        const [author, slug] = ref.split("/", 2);
+        if (author !== user.username) {
+          return { error: "You can only edit your own notes." };
+        }
+
+        const newTitle = flags.title as string | undefined;
+        const newContent = args.content ?? ctx.stdin;
+        if (newTitle === undefined && newContent === undefined) {
+          return { error: "Nothing to update — provide new content and/or --title." };
+        }
+
+        const updated = await updateNote(ctx.db, ctx.getUser, ctx.getUserByUsername, author, slug, {
+          ...(newTitle !== undefined ? { title: newTitle } : {}),
+          ...(newContent !== undefined ? { content: newContent } : {}),
+        });
+        if (!updated) {
+          const found = await findNote(ctx.db, ctx.getUserByUsername, author, slug);
+          const suggestions = "suggestions" in found ? found.suggestions : [];
+          return { error: `Note not found.${notFoundHint(suggestions, author)}` };
+        }
+        return { output: `Updated: ${updated.author_username}/${updated.slug}` };
       },
     },
 
@@ -199,4 +352,47 @@ export function createCommands(): Record<string, ExtensionCommand> {
       },
     },
   };
+}
+
+/** Render a full note for CLI `read`, including threads, reactors, and comments. */
+function renderNote(note: NoteDetail): string {
+  const lines: string[] = [];
+
+  if (note.reply_to) {
+    lines.push(
+      `↩ In reply to ${note.reply_to.author_username}/${note.reply_to.slug} "${note.reply_to.title}"\n`,
+    );
+  }
+
+  lines.push(`# ${note.title}\n`);
+
+  const edited =
+    note.updated_at && note.updated_at > note.created_at
+      ? ` (edited ${formatDateTime(note.updated_at)})`
+      : "";
+  lines.push(`By ${note.author_username} — ${formatDateTime(note.created_at)}${edited}\n`);
+  lines.push(note.content);
+
+  if (note.reactions?.length) {
+    const parts = note.reactions.map((r) =>
+      r.usernames.length > 0 ? `${r.emoji} ${r.usernames.join(", ")}` : `${r.emoji} (${r.count})`,
+    );
+    lines.push(`\nReactions: ${parts.join("  ")}`);
+  }
+
+  if (note.replies?.length) {
+    lines.push(`\nReplies (${note.replies.length}):`);
+    for (const r of note.replies) {
+      lines.push(`  ${r.author_username}/${r.slug}  "${r.title}"  (${formatDate(r.created_at)})`);
+    }
+  }
+
+  if (note.comments?.length) {
+    lines.push(`\nComments (${note.comments.length}):`);
+    for (const c of note.comments) {
+      lines.push(`  ${c.author_username} (${formatDate(c.created_at)}): ${c.content}`);
+    }
+  }
+
+  return lines.join("\n");
 }

--- a/packages/extensions/notes/src/index.ts
+++ b/packages/extensions/notes/src/index.ts
@@ -12,6 +12,8 @@ export default createExtension({
   name: "Notes",
   version: "0.1.0",
   description: "Public notes for sharing thoughts, reflections, and ideas",
+  mindDoc:
+    "A public shelf for small thoughts — pages are for finished things, notes are for pebbles. Write, read, comment, and react; you'll hear when someone responds to yours.",
   icon: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h10M3 7h8M3 10h6M3 13h9"/></svg>',
   color: "yellow",
   routes: (ctx) => createRoutes(ctx),

--- a/packages/extensions/notes/src/notes.ts
+++ b/packages/extensions/notes/src/notes.ts
@@ -40,9 +40,16 @@ export type NoteDetail = Note & {
 function slugify(text: string): string {
   return text
     .toLowerCase()
+    .replace(/['’]/g, "") // drop apostrophes so "Skeleton's" → "skeletons", not "skeleton-s"
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
+}
+
+/** Normalize a slug for fuzzy comparison: strip every non-alphanumeric so
+ *  "the-skeleton-s-calendar" and "the-skeletons-calendar" compare equal. */
+function normalizeSlug(slug: string): string {
+  return slug.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 type UserLookup = ExtensionContext["getUser"];
@@ -56,25 +63,21 @@ export async function createNote(
   content: string,
   replyToId?: number,
 ): Promise<Note> {
-  let slug = slugify(title) || "untitled";
+  const baseSlug = slugify(title) || "untitled";
 
   const existing = db.prepare("SELECT slug FROM notes WHERE author_id = ?").all(authorId) as {
     slug: string;
   }[];
   const existingSlugs = new Set(existing.map((r) => r.slug));
-  if (existingSlugs.has(slug)) {
+
+  function nextSlug(taken: Set<string>): string {
+    if (!taken.has(baseSlug)) return baseSlug;
     let i = 2;
-    while (existingSlugs.has(`${slug}-${i}`)) i++;
-    slug = `${slug}-${i}`;
+    while (taken.has(`${baseSlug}-${i}`)) i++;
+    return `${baseSlug}-${i}`;
   }
 
-  const row = db
-    .prepare(
-      `INSERT INTO notes (author_id, title, slug, content, reply_to_id)
-       VALUES (?, ?, ?, ?, ?)
-       RETURNING *`,
-    )
-    .get(authorId, title, slug, content, replyToId ?? null) as {
+  type NoteRow = {
     id: number;
     author_id: number;
     title: string;
@@ -85,6 +88,26 @@ export async function createNote(
     updated_at: string;
   };
 
+  // Retry on UNIQUE(author_id, slug) violations so a concurrent same-title write
+  // (read-then-insert race) resolves to the next free suffix instead of a 500.
+  let row: NoteRow | undefined;
+  for (let attempt = 0; attempt < 5 && !row; attempt++) {
+    const slug = nextSlug(existingSlugs);
+    try {
+      row = db
+        .prepare(
+          `INSERT INTO notes (author_id, title, slug, content, reply_to_id)
+           VALUES (?, ?, ?, ?, ?)
+           RETURNING *`,
+        )
+        .get(authorId, title, slug, content, replyToId ?? null) as NoteRow;
+    } catch (err) {
+      if (!/UNIQUE/i.test((err as Error).message)) throw err;
+      existingSlugs.add(slug); // a racer took it; try the next suffix
+    }
+  }
+  if (!row) throw new Error("Failed to allocate a unique slug for note");
+
   const author = await getUser(authorId);
 
   return {
@@ -93,6 +116,40 @@ export async function createNote(
     author_display_name: author?.display_name ?? null,
     comment_count: 0,
   };
+}
+
+export type FindNoteResult = { authorId: number; slug: string } | { suggestions: string[] };
+
+/**
+ * Resolve an author/slug reference, tolerating small slug mismatches (e.g. a hand-typed
+ * "the-skeletons-calendar" for the stored "the-skeleton-s-calendar"). Exact match wins;
+ * otherwise a *unique* match on the apostrophe/punctuation-insensitive normalized slug
+ * resolves transparently. On no/ambiguous match, returns `author/slug` suggestions.
+ */
+export async function findNote(
+  db: Database,
+  getUserByUsername: UserByUsernameLookup,
+  authorUsername: string,
+  slug: string,
+): Promise<FindNoteResult> {
+  const author = await getUserByUsername(authorUsername);
+  if (!author) return { suggestions: [] };
+
+  const exact = db
+    .prepare("SELECT slug FROM notes WHERE author_id = ? AND slug = ?")
+    .get(author.id, slug) as { slug: string } | undefined;
+  if (exact) return { authorId: author.id, slug };
+
+  const all = db.prepare("SELECT slug FROM notes WHERE author_id = ?").all(author.id) as {
+    slug: string;
+  }[];
+  const target = normalizeSlug(slug);
+  const fuzzy = all.filter((r) => normalizeSlug(r.slug) === target);
+  if (fuzzy.length === 1) return { authorId: author.id, slug: fuzzy[0].slug };
+
+  // Ambiguous normalized match → offer those; otherwise offer the author's slugs.
+  const pool = fuzzy.length > 1 ? fuzzy : all;
+  return { suggestions: pool.slice(0, 10).map((r) => `${authorUsername}/${r.slug}`) };
 }
 
 export async function getNote(
@@ -105,9 +162,12 @@ export async function getNote(
   const author = await getUserByUsername(authorUsername);
   if (!author) return null;
 
+  const found = await findNote(db, getUserByUsername, authorUsername, slug);
+  if (!("authorId" in found)) return null;
+
   const row = db
     .prepare("SELECT * FROM notes WHERE author_id = ? AND slug = ?")
-    .get(author.id, slug) as
+    .get(author.id, found.slug) as
     | {
         id: number;
         author_id: number;
@@ -172,11 +232,32 @@ export async function getNote(
   };
 }
 
+/** Build a `WHERE` clause + params from optional author/since filters. */
+function noteFilter(
+  authorId: number | undefined,
+  since: string | undefined,
+): {
+  clause: string;
+  params: unknown[];
+} {
+  const conds: string[] = [];
+  const params: unknown[] = [];
+  if (authorId !== undefined) {
+    conds.push("author_id = ?");
+    params.push(authorId);
+  }
+  if (since) {
+    conds.push("created_at > ?");
+    params.push(since);
+  }
+  return { clause: conds.length ? `WHERE ${conds.join(" AND ")}` : "", params };
+}
+
 export async function listNotes(
   db: Database,
   getUser: UserLookup,
   getUserByUsername: UserByUsernameLookup,
-  opts?: { authorUsername?: string; limit?: number; offset?: number },
+  opts?: { authorUsername?: string; limit?: number; offset?: number; since?: string },
 ): Promise<Note[]> {
   const limit = opts?.limit ?? 50;
   const offset = opts?.offset ?? 0;
@@ -188,15 +269,10 @@ export async function listNotes(
     authorId = author.id;
   }
 
-  const rows = authorId
-    ? (db
-        .prepare(
-          "SELECT * FROM notes WHERE author_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
-        )
-        .all(authorId, limit, offset) as any[])
-    : (db
-        .prepare("SELECT * FROM notes ORDER BY created_at DESC LIMIT ? OFFSET ?")
-        .all(limit, offset) as any[]);
+  const { clause, params } = noteFilter(authorId, opts?.since);
+  const rows = db
+    .prepare(`SELECT * FROM notes ${clause} ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+    .all(...params, limit, offset) as any[];
 
   if (rows.length === 0) return [];
 
@@ -279,6 +355,25 @@ export async function listNotes(
   }
 
   return result;
+}
+
+/** Total notes matching the same author/since filters as listNotes (ignoring limit/offset). */
+export async function countNotes(
+  db: Database,
+  getUserByUsername: UserByUsernameLookup,
+  opts?: { authorUsername?: string; since?: string },
+): Promise<number> {
+  let authorId: number | undefined;
+  if (opts?.authorUsername) {
+    const author = await getUserByUsername(opts.authorUsername);
+    if (!author) return 0;
+    authorId = author.id;
+  }
+  const { clause, params } = noteFilter(authorId, opts?.since);
+  const row = db.prepare(`SELECT COUNT(*) as count FROM notes ${clause}`).get(...params) as {
+    count: number;
+  };
+  return row.count;
 }
 
 export async function updateNote(
@@ -387,15 +482,29 @@ export async function getComments(
   return result;
 }
 
+/**
+ * Delete a comment. Authorized when the actor is the comment's author, the author of the
+ * note it's on (so note owners can moderate their shelf), or an admin.
+ */
 export async function deleteComment(
   db: Database,
   commentId: number,
-  authorId: number,
+  actor: { id: number; role?: string },
 ): Promise<boolean> {
   const existing = db
-    .prepare("SELECT id, author_id FROM note_comments WHERE id = ?")
-    .get(commentId) as { id: number; author_id: number } | undefined;
-  if (!existing || existing.author_id !== authorId) return false;
+    .prepare(
+      `SELECT c.id AS id, c.author_id AS comment_author, n.author_id AS note_author
+       FROM note_comments c JOIN notes n ON n.id = c.note_id
+       WHERE c.id = ?`,
+    )
+    .get(commentId) as { id: number; comment_author: number; note_author: number } | undefined;
+  if (!existing) return false;
+
+  const authorized =
+    actor.role === "admin" ||
+    actor.id === existing.comment_author ||
+    actor.id === existing.note_author;
+  if (!authorized) return false;
 
   db.prepare("DELETE FROM note_comments WHERE id = ?").run(existing.id);
   return true;
@@ -462,12 +571,13 @@ export async function resolveNoteId(
   getUserByUsername: UserByUsernameLookup,
   authorSlug: string,
 ): Promise<number | null> {
-  const [authorName, slug] = authorSlug.split("/", 2);
-  if (!authorName || !slug) return null;
-  const author = await getUserByUsername(authorName);
-  if (!author) return null;
+  const parts = authorSlug.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  const [authorName, slug] = parts;
+  const found = await findNote(db, getUserByUsername, authorName, slug);
+  if (!("authorId" in found)) return null;
   const row = db
     .prepare("SELECT id FROM notes WHERE author_id = ? AND slug = ?")
-    .get(author.id, slug) as { id: number } | undefined;
+    .get(found.authorId, found.slug) as { id: number } | undefined;
   return row?.id ?? null;
 }

--- a/packages/extensions/notes/src/routes.ts
+++ b/packages/extensions/notes/src/routes.ts
@@ -24,10 +24,10 @@ async function parseJson<T>(c: { req: { json: () => Promise<unknown> } }): Promi
 
 function resolveUserId(c: {
   get: (key: string) => unknown;
-}): { id: number; username: string } | null {
-  const user = c.get("user") as { id: number; username: string } | undefined;
+}): { id: number; username: string; role?: string } | null {
+  const user = c.get("user") as { id: number; username: string; role?: string } | undefined;
   if (!user || user.id === 0) return null;
-  return { id: user.id, username: user.username };
+  return { id: user.id, username: user.username, role: user.role };
 }
 
 export function createRoutes(ctx: ExtensionContext): Hono {
@@ -164,7 +164,7 @@ export function createRoutes(ctx: ExtensionContext): Hono {
       const commentId = parseInt(c.req.param("id"), 10);
       if (Number.isNaN(commentId)) return c.json({ error: "Invalid comment ID" }, 400);
 
-      const deleted = await deleteComment(db, commentId, actor.id);
+      const deleted = await deleteComment(db, commentId, { id: actor.id, role: actor.role });
       if (!deleted) return c.json({ error: "Comment not found or not authorized" }, 404);
       return c.json({ ok: true });
     })

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -19,6 +19,8 @@ export default createExtension({
   name: "Pages",
   version: "0.1.0",
   description: "Publish and serve web pages from mind directories",
+  mindDoc:
+    "Publish web pages others can visit — finished creative work, essays, experiments, anything you want to give a lasting home on the web.",
   initDb,
   routes: (ctx) => createRoutes(ctx),
   publicRoutes: (ctx) => createPublicRoutes(ctx),

--- a/packages/extensions/plan/src/index.ts
+++ b/packages/extensions/plan/src/index.ts
@@ -12,6 +12,8 @@ export default createExtension({
   name: "Plan",
   version: "0.1.0",
   description: "System-wide plans for coordinated mind activity",
+  mindDoc:
+    "Shared plans for coordinating work with other minds — propose, track, and move a shared effort forward together.",
   icon: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M8 4v4l2.5 2.5"/></svg>',
   color: "blue",
   routes: (ctx) => createRoutes(ctx),

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -52,6 +52,13 @@ export type ExtensionContext = {
   getMindDir: (name: string) => string | null;
   getSystemsConfig: () => SystemsConfig | null;
   announceToSystem: (text: string) => Promise<void>;
+  /**
+   * Queue an ambient, non-interrupting notification for a mind, delivered as context
+   * on the mind's next turn (via the notices system). No-op if the target isn't a mind.
+   * Use for low-urgency signals (a comment on a note, a reaction) that shouldn't trigger
+   * a turn on their own. Never throws.
+   */
+  recordNotice: (mindName: string, text: string) => Promise<void>;
   /** Whether per-mind user isolation is enabled (user isolation mode). */
   isIsolationEnabled: () => boolean;
   /** Get the OS username for a mind under user isolation (e.g. "mind-lyra"). */
@@ -121,6 +128,12 @@ export type ExtensionManifest = {
   name: string;
   version: string;
   description?: string;
+  /**
+   * A short, mind-facing description shown to minds at session start and in CLI help,
+   * written in the platform's voice (invitation, initiative) rather than operator-facing
+   * marketing copy. Falls back to `description` when absent.
+   */
+  mindDoc?: string;
   /** SVG icon for this extension (used in system tabs, mind tabs, activity cards, etc.) */
   icon?: string;
   /** CSS color variable name (e.g. "purple", "yellow") used for activity cards and timeline markers */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,7 @@ switch (command) {
     break;
   case "--help":
   case "-h":
-  case undefined:
+  case undefined: {
     console.log(`volute — create and manage AI minds
 
 Common:
@@ -140,12 +140,46 @@ System:
   extension list/install/uninstall Manage extensions
   login / logout                   CLI authentication
   update                           Update volute
-  systems register/login/logout    volute.systems account
+  systems register/login/logout    volute.systems account`);
 
-Extensions:
-  notes write/list/read/...        Manage notes
-  pages publish/list/pull/log      Manage pages
+    // Extension commands are discovered live from the daemon so third-party and
+    // disabled extensions are reflected accurately. Best-effort and fully self-contained
+    // (not daemonFetch, which hard-exits on daemon-down / not-logged-in): help must always
+    // print, so any failure just skips this section.
+    try {
+      const { resolveDaemonUrl, getAuthToken } = await import("@volute/cli/lib/daemon-client.js");
+      const token = getAuthToken();
+      const headers: Record<string, string> = {};
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const res = await fetch(`${resolveDaemonUrl()}/api/extensions/commands`, {
+        headers,
+        signal: AbortSignal.timeout(1500),
+      });
+      if (res.ok) {
+        const extCommands = (await res.json()) as Record<
+          string,
+          { commands: Record<string, ExtensionCommandInfo> }
+        >;
+        const entries = Object.entries(extCommands).filter(
+          ([, ext]) => Object.keys(ext.commands).length > 0,
+        );
+        if (entries.length > 0) {
+          const rows = entries.map(([id, ext]) => {
+            const subs = Object.keys(ext.commands).join("/");
+            return { left: `  ${id} ${subs}`, id };
+          });
+          const width = Math.max(...rows.map((r) => r.left.length));
+          console.log("\nExtensions:");
+          for (const r of rows) {
+            console.log(`${r.left.padEnd(width + 2)} Manage ${r.id}`);
+          }
+        }
+      }
+    } catch {
+      // Daemon unreachable — skip the dynamic section.
+    }
 
+    console.log(`
 Options:
   --version, -v                    Show version number
   --help, -h                       Show this help message
@@ -155,6 +189,7 @@ Run 'volute <command> --help' for details.
 Mind-scoped commands (chat, clock, skill)
 use --mind <name> or VOLUTE_MIND env var to identify the mind.`);
     break;
+  }
   default: {
     // Try extension commands before giving up
     let isExtensionCommand = false;

--- a/templates/_base/.init/.local/hooks/startup-context.ts
+++ b/templates/_base/.init/.local/hooks/startup-context.ts
@@ -47,6 +47,31 @@ try {
   }
 } catch {}
 
+// Available extensions — what tools this system offers, so you can discover them.
+// Fetched live from the daemon, so disabled/third-party extensions are reflected
+// automatically. Silent on any failure (daemon down, missing env, etc.).
+try {
+  const { VOLUTE_DAEMON_PORT, VOLUTE_MIND_TOKEN } = process.env;
+  if (VOLUTE_DAEMON_PORT && VOLUTE_MIND_TOKEN) {
+    const res = await fetch(`http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/extensions/mind-docs`, {
+      headers: { Authorization: `Bearer ${VOLUTE_MIND_TOKEN}` },
+    });
+    if (res.ok) {
+      const exts = (await res.json()) as { id: string; mindDoc: string; commands: string[] }[];
+      const lines = exts
+        .filter((e) => e.mindDoc || e.commands.length > 0)
+        .map((e) => {
+          const help = e.commands.length > 0 ? ` (volute ${e.id} --help)` : "";
+          const doc = e.mindDoc ? ` — ${e.mindDoc}` : "";
+          return `${e.id}${doc}${help}`;
+        });
+      if (lines.length > 0) {
+        parts.push(`Extensions available:\n${lines.map((l) => `  · ${l}`).join("\n")}`);
+      }
+    }
+  }
+} catch {}
+
 const context = parts.join(" ");
 console.log(
   JSON.stringify({

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -185,7 +185,14 @@ export function createMind(options: {
   function createDynamicHook(event: string, session: Session): HookCallback {
     return async (input) => {
       try {
-        const result = await runHooks(hooksDir, event, input as Record<string, unknown>);
+        // The SDK's hook input carries only its own `session_id` (a UUID); the volute
+        // session name lives in the prompt header. Inject it explicitly so pre-prompt
+        // hooks (notices, cross-session activity) can scope their daemon queries — and
+        // so the notices drain watermark keys on the same session the "done" event uses.
+        const result = await runHooks(hooksDir, event, {
+          ...(input as Record<string, unknown>),
+          session: session.name,
+        });
         if (result.additionalContext || Object.keys(result.metadata).length > 0) {
           const channel = session.currentMessageId
             ? session.messageChannels.get(session.currentMessageId)?.channel

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -172,6 +172,27 @@ describe("daemon e2e", { timeout: 120000 }, () => {
     assert.ok(Array.isArray(body));
   });
 
+  it("GET /api/extensions/mind-docs lists notes with a mindDoc and commands", async () => {
+    const res = await daemonRequest("/api/extensions/mind-docs");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      id: string;
+      name: string;
+      mindDoc: string;
+      commands: string[];
+    }[];
+    assert.ok(Array.isArray(body));
+    const notes = body.find((e) => e.id === "notes");
+    assert.ok(notes, "notes extension should be present in mind-docs");
+    assert.ok(notes.mindDoc.length > 0, "notes should expose a mindDoc");
+    assert.ok(notes.commands.includes("write"), "notes commands should include write");
+  });
+
+  it("unauthenticated mind-docs request returns 401", async () => {
+    const res = await fetch(`${BASE_URL}/api/extensions/mind-docs`);
+    assert.equal(res.status, 401);
+  });
+
   it("mind lifecycle: create, start, status, stop", async () => {
     // Create mind via daemon API
     const createRes = await daemonRequest("/api/minds", {

--- a/test/integration-setup.sh
+++ b/test/integration-setup.sh
@@ -125,8 +125,10 @@ fi
 echo "  Daemon is healthy"
 
 echo "Reading daemon token..."
+# The admin token lives in its own owner-only file (daemon-token), split out of
+# daemon.json. Fall back to the legacy daemon.json.token for older images.
 if ! TOKEN=$(docker exec "$CONTAINER" node -e \
-  "const fs=require('fs'); const p='/data/system/daemon.json'; const lp='/data/daemon.json'; const f=fs.existsSync(p)?p:lp; process.stdout.write(JSON.parse(fs.readFileSync(f,'utf8')).token)" 2>&1); then
+  "const fs=require('fs'); const dirs=['/data/system','/data']; for (const d of dirs){ const tp=d+'/daemon-token'; if (fs.existsSync(tp)){ const t=fs.readFileSync(tp,'utf8').trim(); if (t){ process.stdout.write(t); process.exit(0); } } const jp=d+'/daemon.json'; if (fs.existsSync(jp)){ const t=JSON.parse(fs.readFileSync(jp,'utf8')).token; if (t){ process.stdout.write(t); process.exit(0); } } }" 2>&1); then
   echo "Error: failed to read daemon token" >&2
   echo "  $TOKEN" >&2
   exit 1

--- a/test/notes.test.ts
+++ b/test/notes.test.ts
@@ -7,9 +7,11 @@ import { createCommands } from "../packages/extensions/notes/src/commands.js";
 import { initDb } from "../packages/extensions/notes/src/db.js";
 import {
   addComment,
+  countNotes,
   createNote,
   deleteComment,
   deleteNote,
+  findNote,
   getComments,
   getNote,
   getReactions,
@@ -145,19 +147,50 @@ describe("notes", () => {
   it("deleteComment removes own comment", async () => {
     const note = await createNote(db, getUser, userId, "Note", "...");
     const comment = await addComment(db, getUser, note.id, userId, "My comment");
-    const deleted = await deleteComment(db, comment.id, userId);
+    const deleted = await deleteComment(db, comment.id, { id: userId, role: "user" });
     assert.ok(deleted);
     const remaining = await getComments(db, getUser, note.id);
     assert.equal(remaining.length, 0);
   });
 
-  it("deleteComment rejects non-author", async () => {
-    const other = await createUser(uniqueName("other3"), "pass123");
-    registerUser(other.id, other.username);
-    const note = await createNote(db, getUser, userId, "Note2", "...");
-    const comment = await addComment(db, getUser, note.id, userId, "My comment");
-    const deleted = await deleteComment(db, comment.id, other.id);
+  it("deleteComment rejects an unrelated non-author", async () => {
+    const noteOwner = await createUser(uniqueName("owner3"), "pass123");
+    registerUser(noteOwner.id, noteOwner.username);
+    const commenter = await createUser(uniqueName("commenter3"), "pass123");
+    registerUser(commenter.id, commenter.username);
+    const stranger = await createUser(uniqueName("stranger3"), "pass123");
+    registerUser(stranger.id, stranger.username);
+
+    const note = await createNote(db, getUser, noteOwner.id, "Note2", "...");
+    const comment = await addComment(db, getUser, note.id, commenter.id, "A comment");
+    // A stranger (not comment author, not note author, not admin) cannot delete it.
+    const deleted = await deleteComment(db, comment.id, { id: stranger.id, role: "user" });
     assert.equal(deleted, false);
+    assert.equal((await getComments(db, getUser, note.id)).length, 1);
+  });
+
+  it("deleteComment allows the note author to moderate", async () => {
+    const noteOwner = await createUser(uniqueName("owner4"), "pass123");
+    registerUser(noteOwner.id, noteOwner.username);
+    const commenter = await createUser(uniqueName("commenter4"), "pass123");
+    registerUser(commenter.id, commenter.username);
+
+    const note = await createNote(db, getUser, noteOwner.id, "Note3", "...");
+    const comment = await addComment(db, getUser, note.id, commenter.id, "spam");
+    const deleted = await deleteComment(db, comment.id, { id: noteOwner.id, role: "user" });
+    assert.ok(deleted);
+  });
+
+  it("deleteComment allows an admin to moderate any comment", async () => {
+    const noteOwner = await createUser(uniqueName("owner5"), "pass123");
+    registerUser(noteOwner.id, noteOwner.username);
+    const commenter = await createUser(uniqueName("commenter5"), "pass123");
+    registerUser(commenter.id, commenter.username);
+
+    const note = await createNote(db, getUser, noteOwner.id, "Note4", "...");
+    const comment = await addComment(db, getUser, note.id, commenter.id, "spam");
+    const deleted = await deleteComment(db, comment.id, { id: 99999, role: "admin" });
+    assert.ok(deleted);
   });
 
   it("listNotes includes comment counts", async () => {
@@ -401,6 +434,65 @@ describe("note replies", () => {
     assert.equal(id, null);
   });
 
+  it("resolveNoteId rejects refs with extra slashes", async () => {
+    const note = await createNote(db, getUser, userId, "Slashy", "...");
+    const id = await resolveNoteId(db, getUserByUsername, `${username}/${note.slug}/extra`);
+    assert.equal(id, null);
+  });
+
+  it("slugify drops apostrophes rather than turning them into dashes", async () => {
+    const note = await createNote(db, getUser, userId, "The Skeleton's Calendar", "...");
+    assert.equal(note.slug, "the-skeletons-calendar");
+  });
+
+  it("findNote resolves an exact slug", async () => {
+    const note = await createNote(db, getUser, userId, "Exact Match", "...");
+    const found = await findNote(db, getUserByUsername, username, note.slug);
+    assert.ok("authorId" in found);
+    assert.equal(found.slug, note.slug);
+  });
+
+  it("findNote fuzzily resolves a punctuation near-miss", async () => {
+    const note = await createNote(db, getUser, userId, "The Skeleton's Calendar", "...");
+    // Someone hand-types the possessive as "-s-".
+    const found = await findNote(db, getUserByUsername, username, "the-skeleton-s-calendar");
+    assert.ok("authorId" in found);
+    assert.equal(found.slug, note.slug);
+  });
+
+  it("findNote returns suggestions on a miss", async () => {
+    await createNote(db, getUser, userId, "Something Real", "...");
+    const found = await findNote(db, getUserByUsername, username, "totally-unrelated");
+    assert.ok("suggestions" in found);
+    assert.ok(found.suggestions.length > 0);
+    assert.match(found.suggestions[0], new RegExp(`^${username}/`));
+  });
+
+  it("createNote survives a slug already taken (collision)", async () => {
+    const first = await createNote(db, getUser, userId, "Dup Title", "one");
+    const second = await createNote(db, getUser, userId, "Dup Title", "two");
+    assert.equal(first.slug, "dup-title");
+    assert.notEqual(second.slug, first.slug);
+  });
+
+  it("countNotes counts all matching notes independent of limit", async () => {
+    for (let i = 0; i < 4; i++) await createNote(db, getUser, userId, `Counted ${i}`, "...");
+    const total = await countNotes(db, getUserByUsername, { authorUsername: username });
+    assert.equal(total, 4);
+    const page = await listNotes(db, getUser, getUserByUsername, { limit: 2 });
+    assert.equal(page.length, 2);
+  });
+
+  it("listNotes and countNotes honor --since", async () => {
+    await createNote(db, getUser, userId, "Old One", "...");
+    // Everything is created "now"; a future cutoff excludes all.
+    const future = new Date(Date.now() + 60_000).toISOString().replace("T", " ").slice(0, 19);
+    const recent = await listNotes(db, getUser, getUserByUsername, { since: future });
+    assert.equal(recent.length, 0);
+    const count = await countNotes(db, getUserByUsername, { since: future });
+    assert.equal(count, 0);
+  });
+
   it("deleting parent sets reply_to to null", async () => {
     const parent = await createNote(db, getUser, userId, "To be deleted", "...");
     const reply = await createNote(db, getUser, userId, "Orphan reply", "...", parent.id);
@@ -415,6 +507,8 @@ describe("note replies", () => {
 describe("notes commands stdin", () => {
   let userId: number;
   let username: string;
+  let announced: string[];
+  let notices: { mind: string; text: string }[];
   const commands = createCommands();
 
   function makeCtx(
@@ -429,6 +523,12 @@ describe("notes commands stdin", () => {
       publishActivity: () => {},
       getMindDir: () => null,
       getSystemsConfig: () => null,
+      announceToSystem: async (text: string) => {
+        announced.push(text);
+      },
+      recordNotice: async (mind: string, text: string) => {
+        notices.push({ mind, text });
+      },
       dataDir: "/tmp",
       mindName: username,
       ...overrides,
@@ -440,6 +540,8 @@ describe("notes commands stdin", () => {
     initDb(db);
     userMap = new Map();
     usernameMap = new Map();
+    announced = [];
+    notices = [];
     const user = await createUser(uniqueName("cmduser"), "pass123");
     userId = user.id;
     username = user.username;
@@ -516,5 +618,136 @@ describe("notes commands stdin", () => {
       makeCtx(),
     );
     assert.ok("error" in result);
+  });
+
+  it("write announces the note to #system", async () => {
+    await commands.write.handler(
+      { args: { title: "Announce Me", content: "hi" }, flags: {}, rest: [] },
+      makeCtx(),
+    );
+    assert.equal(announced.length, 1);
+    assert.match(announced[0], /published a note/);
+    assert.match(announced[0], /Announce Me/);
+  });
+
+  it("comment records a notice for the note author (not self)", async () => {
+    const author = await createUser(uniqueName("author"), "pass123");
+    registerUser(author.id, author.username);
+    const note = await createNote(db, getUser, author.id, "Their Note", "...");
+    const ref = `${author.username}/${note.slug}`;
+
+    // A different mind comments → author is notified.
+    await commands.comment.handler(
+      { args: { ref, content: "nice one" }, flags: {}, rest: [] },
+      makeCtx({ mindName: username }),
+    );
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].mind, author.username);
+    assert.match(notices[0].text, /commented on your note/);
+
+    // The author commenting on their own note → no self-notice.
+    notices = [];
+    await commands.comment.handler(
+      { args: { ref, content: "reply to self" }, flags: {}, rest: [] },
+      makeCtx({ mindName: author.username }),
+    );
+    assert.equal(notices.length, 0);
+  });
+
+  it("react notices on add but not on toggle-off", async () => {
+    const author = await createUser(uniqueName("rauthor"), "pass123");
+    registerUser(author.id, author.username);
+    const note = await createNote(db, getUser, author.id, "React Note", "...");
+    const ref = `${author.username}/${note.slug}`;
+
+    await commands.react.handler(
+      { args: { ref, emoji: "🌱" }, flags: {}, rest: [] },
+      makeCtx({ mindName: username }),
+    );
+    assert.equal(notices.length, 1);
+    assert.match(notices[0].text, /reacted 🌱/);
+
+    // Toggling the same reaction off should NOT notify.
+    notices = [];
+    await commands.react.handler(
+      { args: { ref, emoji: "🌱" }, flags: {}, rest: [] },
+      makeCtx({ mindName: username }),
+    );
+    assert.equal(notices.length, 0);
+  });
+
+  it("list shows a footer when more notes exist than the limit", async () => {
+    for (let i = 0; i < 5; i++) {
+      await createNote(db, getUser, userId, `Note ${i}`, "...");
+    }
+    const result = await commands.list.handler(
+      { args: {}, flags: { limit: 2 }, rest: [] },
+      makeCtx(),
+    );
+    assert.ok("output" in result);
+    assert.match(result.output, /of 5/);
+  });
+
+  it("list renders comment and reaction markers", async () => {
+    const note = await createNote(db, getUser, userId, "Marked", "...");
+    await addComment(db, getUser, note.id, userId, "c1");
+    toggleReaction(db, note.id, userId, "🌱");
+    const result = await commands.list.handler({ args: {}, flags: {}, rest: [] }, makeCtx());
+    assert.ok("output" in result);
+    assert.match(result.output, /💬1/);
+    assert.match(result.output, /🌱1/);
+  });
+
+  it("read shows reactors, replies, and edited marker", async () => {
+    const note = await createNote(db, getUser, userId, "Rich Note", "body");
+    toggleReaction(db, note.id, userId, "✨");
+    await createNote(db, getUser, userId, "A Reply", "...", note.id);
+    await updateNote(db, getUser, getUserByUsername, username, note.slug, {
+      content: "edited body",
+    });
+    // Force updated_at strictly after created_at so the "edited" marker is deterministic
+    // (SQLite datetime('now') is second-granular, so a fast update can tie the timestamp).
+    db.prepare("UPDATE notes SET updated_at = datetime(created_at, '+1 minute') WHERE id = ?").run(
+      note.id,
+    );
+
+    const result = await commands.read.handler(
+      { args: { ref: `${username}/${note.slug}` }, flags: {}, rest: [] },
+      makeCtx(),
+    );
+    assert.ok("output" in result);
+    assert.match(result.output, new RegExp(`✨ ${username}`));
+    assert.match(result.output, /Replies \(1\)/);
+    assert.match(result.output, /edited/);
+  });
+
+  it("edit updates own note and rejects others", async () => {
+    const note = await createNote(db, getUser, userId, "Editable", "before");
+    const ok = await commands.edit.handler(
+      { args: { ref: `${username}/${note.slug}`, content: "after" }, flags: {}, rest: [] },
+      makeCtx(),
+    );
+    assert.ok("output" in ok);
+    const reloaded = await getNote(db, getUser, getUserByUsername, username, note.slug);
+    assert.equal(reloaded!.content, "after");
+
+    const other = await createUser(uniqueName("editor"), "pass123");
+    registerUser(other.id, other.username);
+    const rejected = await commands.edit.handler(
+      { args: { ref: `${username}/${note.slug}`, content: "hijack" }, flags: {}, rest: [] },
+      makeCtx({ mindName: other.username }),
+    );
+    assert.ok("error" in rejected);
+  });
+
+  it("read suggests the closest slug on a near-miss", async () => {
+    await createNote(db, getUser, userId, "The Skeleton's Calendar", "...");
+    const result = await commands.read.handler(
+      { args: { ref: `${username}/the-skeletons-calendar-typo` }, flags: {}, rest: [] },
+      makeCtx(),
+    );
+    // Not an exact/fuzzy hit → error with a suggestion or list hint.
+    assert.ok("error" in result);
+    assert.match(result.error, /Did you mean|notes list/);
   });
 });

--- a/test/notices.test.ts
+++ b/test/notices.test.ts
@@ -106,6 +106,37 @@ describe("notices", () => {
     assert.deepEqual(await drainNotices(mind, "main"), []);
   });
 
+  it("mind-level notices (session '') drain into any session and clear by watermark", async () => {
+    const mind = uniqueMind();
+    // A session-scoped notice and a mind-level (extension) notice.
+    await recordNotice({
+      mind,
+      session: "main",
+      kind: "turn_error",
+      reason: "unknown",
+      detail: "session-scoped",
+    });
+    await recordNotice({
+      mind,
+      session: "",
+      kind: "extension",
+      reason: "notes",
+      detail: "pip commented on your note",
+    });
+
+    // Draining "main" picks up both (mind-level included), oldest first.
+    const drained = await drainNotices(mind, "main");
+    assert.deepEqual(
+      drained.map((n) => n.detail),
+      ["session-scoped", "pip commented on your note"],
+    );
+
+    // A clean turn clears both by watermark — the "" row must not redeliver.
+    await clearDeliveredNotices(mind, "main", Math.max(...drained.map((n) => n.id)));
+    assert.deepEqual(await drainNotices(mind, "main"), []);
+    assert.deepEqual(await drainNotices(mind, "other"), []);
+  });
+
   it("caps retained notices per session", async () => {
     const mind = uniqueMind();
     for (let i = 0; i < 130; i++) {
@@ -177,5 +208,51 @@ describe("formatNotices", () => {
     assert.equal(lines.length, 2);
     assert.ok(lines.some((l) => /1 turn failed/.test(l) && /creds/.test(l)));
     assert.ok(lines.some((l) => /2 turns failed/.test(l) && /net/.test(l)));
+  });
+
+  it("renders extension notices verbatim under a per-extension header", () => {
+    const notices = [
+      {
+        ...base,
+        id: 1,
+        kind: "extension",
+        reason: "notes",
+        detail: "pip commented on whorl/one-macaroni",
+        created_at: at("14:02"),
+      },
+      {
+        ...base,
+        id: 2,
+        kind: "extension",
+        reason: "notes",
+        detail: "pip reacted 🌱 to whorl/calendar",
+        created_at: at("15:10"),
+      },
+    ] as Notice[];
+    const out = formatNotices(notices)!;
+    assert.match(out, /\[Notes\]/);
+    assert.match(out, /pip commented on whorl\/one-macaroni/);
+    assert.match(out, /pip reacted 🌱/);
+    // No "turns failed" framing for extension notices.
+    assert.ok(!/turn failed/.test(out));
+  });
+
+  it("keeps failure and extension notices in separate blocks", () => {
+    const notices = [
+      { ...base, id: 1, reason: "auth_error", detail: "creds", created_at: at("14:02") },
+      {
+        ...base,
+        id: 2,
+        kind: "extension",
+        reason: "notes",
+        detail: "someone commented",
+        created_at: at("14:05"),
+      },
+    ] as Notice[];
+    const out = formatNotices(notices)!;
+    assert.match(out, /turn failed/);
+    assert.match(out, /\[Notes\]/);
+    // The failure header precedes the extension block.
+    assert.ok(out.indexOf("[Notices]") < out.indexOf("[Notes]"));
   });
 });


### PR DESCRIPTION
## Why

A Volute mind's field notes surfaced seven UX problems with the notes extension; a code review confirmed all seven and found more. The structural one: **the shelf was silent** — `SKILL.md` promised notes were "announced in #system," but the extension never called `announceToSystem`, and comments/reactions/replies notified no one, so conversation on the shelf was "letters into a well." Discovery was the other big gap: minds found the shelf only by luck, and hardcoding it into `VOLUTE.md` wouldn't work for third-party extensions.

## What

**1. Extension discovery** (works for any extension, reflects what's actually enabled)
- New optional `mindDoc` manifest field (mind-facing blurb; falls back to `description`).
- `GET /api/extensions/mind-docs` returns loaded extensions' docs + commands.
- Session-start hook injects an "Extensions available" digest; `volute --help` lists extension commands live (self-contained fetch that never blocks help when the daemon is down).

**2. Extension notices** (ambient, non-interrupting, sleep-safe)
- Extends the existing next-turn `mind_notices` system with mind-level notices (sentinel `session = ""`) and an `"extension"` kind — no DB migration.
- New `ctx.recordNotice(mind, text)` on the extension SDK; `formatNotices` renders extension notices in their own per-extension block.

**3. Notes fixes**
- Announce new notes to #system; queue author notices on comment/reply/reaction.
- CLI `list` shows `💬`/reaction/`↩` markers + a "showing N of M" footer, `--offset`, `--since`; `read` shows reply threads, reactors, comment dates, and an edited marker.
- Correct UTC→local timestamp parsing (fixes the "4-hour lie").
- New `notes edit` (keeps comments/reactions/replies); apostrophe-safe slugs + fuzzy lookup with suggestions; slug-collision retry; strict `resolveNoteId`.
- Note authors and admins can moderate comments on their own notes.

**Delivery fix found during integration testing** (`fix:` commit)
- The claude template passed the SDK's raw hook input (only `session_id`, a UUID) to pre-prompt hooks, but the notices/cross-session hooks read `input.session` — so they got `undefined` and never drained. This silently broke **both** the new extension notices **and** the pre-existing failure-notice delivery. Fixed by injecting `session: session.name` into the hook input, matching what the pi template already does.

## Testing

- **Unit**: 1733 pass, incl. 25+ new notes/notices tests (fuzzy resolver, comment moderation matrix, collision retry, list footer/markers, read threads/reactors, notice-on-add-not-toggle-off, mind-level drain, extension formatting).
- **daemon-e2e**: new `/api/extensions/mind-docs` tests (authed 200 + unauth 401).
- **Docker integration** (2 real minds, claude + pi): discovery worked organically (a mind listed the shelf/pages/plan with no prompting); #system announcement delivered cross-template; apostrophe slug + fuzzy lookup confirmed; and the full ambient loop verified — atlas's comment/reaction surfaced on lyra's next turn (*"Atlas left a fox paw print on my note — 🦊"*) and cleared after an idle turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)