### PR TITLE
fix: route memory consolidation through ai-service and bound input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,9 +124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -141,9 +138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -158,9 +152,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -175,9 +166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -781,9 +769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -801,9 +786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -821,9 +803,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -841,9 +820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1820,7 +1796,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1943,9 +1919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1953,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +1970,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +1987,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4613,9 +4574,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4633,9 +4591,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4653,9 +4608,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4673,9 +4625,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4699,9 +4648,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4725,9 +4671,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5535,9 +5478,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5555,9 +5495,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5575,9 +5512,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5595,9 +5529,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5615,9 +5546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5635,9 +5563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12901,9 +12826,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12921,9 +12843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12941,9 +12860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12961,9 +12877,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12981,9 +12894,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13001,9 +12911,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13027,9 +12934,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13053,9 +12957,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13079,9 +12980,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13105,9 +13003,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/packages/daemon/src/lib/mind/consolidate.ts
+++ b/packages/daemon/src/lib/mind/consolidate.ts
@@ -1,47 +1,82 @@
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { aiCompleteUtility } from "../ai-service.js";
+import log from "../util/logger.js";
+
+const cLog = log.child("consolidate");
 
 /**
- * One-shot memory consolidation using the Anthropic Messages API directly.
- * Reads daily logs from a mind directory and produces consolidated MEMORY.md content.
- * No SDK dependency — works for any template.
+ * Upper bound on daily-log characters fed to the model, so a mind with a huge
+ * backlog of logs can't blow the context window. Roughly ~50k tokens at 4
+ * chars/token, leaving ample room for the system prompt and the output. When
+ * the logs exceed this, the most recent entries are kept.
  */
-export async function consolidateMemory(mindDir: string): Promise<void> {
+export const MAX_CONSOLIDATION_INPUT_CHARS = 200_000;
+
+/** Read non-empty daily logs (YYYY-MM-DD.md) from a mind's memory dir, oldest first. */
+export function readDailyLogs(memoryDir: string): string[] {
+  let files: string[];
+  try {
+    files = readdirSync(memoryDir)
+      .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
+      .sort();
+  } catch {
+    return [];
+  }
+  const logs: string[] = [];
+  for (const filename of files) {
+    const date = filename.replace(".md", "");
+    const content = readFileSync(resolve(memoryDir, filename), "utf-8").trim();
+    if (content) logs.push(`### ${date}\n\n${content}`);
+  }
+  return logs;
+}
+
+/**
+ * Join the daily logs (oldest first) into a single block bounded by maxChars.
+ * The most recent whole logs that fit within the budget are kept; older ones
+ * are dropped. If not even the most recent log fits, its tail is truncated so
+ * the result is always within the bound.
+ */
+export function boundLogText(logs: string[], maxChars = MAX_CONSOLIDATION_INPUT_CHARS): string {
+  const kept: string[] = [];
+  let total = 0;
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const len = logs[i].length + (kept.length > 0 ? 2 : 0); // "\n\n" separator
+    if (total + len > maxChars) break;
+    kept.unshift(logs[i]);
+    total += len;
+  }
+  if (kept.length === 0 && logs.length > 0) {
+    return logs[logs.length - 1].slice(-maxChars);
+  }
+  return kept.join("\n\n");
+}
+
+/**
+ * One-shot memory consolidation. Reads daily logs from a mind directory and
+ * produces consolidated MEMORY.md content via the system AI service (the same
+ * utility model used for turn summaries), so it works for any template and
+ * isn't pinned to a retired model. No-ops if no logs exist or no model is
+ * configured. The `complete` param is injectable for testing.
+ */
+export async function consolidateMemory(
+  mindDir: string,
+  complete: (system: string, user: string) => Promise<string | null> = aiCompleteUtility,
+): Promise<void> {
   const soulPath = resolve(mindDir, "home/SOUL.md");
   const memoryPath = resolve(mindDir, "home/MEMORY.md");
   const memoryDir = resolve(mindDir, "home/memory");
 
   const soul = readFileSync(soulPath, "utf-8");
-
-  // Read all daily logs
-  const logs: string[] = [];
-  try {
-    const files = readdirSync(memoryDir)
-      .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
-      .sort();
-    for (const filename of files) {
-      const date = filename.replace(".md", "");
-      const content = readFileSync(resolve(memoryDir, filename), "utf-8").trim();
-      if (content) {
-        logs.push(`### ${date}\n\n${content}`);
-      }
-    }
-  } catch {
-    // No logs directory
-  }
+  const logs = readDailyLogs(memoryDir);
 
   if (logs.length === 0) {
-    console.log("No daily logs found.");
+    cLog.info("No daily logs found; skipping memory consolidation.");
     return;
   }
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    console.error("ANTHROPIC_API_KEY not set, skipping memory consolidation.");
-    return;
-  }
-
-  console.log("Consolidating memory from daily logs...");
+  cLog.info("Consolidating memory from daily logs...");
 
   const userMessage = [
     "You have daily logs from a previous environment but no long-term memory file yet.",
@@ -50,44 +85,14 @@ export async function consolidateMemory(mindDir: string): Promise<void> {
     "",
     "## Daily logs",
     "",
-    logs.join("\n\n"),
+    boundLogText(logs),
   ].join("\n");
 
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 4096,
-      system: soul,
-      messages: [{ role: "user", content: userMessage }],
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    console.error(`Anthropic API error (${res.status}): ${body}`);
-    return;
-  }
-
-  const data = (await res.json()) as {
-    content: Array<{ type: string; text?: string }>;
-  };
-
-  const content = data.content
-    .filter((b) => b.type === "text" && b.text)
-    .map((b) => b.text!)
-    .join("")
-    .trim();
-
+  const content = (await complete(soul, userMessage))?.trim();
   if (content) {
     writeFileSync(memoryPath, `${content}\n`);
-    console.log("MEMORY.md created successfully.");
+    cLog.info("MEMORY.md created successfully.");
   } else {
-    console.warn("Warning: No content produced.");
+    cLog.warn("No content produced; skipping memory consolidation.");
   }
 }

