### PR TITLE
fix(web): wake-trigger checkboxes reflect runtime defaults

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -16,7 +16,7 @@ import { sendSystemMessageDirect } from "../chat/system-chat.js";
 import { getDb } from "../db.js";
 import { type ActivityEvent, subscribe } from "../events/activity-events.js";
 import { findMind, mindDir, voluteSystemDir } from "../mind/registry.js";
-import { readVoluteConfig, type SleepConfig } from "../mind/volute-config.js";
+import { readVoluteConfig, resolveWakeTriggers, type SleepConfig } from "../mind/volute-config.js";
 import { getPrompt } from "../prompts.js";
 import { deliveryQueue } from "../schema.js";
 import log from "../util/logger.js";
@@ -421,8 +421,7 @@ export class SleepManager {
     const triggers = config?.wakeTriggers;
 
     // Default: mentions and DMs wake the mind
-    const mentionsEnabled = triggers?.mentions !== false;
-    const dmsEnabled = triggers?.dms !== false;
+    const { mentions: mentionsEnabled, dms: dmsEnabled } = resolveWakeTriggers(triggers);
 
     // Check DM trigger
     if (dmsEnabled && payload.isDM) return true;

--- a/packages/daemon/src/lib/mind/volute-config.ts
+++ b/packages/daemon/src/lib/mind/volute-config.ts
@@ -20,6 +20,25 @@ export type WakeTriggerConfig = {
   senders?: string[];
 };
 
+/**
+ * Effective defaults for wake triggers when a mind hasn't configured them.
+ * Mentions and DMs wake a sleeping mind by default. This is the single source
+ * of truth for the runtime default; the web UI mirrors these values so the
+ * settings form reflects actual behavior.
+ */
+export const WAKE_TRIGGER_DEFAULTS = { mentions: true, dms: true } as const;
+
+/** Resolve the effective mentions/dms wake-trigger settings, applying defaults. */
+export function resolveWakeTriggers(triggers?: WakeTriggerConfig): {
+  mentions: boolean;
+  dms: boolean;
+} {
+  return {
+    mentions: triggers?.mentions ?? WAKE_TRIGGER_DEFAULTS.mentions,
+    dms: triggers?.dms ?? WAKE_TRIGGER_DEFAULTS.dms,
+  };
+}
+
 export type SleepConfig = {
   enabled?: boolean;
   schedule?: { sleep: string; wake: string };

--- a/packages/web/src/ui/components/mind/MindSettingsRhythms.svelte
+++ b/packages/web/src/ui/components/mind/MindSettingsRhythms.svelte
@@ -10,6 +10,7 @@ import {
   type SleepConfig,
   updateSchedule,
   updateSleepConfig,
+  WAKE_TRIGGER_DEFAULTS,
 } from "../../lib/client";
 import {
   fmtTime,
@@ -35,8 +36,8 @@ let wakeMinute = $state(0);
 let useCustomCron = $state(false);
 let editSleepCron = $state("");
 let editWakeCron = $state("");
-let wakeOnMentions = $state(false);
-let wakeOnDms = $state(false);
+let wakeOnMentions = $state(WAKE_TRIGGER_DEFAULTS.mentions);
+let wakeOnDms = $state(WAKE_TRIGGER_DEFAULTS.dms);
 let wakeChannels = $state("");
 let wakeSenders = $state("");
 
@@ -79,8 +80,8 @@ function syncSleepState(cfg: SleepConfig) {
   } else if (editSleepCron || editWakeCron) {
     useCustomCron = true;
   }
-  wakeOnMentions = cfg.wakeTriggers?.mentions ?? false;
-  wakeOnDms = cfg.wakeTriggers?.dms ?? false;
+  wakeOnMentions = cfg.wakeTriggers?.mentions ?? WAKE_TRIGGER_DEFAULTS.mentions;
+  wakeOnDms = cfg.wakeTriggers?.dms ?? WAKE_TRIGGER_DEFAULTS.dms;
   wakeChannels = (cfg.wakeTriggers?.channels ?? []).join(", ");
   wakeSenders = (cfg.wakeTriggers?.senders ?? []).join(", ");
 }

--- a/packages/web/src/ui/components/system/MindDefaults.svelte
+++ b/packages/web/src/ui/components/system/MindDefaults.svelte
@@ -18,6 +18,7 @@ import {
   type MindDefaults,
   type MindDefaultsSchedule,
   saveMindDefaults,
+  WAKE_TRIGGER_DEFAULTS,
 } from "../../lib/client";
 import {
   fmtTime,
@@ -48,8 +49,8 @@ let wakeMinute = $state(0);
 let useCustomCron = $state(false);
 let editSleepCron = $state("");
 let editWakeCron = $state("");
-let wakeOnMentions = $state(false);
-let wakeOnDms = $state(false);
+let wakeOnMentions = $state(WAKE_TRIGGER_DEFAULTS.mentions);
+let wakeOnDms = $state(WAKE_TRIGGER_DEFAULTS.dms);
 let wakeChannels = $state("");
 let wakeSenders = $state("");
 
@@ -282,8 +283,8 @@ onMount(async () => {
         editSleepCron = defaults.sleep.schedule.sleep;
         editWakeCron = defaults.sleep.schedule.wake;
       }
-      wakeOnMentions = defaults.sleep.wakeTriggers?.mentions ?? false;
-      wakeOnDms = defaults.sleep.wakeTriggers?.dms ?? false;
+      wakeOnMentions = defaults.sleep.wakeTriggers?.mentions ?? WAKE_TRIGGER_DEFAULTS.mentions;
+      wakeOnDms = defaults.sleep.wakeTriggers?.dms ?? WAKE_TRIGGER_DEFAULTS.dms;
       wakeChannels = (defaults.sleep.wakeTriggers?.channels ?? []).join(", ");
       wakeSenders = (defaults.sleep.wakeTriggers?.senders ?? []).join(", ");
     }

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -796,6 +796,16 @@ export type SleepConfig = {
   };
 };
 
+/**
+ * Effective defaults for wake triggers when unset. Mirrors the daemon's
+ * WAKE_TRIGGER_DEFAULTS (mind/volute-config.ts) so the settings UI reflects
+ * actual runtime behavior — mentions and DMs wake a sleeping mind by default.
+ */
+export const WAKE_TRIGGER_DEFAULTS: { mentions: boolean; dms: boolean } = {
+  mentions: true,
+  dms: true,
+};
+
 export type ScheduleEntry = {
   id: string;
   cron?: string;

--- a/test/volute-config.test.ts
+++ b/test/volute-config.test.ts
@@ -3,7 +3,11 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
-import { readVoluteConfig } from "../packages/daemon/src/lib/mind/volute-config.js";
+import {
+  readVoluteConfig,
+  resolveWakeTriggers,
+  WAKE_TRIGGER_DEFAULTS,
+} from "../packages/daemon/src/lib/mind/volute-config.js";
 
 let testDir: string;
 
@@ -39,5 +43,22 @@ describe("readVoluteConfig", () => {
     const dir = resolve(tmpdir(), `volute-config-missing-${Date.now()}`);
     const config = readVoluteConfig(dir);
     assert.equal(config, null);
+  });
+});
+
+describe("resolveWakeTriggers", () => {
+  it("defaults mentions and DMs to on when unset", () => {
+    assert.deepEqual(WAKE_TRIGGER_DEFAULTS, { mentions: true, dms: true });
+    assert.deepEqual(resolveWakeTriggers(undefined), { mentions: true, dms: true });
+    assert.deepEqual(resolveWakeTriggers({}), { mentions: true, dms: true });
+  });
+
+  it("respects explicit false values", () => {
+    assert.deepEqual(resolveWakeTriggers({ mentions: false }), { mentions: false, dms: true });
+    assert.deepEqual(resolveWakeTriggers({ dms: false }), { mentions: true, dms: false });
+    assert.deepEqual(resolveWakeTriggers({ mentions: false, dms: false }), {
+      mentions: false,
+      dms: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary

The sleep-settings wake-on-mention / wake-on-DM checkboxes rendered **unchecked** even though the runtime default is **ON**. A user who opened the Rhythms form and saved without touching them silently disabled their mind's wake triggers.

The runtime default lived only as inline `triggers?.mentions !== false` logic in the sleep-manager, while both UI components defaulted to `?? false` on load — so UI and runtime disagreed.

This change:
- Extracts the runtime default into a single source of truth: `WAKE_TRIGGER_DEFAULTS` + `resolveWakeTriggers()` in `packages/daemon/src/lib/mind/volute-config.ts`, and refactors `sleep-manager.checkWakeTrigger` to use it.
- Mirrors the same constant in the web client (`WAKE_TRIGGER_DEFAULTS` in `packages/web/src/ui/lib/client.ts`), used by both the per-mind **Rhythms** tab (`MindSettingsRhythms.svelte`) and the system **Mind Defaults** form (`MindDefaults.svelte`) — for both initial `$state` and config-load fallbacks.

Now the checkboxes load ON to match effective behavior, so saving an untouched form persists `mentions: true` / `dms: true`, which equals the runtime default — no silent change.

## Test plan
- Added `resolveWakeTriggers` unit tests in `test/volute-config.test.ts` (defaults on when unset/empty; explicit `false` respected).
- Existing `sleep-manager.test.ts` wake-trigger cases still pass (behavior preserved by the refactor).
- Full suite: `npm test` → 1777 pass / 0 fail.
- `svelte-check` clean on both changed components.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)