### PR TITLE
fix: accept home-relative avatar paths in mind profile updates

### DIFF
--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -7,7 +7,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import { zValidator } from "@hono/zod-validator";
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
@@ -101,6 +101,7 @@ import { computeTemplateHash } from "../../lib/template/template-hash.js";
 import { exec, gitExec } from "../../lib/util/exec.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
+import { safeResolveWithinBase } from "../../lib/util/paths.js";
 import { fireWebhook } from "../../lib/webhook.js";
 import {
   type AuthEnv,
@@ -1602,10 +1603,19 @@ const app = new Hono<AuthEnv>()
 
     if (body.displayName !== undefined) profile.displayName = body.displayName;
     if (body.description !== undefined) profile.description = body.description;
-    // Store only a bare filename — avatars live directly in the mind's home dir.
-    // Prevents a traversal/absolute path from being persisted and later used in
-    // filesystem operations (e.g. avatar deletion).
-    if (body.avatar !== undefined) profile.avatar = basename(body.avatar);
+    // Store a home-relative path — never persist a value that escapes home/,
+    // since it's later used in filesystem operations (avatar serving/deletion).
+    if (body.avatar !== undefined) {
+      const homeDir = resolve(dir, "home");
+      const avatarPath = safeResolveWithinBase(homeDir, body.avatar);
+      if (!avatarPath) {
+        return c.json({ error: "Avatar path must be inside the mind's home directory" }, 400);
+      }
+      if (!existsSync(avatarPath)) {
+        return c.json({ error: `Avatar file not found: ${relative(homeDir, avatarPath)}` }, 400);
+      }
+      profile.avatar = relative(homeDir, avatarPath);
+    }
 
     config.profile = profile;
     writeVoluteConfig(dir, config);

--- a/test/web-mind-avatar.test.ts
+++ b/test/web-mind-avatar.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, mindDir, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import { readVoluteConfig } from "../packages/daemon/src/lib/mind/volute-config.js";
+import { sessions, users } from "../packages/daemon/src/lib/schema.js";
+import filesApp from "../packages/daemon/src/web/api/files.js";
+import mindsApp from "../packages/daemon/src/web/api/minds.js";
+import { type AuthEnv, authMiddleware } from "../packages/daemon/src/web/middleware/auth.js";
+
+const testMindName = `avatar-route-test-${Date.now()}`;
+let adminCookie: string;
+
+// 1x1 transparent PNG
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+function createApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("/*", authMiddleware);
+  app.route("/minds", mindsApp);
+  app.route("/minds", filesApp);
+  return app;
+}
+
+async function patchProfile(app: Hono<AuthEnv>, body: Record<string, string>) {
+  return app.request(`/minds/${testMindName}/profile`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", Cookie: adminCookie },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("mind profile avatar", () => {
+  before(async () => {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "avatar-route-admin"));
+    const [user] = await db
+      .insert(users)
+      .values({ username: "avatar-route-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    adminCookie = `volute_session=${sessionId}`;
+
+    await addMind(testMindName, 4198);
+    const home = join(mindDir(testMindName), "home");
+    mkdirSync(join(home, ".config"), { recursive: true });
+    mkdirSync(join(home, "images"), { recursive: true });
+    writeFileSync(join(home, ".config", "volute.json"), "{}");
+    writeFileSync(join(home, "images", "sub-avatar.png"), PNG_BYTES);
+    writeFileSync(join(home, "top-avatar.png"), PNG_BYTES);
+  });
+
+  after(async () => {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "avatar-route-admin"));
+    await db.delete(users).where(eq(users.username, testMindName));
+    await removeMind(testMindName);
+    const dir = mindDir(testMindName);
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  });
+
+  it("accepts a home-relative subdirectory path and serves the avatar", async () => {
+    const app = createApp();
+    const res = await patchProfile(app, { avatar: "images/sub-avatar.png" });
+    assert.equal(res.status, 200);
+
+    const config = readVoluteConfig(mindDir(testMindName));
+    assert.equal(config?.profile?.avatar, "images/sub-avatar.png");
+
+    const serve = await app.request(`/minds/${testMindName}/avatar`, {
+      headers: { Cookie: adminCookie },
+    });
+    assert.equal(serve.status, 200);
+    assert.equal(serve.headers.get("Content-Type"), "image/png");
+  });
+
+  it("accepts a bare filename at the top of home", async () => {
+    const app = createApp();
+    const res = await patchProfile(app, { avatar: "top-avatar.png" });
+    assert.equal(res.status, 200);
+    const config = readVoluteConfig(mindDir(testMindName));
+    assert.equal(config?.profile?.avatar, "top-avatar.png");
+  });
+
+  it("accepts an absolute path inside home and stores it relative", async () => {
+    const app = createApp();
+    const abs = join(mindDir(testMindName), "home", "images", "sub-avatar.png");
+    const res = await patchProfile(app, { avatar: abs });
+    assert.equal(res.status, 200);
+    const config = readVoluteConfig(mindDir(testMindName));
+    assert.equal(config?.profile?.avatar, "images/sub-avatar.png");
+  });
+
+  it("rejects a path that escapes home", async () => {
+    const app = createApp();
+    const res = await patchProfile(app, { avatar: "../../../etc/passwd" });
+    assert.equal(res.status, 400);
+    const config = readVoluteConfig(mindDir(testMindName));
+    assert.notEqual(config?.profile?.avatar, "../../../etc/passwd");
+  });
+
+  it("rejects a nonexistent file", async () => {
+    const app = createApp();
+    const res = await patchProfile(app, { avatar: "images/missing.png" });
+    assert.equal(res.status, 400);
+  });
+});


### PR DESCRIPTION
## Problem

`PATCH /api/minds/:name/profile` flattened the avatar value to `basename()` without copying the file. Any avatar living outside the top level of `home/` (e.g. `images/pip-avatar.png`) was recorded as a bare filename the serve route could never find, so `GET /api/minds/:name/avatar` returned 404 "Avatar file not found" with no feedback at set-time. This is how pip's avatar on bardo broke.

## Fix

Store the home-relative path instead:

- resolve the given path against the mind's `home/` with `safeResolveWithinBase`; reject escapes with 400
- reject nonexistent files with 400 so minds get immediate feedback instead of a silent later 404
- normalize absolute-inside-home paths to home-relative before persisting

No other changes needed: the serve route, delivery-manager avatar enrichment, and avatar size migration already resolve `profile.avatar` relative to `home/` with containment checks, and the frontend only uses the value as a truthiness flag before hitting the avatar endpoint.

## Tests

New route-level tests in `test/web-mind-avatar.test.ts` (subdirectory path accepted and served end-to-end, bare filename, absolute-inside-home normalization, traversal rejected, missing file rejected). Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)