### PR TITLE
feat: restic-based system backups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - name: Install restic (backup round-trip tests skip without it)
+        run: sudo apt-get update && sudo apt-get install -y restic
       - name: Configure git identity
         run: |
           git config --global user.email "ci@test.com"
@@ -54,6 +56,8 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - name: Install restic (backup e2e test skips without it)
+        run: sudo apt-get update && sudo apt-get install -y restic
       - name: Configure git identity
         run: |
           git config --global user.email "ci@test.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ A single daemon process (`volute up`) manages all minds, bridges, and schedules:
 - **Scheduler** (`packages/daemon/src/lib/daemon/scheduler.ts`) — Cron-based scheduled messages and scripts for minds
 - **SleepManager** (`packages/daemon/src/lib/daemon/sleep-manager.ts`) — Sleep/wake cycles: cron-based scheduling, pre-sleep ritual, session archival, message queuing, wake triggers, trigger-wake with return-to-sleep
 - **MailPoller** (`packages/daemon/src/lib/daemon/mail-poller.ts`) — System-wide email polling via volute.systems API (auto-activates when a systems account exists)
+- **BackupManager** (`packages/daemon/src/lib/daemon/backup-manager.ts`) — Cron-scheduled restic backups of the whole system
 - **DaemonClient** (`packages/cli/src/lib/daemon-client.ts`) — CLI commands talk to the daemon via HTTP API
 
 CLI commands like `mind start`, `mind stop`, `chat send`, `mind split`, `mind join` all proxy through the daemon API.
@@ -233,6 +234,12 @@ Extensions add functionality to Volute — custom UI sections, API routes, datab
 | `volute setup [--name N] [--system] [--service] [--dir D] [--port N] [--host H]` | Required first-run setup (interactive or non-interactive) |
 | `volute up [--port N] [--foreground] [--no-sandbox]` | Start the daemon (default: 1618) |
 | `volute down` | Stop the daemon |
+| `volute backup init [--repo R] [--password P]` | Configure and initialize the restic backup repository (prompts if flags omitted) |
+| `volute backup create` | Run a backup now (via daemon) |
+| `volute backup list` | List backup snapshots |
+| `volute backup schedule [--enable\|--disable] [--cron "..."]` | Manage scheduled backups |
+| `volute backup status` | Show backup config and last run |
+| `volute backup restore [--repo R] [--snapshot ID] [--target D] [--yes]` | Restore the system from a backup (in-place restore stops the daemon; --target inspects without touching it) |
 | `volute restart [--port N]` | Restart the daemon |
 | `volute status` | Show daemon status, service info, version, and minds |
 | `volute login` | CLI authentication to the daemon |
@@ -318,6 +325,7 @@ Mind-scoped commands (`chat`, `clock`, `skill`) use `--mind <name>` or `VOLUTE_M
 | `bridge-manager.ts` | Manages bridge processes per mind, resolves built-in → shared → mind-specific bridges |
 | `scheduler.ts` | Cron-based scheduled messages and scripts, per-mind schedule loading |
 | `mail-poller.ts` | Daemon-integrated mail polling (system-wide, uses volute.systems API) |
+| `backup-manager.ts` | Cron-scheduled restic backups (see `packages/daemon/src/lib/backup/`) |
 | `token-budget.ts` | Per-mind token budget enforcement |
 | `restart-tracker.ts` | Tracks mind restart state |
 | `sleep-manager.ts` | Sleep/wake cycles, cron scheduling, message queuing, wake triggers |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-slim
 
-# git needed for mind git init + variants; procps/lsof for process management; curl for hooks/scripts
-RUN apt-get update && apt-get install -y --no-install-recommends git procps lsof ca-certificates curl \
+# git needed for mind git init + variants; procps/lsof for process management; curl for hooks/scripts; restic for backups
+RUN apt-get update && apt-get install -y --no-install-recommends git procps lsof ca-certificates curl restic \
     && rm -rf /var/lib/apt/lists/* \
     && git config --system user.name "Volute" \
     && git config --system user.email "volute@localhost"

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import { format } from "node:util";
 import { setProviderRefreshHook } from "./lib/ai-service.js";
 import { ensureSystemChannel } from "./lib/chat/system-channel.js";
+import { initBackupManager } from "./lib/daemon/backup-manager.js";
 import { initBridgeManager } from "./lib/daemon/bridge-manager.js";
 import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
 import { initMailPoller } from "./lib/daemon/mail-poller.js";
@@ -259,6 +260,8 @@ export async function startDaemon(opts: {
   sleepManager.start();
   const summarizer = initSummarizer();
   summarizer.start();
+  const backupManager = initBackupManager();
+  backupManager.start();
   const unsubscribeWebhook = initWebhook();
 
   // Clean up any turns left active from a previous daemon session and generate their summaries
@@ -425,6 +428,7 @@ export async function startDaemon(opts: {
       safe("mailPoller.stop", () => mailPoller.stop());
       safe("tokenBudget.stop", () => tokenBudget.stop());
       safe("summarizer.stop", () => summarizer.stop());
+      safe("backupManager.stop", () => backupManager.stop());
       safe("stopApiKeyRefresh", stopApiKeyRefresh);
       safe("delivery.dispose", () => delivery.dispose());
       await safe("bridgeManager.stopAll", () => bridgeManager.stopAll());

--- a/packages/daemon/src/lib/backup/backup.ts
+++ b/packages/daemon/src/lib/backup/backup.ts
@@ -1,0 +1,286 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { sql } from "drizzle-orm";
+import { type BackupConfig, readGlobalConfig } from "../config/setup.js";
+import { getDb } from "../db.js";
+import { readAllMinds, voluteHome, voluteSystemDir } from "../mind/registry.js";
+import log from "../util/logger.js";
+import { runRestic, writeExcludeFile } from "./restic.js";
+
+const blog = log.child("backup");
+
+export type BackupState = {
+  /** Last successful run — these three always describe the same run. */
+  lastRun?: string;
+  lastSnapshotId?: string;
+  lastDurationMs?: number;
+  /** Last failed attempt. */
+  lastAttempt?: string;
+  lastError?: string;
+  /** Set when the snapshot succeeded but retention pruning failed. */
+  pruneError?: string;
+};
+
+export type BackupSummary = {
+  snapshotId: string;
+  filesNew: number;
+  filesChanged: number;
+  dataAdded: number;
+  totalFilesProcessed: number;
+  durationMs: number;
+};
+
+export type Snapshot = {
+  id: string;
+  short_id: string;
+  time: string;
+  hostname: string;
+  paths: string[];
+};
+
+const DEFAULT_KEEP = { daily: 7, weekly: 4, monthly: 12 };
+
+function stateFilePath(): string {
+  return resolve(voluteSystemDir(), "backup-state.json");
+}
+
+export function readBackupState(): BackupState {
+  const path = stateFilePath();
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    blog.warn("backup-state.json unreadable, treating as empty", log.errorData(err));
+    return {};
+  }
+}
+
+/** Never throws: a state-bookkeeping failure must not mask the run's real outcome. */
+function writeBackupState(state: BackupState): void {
+  try {
+    writeFileSync(stateFilePath(), `${JSON.stringify(state, null, 2)}\n`);
+  } catch (err) {
+    blog.error("failed to write backup-state.json", log.errorData(err));
+  }
+}
+
+export function stagingDir(): string {
+  return resolve(voluteSystemDir(), "backup-staging");
+}
+
+/**
+ * Produce consistent copies of every live SQLite DB into backup-staging/,
+ * mirroring their real layout so restore is a mechanical move-back. Raw file
+ * copies of a WAL database are not safe; VACUUM INTO is.
+ */
+export async function stageDatabases(): Promise<string[]> {
+  const staging = stagingDir();
+  rmSync(staging, { recursive: true, force: true });
+  mkdirSync(staging, { recursive: true });
+
+  const staged: string[] = [];
+
+  // Main system DB via the daemon's own connection.
+  const mainTarget = resolve(staging, "volute.db");
+  const db = await getDb();
+  await db.run(sql.raw(`VACUUM INTO '${mainTarget.replaceAll("'", "''")}'`));
+  staged.push(mainTarget);
+
+  // Extension DBs: enumerate on disk (covers disabled extensions too) and
+  // vacuum each through a fresh libsql connection.
+  const extDataDir = resolve(voluteSystemDir(), "extension-data");
+  if (existsSync(extDataDir)) {
+    const { default: Database } = await import("libsql");
+    for (const id of readdirSync(extDataDir)) {
+      const dbPath = resolve(extDataDir, id, "data.db");
+      if (!existsSync(dbPath)) continue;
+      const target = resolve(staging, "extension-data", id, "data.db");
+      mkdirSync(dirname(target), { recursive: true });
+      const extDb = new Database(dbPath);
+      try {
+        extDb.exec(`VACUUM INTO '${target.replaceAll("'", "''")}'`);
+        staged.push(target);
+      } finally {
+        extDb.close();
+      }
+    }
+  }
+
+  return staged;
+}
+
+export async function backupRoots(): Promise<string[]> {
+  const roots = new Set<string>([voluteHome()]);
+  const mindsDir = process.env.VOLUTE_MINDS_DIR;
+  if (mindsDir && existsSync(mindsDir)) roots.add(resolve(mindsDir));
+  // Minds with a custom dir outside the standard roots (e.g. imported minds).
+  for (const mind of await readAllMinds()) {
+    if (!mind.dir || !existsSync(mind.dir)) continue;
+    const dir = resolve(mind.dir);
+    if (![...roots].some((root) => dir === root || dir.startsWith(`${root}/`))) {
+      roots.add(dir);
+    }
+  }
+  return [...roots];
+}
+
+let backupInFlight = false;
+
+export async function runBackup(): Promise<BackupSummary> {
+  if (backupInFlight) throw new Error("A backup is already running");
+  backupInFlight = true;
+  const started = Date.now();
+  try {
+    const config = readGlobalConfig().backup ?? {};
+    if (!config.repository || !config.password) {
+      throw new Error("Backup repository is not configured. Run: volute backup init");
+    }
+    blog.info("starting backup", { repository: config.repository });
+
+    await stageDatabases();
+    const roots = await backupRoots();
+    const excludeFile = writeExcludeFile(config);
+
+    const out = await runRestic(
+      [
+        "backup",
+        ...roots,
+        "--exclude-file",
+        excludeFile,
+        "--exclude-caches",
+        "--tag",
+        "volute",
+        "--json",
+      ],
+      config,
+    );
+    const summary = parseBackupSummary(out, Date.now() - started);
+
+    // Retention pruning is separate from the backup: the snapshot already
+    // exists, so a prune failure (e.g. repo lock contention) must not report
+    // the backup itself as failed or leave the snapshot unrecorded.
+    const keep = { ...DEFAULT_KEEP, ...config.keep };
+    let pruneError: string | undefined;
+    try {
+      await runRestic(
+        [
+          "forget",
+          "--tag",
+          "volute",
+          "--keep-daily",
+          String(keep.daily),
+          "--keep-weekly",
+          String(keep.weekly),
+          "--keep-monthly",
+          String(keep.monthly),
+          "--prune",
+        ],
+        config,
+      );
+    } catch (err) {
+      pruneError = err instanceof Error ? err.message : String(err);
+      blog.warn("retention prune failed (snapshot is intact)", log.errorData(err));
+    }
+
+    writeBackupState({
+      lastRun: new Date().toISOString(),
+      lastSnapshotId: summary.snapshotId,
+      lastDurationMs: summary.durationMs,
+      ...(pruneError ? { pruneError } : {}),
+    });
+    blog.info("backup complete", { snapshot: summary.snapshotId, ms: summary.durationMs });
+    return summary;
+  } catch (err) {
+    writeBackupState({
+      ...readBackupState(),
+      lastAttempt: new Date().toISOString(),
+      lastError: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  } finally {
+    backupInFlight = false;
+  }
+}
+
+/** Parse the summary line from `restic backup --json` output. */
+function parseBackupSummary(output: string, durationMs: number): BackupSummary {
+  for (const line of output.trim().split("\n").reverse()) {
+    let msg: {
+      message_type?: string;
+      snapshot_id?: string;
+      files_new?: number;
+      files_changed?: number;
+      data_added?: number;
+      total_files_processed?: number;
+    };
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue; // non-JSON line (progress noise) — keep scanning
+    }
+    if (msg.message_type !== "summary") continue;
+    if (!msg.snapshot_id) throw new Error("restic summary is missing snapshot_id");
+    return {
+      snapshotId: msg.snapshot_id,
+      filesNew: msg.files_new ?? 0,
+      filesChanged: msg.files_changed ?? 0,
+      dataAdded: msg.data_added ?? 0,
+      totalFilesProcessed: msg.total_files_processed ?? 0,
+      durationMs,
+    };
+  }
+  throw new Error("restic backup produced no summary");
+}
+
+export async function listSnapshots(): Promise<Snapshot[]> {
+  const config = readGlobalConfig().backup ?? {};
+  const out = await runRestic(["snapshots", "--tag", "volute", "--json"], config);
+  const parsed = JSON.parse(out || "[]") as Snapshot[];
+  return parsed.map((s) => ({
+    id: s.id,
+    short_id: s.short_id,
+    time: s.time,
+    hostname: s.hostname,
+    paths: s.paths,
+  }));
+}
+
+/**
+ * Initialize the restic repository. Takes the config explicitly so callers can
+ * init with a not-yet-persisted passphrase (the API only saves a generated one
+ * after init succeeds). Idempotent: an already-initialized repo is fine.
+ */
+export async function initRepo(config: BackupConfig): Promise<void> {
+  try {
+    await runRestic(["init"], config);
+  } catch (err) {
+    const stderr = (err as Error & { stderr?: string }).stderr ?? "";
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/already exists|already initialized/i.test(stderr + msg)) return;
+    throw err;
+  }
+}
+
+/**
+ * Move a staged DB copy into its live location, clearing stale WAL/SHM files
+ * so a leftover journal can't corrupt the restored database on next open.
+ * Returns false — without touching the live DB — when the staged copy is
+ * missing; the caller decides whether that is fatal.
+ */
+export function restoreStagedDb(stagedPath: string, livePath: string): boolean {
+  if (!existsSync(stagedPath)) return false;
+  mkdirSync(dirname(livePath), { recursive: true });
+  rmSync(livePath, { force: true });
+  rmSync(`${livePath}-wal`, { force: true });
+  rmSync(`${livePath}-shm`, { force: true });
+  renameSync(stagedPath, livePath);
+  return true;
+}

