### PR TITLE
fix: attach menu in web chat instantly self-closing

### DIFF
--- a/packages/ui/src/components/Dropdown.svelte
+++ b/packages/ui/src/components/Dropdown.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
-import { onMount } from "svelte";
 
 let {
   open = false,
@@ -35,7 +34,10 @@ function handleKeydown(e: KeyboardEvent) {
   }
 }
 
-onMount(() => {
+$effect(() => {
+  if (!open) return;
+  // Defer one frame so the click that opened the dropdown doesn't
+  // bubble to document and immediately close it.
   const raf = requestAnimationFrame(() => {
     document.addEventListener("click", handleClickOutside);
   });


### PR DESCRIPTION
## Problem

The **+** attach button in web chat did nothing when clicked — no menu ever appeared, so images/files couldn't be sent from the web UI even though the whole send pipeline (base64 upload, image content blocks, file staging for `volute chat accept`) has been in place since #188/#216.

## Root cause

The shared `Dropdown` component (`packages/ui/src/components/Dropdown.svelte`) registered its close-on-click-outside `document` listener permanently on mount. The click that opens a dropdown bubbles up to `document` *after* Svelte has rendered the menu, so the listener saw a click "outside the menu" and closed it immediately. A MutationObserver showed the menu being added and removed **0.1 ms apart** — it opened and self-closed before paint.

`ConversationList` accidentally dodged this by calling `stopPropagation()` on its trigger; `MessageInput` didn't. (`StatusBar` also uses the vulnerable pattern but is currently unmounted dead code.)

## Fix

Attach the click-outside listener only while the dropdown is open, deferred one frame (`requestAnimationFrame`) so the opening click can't cancel it. Fixes all current and future `Dropdown` consumers with no per-trigger `stopPropagation` hacks needed.

## Verification

Playwright against an isolated daemon (scratch `VOLUTE_HOME`):
- menu opens on **+** click ✔ (was: added+removed in 0.1 ms)
- second **+** click toggles it closed ✔
- click outside closes it ✔
- Image attach → preview strip → send → renders in conversation ✔
- File attach → chip → send ✔
- `svelte-check`: 0 errors; svelte-autofixer: no issues

Note: local `npm test` hangs in my sandbox environment (unrelated daemon-side tests, none import `packages/ui`); pushed with hooks skipped per @mimsy — relying on CI for the suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)