### PR TITLE
fix: sleep-queue flush double-records messages and mishandles failures

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -11,9 +11,10 @@ import {
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { CronExpressionParser } from "cron-parser";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { sendSystemMessageDirect } from "../chat/system-chat.js";
 import { getDb } from "../db.js";
+import type { DeliveryPayload } from "../delivery/delivery-router.js";
 import { type ActivityEvent, subscribe } from "../events/activity-events.js";
 import { findMind, mindDir, voluteSystemDir } from "../mind/registry.js";
 import { readVoluteConfig, type SleepConfig } from "../mind/volute-config.js";
@@ -496,34 +497,58 @@ export class SleepManager {
 
       if (rows.length === 0) return 0;
 
-      // Import deliverMessage lazily to avoid circular deps
-      const { deliverMessage } = await import("../delivery/message-delivery.js");
-
-      const delivered: number[] = [];
+      let deliveredCount = 0;
       for (const row of rows) {
+        let payload: DeliveryPayload;
         try {
-          await deliverMessage(name, JSON.parse(row.payload));
-          delivered.push(row.id);
+          payload = JSON.parse(row.payload);
         } catch (err) {
-          slog.warn(`failed to flush queued message ${row.id} for ${name}`, log.errorData(err));
+          // An unparseable payload can never be delivered — drop it so it doesn't wedge the
+          // rest of the flush (and replay forever on every wake).
+          slog.warn(
+            `dropping unparseable queued message ${row.id} for ${name}`,
+            log.errorData(err),
+          );
+          await db.delete(deliveryQueue).where(eq(deliveryQueue.id, row.id));
+          continue;
         }
-      }
 
-      // Delete only successfully delivered messages
-      if (delivered.length > 0) {
-        await db.delete(deliveryQueue).where(inArray(deliveryQueue.id, delivered));
+        const delivered = await this.deliverQueued(name, payload);
+        if (!delivered) {
+          // Delivery genuinely failed. Leave this row (and the untouched tail) queued so they
+          // retry on the next wake in order, rather than being silently dropped.
+          slog.warn(`failed to flush queued message ${row.id} for ${name}; leaving it queued`);
+          break;
+        }
+
+        // Delete per-row immediately after each successful delivery so a crash mid-flush
+        // replays only the undelivered tail, not the whole backlog.
+        await db.delete(deliveryQueue).where(eq(deliveryQueue.id, row.id));
+        deliveredCount++;
       }
 
       const state = this.states.get(name);
       if (state) {
-        state.queuedMessageCount = Math.max(0, state.queuedMessageCount - delivered.length);
+        state.queuedMessageCount = Math.max(0, state.queuedMessageCount - deliveredCount);
       }
 
-      return delivered.length;
+      return deliveredCount;
     } catch (err) {
       slog.warn(`failed to flush queued messages for ${name}`, log.errorData(err));
       return 0;
     }
+  }
+
+  /**
+   * Deliver one queued message on the wake path. `isFlush` skips the queue-time inbound
+   * recording (kept once, at arrival) and bypasses the sleep re-queue so the now-waking mind
+   * actually receives it. Returns whether the message was handed off to the delivery manager.
+   * Extracted as a seam so the flush loop can be unit-tested without the real delivery stack.
+   */
+  protected async deliverQueued(name: string, payload: DeliveryPayload): Promise<boolean> {
+    // Import lazily to avoid a circular dependency with message-delivery.
+    const { deliverMessage } = await import("../delivery/message-delivery.js");
+    return deliverMessage(name, payload, { isFlush: true });
   }
 
   // --- Internal methods ---

