### PR TITLE
chore: restore voluteHome source-mode test-safety guard

### DIFF
--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import { getDb } from "../db.js";
@@ -28,9 +28,10 @@ export function voluteHome(): string {
 
   // When running from source (tsx), require explicit VOLUTE_HOME to prevent
   // tests from accidentally touching the real ~/.volute directory.
-  // Built code (dist/) falls through to the homedir() default.
-  const dir = dirname(fileURLToPath(import.meta.url));
-  if (dir.endsWith("/src/lib")) {
+  // Built code (dist/) is bundled to .js and falls through to the homedir()
+  // default. Keying off the file extension (rather than a directory segment)
+  // keeps this guard working even if the file moves within the source tree.
+  if (fileURLToPath(import.meta.url).endsWith(".ts")) {
     throw new Error(
       "VOLUTE_HOME must be set when running from source. " +
         'For tests, run via "npm test" or add "--import ./test/setup.ts".',

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -170,6 +170,26 @@ describe("variants", () => {
   });
 });
 
+describe("voluteHome source-mode guard", () => {
+  const original = process.env.VOLUTE_HOME;
+  afterEach(() => {
+    if (original === undefined) delete process.env.VOLUTE_HOME;
+    else process.env.VOLUTE_HOME = original;
+  });
+
+  it("throws when VOLUTE_HOME is unset while running from source", () => {
+    // Tests run via tsx, so registry.ts resolves to a .ts file — the guard
+    // that protects the real ~/.volute must fire when VOLUTE_HOME is missing.
+    delete process.env.VOLUTE_HOME;
+    assert.throws(() => voluteHome(), /VOLUTE_HOME must be set/);
+  });
+
+  it("returns VOLUTE_HOME when it is set", () => {
+    process.env.VOLUTE_HOME = "/tmp/volute-guard-test";
+    assert.equal(voluteHome(), "/tmp/volute-guard-test");
+  });
+});
+
 describe("mindDir", () => {
   const originalMindsDir = process.env.VOLUTE_MINDS_DIR;
   afterEach(() => {


### PR DESCRIPTION
## Summary

Restores the dead `voluteHome()` source-mode safety guard that protects the developer's real `~/.volute` from stray test runs (issue #335, item 4).

The guard checked `dir.endsWith("/src/lib")`, but the monorepo split moved the file to `packages/daemon/src/lib/mind/registry.ts` — `dirname` now ends in `/src/lib/mind`, so the guard never fired. Any source-mode (tsx) run without `VOLUTE_HOME` silently used the real `~/.volute` instead of throwing.

The fix keys off the file extension instead: source runs via tsx as `.ts`, built code is bundled to `.js`. This restores the intended behavior and, unlike a hard-coded directory segment, survives future moves within the source tree.

**Note on the e2e wiring:** issue #335 also asked to run the e2e suite in CI. That is already done on `main` — `.github/workflows/ci.yml` has a `test-e2e` job running `npm run test:e2e`. This PR covers the remaining guard portion. Issue items 2 (built-artifact smoke test), 3 (composed-template compile gate), and 5 (`drizzle.config.ts` paths) are out of scope here and left open.

## Test plan

- Added two tests in `test/registry.test.ts` that verify the guard actually trips: throws when `VOLUTE_HOME` is unset under source-mode (tsx), and returns the value when set.
- `npm test` — all 1769 unit tests pass (includes the new guard tests).
- `npm run test:e2e` — all 50 e2e tests pass; the restored, stricter guard does not break daemon/mind subprocesses (they inherit `VOLUTE_HOME` from `test/setup.ts`).
- lint + typecheck pass (pre-commit + pre-push hooks green).

Refs #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)