--- a/packages/daemon/src/lib/backup/restic.ts
+++ b/packages/daemon/src/lib/backup/restic.ts
@@ -1,0 +1,130 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { BackupConfig } from "../config/setup.js";
+import { voluteSystemDir } from "../mind/registry.js";
+import { exec } from "../util/exec.js";
+import log from "../util/logger.js";
+
+export const RESTIC_INSTALL_HINT =
+  "Install restic: `brew install restic` (macOS), `apt-get install restic` (Debian/Ubuntu), or see https://restic.net";
+
+/** Check that the restic binary is on PATH. Returns its version string, or null. */
+export async function resticVersion(): Promise<string | null> {
+  try {
+    const out = await exec("restic", ["version"]);
+    return out.trim();
+  } catch (err) {
+    // ENOENT means "not installed"; anything else (broken binary, EACCES) is a
+    // different problem the install hint would misdiagnose — log the real error.
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.child("backup").warn("restic exists but failed to run", log.errorData(err));
+    }
+    return null;
+  }
+}
+
+export function resticEnv(config: BackupConfig): NodeJS.ProcessEnv {
+  if (!config.repository) throw new Error("Backup repository is not configured");
+  if (!config.password) throw new Error("Backup password is not configured");
+  return {
+    ...process.env,
+    ...config.env,
+    RESTIC_REPOSITORY: config.repository,
+    RESTIC_PASSWORD: config.password,
+  };
+}
+
+/** Run restic with the given args. Argv array only — never a shell string. */
+export async function runRestic(
+  args: string[],
+  config: BackupConfig,
+  options?: { cwd?: string },
+): Promise<string> {
+  if (!(await resticVersion())) {
+    throw new Error(`restic is not installed. ${RESTIC_INSTALL_HINT}`);
+  }
+  return exec("restic", args, { cwd: options?.cwd, env: resticEnv(config) });
+}
+
+/**
+ * Default exclude patterns. Restic matches bare names against any path
+ * component, so `node_modules` excludes them at every depth — including inside
+ * projects minds created for themselves.
+ */
+const BASE_EXCLUDES = [
+  // dependency trees and build output — rehydrated via lockfiles
+  "node_modules",
+  ".venv",
+  "venv",
+  "__pycache__",
+  "dist",
+  // mind runtime state that is regenerated
+  ".variants",
+  ".worktrees",
+  ".mind/tmp",
+  ".npm",
+  // toolchains and caches minds install into their home. home/.local must NOT
+  // be excluded wholesale: .local/hooks and .local/bin hold mind-authored hooks
+  // and skill shims that are never regenerated — only its toolchain subdirs go.
+  "home/.cache",
+  "home/.npm",
+  "home/.rustup",
+  "home/.cargo",
+  "home/.local/share",
+  "home/.local/state",
+  "home/.local/lib",
+  "home/.local/pipx",
+];
+
+/**
+ * System-dir files excluded by absolute path so the patterns can't collide
+ * with same-named files inside mind directories. Live DBs are excluded because
+ * the backup carries consistent VACUUM INTO copies under backup-staging/.
+ */
+function systemExcludes(): string[] {
+  const sys = voluteSystemDir();
+  return [
+    resolve(sys, "volute.db"),
+    resolve(sys, "volute.db-wal"),
+    resolve(sys, "volute.db-shm"),
+    `${resolve(sys, "extension-data")}/*/data.db`,
+    `${resolve(sys, "extension-data")}/*/data.db-wal`,
+    `${resolve(sys, "extension-data")}/*/data.db-shm`,
+    `${resolve(sys, "state")}/*/logs`,
+    resolve(sys, "daemon.log"),
+    resolve(sys, "daemon.pid"),
+    resolve(sys, "backup-excludes.txt"),
+  ];
+}
+
+/**
+ * Session transcripts, excluded unless includeSessions. Locations are
+ * template-dependent: codex writes under .mind/codex/sessions, pi under
+ * .mind/pi-sessions. The Claude Agent SDK writes under home/.claude only when
+ * HOME is remapped into the mind dir (user isolation); on other installs its
+ * transcripts live in the host ~/.claude, outside every backup root, so
+ * includeSessions cannot capture them. Durable history lives in volute.db;
+ * a restored mind wakes with a fresh session.
+ */
+const SESSION_EXCLUDES = [
+  "home/.claude/projects",
+  "home/.claude/debug",
+  "home/.claude/telemetry",
+  "home/.claude/todos",
+  "home/.claude/session-env",
+  ".mind/codex/sessions",
+  ".mind/pi-sessions",
+];
+
+export function buildExcludePatterns(config: BackupConfig): string[] {
+  const patterns = [...BASE_EXCLUDES, ...systemExcludes()];
+  if (!config.includeSessions) patterns.push(...SESSION_EXCLUDES);
+  return patterns;
+}
+
+/** Write the exclude file for a backup run and return its path. */
+export function writeExcludeFile(config: BackupConfig): string {
+  const path = resolve(voluteSystemDir(), "backup-excludes.txt");
+  writeFileSync(path, `${buildExcludePatterns(config).join("\n")}\n`);
+  return path;
+}

--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -49,6 +49,32 @@ export type ImagegenConfig = {
   defaultModel?: string;
 };
 
+export type BackupSettings = {
+  /** Restic repository string: a local path, `s3:...`, `b2:...`, `sftp:...`, etc. */
+  repository?: string;
+  /** Cron expression for scheduled backups (default "0 3 * * *") */
+  schedule?: string;
+  /** Whether scheduled backups run */
+  enabled?: boolean;
+  /** Retention policy passed to `restic forget` (default 7/4/12) */
+  keep?: { daily?: number; weekly?: number; monthly?: number };
+  /** Include session transcripts (claude/codex/pi) in backups (default false) */
+  includeSessions?: boolean;
+};
+
+/**
+ * Never written to config.json (0644) or returned by the API. A new secret
+ * field belongs here AND in splitConfig + redactedConfig (web/api/backup.ts).
+ */
+export type BackupSecrets = {
+  /** Restic repository passphrase */
+  password?: string;
+  /** Extra env vars for restic, e.g. AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY */
+  env?: Record<string, string>;
+};
+
+export type BackupConfig = BackupSettings & BackupSecrets;
+
 export type GlobalConfig = {
   name?: string;
   description?: string;
@@ -73,6 +99,8 @@ export type GlobalConfig = {
   disabledExtensions?: string[];
   /** Default settings applied when creating new minds */
   mindDefaults?: MindDefaults;
+  /** Restic-based system backup configuration */
+  backup?: BackupConfig;
 };
 
 export type MindDefaultsCognition = CognitionConfig & {
@@ -105,6 +133,7 @@ export function secretsPath(): string {
 type ConfigSecrets = {
   ai?: { providers: Record<string, AiProviderConfig> };
   imagegen?: { providers: Record<string, ServiceProviderConfig> };
+  backup?: BackupSecrets;
 };
 
 function hasEntries(obj: Record<string, unknown> | undefined): boolean {
@@ -125,6 +154,15 @@ function splitConfig(config: GlobalConfig): { publicConfig: GlobalConfig; secret
     publicConfig.imagegen = { ...rest };
     if (providers && Object.keys(providers).length > 0) secrets.imagegen = { providers };
   }
+  if (config.backup) {
+    const { password, env, ...rest } = config.backup;
+    publicConfig.backup = { ...rest };
+    if (password || hasEntries(env)) {
+      secrets.backup = {};
+      if (password) secrets.backup.password = password;
+      if (hasEntries(env)) secrets.backup.env = env;
+    }
+  }
   return { publicConfig, secrets };
 }
 
@@ -136,6 +174,9 @@ function mergeSecrets(publicConfig: GlobalConfig, secrets: ConfigSecrets): Globa
   }
   if (secrets.imagegen?.providers) {
     merged.imagegen = { ...(merged.imagegen ?? {}), providers: secrets.imagegen.providers };
+  }
+  if (secrets.backup) {
+    merged.backup = { ...(merged.backup ?? {}), ...secrets.backup };
   }
   return merged;
 }
@@ -219,7 +260,11 @@ export function migrateConfigSecrets(): void {
   } catch {
     return;
   }
-  const embedsSecrets = hasEntries(parsed.ai?.providers) || hasEntries(parsed.imagegen?.providers);
+  const embedsSecrets =
+    hasEntries(parsed.ai?.providers) ||
+    hasEntries(parsed.imagegen?.providers) ||
+    !!parsed.backup?.password ||
+    hasEntries(parsed.backup?.env);
   const mode = statSync(path).mode & 0o777;
   if (!embedsSecrets && mode === 0o644) return; // already migrated
   _resetConfigCache();

--- a/packages/daemon/src/lib/daemon/backup-manager.ts
+++ b/packages/daemon/src/lib/daemon/backup-manager.ts
@@ -1,0 +1,83 @@
+import { CronExpressionParser } from "cron-parser";
+import { runBackup } from "../backup/backup.js";
+import { readGlobalConfig } from "../config/setup.js";
+import log from "../util/logger.js";
+
+const blog = log.child("backup");
+
+export const DEFAULT_BACKUP_SCHEDULE = "0 3 * * *";
+
+/**
+ * Runs scheduled backups. Config is re-read each tick so enabling/changing the
+ * schedule via the API takes effect without a daemon restart.
+ */
+export class BackupManager {
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private lastFiredMinute = -1;
+  private warnedUnconfigured = false;
+
+  start(): void {
+    this.interval = setInterval(() => {
+      this.tick().catch((err) => blog.error("backup tick failed", log.errorData(err)));
+    }, 60_000);
+  }
+
+  stop(): void {
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+  }
+
+  /**
+   * True at most once per scheduled fire minute (records the minute it
+   * consumed), and only when backups are enabled and runnable. Not a pure
+   * predicate — a second call in the same minute returns false.
+   */
+  isDue(now: Date = new Date()): boolean {
+    const config = readGlobalConfig().backup;
+    if (!config?.enabled) return false;
+    if (!config.repository || !config.password) {
+      if (!this.warnedUnconfigured) {
+        blog.warn("scheduled backups are enabled but no repository is initialized — not running");
+        this.warnedUnconfigured = true;
+      }
+      return false;
+    }
+    this.warnedUnconfigured = false;
+    const cron = config.schedule || DEFAULT_BACKUP_SCHEDULE;
+    const epochMinute = Math.floor(now.getTime() / 60000);
+    if (epochMinute === this.lastFiredMinute) return false;
+    let prevMinute: number;
+    try {
+      const interval = CronExpressionParser.parse(cron, { currentDate: now });
+      prevMinute = Math.floor(interval.prev().toDate().getTime() / 60000);
+    } catch (err) {
+      blog.warn(`invalid backup cron "${cron}"`, log.errorData(err));
+      return false;
+    }
+    if (prevMinute !== epochMinute) return false;
+    this.lastFiredMinute = epochMinute;
+    return true;
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.isDue()) return;
+    blog.info("scheduled backup starting");
+    try {
+      await runBackup();
+    } catch (err) {
+      blog.error("scheduled backup failed", log.errorData(err));
+    }
+  }
+}
+
+let backupManager: BackupManager | null = null;
+
+export function initBackupManager(): BackupManager {
+  if (!backupManager) backupManager = new BackupManager();
+  return backupManager;
+}
+
+export function getBackupManager(): BackupManager {
+  if (!backupManager) throw new Error("BackupManager not initialized");
+  return backupManager;
+}