--- a/packages/daemon/src/lib/delivery/message-delivery.ts
+++ b/packages/daemon/src/lib/delivery/message-delivery.ts
@@ -226,49 +226,64 @@ export function resolveSleepAction(
 
 /**
  * Deliver a message to a mind via the delivery manager (routes, batches, gates).
- * Fire-and-forget — logs errors but does not throw.
+ * Fire-and-forget for normal callers — logs errors and returns `false` rather than throwing.
+ * Returns `true` when the message was handled (delivered, queued, or intentionally skipped).
+ *
+ * `isFlush` is set only by SleepManager.flushQueuedMessages when a mind wakes. On that path
+ * the inbound was already recorded (with its true arrival time) at queue time, and the sleep
+ * branch must be bypassed so the message is actually delivered to the now-waking mind rather
+ * than re-recorded and re-queued. The returned boolean lets the flush loop delete only
+ * genuinely-delivered rows.
  */
-export async function deliverMessage(mindName: string, payload: DeliveryPayload): Promise<void> {
+export async function deliverMessage(
+  mindName: string,
+  payload: DeliveryPayload,
+  opts: { isFlush?: boolean } = {},
+): Promise<boolean> {
   try {
     const baseName = await getBaseName(mindName);
     const entry = await findMind(baseName);
     if (!entry) {
       dlog.warn(`cannot deliver to ${mindName}: mind not found`);
-      return;
+      return false;
     }
 
-    const textContent = extractTextContent(payload.content);
-    await recordInbound(baseName, payload.channel, payload.sender ?? null, textContent);
+    if (!opts.isFlush) {
+      const textContent = extractTextContent(payload.content);
+      await recordInbound(baseName, payload.channel, payload.sender ?? null, textContent);
 
-    // Check if mind is sleeping — handle based on whileSleeping or wake triggers
-    const sleepManager = getSleepManagerIfReady();
-    if (sleepManager?.isSleeping(baseName)) {
-      const sleepState = sleepManager.getState(baseName);
-      const action = resolveSleepAction(
-        payload.whileSleeping,
-        sleepState.wokenByTrigger,
-        sleepManager.checkWakeTrigger(baseName, payload),
-      );
-
-      if (action === "skip") {
-        dlog.info(
-          `skipped delivery to ${baseName} (sleeping, whileSleeping=skip, channel=${payload.channel})`,
+      // Check if mind is sleeping — handle based on whileSleeping or wake triggers
+      const sleepManager = getSleepManagerIfReady();
+      if (sleepManager?.isSleeping(baseName)) {
+        const sleepState = sleepManager.getState(baseName);
+        const action = resolveSleepAction(
+          payload.whileSleeping,
+          sleepState.wokenByTrigger,
+          sleepManager.checkWakeTrigger(baseName, payload),
         );
-        return;
-      }
 
-      await sleepManager.queueSleepMessage(baseName, payload);
-      if (action === "queue-and-wake") {
-        sleepManager
-          .initiateWake(baseName, { trigger: { channel: payload.channel } })
-          .catch((err) => dlog.warn(`failed to trigger-wake ${baseName}`, log.errorData(err)));
+        if (action === "skip") {
+          dlog.info(
+            `skipped delivery to ${baseName} (sleeping, whileSleeping=skip, channel=${payload.channel})`,
+          );
+          return true;
+        }
+
+        await sleepManager.queueSleepMessage(baseName, payload);
+        if (action === "queue-and-wake") {
+          sleepManager
+            .initiateWake(baseName, { trigger: { channel: payload.channel } })
+            .catch((err) => dlog.warn(`failed to trigger-wake ${baseName}`, log.errorData(err)));
+        }
+        return true;
       }
-      return;
     }
 
     const manager = getDeliveryManager();
     await manager.routeAndDeliver(mindName, payload);
+    return true;
   } catch (err) {
     dlog.warn(`unexpected error delivering to ${mindName}`, log.errorData(err));
+    return false;
   }
 }

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { extractTextContent } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import {
+  deliverMessage,
   linkToolResultToTurn,
   recordInbound,
   recordOutbound,
@@ -11,6 +12,7 @@ import {
 } from "../packages/daemon/src/lib/delivery/message-delivery.js";
 import { publish as publishActivity } from "../packages/daemon/src/lib/events/activity-events.js";
 import { type MindEvent, subscribe } from "../packages/daemon/src/lib/events/mind-events.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import {
   activity,
   conversations,
@@ -97,6 +99,72 @@ describe("resolveSleepAction", () => {
 
   it("unknown behavior falls through to queue", () => {
     assert.equal(resolveSleepAction("invalid-value", false, true), "queue");
+  });
+});
+
+describe("deliverMessage flush recording", () => {
+  const FLUSH_MIND = "test-flush";
+  const FLUSH_PORT = 41999;
+
+  afterEach(async () => {
+    const db = await getDb();
+    await db.delete(mindHistory).where(eq(mindHistory.mind, FLUSH_MIND));
+    await removeMind(FLUSH_MIND);
+  });
+
+  it("records the inbound once on the normal (non-flush) path", async () => {
+    await addMind(FLUSH_MIND, FLUSH_PORT);
+    // No delivery manager is initialized, so routeAndDeliver throws and delivery reports
+    // failure — but the inbound must still have been recorded exactly once.
+    const ok = await deliverMessage(FLUSH_MIND, {
+      channel: "@volute",
+      sender: "volute",
+      content: "hi",
+    });
+    assert.equal(ok, false, "delivery fails without a delivery manager");
+
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, FLUSH_MIND), eq(mindHistory.type, "inbound")));
+    assert.equal(rows.length, 1);
+  });
+
+  it("skips re-recording the inbound on the flush path (isFlush)", async () => {
+    await addMind(FLUSH_MIND, FLUSH_PORT);
+    const events: MindEvent[] = [];
+    const unsub = subscribe(FLUSH_MIND, (e) => events.push(e));
+    try {
+      const ok = await deliverMessage(
+        FLUSH_MIND,
+        { channel: "@volute", sender: "volute", content: "hi" },
+        { isFlush: true },
+      );
+      // Delivery fails (no manager) → returns false so the flush loop won't delete the row.
+      assert.equal(ok, false);
+    } finally {
+      unsub();
+    }
+
+    // The flush path must NOT create a second inbound row or publish a duplicate event —
+    // the queue-time recording (with the true arrival time) is the only one.
+    assert.equal(events.filter((e) => e.type === "inbound").length, 0);
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, FLUSH_MIND), eq(mindHistory.type, "inbound")));
+    assert.equal(rows.length, 0);
+  });
+
+  it("returns false when the mind is not registered", async () => {
+    const ok = await deliverMessage(
+      "no-such-mind",
+      { channel: "@volute", sender: "volute", content: "hi" },
+      { isFlush: true },
+    );
+    assert.equal(ok, false);
   });
 });
 

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -3,11 +3,14 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
+import { and, eq } from "drizzle-orm";
 import {
   matchesGlob,
   SleepManager,
   type SleepState,
 } from "../packages/daemon/src/lib/daemon/sleep-manager.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { deliveryQueue } from "../packages/daemon/src/lib/schema.js";
 
 // We test the SleepManager's pure logic methods without starting the daemon.
 // The class methods like checkWakeTrigger, formatDuration, etc. are tested directly.
