### PR TITLE
fix: harden variant join — abort failed merges, stop variant server, use registry dirs

### DIFF
--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -57,6 +57,11 @@ const app = new Hono<AuthEnv>()
     if (!entry) return c.json({ error: "Mind not found" }, 404);
     if (entry.stage === "seed")
       return c.json({ error: "Seed minds cannot create variants — sprout first" }, 403);
+    if (entry.parent)
+      return c.json(
+        { error: "Cannot split from a variant — split from the base mind instead" },
+        403,
+      );
 
     let body: { name: string; soul?: string; port?: number; noStart?: boolean };
     try {
@@ -76,7 +81,7 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: `Name already in use: ${variantName}` }, 409);
     }
 
-    const projectRoot = mindDir(mindName);
+    const projectRoot = entry.dir ?? mindDir(mindName);
     const variantDir = resolve(projectRoot, ".variants", variantName);
 
     if (existsSync(variantDir)) {
@@ -167,7 +172,7 @@ const app = new Hono<AuthEnv>()
       // No body is fine — all fields optional
     }
 
-    const projectRoot = mindDir(mindName);
+    const projectRoot = parentEntry.dir ?? mindDir(mindName);
 
     // Auto-commit any uncommitted changes in the variant worktree
     if (existsSync(variantEntry.dir)) {
@@ -207,7 +212,10 @@ const app = new Hono<AuthEnv>()
       const verified = await verify(result.actualPort);
 
       try {
-        process.kill(result.child.pid!);
+        // The verify server is detached (its own process-group leader), so kill
+        // the whole group — under sandbox/isolation the real server is a wrapped
+        // grandchild that a single-PID SIGTERM would leave running.
+        process.kill(-result.child.pid!, "SIGTERM");
       } catch {}
 
       if (!verified) {
@@ -238,10 +246,36 @@ const app = new Hono<AuthEnv>()
     try {
       await gitExec(["merge", variantEntry.branch], { cwd: projectRoot });
     } catch (_e) {
-      return c.json({ error: "Merge failed. Resolve conflicts manually." }, 500);
+      // Collect the conflicting files before aborting so the caller/mind knows
+      // what collided.
+      let conflicts: string[] = [];
+      try {
+        const out = (
+          await gitExec(["diff", "--name-only", "--diff-filter=U"], { cwd: projectRoot })
+        ).trim();
+        conflicts = out ? out.split("\n") : [];
+      } catch (err) {
+        log.warn(`failed to list merge conflicts for ${mindName}`, log.errorData(err));
+      }
+      // Restore the parent worktree so the still-running parent mind never
+      // auto-commits conflict markers into SOUL.md/MEMORY.md.
+      try {
+        await gitExec(["merge", "--abort"], { cwd: projectRoot });
+      } catch (err) {
+        log.warn(`failed to abort merge for ${mindName}`, log.errorData(err));
+      }
+      // Leave the variant intact so the conflict can be resolved in the variant
+      // and the join retried.
+      return c.json(
+        {
+          error: "Merge failed. Resolve conflicts in the variant and retry the join.",
+          conflicts,
+        },
+        500,
+      );
     }
 
-    await cleanupVariant(variantName, projectRoot, variantEntry.dir);
+    await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
 
     // Update template hash after upgrade merge
     if (variantName.endsWith("-upgrade") || variantName === "upgrade") {
@@ -310,7 +344,7 @@ const app = new Hono<AuthEnv>()
 
     if (!variantEntry.dir) return c.json({ error: `Variant ${variantName} has no directory` }, 500);
 
-    const projectRoot = mindDir(mindName);
+    const projectRoot = parentEntry.dir ?? mindDir(mindName);
 
     await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -588,6 +588,78 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
+  it("variants: a merge conflict aborts cleanly and leaves the variant joinable", {
+    timeout: 300000,
+  }, async () => {
+    await ensureTestMind();
+    const parentDir = mindDir(TEST_MIND);
+
+    // Split without starting its server.
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "e2e-conflict-var", noStart: true }),
+    });
+    assert.equal(createRes.status, 200, `Split: ${await createRes.clone().text()}`);
+    const created = (await createRes.json()) as { variant: { path: string } };
+
+    const gitCommit = (cwd: string, file: string, content: string, msg: string) => {
+      writeFileSync(resolve(cwd, file), content);
+      execFileSync(
+        "git",
+        ["-c", "user.name=e2e", "-c", "user.email=e2e@test", "commit", "-am", msg],
+        {
+          cwd,
+          env: cleanEnv,
+        },
+      );
+    };
+
+    // Conflicting edits to the same tracked file in both parent and variant.
+    const conflictFile = "home/MEMORY.md";
+    gitCommit(parentDir, conflictFile, "parent version of memory\n", "parent conflict edit");
+    gitCommit(
+      created.variant.path,
+      conflictFile,
+      "variant version of memory\n",
+      "variant conflict edit",
+    );
+
+    // Join must fail with a structured conflict error naming the file.
+    const mergeRes = await daemonRequest(
+      `/api/minds/${TEST_MIND}/variants/e2e-conflict-var/merge`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skipVerify: true }),
+      },
+    );
+    assert.equal(mergeRes.status, 500, `Merge should fail: ${await mergeRes.clone().text()}`);
+    const mergeBody = (await mergeRes.json()) as { error: string; conflicts: string[] };
+    assert.ok(
+      mergeBody.conflicts.includes(conflictFile),
+      `expected ${conflictFile} in conflicts: ${JSON.stringify(mergeBody.conflicts)}`,
+    );
+
+    // Parent worktree is restored: no in-progress merge, working tree clean.
+    assert.ok(
+      !existsSync(resolve(parentDir, ".git", "MERGE_HEAD")),
+      "parent should not be left mid-merge",
+    );
+    const porcelain = execFileSync("git", ["status", "--porcelain"], {
+      cwd: parentDir,
+      encoding: "utf-8",
+    }).trim();
+    assert.equal(porcelain, "", `parent worktree should be clean, got: ${porcelain}`);
+
+    // The variant survives and is still joinable.
+    assert.ok(await findMind("e2e-conflict-var"), "variant should still be registered");
+    assert.ok(existsSync(created.variant.path), "variant worktree should still exist");
+
+    // Clean up the variant so later tests aren't affected.
+    await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-conflict-var`, { method: "DELETE" });
+  });
+
   // ── Bridge & Chat Integration Tests ──
 
   /** Ensure the test mind exists in the registry (creates via API if not). */


### PR DESCRIPTION
## Summary

Hardens the variant join/merge paths in `packages/daemon/src/web/api/variants.ts` against three related defects:

- **#441 — failed merges no longer wedge the parent repo.** When `git merge` fails during a join, the handler now collects the conflicting files (`git diff --name-only --diff-filter=U`), runs `git merge --abort` (best-effort) to restore the parent worktree, and returns a structured 500 with a `conflicts` array. The variant is left intact so the conflict can be resolved in the variant and the join retried. Previously the parent was left mid-merge with conflict markers while the parent mind kept running — its next auto-commit could commit conflict markers into SOUL.md/MEMORY.md.
- **#442 — variant server no longer leaked on join.** The merge path now calls `cleanupVariant(..., { stop: true })`, matching the delete endpoint, so the variant's process is stopped and its port freed. The pre-merge verify kill also switched from a single-PID SIGTERM to a process-group kill (`process.kill(-pid, "SIGTERM")`) so sandbox/isolation-wrapped grandchildren die too (the verify server is spawned detached, i.e. its own group leader).
- **#443 — split/merge/delete use the registry's stored dir.** `projectRoot` is now `entry.dir ?? mindDir(name)` in all three handlers, so custom-dir minds (e.g. the spirit) work. Splitting *from* a variant is now explicitly rejected with a 403 ("split from the base mind instead") rather than failing later with a confusing git error.

Scope intentionally excludes the #330 merge-logic consolidation and follow-ups #440/#444/#447/#373.

## Test plan

- New daemon e2e test: split, commit conflicting edits to `home/MEMORY.md` in both parent and variant, join → asserts 500 with the conflicting file named in `conflicts`, parent worktree clean (no `MERGE_HEAD`, empty `git status --porcelain`), variant still registered and its worktree intact, then deletes the variant.
- `npm run test:e2e` — both variant tests pass (existing split/merge happy path + new conflict-abort test). The only failure is the pre-existing, unrelated `backup API e2e` (restic xattr error on macOS `/tmp`).
- `npm test` — passes (runs in the pre-push hook: 0 failures).

Closes #441
Closes #442
Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)