--- a/test/consolidate.test.ts
+++ b/test/consolidate.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  boundLogText,
+  consolidateMemory,
+  MAX_CONSOLIDATION_INPUT_CHARS,
+  readDailyLogs,
+} from "../packages/daemon/src/lib/mind/consolidate.js";
+
+function makeMind(logs: Record<string, string>, soul = "You are Test.\n"): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "consolidate-test-"));
+  const home = resolve(dir, "home");
+  const memory = resolve(home, "memory");
+  mkdirSync(memory, { recursive: true });
+  writeFileSync(resolve(home, "SOUL.md"), soul);
+  for (const [name, content] of Object.entries(logs)) {
+    writeFileSync(resolve(memory, name), content);
+  }
+  return dir;
+}
+
+describe("readDailyLogs", () => {
+  it("reads dated logs oldest-first, skipping empties and non-dated files", () => {
+    const dir = makeMind({
+      "2026-01-02.md": "second",
+      "2026-01-01.md": "first",
+      "2026-01-03.md": "   ", // whitespace only → skipped
+      "notes.md": "not a daily log", // wrong name → skipped
+    });
+    const logs = readDailyLogs(resolve(dir, "home/memory"));
+    assert.deepEqual(logs, ["### 2026-01-01\n\nfirst", "### 2026-01-02\n\nsecond"]);
+  });
+
+  it("returns an empty array when the memory dir is missing", () => {
+    assert.deepEqual(readDailyLogs(resolve(tmpdir(), "does-not-exist-xyz")), []);
+  });
+});
+
+describe("boundLogText", () => {
+  it("returns all logs joined when under the budget", () => {
+    assert.equal(boundLogText(["a", "b", "c"], 1000), "a\n\nb\n\nc");
+  });
+
+  it("drops the oldest logs when over budget, keeping the most recent", () => {
+    // Each log is 10 chars; budget of 25 fits two (10 + 2 + 10 = 22).
+    const logs = ["0000000000", "1111111111", "2222222222"];
+    const out = boundLogText(logs, 25);
+    assert.equal(out, "1111111111\n\n2222222222");
+    assert.ok(out.length <= 25);
+  });
+
+  it("truncates a single oversized log to the budget (tail kept)", () => {
+    const big = `${"x".repeat(500)}END`;
+    const out = boundLogText([big], 100);
+    assert.equal(out.length, 100);
+    assert.ok(out.endsWith("END"));
+  });
+});
+
+describe("consolidateMemory", () => {
+  it("skips (and never calls the model) when there are no logs", async () => {
+    const dir = makeMind({});
+    let called = false;
+    await consolidateMemory(dir, async () => {
+      called = true;
+      return "should not run";
+    });
+    assert.equal(called, false);
+    assert.equal(existsSync(resolve(dir, "home/MEMORY.md")), false);
+  });
+
+  it("passes SOUL.md as the system prompt and writes returned content to MEMORY.md", async () => {
+    const dir = makeMind({ "2026-01-01.md": "did a thing" }, "You are Soulful.\n");
+    let seenSystem: string | undefined;
+    let seenUser: string | undefined;
+    await consolidateMemory(dir, async (system, user) => {
+      seenSystem = system;
+      seenUser = user;
+      return "# Memory\n\nConsolidated.";
+    });
+    assert.equal(seenSystem, "You are Soulful.\n");
+    assert.ok(seenUser?.includes("did a thing"));
+    assert.equal(
+      readFileSync(resolve(dir, "home/MEMORY.md"), "utf-8"),
+      "# Memory\n\nConsolidated.\n",
+    );
+  });
+
+  it("does not write MEMORY.md when the model returns null (e.g. no model configured)", async () => {
+    const dir = makeMind({ "2026-01-01.md": "did a thing" });
+    await consolidateMemory(dir, async () => null);
+    assert.equal(existsSync(resolve(dir, "home/MEMORY.md")), false);
+  });
+
+  it("bounds the log text handed to the model", async () => {
+    // 20 logs of ~50k chars each = ~1M chars, far over the bound.
+    const logs: Record<string, string> = {};
+    for (let i = 0; i < 20; i++) {
+      const day = String(i + 1).padStart(2, "0");
+      logs[`2026-01-${day}.md`] = "z".repeat(50_000);
+    }
+    const dir = makeMind(logs);
+    let seenUser = "";
+    await consolidateMemory(dir, async (_system, user) => {
+      seenUser = user;
+      return "ok";
+    });
+    // Instruction preamble is small; the whole message stays near the bound.
+    assert.ok(seenUser.length <= MAX_CONSOLIDATION_INPUT_CHARS + 500);
+  });
+});


### PR DESCRIPTION
## Summary

Memory consolidation (`packages/daemon/src/lib/mind/consolidate.ts`) called the Anthropic API directly with a hardcoded `claude-sonnet-4-20250514` — a model retired in June 2026 — and required `ANTHROPIC_API_KEY`, so import-time consolidation was broken.

- Route consolidation through `aiCompleteUtility()` (the same system AI service / utility model used by the turn summarizer), so it works with any configured provider and follows the admin's model selection.
- Bound the daily-log input to `MAX_CONSOLIDATION_INPUT_CHARS` (200k chars, ~50k tokens): the most recent whole logs that fit are kept, oldest dropped; a single oversized log is tail-truncated. Huge backlogs can no longer blow the context window.
- No-ops cleanly (with a log line) when no logs exist or no model is configured, instead of erroring.

## Test plan

- New `test/consolidate.test.ts` covering: daily-log reading (ordering, empty/non-dated files skipped, missing dir), input bounding (under budget, drops oldest, truncates single oversized log), and `consolidateMemory` behavior (SOUL.md as system prompt, MEMORY.md written from model output, no write on null completion, no model call when no logs, bounded input actually handed to the model).
- Full suite passes via `npm test` (1784 pass, 0 fail); typecheck and lint clean.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)