@@ -76,6 +79,16 @@ class TestSleepManager extends SleepManager {
   // Expose buildTriggerWakeSummary for testing
   testBuildTriggerWakeSummary(state: SleepState): string {
     return (this as any).buildTriggerWakeSummary(state);
+  }
+
+  // Stub the delivery seam so flushQueuedMessages can be tested without the real delivery
+  // stack. `deliverResult` decides per-payload whether delivery "succeeds".
+  deliveredPayloads: unknown[] = [];
+  deliverResult: (payload: unknown) => boolean = () => true;
+
+  override async deliverQueued(_name: string, payload: unknown): Promise<boolean> {
+    this.deliveredPayloads.push(payload);
+    return this.deliverResult(payload);
   }
 }
 
@@ -770,5 +783,109 @@ describe("SleepManager.buildTriggerWakeSummary", () => {
     const state = sm.getStateForTest("normal");
     assert.equal(state?.sleeping, true);
     assert.equal(state?.wokenByTrigger, false);
+  });
+});
+
+describe("SleepManager.flushQueuedMessages", () => {
+  let counter = 0;
+  // Unique mind name per test so rows in the shared delivery_queue don't cross-contaminate.
+  function uniqueMind(): string {
+    return `flush-mind-${process.pid}-${counter++}`;
+  }
+
+  async function queue(mind: string, content: string): Promise<void> {
+    const db = await getDb();
+    await db.insert(deliveryQueue).values({
+      mind,
+      session: "sleep",
+      channel: "@volute",
+      sender: "volute",
+      status: "sleep-queued",
+      payload: JSON.stringify({ channel: "@volute", sender: "volute", content }),
+    });
+  }
+
+  async function queuedRows(mind: string) {
+    const db = await getDb();
+    return db
+      .select()
+      .from(deliveryQueue)
+      .where(and(eq(deliveryQueue.mind, mind), eq(deliveryQueue.status, "sleep-queued")))
+      .all();
+  }
+
+  it("delivers each queued message once and deletes delivered rows", async () => {
+    const mind = uniqueMind();
+    await queue(mind, "a");
+    await queue(mind, "b");
+    await queue(mind, "c");
+
+    const sm = new TestSleepManager();
+    sm.setStateForTest(mind, sleepingState({ queuedMessageCount: 3 }));
+
+    const flushed = await sm.flushQueuedMessages(mind);
+
+    assert.equal(flushed, 3);
+    assert.equal(sm.deliveredPayloads.length, 3, "each message delivered exactly once");
+    assert.equal((await queuedRows(mind)).length, 0, "all delivered rows deleted");
+    assert.equal(sm.getState(mind).queuedMessageCount, 0);
+  });
+
+  it("leaves the row queued when delivery fails (no silent drop)", async () => {
+    const mind = uniqueMind();
+    await queue(mind, "a");
+
+    const sm = new TestSleepManager();
+    sm.deliverResult = () => false; // delivery fails
+
+    const flushed = await sm.flushQueuedMessages(mind);
+
+    assert.equal(flushed, 0);
+    assert.equal((await queuedRows(mind)).length, 1, "failed delivery must not delete the row");
+  });
+
+  it("deletes per-row so a mid-flush failure replays only the undelivered tail", async () => {
+    const mind = uniqueMind();
+    await queue(mind, "first");
+    await queue(mind, "second");
+    await queue(mind, "third");
+
+    const sm = new TestSleepManager();
+    sm.setStateForTest(mind, sleepingState({ queuedMessageCount: 3 }));
+    // First delivery succeeds, then the mind "crashes" — the rest must survive.
+    let calls = 0;
+    sm.deliverResult = () => {
+      calls++;
+      return calls === 1;
+    };
+
+    const flushed = await sm.flushQueuedMessages(mind);
+
+    assert.equal(flushed, 1, "only the first row was delivered");
+    const remaining = await queuedRows(mind);
+    assert.equal(remaining.length, 2, "the undelivered tail stays queued for the next wake");
+    // The remaining rows are the tail (second, third), in order — the delivered head is gone.
+    const contents = remaining.map((r) => JSON.parse(r.payload).content).sort();
+    assert.deepEqual(contents, ["second", "third"]);
+    assert.equal(sm.getState(mind).queuedMessageCount, 2);
+  });
+
+  it("drops an unparseable payload instead of replaying it forever", async () => {
+    const mind = uniqueMind();
+    const db = await getDb();
+    await db.insert(deliveryQueue).values({
+      mind,
+      session: "sleep",
+      status: "sleep-queued",
+      payload: "not-json{{{",
+    });
+    await queue(mind, "good");
+
+    const sm = new TestSleepManager();
+    const flushed = await sm.flushQueuedMessages(mind);
+
+    assert.equal(flushed, 1, "the good message delivered");
+    assert.equal(sm.deliveredPayloads.length, 1, "the unparseable row never reached delivery");
+    assert.equal((await queuedRows(mind)).length, 0, "both rows cleared from the queue");
   });
 });


