### PR TITLE
fix: skip restic round-trip cleanly when restic is not installed

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,8 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
       - run: npm ci
+      - name: Install restic (backup round-trip tests skip without it)
+        run: sudo apt-get update && sudo apt-get install -y restic
       - name: Configure git identity
         run: |
           git config --global user.email "ci@test.com"

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { afterEach, before, describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import {
   backupRoots,
   stageDatabases,
@@ -406,10 +406,6 @@ describe("backup manager scheduling", () => {
 // Round-trip against a real restic binary; skipped when restic is not on PATH.
 describe("restic round-trip", async () => {
   const available = (await resticVersion()) !== null;
-
-  before((t) => {
-    if (!available) t.skip("restic not installed");
-  });
 
   afterEach(() => {
     _resetConfigCache();


### PR DESCRIPTION
## Why the 0.45.0 release run failed when the PR didn't

The `restic round-trip` suite in `test/backup.test.ts` had a suite-level `before()` hook that called `t.skip()` when restic isn't on PATH. But node:test passes a **SuiteContext** to suite hooks, and SuiteContext has no `skip()` method — so the "skip" path itself threw `TypeError: t.skip is not a function`, failing the suite and cancelling its test.

PR CI (`ci.yml`) installs restic before running tests, so the broken branch never executed there. The release workflow's publish job runs `npm test` **without** installing restic, so it was the first environment to actually take the skip path — and it blew up, aborting the 0.45.0 publish ([failed run](https://github.com/mimsy/volute/actions/runs/28879109855/job/85662209162)).

## Fix

- Remove the broken `before()` hook. The suite's only test already has a valid per-test guard (`if (!available) return t.skip(...)` — valid because `it` receives a TestContext, which does have `skip()`).
- Install restic in the release publish job for parity with CI, so the round-trip test actually runs before publishing.

## Verified

- Without restic on PATH: suite skips cleanly (18 pass, 1 skipped, 0 fail)
- With restic: full round-trip passes (19 pass)

Note: 0.45.0 was tagged but never published to npm. Merging this `fix:` will make release-please cut 0.45.1, which will publish normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)