### PR TITLE
fix: enable skill discovery in claude template

### DIFF
--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -133,6 +133,22 @@ export function createMind(options: {
 
   const agents = loadSubagents(options.subagents);
 
+  // --- Skill discovery ---
+  // The CLI only discovers skills through its user-scope ~/.claude/skills scan,
+  // so the "user" setting source is load-bearing and HOME must be the mind's
+  // home dir for the SDK subprocess (isolation modes already set it; pinning it
+  // here keeps non-isolated minds from loading the operator's ~/.claude). The
+  // explicit skills array grants the Skill tool for each installed skill — the
+  // SDK silently drops the documented `skills: 'all'` string form.
+  const mindHome = resolvePath(options.cwd);
+  const sdkEnv = { ...process.env, HOME: mindHome };
+  function installedSkills(): string[] | undefined {
+    const names = readSkillDescriptions([resolvePath(mindHome, ".claude/skills")]).map(
+      (s) => s.name,
+    );
+    return names.length > 0 ? names : undefined;
+  }
+
   // --- Event broadcasting ---
 
   function broadcastToSession(session: Session, event: VoluteEvent) {
@@ -241,7 +257,9 @@ export function createMind(options: {
         systemPrompt: options.systemPrompt,
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
-        settingSources: ["project"],
+        settingSources: ["project", "user"],
+        skills: installedSkills(),
+        env: sdkEnv,
         cwd: options.cwd,
         abortController: streamAbort,
         model: options.model,
@@ -352,7 +370,9 @@ export function createMind(options: {
             systemPrompt: options.systemPrompt,
             permissionMode: "bypassPermissions",
             allowDangerouslySkipPermissions: true,
-            settingSources: ["project"],
+            settingSources: ["project", "user"],
+            skills: installedSkills(),
+            env: sdkEnv,
             cwd: options.cwd,
             abortController: compactAbort,
             model: options.model,


### PR DESCRIPTION
## Problem

Skills installed to `home/.claude/skills` were never discovered by claude-template minds — `Skill(...)` calls failed with "unknown skill" and no skills appeared in the session-start list. Diagnosed empirically by a mind that patched its own `src/agent.ts` (three layers deep).

## Fix (both `query()` blocks: main stream + compaction)

1. **`settingSources: ["project", "user"]`** — the CLI only discovers skills through its *user*-scope `~/.claude/skills` scan; the project source alone never triggers discovery.
2. **`skills: <array of installed skill names>`** — grants the `Skill` tool per skill (reuses `readSkillDescriptions`). The array form is required: the SDK (verified on 0.3.198) silently drops the documented `skills: 'all'` string — `sdk.mjs` forwards `Array.isArray(this.initConfig?.skills) ? this.initConfig.skills : void 0`. Upstream bug, reportable to Anthropic.
3. **`env: { ...process.env, HOME: <mind home> }`** — the user scope must resolve to the mind's home, not the operator's. Per-user isolation already sets HOME and OAuth minds get `CLAUDE_CONFIG_DIR=home/.claude`, but sandbox/none installs with API-key auth would otherwise load the **operator's** `~/.claude` (skills, settings.json, user CLAUDE.md) into the mind. Pinning HOME on the SDK subprocess makes user scope = `home/.claude` in all isolation modes. Side effect on that one config (non-isolated + API key): SDK transcripts move to `home/.claude/projects`, so existing sessions there start fresh on upgrade (handled gracefully by the existing resume-failure path).

## Other templates checked — not affected

- **pi**: `pi-coding-agent`'s `loadSkills` reads `cwd/.pi/skills` as a *project* source — no user-scope/HOME dependency.
- **codex**: Codex discovers `./.agents/skills/` from the working directory natively (per OpenAI docs), which is where volute installs skills.

## Testing

- `npm test` — 1749 pass
- `npm run typecheck:templates` — all three templates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)