### PR DESCRIPTION
## Summary

Fixes three defects in sleep-queued message delivery (`deliverMessage` → `queueSleepMessage` → `flushQueuedMessages`):

1. **Double-recording** — `deliverMessage` recorded the inbound to `mind_history` before the sleep check, and the wake flush re-entered `deliverMessage`, recording a second row for every message queued during sleep. `deliverMessage` now takes `{ isFlush }` (set only by `SleepManager.flushQueuedMessages`), which skips the re-record — the queue-time row with the true arrival time is the one kept — and bypasses the sleep branch so the message actually reaches the now-waking mind.
2. **False flush success** — `deliverMessage` swallowed all errors, so the flush loop deleted queue rows even when delivery failed (silent drop). It now returns a boolean outcome; the flush loop stops at the first failure and leaves the failed row plus the untouched tail queued, in order, for the next wake.
3. **Whole-backlog replay after a mid-flush crash** — the queue delete was one batch at the end of the flush, so a crash mid-flush replayed the entire backlog on the next wake (see the 371-heartbeat floods on bardo). Rows are now deleted individually, immediately after each successful delivery, so only the undelivered tail replays.

Also drops unparseable queued payloads (they can never deliver and would otherwise replay forever), and extracts a `deliverQueued` seam on `SleepManager` so the flush loop is unit-testable.

Point 4 of #417 (coalescing recurring schedule fires) is intentionally left for a follow-up to land with #424, per the sequencing note on the issue. #419 (wake-failure loop) is likewise separate.

## Test plan

- New unit tests in `test/message-delivery.test.ts`: normal path records the inbound exactly once and returns `false` when delivery can't complete; `isFlush` path records no inbound row and publishes no duplicate event; unknown mind returns `false`.
- New unit tests in `test/sleep-manager.test.ts` (`SleepManager.flushQueuedMessages`): queue → flush delivers each message once and deletes all rows; a delivery failure leaves the row queued (not deleted); a mid-flush failure keeps only the undelivered tail queued (per-row delete); an unparseable payload is dropped instead of replaying forever.
- Full suite: `npm test` — 1782 tests, 0 failures.

Closes #417
Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)