### PR TITLE
fix: run schedule scripts with the mind's auth env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,9 +124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -141,9 +138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -158,9 +152,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -175,9 +166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -781,9 +769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -801,9 +786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -821,9 +803,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -841,9 +820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1820,7 +1796,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1943,9 +1919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1953,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +1970,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +1987,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4613,9 +4574,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4633,9 +4591,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4653,9 +4608,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4673,9 +4625,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4699,9 +4648,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4725,9 +4671,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5535,9 +5478,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5555,9 +5495,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5575,9 +5512,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5595,9 +5529,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5615,9 +5546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5635,9 +5563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12901,9 +12826,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12921,9 +12843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12941,9 +12860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12961,9 +12877,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12981,9 +12894,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13001,9 +12911,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13027,9 +12934,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13053,9 +12957,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13079,9 +12980,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13105,9 +13003,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -1,12 +1,15 @@
 import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { sendSystemMessage } from "../chat/system-chat.js";
-import { mindDir, mindTmpDir, voluteSystemDir } from "../mind/registry.js";
+import { loadMergedEnv } from "../config/env.js";
+import { findMind, mindDir, mindTmpDir, stateDir, voluteSystemDir } from "../mind/registry.js";
 import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
 import { readVoluteConfig, type Schedule, writeVoluteConfig } from "../mind/volute-config.js";
 import { exec } from "../util/exec.js";
 import { clearJsonMap, loadJsonMap, saveJsonMapAsync } from "../util/json-state.js";
 import log from "../util/logger.js";
+import { buildMindBaseEnv } from "./mind-manager.js";
+import { generateMindToken, getMindToken } from "./mind-tokens.js";
 
 const slog = log.child("scheduler");
 
@@ -191,6 +194,11 @@ export class Scheduler {
   }
 
   protected async runScript(script: string, cwd: string, mindName: string): Promise<string> {
+    // Scheduled scripts run with the same environment a mind process gets —
+    // scoped to the mind's own non-admin token — so that a script invoking the
+    // `volute` CLI authenticates as the mind instead of getting 401s.
+    const env = await this.buildScriptEnv(mindName);
+
     // Mind-authored scripts must never run in the daemon's trust domain. Under
     // sandbox mode, wrap with the mind's sandbox (exec only applies user
     // isolation, never the sandbox). Isolation and sandbox modes are mutually
@@ -201,9 +209,35 @@ export class Scheduler {
         dir,
         mindTmpDir(dir),
       ]);
-      return exec(cmd, args, { cwd });
+      return exec(cmd, args, { cwd, env });
     }
-    return exec("bash", ["-c", script], { cwd, mindName });
+    return exec("bash", ["-c", script], { cwd, mindName, env });
+  }
+
+  /**
+   * Build the environment for a scheduled script — mirrors the mind process env
+   * (allowlisted base + merged mind env + VOLUTE_* runtime vars), authenticated
+   * with the mind's own per-mind, non-admin token. Reuses the running mind's
+   * token when present; otherwise mints one (stable across fires, regenerated on
+   * next mind start). The daemon admin token is never included.
+   */
+  private async buildScriptEnv(mindName: string): Promise<Record<string, string | undefined>> {
+    const dir = this.mindDirs.get(mindName) ?? mindDir(mindName);
+    const entry = await findMind(mindName);
+    const token = getMindToken(mindName) ?? generateMindToken(mindName);
+    const mindLocalBin = resolve(dir, "home", ".local", "bin");
+    const currentPath = process.env.PATH ?? "";
+    return {
+      ...buildMindBaseEnv(),
+      ...loadMergedEnv(mindName),
+      VOLUTE_MIND: mindName,
+      VOLUTE_STATE_DIR: stateDir(mindName),
+      VOLUTE_MIND_DIR: dir,
+      VOLUTE_MIND_PORT: entry ? String(entry.port) : undefined,
+      VOLUTE_MIND_TOKEN: token,
+      TMPDIR: mindTmpDir(dir),
+      PATH: `${mindLocalBin}:${currentPath}`,
+    };
   }
 
   protected deliverSystem(

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -3,6 +3,10 @@ import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
+import {
+  resolveMindToken,
+  revokeMindToken,
+} from "../packages/daemon/src/lib/daemon/mind-tokens.js";
 import { Scheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
 import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
 import { SandboxUnavailableError } from "../packages/daemon/src/lib/mind/sandbox.js";
@@ -293,6 +297,36 @@ describe("scheduler runScript sandboxing", () => {
       }
     ).runScript("echo scheduled-ok", "/tmp", "alice");
     assert.ok(out.includes("scheduled-ok"));
+  });
+
+  it("runs scripts with the mind's auth env and no daemon admin token", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    // A leaked daemon admin token would grant scripts admin privileges — it must
+    // be withheld and replaced by the mind's own non-admin token.
+    process.env.VOLUTE_DAEMON_TOKEN = "super-secret-admin";
+    try {
+      const scheduler = new Scheduler();
+      const out = await (
+        scheduler as unknown as {
+          runScript: (s: string, cwd: string, m: string) => Promise<string>;
+        }
+      ).runScript(
+        'printf "%s\\n%s\\n%s" "$VOLUTE_MIND" "$VOLUTE_MIND_TOKEN" "$VOLUTE_DAEMON_TOKEN"',
+        "/tmp",
+        "alice",
+      );
+      const [mind, token, admin] = out.split("\n");
+      assert.equal(mind, "alice");
+      assert.ok(token && token.length > 0, "script should receive a mind token");
+      // The token is non-admin and scoped to this mind.
+      assert.equal(resolveMindToken(token), "alice");
+      // The daemon admin token is never handed to the script (expands to empty).
+      assert.equal(admin, "");
+    } finally {
+      delete process.env.VOLUTE_DAEMON_TOKEN;
+      revokeMindToken("alice");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Scheduled scripts (the scheduler's `runScript`) previously ran with no explicit environment. They inherited the daemon's `process.env` but lacked `VOLUTE_MIND` / `VOLUTE_MIND_TOKEN`, so a script that invoked the `volute` CLI authenticated as nobody and got 401s. This broke the seed-nurture flow, whose schedule runs `volute seed check <name>`.

The fix builds the same environment a mind process gets — the allowlisted base env (`buildMindBaseEnv`) plus the merged mind env plus the `VOLUTE_*` runtime vars (`VOLUTE_MIND`, `VOLUTE_STATE_DIR`, `VOLUTE_MIND_DIR`, `VOLUTE_MIND_PORT`, `VOLUTE_MIND_TOKEN`, `TMPDIR`, and the mind's `.local/bin` on `PATH`) — and passes it to `exec` in both the sandbox and non-sandbox branches.

Authentication uses the mind's own per-mind, non-admin token: it reuses the running mind's token when present, otherwise mints one (stable across fires, regenerated on the mind's next start). The daemon admin token (`VOLUTE_DAEMON_TOKEN`) is explicitly withheld by `buildMindBaseEnv`, so scripts never run with daemon privileges.

## Test plan

- Added a scheduler test (sandbox disabled) that runs a real script echoing `VOLUTE_MIND`, `VOLUTE_MIND_TOKEN`, and `VOLUTE_DAEMON_TOKEN`, asserting: the mind name is passed through, the token resolves to that mind via `resolveMindToken` (proving it's the non-admin per-mind token), and the daemon admin token is absent.
- `npm test` — 1776 passing, 0 failing.
- `tsc --noEmit` clean.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)