### PR TITLE
fix: record tool-call errors in mind history and link results by tool id

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -148,7 +148,7 @@ export function getTimeRange(
 
 // ── Turn summarization (event-driven) ──
 
-type HistoryRow = {
+export type HistoryRow = {
   id: number;
   type: string;
   channel: string | null;
@@ -288,7 +288,7 @@ function buildTurnDeterministicSummary(
   return parts.length > 0 ? `${parts.join(". ")}.` : "Turn completed.";
 }
 
-function buildTranscript(
+export function buildTranscript(
   events: HistoryRow[],
   parsedMeta: Map<number, Record<string, unknown>>,
 ): string {
@@ -317,7 +317,9 @@ function buildTranscript(
         const content = ev.content ?? "";
         const meta = parsedMeta.get(ev.id);
         const isError = !!meta?.is_error;
-        lines.push(isError ? "[result error]" : `[result] ${content.slice(0, 200)}`);
+        lines.push(
+          isError ? `[result error] ${content.slice(0, 200)}` : `[result] ${content.slice(0, 200)}`,
+        );
         break;
       }
       case "thinking":

--- a/packages/daemon/src/lib/daemon/turn-lifecycle.ts
+++ b/packages/daemon/src/lib/daemon/turn-lifecycle.ts
@@ -18,7 +18,7 @@ import {
   completeTurn,
   createTurn,
   getActiveTurnId,
-  getLastToolUseEventId,
+  getToolUseEventId,
   markErrored,
   takeErrored,
   trackToolUse,
@@ -173,13 +173,22 @@ export async function handleMindEvent(
       .returning({ id: mindHistory.id });
     insertedId = result[0]?.id;
   } catch (err) {
-    llog.error(`failed to persist event for ${mind}`, log.errorData(err));
-    // Continue — persistence is best-effort, don't block real-time streaming.
+    // A dropped event is a permanent gap in this mind's history/timeline — surface it
+    // with enough context to spot which mind/session/channel lost what, rather than
+    // failing silently. Persistence stays best-effort so real-time streaming continues.
+    llog.error(
+      `HISTORY GAP: failed to persist ${event.type} event for ${mind}` +
+        `${event.session ? ` (session ${event.session})` : ""}` +
+        `${event.channel ? ` on ${event.channel}` : ""}`,
+      log.errorData(err),
+    );
   }
 
-  // Track tool_use events for source_event_id linking.
+  // Track tool_use events for source_event_id linking, indexed by the SDK tool_use id
+  // (in metadata.id) so a parallel tool_result resolves to its own tool_use.
   if (event.type === "tool_use" && insertedId != null) {
-    trackToolUse(mind, event.session, insertedId);
+    const toolUseId = typeof event.metadata?.id === "string" ? event.metadata.id : undefined;
+    trackToolUse(mind, event.session, insertedId, toolUseId);
   }
 
   // Fallback/activity linking via correlation markers. Outbound turn attribution is now
@@ -187,7 +196,9 @@ export async function handleMindEvent(
   // is idempotent (won't re-publish an already-attributed outbound) and still links
   // extension activities and any outbound the direct path couldn't attribute.
   if (event.type === "tool_result" && turnId && event.content) {
-    const toolUseEventId = getLastToolUseEventId(mind, event.session);
+    const resultToolUseId =
+      typeof event.metadata?.tool_use_id === "string" ? event.metadata.tool_use_id : undefined;
+    const toolUseEventId = getToolUseEventId(mind, event.session, resultToolUseId);
     try {
       await linkToolResultToTurn(mind, turnId, event.content, toolUseEventId);
     } catch (err) {

--- a/packages/daemon/src/lib/daemon/turn-tracker.ts
+++ b/packages/daemon/src/lib/daemon/turn-tracker.ts
@@ -10,6 +10,8 @@ const tlog = log.child("turn-tracker");
 type ActiveTurn = {
   turnId: string;
   lastToolUseEventId: number | undefined;
+  /** SDK tool_use id → mind_history event id, so a tool_result links to its own tool_use. */
+  toolUseEventIds: Map<string, number>;
 };
 
 /** In-memory map of active turns, keyed by `mind:session` (or `mind:*` for sessionless). */
@@ -51,7 +53,11 @@ export async function createTurn(mind: string): Promise<string | undefined> {
   if (existing) return existing.turnId;
 
   const turnId = randomUUID();
-  const entry: ActiveTurn = { turnId, lastToolUseEventId: undefined };
+  const entry: ActiveTurn = {
+    turnId,
+    lastToolUseEventId: undefined,
+    toolUseEventIds: new Map(),
+  };
   // Reserve the slot synchronously to prevent concurrent callers from creating duplicates
   activeTurns.set(k, entry);
 
@@ -110,19 +116,45 @@ export async function linkInboundToActiveTurn(
     );
 }
 
-/** Record the last tool_use event ID for a mind+session. */
+/**
+ * Record a tool_use event ID for a mind+session. When the SDK's `toolUseId` is known it's
+ * also indexed so the matching tool_result can resolve its exact source (parallel tool calls
+ * in one turn would otherwise all collapse onto "the last tool_use").
+ */
 export function trackToolUse(
   mind: string,
   session: string | null | undefined,
   eventId: number,
+  toolUseId?: string,
 ): void {
   const entry = activeTurns.get(key(mind, session)) ?? activeTurns.get(key(mind));
-  if (entry) entry.lastToolUseEventId = eventId;
+  if (!entry) return;
+  entry.lastToolUseEventId = eventId;
+  if (toolUseId) entry.toolUseEventIds.set(toolUseId, eventId);
 }
 
 /** Get the last tool_use event ID for a mind+session. */
 export function getLastToolUseEventId(mind: string, session?: string | null): number | undefined {
   return (activeTurns.get(key(mind, session)) ?? activeTurns.get(key(mind)))?.lastToolUseEventId;
+}
+
+/**
+ * Resolve the source tool_use event ID for a tool_result, preferring an exact match on the
+ * SDK `toolUseId`. Falls back to the last tool_use in the turn when the id is absent (older
+ * templates) or unknown, preserving prior behavior.
+ */
+export function getToolUseEventId(
+  mind: string,
+  session: string | null | undefined,
+  toolUseId?: string,
+): number | undefined {
+  const entry = activeTurns.get(key(mind, session)) ?? activeTurns.get(key(mind));
+  if (!entry) return undefined;
+  if (toolUseId) {
+    const id = entry.toolUseEventIds.get(toolUseId);
+    if (id != null) return id;
+  }
+  return entry.lastToolUseEventId;
 }
 
 /**

--- a/templates/claude/src/lib/stream-consumer.ts
+++ b/templates/claude/src/lib/stream-consumer.ts
@@ -65,11 +65,11 @@ export async function consumeStream(
           const text = (b as { text: string }).text;
           emit(session, { type: "text", content: text });
         } else if (b.type === "tool_use") {
-          const tb = b as { name: string; input: unknown };
+          const tb = b as { id: string; name: string; input: unknown };
           emit(session, {
             type: "tool_use",
             content: JSON.stringify(tb.input),
-            metadata: { name: tb.name },
+            metadata: { name: tb.name, id: tb.id },
           });
         }
       }
@@ -99,13 +99,16 @@ export async function consumeStream(
               : typeof b.content === "string"
                 ? b.content
                 : "";
-            if (resultContent) {
+            // A failed tool call must be recorded even when it produced no text
+            // body, so downstream (summary transcript + timeline UI) can flag it.
+            const isError = "is_error" in b && b.is_error === true;
+            if (resultContent || isError) {
               const toolUseId =
                 "tool_use_id" in b && typeof b.tool_use_id === "string" ? b.tool_use_id : "unknown";
               emit(session, {
                 type: "tool_result",
                 content: resultContent,
-                metadata: { tool_use_id: toolUseId },
+                metadata: { tool_use_id: toolUseId, is_error: isError },
               });
             }
           }

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -323,6 +323,9 @@ export function createMind(options: {
             case "item.started": {
               const item = event.item;
               if (!item) break;
+              // Stable per-item id so a tool_result links to its own tool_use (see
+              // item.completed). Codex reuses this id across the item's start/end events.
+              const itemId = event.itemId ?? item.id;
 
               if (item.type === "agent_message" || item.type === "agentMessage") {
                 itemText.set(event.itemId ?? item.id, "");
@@ -335,7 +338,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_use",
                   content: JSON.stringify({ command: cmd }),
-                  metadata: { name: "command" },
+                  metadata: { name: "command", id: itemId },
                 });
                 broadcast(session, {
                   type: "tool_use",
@@ -347,7 +350,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_use",
                   content: JSON.stringify({ path: filePath }),
-                  metadata: { name: "file_change" },
+                  metadata: { name: "file_change", id: itemId },
                 });
                 broadcast(session, {
                   type: "tool_use",
@@ -359,7 +362,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_use",
                   content: JSON.stringify(item.input ?? item.arguments ?? {}),
-                  metadata: { name: toolName },
+                  metadata: { name: toolName, id: itemId },
                 });
                 broadcast(session, {
                   type: "tool_use",
@@ -370,7 +373,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_use",
                   content: JSON.stringify({ query: item.query ?? "" }),
-                  metadata: { name: "web_search" },
+                  metadata: { name: "web_search", id: itemId },
                 });
                 broadcast(session, {
                   type: "tool_use",
@@ -403,6 +406,8 @@ export function createMind(options: {
               const item = event.item;
               if (!item) break;
               const itemType = item.type;
+              // Same id emitted on item.started, so the daemon links this result to its tool_use.
+              const itemId = event.itemId ?? item.id;
 
               if (itemType === "reasoning") {
                 const text = item.text ?? item.content ?? "";
@@ -426,7 +431,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_result",
                   content: output,
-                  metadata: { name: "command", is_error: exitCode !== 0 },
+                  metadata: { name: "command", is_error: exitCode !== 0, tool_use_id: itemId },
                 });
                 broadcast(session, {
                   type: "tool_result",
@@ -446,7 +451,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_result",
                   content: item.diff ?? `changed: ${filePath}`,
-                  metadata: { name: "file_change" },
+                  metadata: { name: "file_change", tool_use_id: itemId },
                 });
                 broadcast(session, {
                   type: "tool_result",
@@ -460,6 +465,7 @@ export function createMind(options: {
                   content: output,
                   metadata: {
                     name: `mcp:${item.serverName ?? ""}/${item.toolName ?? item.name ?? ""}`,
+                    tool_use_id: itemId,
                   },
                 });
                 broadcast(session, { type: "tool_result", output });
@@ -467,7 +473,7 @@ export function createMind(options: {
                 emit(session, {
                   type: "tool_result",
                   content: "search completed",
-                  metadata: { name: "web_search" },
+                  metadata: { name: "web_search", tool_use_id: itemId },
                 });
                 broadcast(session, { type: "tool_result", output: "search completed" });
               }

--- a/templates/pi/src/lib/event-handler.ts
+++ b/templates/pi/src/lib/event-handler.ts
@@ -107,7 +107,7 @@ export function createEventHandler(session: EventSession, options: EventHandlerO
         emit(session, {
           type: "tool_use",
           content: JSON.stringify(event.args),
-          metadata: { name: event.toolName },
+          metadata: { name: event.toolName, id: event.toolCallId },
         });
       }
 
@@ -117,7 +117,11 @@ export function createEventHandler(session: EventSession, options: EventHandlerO
         emit(session, {
           type: "tool_result",
           content: output,
-          metadata: { name: event.toolName, is_error: event.isError },
+          metadata: {
+            name: event.toolName,
+            is_error: event.isError,
+            tool_use_id: event.toolCallId,
+          },
         });
 
         // Auto-commit file changes in home/

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
 import {
+  buildTranscript,
   getPeriodKey,
   getPreviousPeriodKey,
   getTimeRange,
+  type HistoryRow,
   type Period,
   reconcileWedgedTurns,
   summarizePeriod,
@@ -260,6 +262,37 @@ describe("summarizer", () => {
         .from(summaries)
         .where(and(eq(summaries.mind, mind3), eq(summaries.period, "turn")));
       assert.equal(rows.length, 0, "no summary should be inserted for empty turn");
+    });
+  });
+
+  // ── Transcript building ──
+
+  describe("buildTranscript", () => {
+    function row(id: number, type: string, content: string | null): HistoryRow {
+      return { id, type, channel: null, session: null, content, metadata: null, created_at: "" };
+    }
+
+    it("includes error result content so the summary can describe the failure", () => {
+      const events: HistoryRow[] = [
+        row(1, "tool_use", null),
+        row(2, "tool_result", "ENOENT: no such file or directory, open '/nope'"),
+      ];
+      const meta = new Map<number, Record<string, unknown>>([
+        [1, { name: "Read" }],
+        [2, { is_error: true }],
+      ]);
+
+      const transcript = buildTranscript(events, meta);
+      assert.match(transcript, /\[result error\] ENOENT: no such file/);
+    });
+
+    it("labels successful results distinctly from errors", () => {
+      const events: HistoryRow[] = [row(1, "tool_result", "ok, wrote 3 lines")];
+      const meta = new Map<number, Record<string, unknown>>([[1, { is_error: false }]]);
+
+      const transcript = buildTranscript(events, meta);
+      assert.match(transcript, /\[result\] ok, wrote 3 lines/);
+      assert.doesNotMatch(transcript, /result error/);
     });
   });
 

--- a/test/turn-tracker.test.ts
+++ b/test/turn-tracker.test.ts
@@ -9,6 +9,7 @@ import {
   createTurn,
   getActiveTurnId,
   getLastToolUseEventId,
+  getToolUseEventId,
   markErrored,
   sweepWedgedTurns,
   takeErrored,
@@ -85,6 +86,34 @@ describe("turn-tracker", () => {
 
     trackToolUse(mind, null, 99);
     assert.equal(getLastToolUseEventId(mind), 99);
+
+    await clearMind(mind);
+  });
+
+  it("getToolUseEventId resolves the matching tool_use by SDK id", async () => {
+    await createTurn(mind);
+
+    // Two tool calls in one turn (e.g. parallel), tracked with their SDK ids.
+    trackToolUse(mind, null, 10, "toolu_a");
+    trackToolUse(mind, null, 11, "toolu_b");
+
+    // A result must link to its OWN tool_use, not just the most recent one.
+    assert.equal(getToolUseEventId(mind, null, "toolu_a"), 10);
+    assert.equal(getToolUseEventId(mind, null, "toolu_b"), 11);
+
+    await clearMind(mind);
+  });
+
+  it("getToolUseEventId falls back to the last tool_use when id is absent/unknown", async () => {
+    await createTurn(mind);
+
+    trackToolUse(mind, null, 10, "toolu_a");
+    trackToolUse(mind, null, 11, "toolu_b");
+
+    // No id (older template) → last tool_use.
+    assert.equal(getToolUseEventId(mind, null), 11);
+    // Unknown id → last tool_use.
+    assert.equal(getToolUseEventId(mind, null, "toolu_missing"), 11);
 
     await clearMind(mind);
   });


### PR DESCRIPTION
## Summary

Mind history previously dropped tool-call **errors** on the default (claude) template, and tool results weren't reliably linked back to the tool call that produced them. This fixes both, plus makes error summaries and cross-template metadata consistent.

## Changes

**1. Record tool-call errors (claude template)** — `stream-consumer.ts` now reads `is_error` off SDK `tool_result` blocks and emits a `tool_result` event even when the failure produced no text body, so downstream (summary transcript + timeline UI) can flag it. The daemon and web UI already consumed `is_error`; only this producer was one-sided.

**2. Error-aware summary transcripts** — `summarizer.ts` `buildTranscript` now renders `[result error] …` vs `[result] …` so the AI summarizer sees which tool calls failed. Exported `buildTranscript`/`HistoryRow` for testing.

**3. Link results to calls by tool id** — every template now emits the SDK tool id on `tool_use` (`metadata.id`) and echoes it on `tool_result` (`metadata.tool_use_id`). The daemon keys linkage on it via a new `getToolUseEventId()`, falling back to last-tool-use when an id is absent (so older templates keep prior behavior). Parity added across **claude**, **pi**, and **codex** templates.

**4. Surface persistence failures** — a dropped history event now logs a visible `HISTORY GAP: …` error with mind/session/channel context instead of failing silently.

## Testing

- Added unit tests: `getToolUseEventId` (keyed match + fallback) and `buildTranscript` (error vs success rendering).
- Full suite green; all three template typechecks pass (pre-commit).
- Docker integration test with real minds on **two** templates (claude + pi): both recorded `is_error:true` on failing tool calls, `is_error:false` on successes, and exact `tool_use_id` ↔ `tool_use.id` linkage. Zero HISTORY GAPs, zero SQLITE_BUSY, no crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