--- a/packages/daemon/src/web/api/backup.ts
+++ b/packages/daemon/src/web/api/backup.ts
@@ -1,0 +1,139 @@
+import { randomBytes } from "node:crypto";
+import { zValidator } from "@hono/zod-validator";
+import { CronExpressionParser } from "cron-parser";
+import { Hono } from "hono";
+import { z } from "zod";
+import { initRepo, listSnapshots, readBackupState, runBackup } from "../../lib/backup/backup.js";
+import { RESTIC_INSTALL_HINT, resticVersion } from "../../lib/backup/restic.js";
+import { readGlobalConfig, writeGlobalConfig } from "../../lib/config/setup.js";
+import { DEFAULT_BACKUP_SCHEDULE } from "../../lib/daemon/backup-manager.js";
+import { type AuthEnv, requireAdmin } from "../middleware/auth.js";
+
+/**
+ * Backup config with secrets redacted: password → hasPassword, env → key
+ * names only. Built field-by-field (no spread) so a future BackupConfig field
+ * can't reach the API without an explicit decision here.
+ */
+function redactedConfig() {
+  const backup = readGlobalConfig().backup ?? {};
+  return {
+    repository: backup.repository,
+    schedule: backup.schedule ?? DEFAULT_BACKUP_SCHEDULE,
+    enabled: backup.enabled,
+    keep: backup.keep,
+    includeSessions: backup.includeSessions,
+    hasPassword: !!backup.password,
+    envKeys: Object.keys(backup.env ?? {}),
+  };
+}
+
+const configSchema = z.object({
+  repository: z.string().optional(),
+  schedule: z
+    .string()
+    .refine(
+      (cron) => {
+        try {
+          CronExpressionParser.parse(cron);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: "Invalid cron expression" },
+    )
+    .optional(),
+  enabled: z.boolean().optional(),
+  keep: z
+    .object({
+      daily: z.number().int().min(0).optional(),
+      weekly: z.number().int().min(0).optional(),
+      monthly: z.number().int().min(0).optional(),
+    })
+    .refine((keep) => !(keep.daily === 0 && keep.weekly === 0 && keep.monthly === 0), {
+      message: "Retention cannot be zero everywhere — prune would delete every snapshot",
+    })
+    .optional(),
+  includeSessions: z.boolean().optional(),
+  password: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+});
+
+const backup = new Hono<AuthEnv>()
+  .get("/config", requireAdmin, (c) => c.json(redactedConfig()))
+
+  .put("/config", requireAdmin, zValidator("json", configSchema), (c) => {
+    const updates = c.req.valid("json");
+    const config = readGlobalConfig();
+    const current = config.backup ?? {};
+    config.backup = {
+      ...current,
+      ...updates,
+      // Empty-string password means "keep existing" so the UI can save
+      // settings without re-entering the passphrase.
+      password: updates.password || current.password,
+      env: updates.env ?? current.env,
+    };
+    writeGlobalConfig(config);
+    return c.json(redactedConfig());
+  })
+
+  .post("/init", requireAdmin, async (c) => {
+    const config = readGlobalConfig();
+    if (!config.backup?.repository) {
+      return c.json({ error: "Backup repository is not configured" }, 400);
+    }
+    let generatedPassword: string | null = null;
+    if (!config.backup.password) {
+      generatedPassword = randomBytes(32).toString("base64url");
+      config.backup.password = generatedPassword;
+    }
+    try {
+      await initRepo(config.backup);
+    } catch (err) {
+      // The generated passphrase is deliberately NOT persisted on failure:
+      // a retry generates a fresh one, so a passphrase the operator never
+      // saw can't end up guarding the repository.
+      const stderr = (err as Error & { stderr?: string }).stderr;
+      const detail = err instanceof Error ? err.message : String(err);
+      return c.json({ error: stderr?.trim() || detail }, 500);
+    }
+    if (generatedPassword) writeGlobalConfig(config);
+    // The passphrase is returned exactly once, by the successful init that
+    // generated it — the caller must surface it to the operator.
+    return c.json({ ok: true, password: generatedPassword });
+  })
+
+  .post("/run", requireAdmin, async (c) => {
+    try {
+      const summary = await runBackup();
+      return c.json(summary);
+    } catch (err) {
+      const stderr = (err as Error & { stderr?: string }).stderr;
+      const detail = err instanceof Error ? err.message : String(err);
+      return c.json({ error: stderr?.trim() || detail }, 500);
+    }
+  })
+
+  .get("/snapshots", requireAdmin, async (c) => {
+    try {
+      return c.json(await listSnapshots());
+    } catch (err) {
+      const stderr = (err as Error & { stderr?: string }).stderr;
+      const detail = err instanceof Error ? err.message : String(err);
+      return c.json({ error: stderr?.trim() || detail }, 500);
+    }
+  })
+
+  .get("/status", requireAdmin, async (c) => {
+    const version = await resticVersion();
+    return c.json({
+      resticInstalled: version !== null,
+      resticVersion: version,
+      installHint: version === null ? RESTIC_INSTALL_HINT : null,
+      config: redactedConfig(),
+      state: readBackupState(),
+    });
+  });
+
+export default backup;

--- a/packages/daemon/src/web/app.ts
+++ b/packages/daemon/src/web/app.ts
@@ -7,6 +7,7 @@ import { checkForUpdateCached, getCurrentVersion } from "../lib/update-check.js"
 import log from "../lib/util/logger.js";
 import activityRoutes from "./api/activity.js";
 import auth from "./api/auth.js";
+import backupRoutes from "./api/backup.js";
 import bridges from "./api/bridges.js";
 import channels from "./api/channels.js";
 import configRoutes from "./api/config.js";
@@ -121,6 +122,7 @@ app.use("/api/skills/*", authMiddleware);
 app.use("/api/extensions/*", authMiddleware);
 app.use("/api/bridges/*", authMiddleware);
 app.use("/api/config/*", authMiddleware);
+app.use("/api/backup/*", authMiddleware);
 
 // v1 API auth
 app.use("/api/v1/*", authMiddleware);
@@ -138,6 +140,7 @@ const routes = app
   .route("/api/auth", auth)
   .route("/api/system", system)
   .route("/api/system", update)
+  .route("/api/backup", backupRoutes)
   .route("/api/minds", minds)
   .route("/api/minds", chat)
   .route("/api/minds", schedules)

--- a/packages/web/src/ui/components/system/Backups.svelte
+++ b/packages/web/src/ui/components/system/Backups.svelte
@@ -1,0 +1,595 @@
+<script lang="ts">
+import {
+  Button,
+  EmptyState,
+  ErrorMessage,
+  Input,
+  SettingRow,
+  SettingsSection,
+  Toggle,
+} from "@volute/ui";
+import { onMount } from "svelte";
+import {
+  type BackupRunSummary,
+  type BackupSnapshot,
+  type BackupState,
+  fetchBackupStatus,
+  initBackupRepo,
+  listBackupSnapshots,
+  runBackupNow,
+  saveBackupConfig,
+} from "../../lib/client";
+
+const ENV_PLACEHOLDER = "AWS_ACCESS_KEY_ID=...\nAWS_SECRET_ACCESS_KEY=...";
+
+// Restic status
+let resticInstalled = $state(false);
+let resticVersion = $state<string | null>(null);
+let installHint = $state<string | null>(null);
+let backupState = $state<BackupState>({});
+
+// Repository
+let editRepository = $state("");
+let editPassword = $state("");
+let hasPassword = $state(false);
+let envKeys = $state<string[]>([]);
+let envText = $state("");
+let envEdited = $state(false);
+
+// Schedule
+let scheduleEnabled = $state(false);
+let editSchedule = $state("0 3 * * *");
+let keepDaily = $state("");
+let keepWeekly = $state("");
+let keepMonthly = $state("");
+let includeSessions = $state(false);
+
+// Actions
+let initializing = $state(false);
+let generatedPassword = $state<string | null>(null);
+let passwordCopied = $state(false);
+let copyError = $state("");
+let running = $state(false);
+let runResult = $state<BackupRunSummary | null>(null);
+let runError = $state("");
+let snapshots = $state<BackupSnapshot[] | null>(null);
+let snapshotsLoading = $state(false);
+let snapshotsError = $state("");
+
+// General
+let error = $state("");
+let loading = $state(true);
+let loadFailed = $state(false);
+let saveStatus = $state<"idle" | "saving" | "saved">("idle");
+let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+function parseKeepInt(val: string): number | undefined {
+  if (!val.trim()) return undefined;
+  const n = parseInt(val, 10);
+  return Number.isNaN(n) ? undefined : n;
+}
+
+function parseEnvText(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1);
+  }
+  return env;
+}
+
+async function refreshStatus() {
+  const status = await fetchBackupStatus();
+  resticInstalled = status.resticInstalled;
+  resticVersion = status.resticVersion;
+  installHint = status.installHint;
+  backupState = status.state;
+  editRepository = status.config.repository ?? "";
+  hasPassword = status.config.hasPassword;
+  envKeys = status.config.envKeys;
+  scheduleEnabled = status.config.enabled ?? false;
+  editSchedule = status.config.schedule ?? "0 3 * * *";
+  keepDaily = status.config.keep?.daily != null ? String(status.config.keep.daily) : "";
+  keepWeekly = status.config.keep?.weekly != null ? String(status.config.keep.weekly) : "";
+  keepMonthly = status.config.keep?.monthly != null ? String(status.config.keep.monthly) : "";
+  includeSessions = status.config.includeSessions ?? false;
+}
+
+async function save() {
+  saveStatus = "saving";
+  clearTimeout(saveTimer);
+  try {
+    await saveBackupConfig({
+      repository: editRepository,
+      schedule: editSchedule,
+      enabled: scheduleEnabled,
+      keep: {
+        daily: parseKeepInt(keepDaily),
+        weekly: parseKeepInt(keepWeekly),
+        monthly: parseKeepInt(keepMonthly),
+      },
+      includeSessions,
+      // Empty string means "keep existing password"
+      password: editPassword,
+      // env replaces all stored credentials, so only send it when edited
+      env: envEdited ? parseEnvText(envText) : undefined,
+    });
+    editPassword = "";
+    envText = "";
+    envEdited = false;
+    error = "";
+    saveStatus = "saved";
+    saveTimer = setTimeout(() => {
+      saveStatus = "idle";
+    }, 1500);
+  } catch (e) {
+    error = e instanceof Error ? e.message : "Save failed";
+    saveStatus = "idle";
+    return;
+  }
+  try {
+    await refreshStatus();
+  } catch (e) {
+    console.error("Failed to refresh backup status", e);
+  }
+}
+
+async function handleInit() {
+  initializing = true;
+  generatedPassword = null;
+  await save();
+  if (!error) {
+    try {
+      const res = await initBackupRepo();
+      generatedPassword = res.password;
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to initialize repository";
+    }
+    try {
+      await refreshStatus();
+    } catch (e) {
+      console.error("Failed to refresh backup status", e);
+    }
+  }
+  initializing = false;
+}
+
+async function copyPassword() {
+  if (!generatedPassword) return;
+  copyError = "";
+  try {
+    await navigator.clipboard.writeText(generatedPassword);
+  } catch {
+    copyError = "Copy failed — select the text manually";
+    return;
+  }
+  passwordCopied = true;
+  setTimeout(() => {
+    passwordCopied = false;
+  }, 1500);
+}
+
+async function handleRunNow() {
+  running = true;
+  runResult = null;
+  runError = "";
+  try {
+    runResult = await runBackupNow();
+  } catch (e) {
+    runError = e instanceof Error ? e.message : "Backup failed";
+    running = false;
+    return;
+  }
+  try {
+    await refreshStatus();
+    if (snapshots) await loadSnapshots();
+  } catch (e) {
+    console.error("Failed to refresh backup status", e);
+  }
+  running = false;
+}
+
+async function loadSnapshots() {
+  snapshotsLoading = true;
+  snapshotsError = "";
+  try {
+    snapshots = await listBackupSnapshots();
+  } catch (e) {
+    snapshotsError = e instanceof Error ? e.message : "Failed to list snapshots";
+  }
+  snapshotsLoading = false;
+}
+
+function fmtMb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function fmtDuration(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+onMount(async () => {
+  try {
+    await refreshStatus();
+  } catch (e) {
+    error = e instanceof Error ? e.message : "Failed to load backup status";
+    loadFailed = true;
+  }
+  loading = false;
+});
+</script>
+
+<div class="backups">
+  {#if loading}
+    <p class="loading-text">Loading...</p>
+  {:else if loadFailed}
+    <ErrorMessage message={error} />
+  {:else}
+    <SettingsSection title="Status">
+      {#if resticInstalled}
+        <div class="status-line">{resticVersion}</div>
+      {:else}
+        <div class="status-line missing">restic not installed</div>
+        {#if installHint}
+          <div class="install-hint">{installHint}</div>
+        {/if}
+      {/if}
+      {#if backupState.lastRun}
+        <div class="last-run">
+          Last successful backup {new Date(backupState.lastRun).toLocaleString()}
+          {#if backupState.lastSnapshotId}
+            &middot; snapshot <span class="mono">{backupState.lastSnapshotId.slice(0, 8)}</span>
+          {/if}
+          {#if backupState.lastDurationMs != null}
+            &middot; {fmtDuration(backupState.lastDurationMs)}
+          {/if}
+        </div>
+      {/if}
+      {#if backupState.pruneError}
+        <div class="prune-warning">Retention prune failed: {backupState.pruneError}</div>
+      {/if}
+      {#if backupState.lastError}
+        <ErrorMessage
+          message={backupState.lastAttempt
+            ? `Last attempt failed ${new Date(backupState.lastAttempt).toLocaleString()}: ${backupState.lastError}`
+            : `Last attempt failed: ${backupState.lastError}`}
+        />
+      {/if}
+    </SettingsSection>
+
+    <SettingsSection title="Repository">
+      <SettingRow label="Repository">
+        <Input
+          type="text"
+          variant="mono"
+          style="flex:1"
+          bind:value={editRepository}
+          placeholder="/mnt/backups/volute or s3:s3.amazonaws.com/bucket/path"
+        />
+      </SettingRow>
+      <SettingRow label="Passphrase">
+        <Input
+          type="password"
+          style="flex:1"
+          bind:value={editPassword}
+          placeholder={hasPassword ? "(unchanged)" : "passphrase"}
+        />
+      </SettingRow>
+      <div class="env-block">
+        <div class="env-label">Credentials</div>
+        <textarea
+          class="env-textarea"
+          rows="3"
+          bind:value={envText}
+          oninput={() => (envEdited = true)}
+          placeholder={ENV_PLACEHOLDER}
+        ></textarea>
+        <div class="env-hint">
+          One KEY=VALUE per line, passed to restic. Saving replaces all stored credentials.
+          {#if envKeys.length > 0}
+            Currently set: {envKeys.join(", ")}
+          {/if}
+        </div>
+      </div>
+      <div class="section-actions">
+        <Button
+          variant="secondary"
+          onclick={handleInit}
+          disabled={!resticInstalled || initializing || !editRepository.trim()}
+        >
+          {initializing ? "Initializing..." : "Initialize repository"}
+        </Button>
+      </div>
+      {#if generatedPassword}
+        <div class="password-reveal">
+          <div class="password-warning">
+            Store this passphrase somewhere off this machine &mdash; without it your backups are
+            unreadable. It will not be shown again.
+          </div>
+          <div class="password-row">
+            <code class="password-value">{generatedPassword}</code>
+            <Button variant="primary" onclick={copyPassword}>
+              {passwordCopied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+          {#if copyError}
+            <div class="copy-error">{copyError}</div>
+          {/if}
+        </div>
+      {/if}
+    </SettingsSection>
+
+    <SettingsSection title="Schedule">
+      <SettingRow label="Enabled">
+        <Toggle
+          checked={scheduleEnabled}
+          onchange={() => (scheduleEnabled = !scheduleEnabled)}
+          label={scheduleEnabled ? "On" : "Off"}
+        />
+      </SettingRow>
+      <SettingRow label="Cron">
+        <Input variant="mono" width="140px" bind:value={editSchedule} placeholder="0 3 * * *" />
+      </SettingRow>
+      <SettingRow label="Keep">
+        <Input type="number" width="60px" bind:value={keepDaily} placeholder="7" />
+        <span class="setting-hint">daily</span>
+        <Input type="number" width="60px" bind:value={keepWeekly} placeholder="4" />
+        <span class="setting-hint">weekly</span>
+        <Input type="number" width="60px" bind:value={keepMonthly} placeholder="12" />
+        <span class="setting-hint">monthly</span>
+      </SettingRow>
+      <SettingRow label="Sessions">
+        <Toggle
+          checked={includeSessions}
+          onchange={() => (includeSessions = !includeSessions)}
+        />
+        <span class="setting-hint wrap">
+          Include session transcripts &mdash; Claude transcripts are only inside mind directories on
+          user-isolation installs; elsewhere they live in the host ~/.claude and can't be captured.
+        </span>
+      </SettingRow>
+    </SettingsSection>
+
+    <div class="save-row">
+      <Button variant="primary" onclick={save} disabled={saveStatus === "saving"}>Save</Button>
+      {#if error}
+        <ErrorMessage message={error} />
+      {:else if saveStatus === "saving"}
+        <span class="save-status">Saving...</span>
+      {:else if saveStatus === "saved"}
+        <span class="save-status saved">Saved</span>
+      {/if}
+    </div>
+
+    <SettingsSection title="Backups">
+      <div class="section-actions">
+        <Button variant="secondary" onclick={handleRunNow} disabled={!resticInstalled || running}>
+          {running ? "Running backup..." : "Run backup now"}
+        </Button>
+        <Button
+          variant="secondary"
+          onclick={loadSnapshots}
+          disabled={!resticInstalled || snapshotsLoading}
+        >
+          {snapshotsLoading ? "Loading..." : snapshots ? "Refresh snapshots" : "Show snapshots"}
+        </Button>
+      </div>
+      {#if runError}
+        <ErrorMessage message={runError} />
+      {:else if runResult}
+        <div class="run-summary">
+          Snapshot <span class="mono">{runResult.snapshotId.slice(0, 8)}</span> &middot;
+          {runResult.totalFilesProcessed} files processed ({runResult.filesNew} new,
+          {runResult.filesChanged} changed) &middot; {fmtMb(runResult.dataAdded)} added &middot;
+          {fmtDuration(runResult.durationMs)}
+        </div>
+      {/if}
+      {#if snapshotsError}
+        <ErrorMessage message={snapshotsError} />
+      {:else if snapshots}
+        {#if snapshots.length === 0}
+          <EmptyState message="No snapshots yet." />
+        {:else}
+          <div class="snapshot-list">
+            {#each snapshots as snap (snap.id)}
+              <div class="snapshot-row">
+                <span class="mono">{snap.short_id}</span>
+                <span class="snapshot-time">{new Date(snap.time).toLocaleString()}</span>
+                <span class="snapshot-host">{snap.hostname}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {/if}
+    </SettingsSection>
+  {/if}
+</div>
+
+<style>
+  .backups {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  .loading-text {
+    color: var(--text-2);
+    font-size: 13px;
+    text-align: center;
+    padding: 20px;
+  }
+
+  .status-line {
+    font-size: 13px;
+    color: var(--text-1);
+  }
+
+  .status-line.missing {
+    color: var(--red, #f87171);
+  }
+
+  .install-hint {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--text-2);
+    margin-top: 4px;
+    white-space: pre-wrap;
+  }
+
+  .last-run {
+    font-size: 12px;
+    color: var(--text-2);
+    margin-top: 6px;
+  }
+
+  .mono {
+    font-family: var(--mono);
+    font-size: 12px;
+  }
+
+  .setting-hint {
+    font-size: 13px;
+    color: var(--text-2);
+    white-space: nowrap;
+  }
+
+  .setting-hint.wrap {
+    white-space: normal;
+  }
+
+  .prune-warning {
+    font-size: 12px;
+    color: var(--yellow, #facc15);
+    margin-top: 6px;
+  }
+
+  .copy-error {
+    font-size: 12px;
+    color: var(--red, #f87171);
+    margin-top: 6px;
+  }
+
+  .env-block {
+    padding: 4px 0;
+  }
+
+  .env-label {
+    font-size: 14px;
+    color: var(--text-1);
+    margin-bottom: 4px;
+  }
+
+  .env-textarea {
+    width: 100%;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 4px 8px;
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--text-0);
+    resize: vertical;
+  }
+
+  .env-textarea:focus {
+    border-color: var(--accent);
+    outline: none;
+  }
+
+  .env-hint {
+    font-size: 12px;
+    color: var(--text-2);
+    margin-top: 4px;
+  }
+
+  .section-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 8px;
+  }
+
+  .password-reveal {
+    margin-top: 10px;
+    border: 1px solid var(--red, #f87171);
+    border-radius: var(--radius-lg, 8px);
+    padding: 12px;
+  }
+
+  .password-warning {
+    font-size: 13px;
+    color: var(--red, #f87171);
+    margin-bottom: 8px;
+  }
+
+  .password-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .password-value {
+    flex: 1;
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--text-0);
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 6px 8px;
+    word-break: break-all;
+    user-select: all;
+  }
+
+  .save-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 24px;
+    margin-bottom: 24px;
+  }
+
+  .save-status {
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .save-status.saved {
+    color: var(--green, #4ade80);
+  }
+
+  .run-summary {
+    font-size: 12px;
+    color: var(--text-1);
+    margin-top: 8px;
+  }
+
+  .snapshot-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 8px;
+  }
+
+  .snapshot-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+    color: var(--text-1);
+  }
+
+  .snapshot-row:last-child {
+    border-bottom: none;
+  }
+
+  .snapshot-time {
+    flex: 1;
+  }
+
+  .snapshot-host {
+    color: var(--text-2);
+  }
+</style>

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -648,6 +648,88 @@ export function searchImagegenModels(
   return get(`${V1}/system/imagegen/models/search?${params}`);
 }
 
+// --- Backup ---
+
+export type BackupKeep = { daily?: number; weekly?: number; monthly?: number };
+
+/** Server-redacted view: secrets appear only as hasPassword / env key names. */
+export type RedactedBackupConfig = {
+  repository?: string;
+  schedule?: string;
+  enabled?: boolean;
+  keep?: BackupKeep;
+  includeSessions?: boolean;
+  hasPassword: boolean;
+  envKeys: string[];
+};
+
+export type BackupState = {
+  /** Last successful run */
+  lastRun?: string;
+  lastSnapshotId?: string;
+  lastDurationMs?: number;
+  /** Last failed attempt */
+  lastAttempt?: string;
+  lastError?: string;
+  /** Snapshot succeeded but retention pruning failed */
+  pruneError?: string;
+};
+
+export type BackupStatus = {
+  resticInstalled: boolean;
+  resticVersion: string | null;
+  installHint: string | null;
+  config: RedactedBackupConfig;
+  state: BackupState;
+};
+
+export type BackupConfigUpdate = {
+  repository?: string;
+  schedule?: string;
+  enabled?: boolean;
+  keep?: BackupKeep;
+  includeSessions?: boolean;
+  password?: string;
+  env?: Record<string, string>;
+};
+
+export type BackupRunSummary = {
+  snapshotId: string;
+  filesNew: number;
+  filesChanged: number;
+  dataAdded: number;
+  totalFilesProcessed: number;
+  durationMs: number;
+};
+
+export type BackupSnapshot = {
+  id: string;
+  short_id: string;
+  time: string;
+  hostname: string;
+  paths: string[];
+};
+
+export function fetchBackupStatus(): Promise<BackupStatus> {
+  return get("/api/backup/status");
+}
+
+export function saveBackupConfig(config: BackupConfigUpdate): Promise<void> {
+  return put("/api/backup/config", config);
+}
+
+export function initBackupRepo(): Promise<{ ok: true; password: string | null }> {
+  return post("/api/backup/init");
+}
+
+export function runBackupNow(): Promise<BackupRunSummary> {
+  return post("/api/backup/run");
+}
+
+export function listBackupSnapshots(): Promise<BackupSnapshot[]> {
+  return get("/api/backup/snapshots");
+}
+
 // --- Auth (these stay on /api/ since they're not mind-scoped) ---
 
 export function fetchAvailableUsers(type?: string): Promise<AvailableUser[]> {

--- a/packages/web/src/ui/pages/SystemSettingsPage.svelte
+++ b/packages/web/src/ui/pages/SystemSettingsPage.svelte
@@ -5,6 +5,7 @@ import MindSettingsCognition from "../components/mind/MindSettingsCognition.svel
 import MindSettingsEnv from "../components/mind/MindSettingsEnv.svelte";
 import MindSettingsProfile from "../components/mind/MindSettingsProfile.svelte";
 import MindSkills from "../components/mind/MindSkills.svelte";
+import Backups from "../components/system/Backups.svelte";
 import ExtensionManager from "../components/system/ExtensionManager.svelte";
 import MindDefaults from "../components/system/MindDefaults.svelte";
 import SharedSkills from "../components/system/SharedSkills.svelte";
@@ -20,6 +21,7 @@ const TABS = [
   "prompts",
   "skills",
   "extensions",
+  "backups",
   "users",
   "spirit",
 ] as const;
@@ -31,6 +33,7 @@ const TAB_LABELS: Record<Tab, string> = {
   prompts: "Prompts",
   skills: "Skills",
   extensions: "Extensions",
+  backups: "Backups",
   users: "Users",
   spirit: "Spirit",
 };
@@ -105,6 +108,8 @@ async function handleRestart() {
       <SharedSkills />
     {:else if activeTab === "extensions"}
       <ExtensionManager />
+    {:else if activeTab === "backups"}
+      <Backups />
     {:else if activeTab === "users"}
       <UserManagement minds={data.minds} />
     {:else if activeTab === "spirit"}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ const ungatedCommands = new Set([
   "update",
   "up",
   "down",
+  "backup", // `backup restore` must work on a fresh machine before setup
   "restart",
   "status",
   "login",
@@ -75,6 +76,9 @@ switch (command) {
     break;
   case "up":
     await import("./commands/up.js").then((m) => m.run(args));
+    break;
+  case "backup":
+    await import("./commands/backup.js").then((m) => m.run(args));
     break;
   case "down":
     await import("./commands/down.js").then((m) => m.run(args));
@@ -137,6 +141,7 @@ System:
   setup [--system] [--cli]          First-time setup
   up / down / restart              Daemon control
   status                           Show daemon & service status
+  backup init/create/list/restore  Back up and restore the system
   extension list/install/uninstall Manage extensions
   login / logout                   CLI authentication
   update                           Update volute

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -1,0 +1,403 @@
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { getClient, urlOf } from "@volute/cli/lib/api-client.js";
+import { command, subcommands } from "@volute/cli/lib/command.js";
+import { daemonFetch } from "@volute/cli/lib/daemon-client.js";
+import { promptLine, promptPassword } from "@volute/cli/lib/prompt.js";
+import {
+  type BackupState,
+  type BackupSummary,
+  restoreStagedDb,
+  type Snapshot,
+} from "@volute/daemon/lib/backup/backup.js";
+import { RESTIC_INSTALL_HINT, resticVersion } from "@volute/daemon/lib/backup/restic.js";
+import { getServiceMode, modeLabel, stopService } from "@volute/daemon/lib/config/service-mode.js";
+import { _resetConfigCache, readGlobalConfig } from "@volute/daemon/lib/config/setup.js";
+import { chownMindDir, wrapForIsolation } from "@volute/daemon/lib/mind/isolation.js";
+import { voluteHome, voluteSystemDir } from "@volute/daemon/lib/mind/registry.js";
+import { exec, execInherit } from "@volute/daemon/lib/util/exec.js";
+import { stopDaemon } from "./down.js";
+
+function printPassphrase(password: string): void {
+  console.log("\n┌─ BACKUP PASSPHRASE ─────────────────────────────────────────┐");
+  console.log(`   ${password}`);
+  console.log("└─────────────────────────────────────────────────────────────┘");
+  console.log("Store this somewhere OFF this machine (password manager, paper).");
+  console.log("Without it your backups are unreadable — this is the exact");
+  console.log("scenario (lost machine) that backups exist for.\n");
+  console.log(`It is also stored in ${resolve(voluteSystemDir(), "secrets.json")}`);
+}
+
+async function apiError(res: Response, fallback: string): Promise<never> {
+  const data = (await res.json().catch(() => ({}))) as { error?: string };
+  console.error(data.error ?? `${fallback}: HTTP ${res.status}`);
+  process.exit(1);
+}
+
+const initCmd = command({
+  name: "volute backup init",
+  description: "Configure the backup repository and initialize it",
+  flags: {
+    repo: { type: "string", description: "Restic repository (path, s3:..., b2:..., sftp:...)" },
+    password: { type: "string", description: "Repository passphrase (generated if omitted)" },
+  },
+  examples: [
+    "volute backup init --repo /mnt/backups/volute",
+    "volute backup init --repo s3:s3.amazonaws.com/my-bucket/volute",
+  ],
+  run: async ({ flags }) => {
+    let repo = flags.repo;
+    if (!repo) {
+      repo = (await promptLine("Repository (path or s3:/b2:/sftp: URL): ")).trim();
+      if (!repo) {
+        console.error("A repository is required.");
+        process.exit(1);
+      }
+    }
+
+    const client = getClient();
+    const putRes = await daemonFetch(urlOf(client.api.backup.config.$url()), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repository: repo, password: flags.password ?? "" }),
+    });
+    if (!putRes.ok) await apiError(putRes, "Failed to save backup config");
+
+    const initRes = await daemonFetch(urlOf(client.api.backup.init.$url()), { method: "POST" });
+    if (!initRes.ok) await apiError(initRes, "Failed to initialize repository");
+    const { password } = (await initRes.json()) as { password: string | null };
+
+    console.log(`Backup repository initialized: ${repo}`);
+    if (password) printPassphrase(password);
+    console.log("\nEnable scheduled backups with: volute backup schedule --enable");
+    console.log("Or run one now with: volute backup create");
+  },
+});
+
+const createCmd = command({
+  name: "volute backup create",
+  description: "Run a backup now",
+  flags: {},
+  run: async () => {
+    const client = getClient();
+    console.log("Running backup (this may take a while on first run)...");
+    const res = await daemonFetch(urlOf(client.api.backup.run.$url()), { method: "POST" });
+    if (!res.ok) await apiError(res, "Backup failed");
+    const summary = (await res.json()) as BackupSummary;
+    const addedMB = (summary.dataAdded / 1024 / 1024).toFixed(1);
+    console.log(`Snapshot ${summary.snapshotId.slice(0, 8)} created.`);
+    console.log(
+      `  Files: ${summary.totalFilesProcessed} processed, ${summary.filesNew} new, ${summary.filesChanged} changed`,
+    );
+    console.log(`  Data added: ${addedMB} MB in ${(summary.durationMs / 1000).toFixed(1)}s`);
+  },
+});
+
+const listCmd = command({
+  name: "volute backup list",
+  description: "List backup snapshots",
+  flags: {},
+  run: async () => {
+    const client = getClient();
+    const res = await daemonFetch(urlOf(client.api.backup.snapshots.$url()));
+    if (!res.ok) await apiError(res, "Failed to list snapshots");
+    const snapshots = (await res.json()) as Snapshot[];
+    if (snapshots.length === 0) {
+      console.log("No snapshots yet. Run: volute backup create");
+      return;
+    }
+    console.log("ID        TIME                      HOST");
+    for (const s of snapshots) {
+      console.log(`${s.short_id}  ${new Date(s.time).toLocaleString().padEnd(24)}  ${s.hostname}`);
+    }
+  },
+});
+
+const scheduleCmd = command({
+  name: "volute backup schedule",
+  description: "Enable, disable, or set the backup schedule",
+  flags: {
+    enable: { type: "boolean", description: "Enable scheduled backups" },
+    disable: { type: "boolean", description: "Disable scheduled backups" },
+    cron: { type: "string", description: 'Cron expression (default "0 3 * * *")' },
+  },
+  examples: ["volute backup schedule --enable", 'volute backup schedule --cron "30 4 * * *"'],
+  run: async ({ flags }) => {
+    const body: Record<string, unknown> = {};
+    if (flags.enable) body.enabled = true;
+    if (flags.disable) body.enabled = false;
+    if (flags.cron) body.schedule = flags.cron;
+    if (Object.keys(body).length === 0) {
+      console.error("Nothing to change. Use --enable, --disable, or --cron.");
+      process.exit(1);
+    }
+    const client = getClient();
+    const res = await daemonFetch(urlOf(client.api.backup.config.$url()), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) await apiError(res, "Failed to update schedule");
+    const config = (await res.json()) as {
+      enabled?: boolean;
+      schedule?: string;
+      repository?: string;
+      hasPassword?: boolean;
+    };
+    console.log(
+      `Scheduled backups ${config.enabled ? "enabled" : "disabled"} (cron: ${config.schedule})`,
+    );
+    if (config.enabled && (!config.repository || !config.hasPassword)) {
+      console.log("Note: backups will NOT run until a repository is set up: volute backup init");
+    }
+  },
+});
+
+const statusCmd = command({
+  name: "volute backup status",
+  description: "Show backup configuration and last run",
+  flags: {},
+  run: async () => {
+    const client = getClient();
+    const res = await daemonFetch(urlOf(client.api.backup.status.$url()));
+    if (!res.ok) await apiError(res, "Failed to get backup status");
+    const status = (await res.json()) as {
+      resticInstalled: boolean;
+      resticVersion: string | null;
+      installHint: string | null;
+      config: {
+        repository?: string;
+        schedule?: string;
+        enabled?: boolean;
+        hasPassword: boolean;
+        includeSessions?: boolean;
+      };
+      state: BackupState;
+    };
+    console.log(`Restic: ${status.resticVersion ?? "not installed"}`);
+    if (status.installHint) console.log(`  ${status.installHint}`);
+    console.log(`Repository: ${status.config.repository ?? "not configured"}`);
+    console.log(`Passphrase: ${status.config.hasPassword ? "set" : "not set"}`);
+    console.log(
+      `Schedule: ${status.config.enabled ? `enabled (${status.config.schedule})` : "disabled"}`,
+    );
+    if (status.state.lastRun) {
+      console.log(`Last successful backup: ${new Date(status.state.lastRun).toLocaleString()}`);
+      if (status.state.lastSnapshotId) {
+        console.log(`  Snapshot: ${status.state.lastSnapshotId.slice(0, 8)}`);
+      }
+      if (status.state.pruneError) {
+        console.log(`  Retention prune failed: ${status.state.pruneError}`);
+      }
+    } else {
+      console.log("Last successful backup: never");
+    }
+    if (status.state.lastError) {
+      const at = status.state.lastAttempt
+        ? ` at ${new Date(status.state.lastAttempt).toLocaleString()}`
+        : "";
+      console.log(`Last attempt failed${at}: ${status.state.lastError}`);
+    }
+  },
+});
+
+const restoreCmd = command({
+  name: "volute backup restore",
+  description: "Restore the whole system from a backup (stops the daemon)",
+  flags: {
+    repo: { type: "string", description: "Restic repository (defaults to configured one)" },
+    snapshot: { type: "string", description: "Snapshot ID (default: latest)" },
+    target: { type: "string", description: "Restore to this directory instead of in place" },
+    yes: { type: "boolean", description: "Skip confirmation" },
+  },
+  examples: [
+    "volute backup restore",
+    "volute backup restore --repo s3:s3.amazonaws.com/my-bucket/volute",
+    "volute backup restore --snapshot 1a2b3c4d --target /tmp/inspect",
+  ],
+  run: async ({ flags }) => {
+    if (!(await resticVersion())) {
+      console.error(`restic is not installed. ${RESTIC_INSTALL_HINT}`);
+      process.exit(1);
+    }
+
+    // Existing install: read repo/password/env from config + secrets.
+    // Fresh machine: --repo flag + prompted password + ambient env (AWS_* etc.).
+    const backupConfig = readGlobalConfig().backup ?? {};
+    const repo = flags.repo ?? backupConfig.repository;
+    if (!repo) {
+      console.error("No repository configured. Pass --repo <repository>.");
+      process.exit(1);
+    }
+    let password = backupConfig.password ?? process.env.RESTIC_PASSWORD;
+    if (!password) {
+      password = await promptPassword("Repository passphrase: ");
+      if (!password) {
+        console.error("A passphrase is required.");
+        process.exit(1);
+      }
+    }
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...backupConfig.env,
+      RESTIC_REPOSITORY: repo,
+      RESTIC_PASSWORD: password,
+    };
+    const snapshot = flags.snapshot ?? "latest";
+
+    // Inspection mode: extract somewhere else and stop.
+    if (flags.target) {
+      console.log(`Restoring snapshot ${snapshot} to ${flags.target}...`);
+      await execInherit("restic", ["restore", snapshot, "--target", flags.target], { env });
+      console.log("Done. (Inspection restore: no databases moved, no daemon touched.)");
+      return;
+    }
+
+    // Restic restores absolute paths. If the snapshot was taken on a machine
+    // with a different volute home, an in-place restore would put everything
+    // at the old path and silently restore nothing here — refuse up front.
+    const home = voluteHome();
+    try {
+      const out = await exec("restic", ["snapshots", snapshot, "--json"], { env });
+      const snaps = JSON.parse(out || "[]") as { paths?: string[] }[];
+      const paths = snaps[0]?.paths ?? [];
+      if (paths.length > 0 && !paths.includes(home)) {
+        console.error(`This snapshot was taken with a different volute home:`);
+        for (const p of paths) console.error(`  ${p}`);
+        console.error(`This machine's volute home is ${home}, so an in-place restore would`);
+        console.error("write to the old paths and restore nothing here. Either set VOLUTE_HOME");
+        console.error("to match, or inspect with --target and move files manually.");
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error(
+        `Could not read snapshot ${snapshot}: ${err instanceof Error ? err.message : err}`,
+      );
+      process.exit(1);
+    }
+
+    if (!flags.yes) {
+      console.log(`This restores snapshot ${snapshot} from ${repo} IN PLACE:`);
+      console.log("  - the daemon will be stopped");
+      console.log("  - current system state and mind files will be overwritten");
+      console.log(
+        "  - minds wake with fresh sessions (transcripts are excluded unless includeSessions was on)",
+      );
+      const answer = (await promptLine("Continue? [y/N] ")).trim().toLowerCase();
+      if (answer !== "y" && answer !== "yes") {
+        console.log("Aborted.");
+        return;
+      }
+    }
+
+    // Stop the daemon (service or manual) so no process holds the DBs we replace.
+    const mode = getServiceMode();
+    if (mode !== "manual") {
+      console.log(`Stopping volute (${modeLabel(mode)})...`);
+      try {
+        await stopService(mode);
+      } catch (err) {
+        console.error(`Failed to stop service: ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+      }
+    } else {
+      const result = await stopDaemon();
+      if (!result.stopped && result.reason !== "not-running") {
+        console.error("Could not stop the daemon — aborting so live databases aren't replaced.");
+        process.exit(1);
+      }
+    }
+
+    try {
+      console.log(`Restoring snapshot ${snapshot} from ${repo}...`);
+      await execInherit("restic", ["restore", snapshot, "--target", "/"], { env });
+
+      // Move staged (consistent) DB copies into their live locations. The live
+      // volute.db is excluded from snapshots — the staged copy is the ONLY one,
+      // so its absence means the restore did not recover the system database.
+      const systemDir = voluteSystemDir();
+      const staging = resolve(systemDir, "backup-staging");
+      const mainLive = resolve(systemDir, "volute.db");
+      if (!restoreStagedDb(resolve(staging, "volute.db"), mainLive)) {
+        console.error(`\nFATAL: staged database not found at ${staging}/volute.db.`);
+        console.error("The snapshot does not contain a system database; whatever volute.db");
+        console.error("was on disk before this restore is still in place, and it does NOT");
+        console.error("match the restored files. Do not trust this system until you restore");
+        console.error("a snapshot that includes backup-staging/volute.db.");
+        process.exit(1);
+      }
+      console.log(`Restored database: ${mainLive}`);
+      const stagedExt = resolve(staging, "extension-data");
+      if (existsSync(stagedExt)) {
+        for (const id of readdirSync(stagedExt)) {
+          const live = resolve(systemDir, "extension-data", id, "data.db");
+          if (restoreStagedDb(resolve(stagedExt, id, "data.db"), live)) {
+            console.log(`Restored database: ${live}`);
+          } else {
+            console.error(`  Warning: no staged copy for extension DB ${id} — skipped.`);
+          }
+        }
+      }
+      rmSync(staging, { recursive: true, force: true });
+    } catch (err) {
+      console.error(`\nRestore failed: ${err instanceof Error ? err.message : err}`);
+      console.error("The system is in a PARTIALLY RESTORED state (the daemon is stopped and");
+      console.error("some files may already be overwritten). Do not start the daemon.");
+      console.error("Fix the underlying problem and re-run: volute backup restore");
+      process.exit(1);
+    }
+
+    // Rehydrate node_modules for every restored mind (deps are excluded from
+    // backups). Failures here are non-fatal — the databases are already in
+    // place and each mind's install can be re-run by hand.
+    // Re-read config from the restored files: it carries the isolation mode,
+    // which the isolation helpers read from VOLUTE_ISOLATION (only the service
+    // environment sets that; a CLI invocation must derive it itself).
+    _resetConfigCache();
+    if (readGlobalConfig().setup?.isolation === "user") {
+      process.env.VOLUTE_ISOLATION = "user";
+    }
+    const { readAllMinds, mindDir } = await import("@volute/daemon/lib/mind/registry.js");
+    const seen = new Set<string>();
+    for (const mind of await readAllMinds()) {
+      const dir = mind.dir ?? mindDir(mind.name);
+      if (seen.has(dir) || !existsSync(resolve(dir, "package.json"))) continue;
+      seen.add(dir);
+      console.log(`Installing dependencies for ${mind.name}...`);
+      try {
+        // Under per-mind user isolation, restore runs as root: re-own the
+        // restored files and install as the mind's user, like mind create does.
+        await chownMindDir(dir, mind.name);
+        const [cmd, args] = await wrapForIsolation(
+          "npm",
+          ["install", "--no-audit", "--no-fund"],
+          mind.name,
+        );
+        await exec(cmd, args, { cwd: dir });
+      } catch (err) {
+        console.error(
+          `  npm install failed for ${mind.name}: ${err instanceof Error ? err.message : err}`,
+        );
+        console.error(`  Run it manually: cd ${dir} && npm install`);
+      }
+    }
+
+    console.log("\nRestore complete. Start the daemon with: volute up");
+    console.log("Minds' memory and history are restored from the snapshot.");
+  },
+});
+
+const cmd = subcommands({
+  name: "volute backup",
+  description: "Back up and restore the whole volute system (restic-based)",
+  commands: {
+    init: { description: "Configure and initialize the backup repository", run: initCmd.execute },
+    create: { description: "Run a backup now", run: createCmd.execute },
+    list: { description: "List snapshots", run: listCmd.execute },
+    schedule: { description: "Enable/disable/set the backup schedule", run: scheduleCmd.execute },
+    status: { description: "Show backup configuration and last run", run: statusCmd.execute },
+    restore: { description: "Restore the system from a backup", run: restoreCmd.execute },
+  },
+});
+
+export const run = cmd.execute;

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -1,0 +1,491 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, before, describe, it } from "node:test";
+import {
+  backupRoots,
+  stageDatabases,
+  stagingDir,
+} from "../packages/daemon/src/lib/backup/backup.js";
+import {
+  buildExcludePatterns,
+  resticVersion,
+  writeExcludeFile,
+} from "../packages/daemon/src/lib/backup/restic.js";
+import { _resetConfigCache, secretsPath } from "../packages/daemon/src/lib/config/setup.js";
+import { voluteHome, voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
+
+describe("backup exclude patterns", () => {
+  it("excludes dependency trees, caches, and session transcripts by default", () => {
+    const patterns = buildExcludePatterns({});
+    assert.ok(patterns.includes("node_modules"));
+    assert.ok(patterns.includes("home/.cache"));
+    assert.ok(patterns.includes("home/.claude/projects"));
+    assert.ok(patterns.includes(".mind/codex/sessions"));
+  });
+
+  it("keeps mind-authored .local/hooks and .local/bin, excluding only toolchain subdirs", () => {
+    const patterns = buildExcludePatterns({});
+    assert.ok(
+      !patterns.includes("home/.local"),
+      "wholesale home/.local would drop mind hooks and skill shims",
+    );
+    assert.ok(patterns.includes("home/.local/share"));
+    assert.ok(patterns.includes("home/.local/state"));
+  });
+
+  it("keeps session transcripts when includeSessions is set", () => {
+    const patterns = buildExcludePatterns({ includeSessions: true });
+    assert.ok(!patterns.includes("home/.claude/projects"));
+    assert.ok(!patterns.includes(".mind/codex/sessions"));
+    assert.ok(patterns.includes("node_modules"));
+  });
+
+  it("excludes live system DBs by absolute path, not bare name", () => {
+    const patterns = buildExcludePatterns({});
+    assert.ok(!patterns.includes("volute.db"), "bare volute.db would nuke the staged copy");
+    assert.ok(patterns.includes(resolve(voluteSystemDir(), "volute.db")));
+  });
+
+  it("writes the exclude file into the system dir", () => {
+    const path = writeExcludeFile({});
+    assert.ok(existsSync(path));
+    assert.ok(readFileSync(path, "utf-8").includes("node_modules"));
+  });
+});
+
+describe("backup staging", () => {
+  it("VACUUM INTO produces an openable copy of the system DB", async () => {
+    const staged = await stageDatabases();
+    const mainCopy = resolve(stagingDir(), "volute.db");
+    assert.ok(staged.includes(mainCopy));
+    assert.ok(existsSync(mainCopy));
+    // The copy must be a valid, independent SQLite DB.
+    const { default: Database } = await import("libsql");
+    const db = new Database(mainCopy);
+    try {
+      const row = db.prepare("SELECT count(*) AS n FROM sqlite_master").get() as { n: number };
+      assert.ok(row.n >= 0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("stages extension DBs mirroring their layout", async () => {
+    const extDir = resolve(voluteSystemDir(), "extension-data", "testext");
+    mkdirSync(extDir, { recursive: true });
+    const { default: Database } = await import("libsql");
+    const db = new Database(resolve(extDir, "data.db"));
+    db.exec("CREATE TABLE IF NOT EXISTS t (x); INSERT INTO t VALUES (1)");
+    db.close();
+    try {
+      await stageDatabases();
+      const copy = resolve(stagingDir(), "extension-data", "testext", "data.db");
+      assert.ok(existsSync(copy));
+      const check = new Database(copy);
+      try {
+        const row = check.prepare("SELECT count(*) AS n FROM t").get() as { n: number };
+        assert.equal(row.n, 1);
+      } finally {
+        check.close();
+      }
+    } finally {
+      rmSync(extDir, { recursive: true, force: true });
+    }
+  });
+
+  it("collects voluteHome as a backup root", async () => {
+    const roots = await backupRoots();
+    assert.ok(roots.includes(voluteHome()));
+  });
+
+  it("adds custom mind dirs outside the standard roots, without duplicating covered ones", async () => {
+    const { addMind, removeMind } = await import("../packages/daemon/src/lib/mind/registry.js");
+    const { getDb } = await import("../packages/daemon/src/lib/db.js");
+    const { minds } = await import("../packages/daemon/src/lib/schema.js");
+    const { eq } = await import("drizzle-orm");
+
+    const customDir = resolve(voluteHome(), "..", "volute-custom-mind");
+    mkdirSync(customDir, { recursive: true });
+    const insideDir = resolve(voluteHome(), "minds", "inside-mind");
+    mkdirSync(insideDir, { recursive: true });
+    await addMind("custom-root-mind", 4497);
+    await addMind("inside-root-mind", 4498);
+    const db = await getDb();
+    await db.update(minds).set({ dir: customDir }).where(eq(minds.name, "custom-root-mind"));
+    await db.update(minds).set({ dir: insideDir }).where(eq(minds.name, "inside-root-mind"));
+    try {
+      const roots = await backupRoots();
+      assert.ok(roots.includes(customDir), "custom dir outside voluteHome must be a root");
+      assert.ok(!roots.includes(insideDir), "dir under voluteHome must not be duplicated");
+    } finally {
+      await removeMind("custom-root-mind");
+      await removeMind("inside-root-mind");
+      rmSync(customDir, { recursive: true, force: true });
+      rmSync(insideDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runBackup failure bookkeeping", () => {
+  afterEach(() => {
+    _resetConfigCache();
+    for (const f of ["config.json", "backup-state.json"]) {
+      try {
+        unlinkSync(resolve(voluteSystemDir(), f));
+      } catch {}
+    }
+    try {
+      unlinkSync(secretsPath());
+    } catch {}
+  });
+
+  it("rejects before staging when unconfigured, records the failure, and releases the guard", async () => {
+    const { runBackup, readBackupState } = await import(
+      "../packages/daemon/src/lib/backup/backup.js"
+    );
+    await assert.rejects(runBackup(), /not configured/);
+    const state = readBackupState();
+    assert.ok(state.lastAttempt, "failed attempt is timestamped");
+    assert.match(state.lastError ?? "", /not configured/);
+    assert.equal(state.lastRun, undefined, "no success is recorded");
+    // The in-flight guard must be released — not "already running".
+    await assert.rejects(runBackup(), /not configured/);
+  });
+});
+
+describe("restoreStagedDb", () => {
+  const dir = resolve(voluteSystemDir(), "restore-test");
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves the live DB untouched when the staged copy is missing", async () => {
+    const { restoreStagedDb } = await import("../packages/daemon/src/lib/backup/backup.js");
+    mkdirSync(dir, { recursive: true });
+    const live = resolve(dir, "volute.db");
+    writeFileSync(live, "live-data");
+    assert.equal(restoreStagedDb(resolve(dir, "staged", "volute.db"), live), false);
+    assert.equal(readFileSync(live, "utf-8"), "live-data", "live DB must not be deleted");
+  });
+
+  it("moves the staged copy into place, clearing stale WAL/SHM", async () => {
+    const { restoreStagedDb } = await import("../packages/daemon/src/lib/backup/backup.js");
+    mkdirSync(resolve(dir, "staged"), { recursive: true });
+    const live = resolve(dir, "volute.db");
+    writeFileSync(live, "old");
+    writeFileSync(`${live}-wal`, "stale-wal");
+    writeFileSync(`${live}-shm`, "stale-shm");
+    writeFileSync(resolve(dir, "staged", "volute.db"), "restored");
+    assert.equal(restoreStagedDb(resolve(dir, "staged", "volute.db"), live), true);
+    assert.equal(readFileSync(live, "utf-8"), "restored");
+    assert.ok(!existsSync(`${live}-wal`), "stale WAL would corrupt the restored DB");
+    assert.ok(!existsSync(`${live}-shm`));
+    assert.ok(!existsSync(resolve(dir, "staged", "volute.db")), "staged copy is moved, not copied");
+  });
+});
+
+describe("backup API authorization", () => {
+  afterEach(async () => {
+    _resetConfigCache();
+    try {
+      unlinkSync(resolve(voluteSystemDir(), "config.json"));
+    } catch {}
+    try {
+      unlinkSync(secretsPath());
+    } catch {}
+    const { getDb } = await import("../packages/daemon/src/lib/db.js");
+    const { users } = await import("../packages/daemon/src/lib/schema.js");
+    const { inArray } = await import("drizzle-orm");
+    const db = await getDb();
+    await db.delete(users).where(inArray(users.username, ["backup-admin", "backup-mind-test"]));
+    const { removeMind } = await import("../packages/daemon/src/lib/mind/registry.js");
+    try {
+      await removeMind("backup-mind-test");
+    } catch {}
+  });
+
+  async function makeApp() {
+    const { Hono } = await import("hono");
+    const { authMiddleware } = await import("../packages/daemon/src/web/middleware/auth.js");
+    const { default: backupRoutes } = await import("../packages/daemon/src/web/api/backup.js");
+    const app = new Hono();
+    app.use("/api/backup/*", authMiddleware);
+    app.route("/api/backup", backupRoutes);
+    return app;
+  }
+
+  it("rejects a mind token on every backup route", async () => {
+    const { addMind } = await import("../packages/daemon/src/lib/mind/registry.js");
+    const { getOrCreateMindUser, createUser } = await import("../packages/daemon/src/lib/auth.js");
+    const { generateMindToken } = await import("../packages/daemon/src/lib/daemon/mind-tokens.js");
+    await createUser("backup-admin", "pass"); // first user becomes admin
+    await addMind("backup-mind-test", 4499);
+    await getOrCreateMindUser("backup-mind-test");
+    const token = generateMindToken("backup-mind-test");
+    const app = await makeApp();
+    const headers = { Authorization: `Bearer ${token}` };
+
+    for (const [method, path] of [
+      ["GET", "/api/backup/config"],
+      ["PUT", "/api/backup/config"],
+      ["POST", "/api/backup/init"],
+      ["POST", "/api/backup/run"],
+      ["GET", "/api/backup/snapshots"],
+      ["GET", "/api/backup/status"],
+    ] as const) {
+      const res = await app.request(path, { method, headers });
+      assert.equal(res.status, 403, `${method} ${path} must be admin-only`);
+    }
+  });
+
+  it("never returns the password or env values, even to admins", async () => {
+    const { createUser } = await import("../packages/daemon/src/lib/auth.js");
+    const { createSession } = await import("../packages/daemon/src/web/middleware/auth.js");
+    const admin = await createUser("backup-admin", "pass");
+    const sessionId = await createSession(admin.id);
+    const app = await makeApp();
+    const headers = {
+      Cookie: `volute_session=${sessionId}`,
+      "Content-Type": "application/json",
+    };
+
+    const put = await app.request("/api/backup/config", {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({
+        repository: "/tmp/repo",
+        password: "super-secret-passphrase",
+        env: { AWS_SECRET_ACCESS_KEY: "aws-secret-value" },
+      }),
+    });
+    assert.equal(put.status, 200);
+    const putBody = JSON.stringify(await put.json());
+    assert.ok(!putBody.includes("super-secret-passphrase"));
+    assert.ok(!putBody.includes("aws-secret-value"));
+
+    const get = await app.request("/api/backup/config", { headers });
+    const getBody = (await get.json()) as {
+      hasPassword: boolean;
+      envKeys: string[];
+      repository: string;
+    };
+    assert.equal(get.status, 200);
+    assert.equal(getBody.hasPassword, true);
+    assert.deepEqual(getBody.envKeys, ["AWS_SECRET_ACCESS_KEY"]);
+    assert.ok(!JSON.stringify(getBody).includes("super-secret-passphrase"));
+
+    // Saving config without a password keeps the stored one; same for env.
+    const put2 = await app.request("/api/backup/config", {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ repository: "/tmp/repo2", password: "" }),
+    });
+    assert.equal(put2.status, 200);
+    _resetConfigCache();
+    const { readGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    assert.equal(readGlobalConfig().backup?.password, "super-secret-passphrase");
+    assert.equal(readGlobalConfig().backup?.repository, "/tmp/repo2");
+    assert.deepEqual(readGlobalConfig().backup?.env, { AWS_SECRET_ACCESS_KEY: "aws-secret-value" });
+  });
+
+  it("rejects an invalid cron schedule and all-zero retention", async () => {
+    const { createUser } = await import("../packages/daemon/src/lib/auth.js");
+    const { createSession } = await import("../packages/daemon/src/web/middleware/auth.js");
+    const admin = await createUser("backup-admin", "pass");
+    const sessionId = await createSession(admin.id);
+    const app = await makeApp();
+    const headers = {
+      Cookie: `volute_session=${sessionId}`,
+      "Content-Type": "application/json",
+    };
+
+    const badCron = await app.request("/api/backup/config", {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ schedule: "61 3 * * *" }),
+    });
+    assert.equal(badCron.status, 400, "a cron typo must not silently disable backups");
+
+    const zeroKeep = await app.request("/api/backup/config", {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ keep: { daily: 0, weekly: 0, monthly: 0 } }),
+    });
+    assert.equal(zeroKeep.status, 400, "all-zero retention would prune every snapshot");
+
+    const goodCron = await app.request("/api/backup/config", {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ schedule: "30 4 * * *" }),
+    });
+    assert.equal(goodCron.status, 200);
+  });
+
+  it("does not persist a generated passphrase when init fails", async () => {
+    const { createUser } = await import("../packages/daemon/src/lib/auth.js");
+    const { createSession } = await import("../packages/daemon/src/web/middleware/auth.js");
+    const admin = await createUser("backup-admin", "pass");
+    const sessionId = await createSession(admin.id);
+    const app = await makeApp();
+    const headers = {
+      Cookie: `volute_session=${sessionId}`,
+      "Content-Type": "application/json",
+    };
+
+    // Unreachable repo → init fails whether or not restic is installed.
+    const put = await app.request("/api/backup/config", {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ repository: "s3:http://127.0.0.1:9/volute-test-nope" }),
+    });
+    assert.equal(put.status, 200);
+    const init = await app.request("/api/backup/init", { method: "POST", headers });
+    assert.equal(init.status, 500);
+    _resetConfigCache();
+    const { readGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    assert.equal(
+      readGlobalConfig().backup?.password,
+      undefined,
+      "a passphrase the operator never saw must not end up guarding the repository",
+    );
+  });
+});
+
+describe("backup manager scheduling", () => {
+  afterEach(() => {
+    _resetConfigCache();
+    try {
+      unlinkSync(resolve(voluteSystemDir(), "config.json"));
+    } catch {}
+    try {
+      unlinkSync(secretsPath());
+    } catch {}
+  });
+
+  it("is due only on the cron minute, once, and only when enabled + configured", async () => {
+    const { BackupManager } = await import("../packages/daemon/src/lib/daemon/backup-manager.js");
+    const { writeGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    const mgr = new BackupManager();
+    const at3am = new Date("2026-07-07T03:00:30");
+
+    // Not configured → never due.
+    assert.equal(mgr.isDue(at3am), false);
+
+    writeGlobalConfig({
+      backup: { repository: "/tmp/r", password: "p", enabled: true, schedule: "0 3 * * *" },
+    });
+    _resetConfigCache();
+    assert.equal(mgr.isDue(new Date("2026-07-07T02:59:30")), false, "before the cron minute");
+    assert.equal(mgr.isDue(at3am), true, "on the cron minute");
+    assert.equal(mgr.isDue(at3am), false, "does not double-fire in the same minute");
+    assert.equal(mgr.isDue(new Date("2026-07-08T03:00:10")), true, "fires again next day");
+
+    // Disabled → not due even on the minute.
+    writeGlobalConfig({
+      backup: { repository: "/tmp/r", password: "p", enabled: false, schedule: "0 3 * * *" },
+    });
+    _resetConfigCache();
+    assert.equal(mgr.isDue(new Date("2026-07-09T03:00:10")), false);
+  });
+
+  it("returns false without throwing on a malformed cron", async () => {
+    const { BackupManager } = await import("../packages/daemon/src/lib/daemon/backup-manager.js");
+    const { writeGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    writeGlobalConfig({
+      backup: { repository: "/tmp/r", password: "p", enabled: true, schedule: "not-a-cron" },
+    });
+    _resetConfigCache();
+    const mgr = new BackupManager();
+    assert.equal(mgr.isDue(new Date("2026-07-07T03:00:30")), false);
+  });
+});
+
+// Round-trip against a real restic binary; skipped when restic is not on PATH.
+describe("restic round-trip", async () => {
+  const available = (await resticVersion()) !== null;
+
+  before((t) => {
+    if (!available) t.skip("restic not installed");
+  });
+
+  afterEach(() => {
+    _resetConfigCache();
+    try {
+      unlinkSync(resolve(voluteSystemDir(), "config.json"));
+    } catch {}
+    try {
+      unlinkSync(secretsPath());
+    } catch {}
+  });
+
+  it("backs up a volute tree with exclusions and restores the kept files", async (t) => {
+    if (!available) return t.skip("restic not installed");
+    const { runBackup, listSnapshots, initRepo } = await import(
+      "../packages/daemon/src/lib/backup/backup.js"
+    );
+    const { writeGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+
+    // Fabricate a mind tree inside the (test-isolated) volute home.
+    const home = voluteHome();
+    const mindDir = resolve(home, "minds", "testmind");
+    mkdirSync(resolve(mindDir, "home", "memory"), { recursive: true });
+    mkdirSync(resolve(mindDir, "node_modules", "leftpad"), { recursive: true });
+    mkdirSync(resolve(mindDir, "home", ".claude", "projects", "sess"), { recursive: true });
+    mkdirSync(resolve(mindDir, ".mind", "identity"), { recursive: true });
+    mkdirSync(resolve(mindDir, "home", ".local", "hooks", "startup"), { recursive: true });
+    mkdirSync(resolve(mindDir, "home", ".local", "share", "sometool"), { recursive: true });
+    writeFileSync(resolve(mindDir, "home", "SOUL.md"), "# soul\n");
+    writeFileSync(resolve(mindDir, "home", "memory", "note.md"), "remember\n");
+    writeFileSync(resolve(mindDir, "node_modules", "leftpad", "index.js"), "x");
+    writeFileSync(resolve(mindDir, "home", ".claude", "projects", "sess", "a.jsonl"), "{}");
+    writeFileSync(resolve(mindDir, ".mind", "identity", "public.pem"), "pubkey\n");
+    writeFileSync(
+      resolve(mindDir, "home", ".local", "hooks", "startup", "custom.sh"),
+      "#!/bin/sh\n",
+    );
+    writeFileSync(resolve(mindDir, "home", ".local", "share", "sometool", "cache.bin"), "blob");
+
+    const repo = resolve(home, "test-restic-repo");
+    const backupConfig = { repository: repo, password: "test-passphrase" };
+    writeGlobalConfig({ backup: backupConfig });
+
+    await initRepo(backupConfig);
+    await initRepo(backupConfig); // idempotent
+    const summary = await runBackup();
+    assert.ok(summary.snapshotId);
+    assert.ok(summary.totalFilesProcessed > 0);
+
+    const snapshots = await listSnapshots();
+    assert.equal(snapshots.length, 1);
+
+    // Verify exclusions via restic ls.
+    const env = {
+      ...process.env,
+      RESTIC_REPOSITORY: repo,
+      RESTIC_PASSWORD: "test-passphrase",
+    };
+    const listing = execFileSync("restic", ["ls", "latest"], { env, encoding: "utf-8" });
+    assert.ok(listing.includes("SOUL.md"), "kept files present");
+    assert.ok(listing.includes("note.md"), "memory present");
+    assert.ok(listing.includes("public.pem"), "identity present");
+    assert.ok(listing.includes("backup-staging/volute.db"), "staged DB present");
+    assert.ok(listing.includes(".local/hooks/startup/custom.sh"), "mind-authored hooks kept");
+    assert.ok(!listing.includes(".local/share"), "toolchain subdirs excluded");
+    assert.ok(!listing.includes("node_modules"), "node_modules excluded");
+    assert.ok(!listing.includes(".claude/projects"), "session transcripts excluded");
+    assert.ok(!/\bvolute\.db-wal\b/.test(listing), "live WAL excluded");
+
+    // Restore to a target and check contents round-trip.
+    const target = resolve(home, "restore-target");
+    execFileSync("restic", ["restore", "latest", "--target", target], { env });
+    const restoredSoul = resolve(target, mindDir.slice(1), "home", "SOUL.md");
+    assert.equal(readFileSync(restoredSoul, "utf-8"), "# soul\n");
+    assert.ok(
+      !existsSync(resolve(target, mindDir.slice(1), "node_modules")),
+      "excluded paths not restored",
+    );
+  });
+});

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1654,6 +1654,57 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     });
   });
 
+  describe("backup API e2e", () => {
+    it("configures, initializes, runs, and lists a backup end-to-end", async (t) => {
+      // Requires the restic binary; skip (like the unit round-trip) when absent.
+      try {
+        execFileSync("restic", ["version"], { stdio: "ignore" });
+      } catch {
+        return t.skip("restic not installed");
+      }
+
+      const repo = resolve(voluteSystemDir(), "e2e-restic-repo");
+      rmSync(repo, { recursive: true, force: true });
+
+      const putRes = await daemonRequest("/api/backup/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repository: repo }),
+      });
+      assert.equal(putRes.status, 200);
+
+      // Init generates a passphrase and returns it exactly once.
+      const initRes = await daemonRequest("/api/backup/init", { method: "POST" });
+      assert.equal(initRes.status, 200, await initRes.clone().text());
+      const initBody = (await initRes.json()) as { password: string | null };
+      assert.ok(initBody.password, "generated passphrase must be returned at init");
+
+      const runRes = await daemonRequest("/api/backup/run", { method: "POST" });
+      assert.equal(runRes.status, 200, await runRes.clone().text());
+      const summary = (await runRes.json()) as { snapshotId: string; totalFilesProcessed: number };
+      assert.ok(summary.snapshotId);
+      assert.ok(summary.totalFilesProcessed > 0);
+
+      const listRes = await daemonRequest("/api/backup/snapshots");
+      assert.equal(listRes.status, 200);
+      const snapshots = (await listRes.json()) as { short_id: string }[];
+      assert.equal(snapshots.length, 1);
+
+      const statusRes = await daemonRequest("/api/backup/status");
+      assert.equal(statusRes.status, 200);
+      const status = (await statusRes.json()) as {
+        resticInstalled: boolean;
+        config: { hasPassword: boolean };
+        state: { lastSnapshotId?: string };
+      };
+      assert.equal(status.resticInstalled, true);
+      assert.equal(status.config.hasPassword, true);
+      assert.equal(status.state.lastSnapshotId, summary.snapshotId);
+
+      rmSync(repo, { recursive: true, force: true });
+    });
+  });
+
   describe("history API cross-tenant authorization", () => {
     const ALICE = "e2e-hist-alice";
     const BOB = "e2e-hist-bob";

--- a/test/global-config.test.ts
+++ b/test/global-config.test.ts
@@ -98,6 +98,34 @@ describe("readGlobalConfig", () => {
     assert.equal(config.imagegen?.enabled, true);
   });
 
+  it("writes backup password and env to secrets.json, not config.json", () => {
+    mkdirSync(voluteSystemDir(), { recursive: true });
+    writeGlobalConfig({
+      backup: {
+        repository: "s3:s3.amazonaws.com/bucket/volute",
+        schedule: "0 3 * * *",
+        enabled: true,
+        password: "restic-passphrase",
+        env: { AWS_SECRET_ACCESS_KEY: "aws-secret" },
+      },
+    });
+    const configRaw = readFileSync(configPath(), "utf-8");
+    assert.ok(!configRaw.includes("restic-passphrase"), "config.json must not contain passphrase");
+    assert.ok(!configRaw.includes("aws-secret"), "config.json must not contain credentials");
+    assert.ok(configRaw.includes('"repository"'), "non-secret backup fields stay in config.json");
+    const secretsRaw = readFileSync(secretsPath(), "utf-8");
+    assert.ok(secretsRaw.includes("restic-passphrase"));
+    assert.ok(secretsRaw.includes("aws-secret"));
+    assert.equal(statSync(secretsPath()).mode & 0o777, 0o600);
+    // Round-trips on read.
+    _resetConfigCache();
+    const config = readGlobalConfig();
+    assert.equal(config.backup?.password, "restic-passphrase");
+    assert.equal(config.backup?.env?.AWS_SECRET_ACCESS_KEY, "aws-secret");
+    assert.equal(config.backup?.repository, "s3:s3.amazonaws.com/bucket/volute");
+    assert.equal(config.backup?.enabled, true);
+  });
+
   it("migrateConfigSecrets splits a legacy single-file config and relaxes perms", () => {
     // Simulate a v0.41.1 install: everything (incl. secrets) in a 0600 config.json.
     mkdirSync(voluteSystemDir(), { recursive: true });


### PR DESCRIPTION
## Summary

Adds full-system backup and restore built on restic — the first system-level backup story for Volute (previously only `volute mind export` existed). A disk failure no longer loses every mind's memory, history, and identity.

- **Engine**: restic — content-defined dedup, mandatory encryption, built-in retention (`forget --prune`), and cloud backends for free (local path, `s3:`, `b2:`, `sftp:`, rclone). Detected at runtime with an install hint; installed in the Docker image.
- **What's captured**: one exclusion-based profile. Deps/caches/toolchains/session transcripts are excluded (all rehydratable or recorded in `volute.db`), bringing a naive ~15GB production system down to ~1–1.5GB of irreplaceable data. Transcripts are opt-in via `includeSessions`. Mind-authored `.local/hooks` and `.local/bin` are kept.
- **Consistency**: live SQLite DBs (system + per-extension) are excluded and replaced by `VACUUM INTO` staged copies under `backup-staging/`, mirroring live layout so restore is a mechanical move-back.
- **Scheduling**: `BackupManager` daemon service, cron-based (default 3am daily), retention 7 daily / 4 weekly / 12 monthly.
- **Secrets**: repo passphrase + backend credentials (e.g. AWS keys) live in `secrets.json` (0600), never in `config.json` (0644) or API responses (redacted to `hasPassword`/`envKeys`). Generated passphrases are revealed exactly once, by the successful init that created them.
- **API**: admin-only `/api/backup/*` (config, init, run, snapshots, status), cron + retention validation.
- **CLI**: `volute backup init/create/list/schedule/status/restore`. Restore runs daemon-down, refuses cross-machine path mismatches up front, hard-fails if the staged DB is missing (it's the only DB copy in a snapshot), and rehydrates each mind's `node_modules` with isolation-aware installs.
- **UI**: Backups tab in system settings — repo/credentials, one-time passphrase reveal, schedule + retention, run-now, snapshot list, last-success vs last-failure status.

## Verification

- Unit tests: exclusions (incl. hooks-kept/toolchains-dropped), DB staging, `restoreStagedDb`, backup roots, failure bookkeeping + in-flight guard, API authz (mind tokens 403 on every route), secret redaction at the serialized-body level, cron/retention validation, init-failure passphrase handling, scheduler due-checks.
- Real-restic round-trip test (init → backup → `restic ls` assertions → restore) — runs in CI (restic added to workflow).
- Daemon e2e: config → init (one-time passphrase) → run → snapshots → status.
- S3 path proven against a MinIO container; full disaster drill on a scratch install (delete `volute.db` → restore → daemon boots healthy with users intact); UI verified in-browser.

## Follow-ups

- #455 — scheduler catch-up for missed fire minutes (laptop asleep at 3am)
- #456 — active operator notification on repeated scheduled-backup failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)