### PR TITLE
fix: make unread message dots reliable

### DIFF
--- a/packages/daemon/src/lib/events/conversations.ts
+++ b/packages/daemon/src/lib/events/conversations.ts
@@ -594,6 +594,7 @@ export async function leaveChannel(conversationId: string, userId: number): Prom
 export async function getUnreadCounts(
   userId: number,
   conversationIds: string[],
+  username: string,
 ): Promise<Record<string, number>> {
   if (conversationIds.length === 0) return {};
   const db = await getDb();
@@ -614,6 +615,8 @@ export async function getUnreadCounts(
       and(
         inArray(messages.conversation_id, conversationIds),
         sql`${messages.id} > COALESCE(${conversationReads.last_read_message_id}, 0)`,
+        // A user's own messages are never "unread" for them
+        sql`(${messages.sender_name} IS NULL OR ${messages.sender_name} != ${username})`,
       ),
     )
     .groupBy(messages.conversation_id);

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -46,7 +46,7 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         conversations = await listConversationsWithParticipants(user.id);
         if (conversations.length > 0) {
           const convIds = conversations.map((c: any) => c.id);
-          const unreads = await getUnreadCounts(user.id, convIds);
+          const unreads = await getUnreadCounts(user.id, convIds, user.username);
           for (const conv of conversations) {
             conv.unreadCount = unreads[conv.id] ?? 0;
           }

--- a/packages/web/src/ui/lib/stores.svelte.ts
+++ b/packages/web/src/ui/lib/stores.svelte.ts
@@ -132,12 +132,28 @@ function getMentionPattern(username: string, displayName: string): RegExp {
   return regex;
 }
 
+/** Whether this tab is visible. Hidden tabs must not mark conversations read. */
+function isTabVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState !== "hidden";
+}
+
 export function setActiveConversation(id: string | null) {
   unreadState.activeConversationId = id;
-  if (id) {
+  if (id && isTabVisible()) {
     unreadCounts.set(id, 0);
     markAsRead(id).catch((err) => console.warn("[stores] markAsRead failed:", err));
   }
+}
+
+// When the tab becomes visible again, catch up on the conversation being viewed.
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    const id = unreadState.activeConversationId;
+    if (document.visibilityState === "visible" && id) {
+      unreadCounts.set(id, 0);
+      markAsRead(id).catch((err) => console.warn("[stores] markAsRead failed:", err));
+    }
+  });
 }
 
 // --- Unified SSE via connection.svelte.ts ---
@@ -154,10 +170,17 @@ function handleSSEEvent(event: SSEEvent) {
     if (Array.isArray(event.onlineBrains)) {
       for (const name of event.onlineBrains) onlineBrains.add(name);
     }
-    // Populate unread counts from snapshot
+    // Populate unread counts from snapshot. Skip the conversation being
+    // viewed — its snapshot count races the markAsRead POST and would put a
+    // dot on the open conversation after every reconnect. Re-mark it read so
+    // the server cursor catches up to anything missed while disconnected.
+    const activeId = isTabVisible() ? unreadState.activeConversationId : null;
     unreadCounts.clear();
     for (const conv of data.conversations) {
-      if (conv.unreadCount) unreadCounts.set(conv.id, conv.unreadCount);
+      if (conv.unreadCount && conv.id !== activeId) unreadCounts.set(conv.id, conv.unreadCount);
+    }
+    if (activeId && data.conversations.some((c) => c.id === activeId && c.unreadCount)) {
+      markAsRead(activeId).catch((err) => console.warn("[stores] markAsRead failed:", err));
     }
     // Minds not in snapshot — fetch separately since they need health checks
     fetchMinds()
@@ -230,9 +253,11 @@ function handleSSEEvent(event: SSEEvent) {
       };
       (conv as any).updated_at = event.createdAt;
 
-      // Unread tracking + notifications
+      // Unread tracking + notifications. A hidden tab is not "viewing" its
+      // active conversation — treat it as inactive so it accrues a dot and
+      // never silently advances the read cursor for the whole account.
       const isFromSelf = event.senderName === auth.user?.username;
-      const isActive = event.conversationId === unreadState.activeConversationId;
+      const isActive = event.conversationId === unreadState.activeConversationId && isTabVisible();
       if (!isFromSelf && !isActive) {
         const current = unreadCounts.get(event.conversationId) ?? 0;
         unreadCounts.set(event.conversationId, current + 1);

--- a/test/web-v1-conversations.test.ts
+++ b/test/web-v1-conversations.test.ts
@@ -300,7 +300,7 @@ describe("v1 conversations HTTP routes", () => {
     assert.equal(body.ok, true);
 
     // Unread count should be 0 after marking read
-    const counts = await getUnreadCounts(userId, [conv.id]);
+    const counts = await getUnreadCounts(userId, [conv.id], "v1-admin");
     assert.equal(counts[conv.id] ?? 0, 0);
 
     await deleteConversation(conv.id);
@@ -404,8 +404,28 @@ describe("unread tracking", () => {
     await addMessage(conv.id, "assistant", "test-mind", [{ type: "text", text: "Hi" }]);
     await addMessage(conv.id, "assistant", "test-mind", [{ type: "text", text: "How are you?" }]);
 
-    const counts = await getUnreadCounts(user.id, [conv.id]);
-    assert.equal(counts[conv.id], 3);
+    const counts = await getUnreadCounts(user.id, [conv.id], "unread-test");
+    assert.equal(counts[conv.id], 2);
+
+    await deleteConversation(conv.id);
+  });
+
+  it("getUnreadCounts excludes the user's own messages", async () => {
+    const user = await createUser("own-msg-test", "pass");
+    const conv = await createConversation({
+      participantIds: [user.id],
+    });
+
+    // User sends a message and gets no reply — should show 0 unread
+    await addMessage(conv.id, "user", "own-msg-test", [{ type: "text", text: "Hello?" }]);
+
+    const counts = await getUnreadCounts(user.id, [conv.id], "own-msg-test");
+    assert.equal(counts[conv.id] ?? 0, 0);
+
+    // Messages with no sender still count (system messages)
+    await addMessage(conv.id, "assistant", null, [{ type: "text", text: "sys" }]);
+    const counts2 = await getUnreadCounts(user.id, [conv.id], "own-msg-test");
+    assert.equal(counts2[conv.id], 1);
 
     await deleteConversation(conv.id);
   });
@@ -421,7 +441,7 @@ describe("unread tracking", () => {
 
     await markConversationRead(user.id, conv.id);
 
-    const counts = await getUnreadCounts(user.id, [conv.id]);
+    const counts = await getUnreadCounts(user.id, [conv.id], "mark-read-test");
     assert.equal(counts[conv.id] ?? 0, 0);
 
     await deleteConversation(conv.id);
@@ -439,14 +459,14 @@ describe("unread tracking", () => {
     // New message after mark read
     await addMessage(conv.id, "assistant", "test-mind", [{ type: "text", text: "Hi" }]);
 
-    const counts = await getUnreadCounts(user.id, [conv.id]);
+    const counts = await getUnreadCounts(user.id, [conv.id], "new-after-read");
     assert.equal(counts[conv.id], 1);
 
     await deleteConversation(conv.id);
   });
 
   it("getUnreadCounts handles empty conversation list", async () => {
-    const counts = await getUnreadCounts(999, []);
+    const counts = await getUnreadCounts(999, [], "nobody");
     assert.deepEqual(counts, {});
   });
 
@@ -463,7 +483,7 @@ describe("unread tracking", () => {
     await addMessage(conv2.id, "assistant", "test-mind", [{ type: "text", text: "msg2" }]);
     await addMessage(conv2.id, "assistant", "test-mind", [{ type: "text", text: "msg3" }]);
 
-    const counts = await getUnreadCounts(user.id, [conv1.id, conv2.id]);
+    const counts = await getUnreadCounts(user.id, [conv1.id, conv2.id], "multi-conv");
     assert.equal(counts[conv1.id], 1);
     assert.equal(counts[conv2.id], 2);
 
@@ -485,8 +505,8 @@ describe("unread tracking", () => {
     await markConversationRead(userA.id, conv.id);
 
     // User A should have 0 unread, User B should still have 2
-    const countsA = await getUnreadCounts(userA.id, [conv.id]);
-    const countsB = await getUnreadCounts(userB.id, [conv.id]);
+    const countsA = await getUnreadCounts(userA.id, [conv.id], "user-a");
+    const countsB = await getUnreadCounts(userB.id, [conv.id], "user-b");
     assert.equal(countsA[conv.id] ?? 0, 0);
     assert.equal(countsB[conv.id], 2);
 


### PR DESCRIPTION
## Problem

The "new messages" unread dot in the web UI was unreliable: dots appeared on the conversation currently being viewed, and dots for genuinely-new messages sometimes never appeared, especially after being away from the app.

Investigation found four independent root causes. This PR fixes three; the fourth (the SSE stream never delivers events for conversations created after connect) is tracked in #409.

## Fixes

### 1. Own messages counted as unread (server)

`getUnreadCounts()` counted every message above the read cursor, including the user's own — and the client only advances the cursor on *incoming* messages, never on send. So sending a message that got no reply left a phantom server-side unread count, which surfaced as a dot on the open conversation after the next reconnect snapshot.

`getUnreadCounts()` now takes the caller's username and excludes messages they sent (messages with no sender still count).

### 2. Reconnect snapshots clobbered the active conversation (client)

Every SSE reconnect (network blip, laptop wake — the 30s stale timer forces one) delivers a fresh snapshot, and the handler repopulated `unreadCounts` for **all** conversations, including the one being viewed. Nothing re-zeroed it: the derived `activeConversationId` was unchanged, so the mark-read `$effect` never re-fired, and the dot stuck until navigating away and back.

The snapshot handler now skips the actively-viewed conversation and re-POSTs mark-as-read for it, so the server cursor catches up on anything that arrived while disconnected.

### 3. Hidden tabs silently marked messages read (client)

A backgrounded tab, forgotten Electron window, or another device parked on a conversation auto-marked every incoming message read — there was no visibility check anywhere. Messages arriving there were consumed as "read" for the whole account, so no dot appeared on any other session ("away and re-open the app" symptom).

Mark-as-read is now gated on `document.visibilityState`: a hidden tab treats its active conversation like any other (dot accrues, cursor untouched), and a `visibilitychange` listener catches the cursor up when the tab is refocused.

## Tests

TDD on the server fix: updated the unread suite in `test/web-v1-conversations.test.ts` (one existing test had the buggy behavior baked in) and added an "excludes own messages" case — both fail against the old query and pass with the fix. Full suite: 1750/1750.

The client store changes have no test harness (no frontend unit test setup exists); they were verified via svelte-check, typecheck, and a production Vite build.

Fixes #409's sibling symptoms; #409 itself remains open with an implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
