### PR TITLE
fix: scope /api/v1/events presence snapshot to the requesting principal

### DIFF
--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -88,12 +88,30 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         log.error("[v1-events] failed to fetch recent activity", log.errorData(err));
       }
 
+      // Presence scoping: minds are untrusted, so a mind only sees presence
+      // for users it shares a conversation with (plus itself). Admins, system,
+      // and brains keep the global view. Live presence events (brain_online,
+      // mind_active, ...) are already gated by the activity audience filter
+      // below; the snapshot must apply the same policy.
+      let activeMinds = getActiveMinds();
+      let onlineBrains = getOnlineBrains();
+      if (!privileged && user.user_type === "mind") {
+        const visible = new Set<string>(
+          conversations.flatMap((conv: any) =>
+            (conv.participants ?? []).map((p: any) => p.username),
+          ),
+        );
+        if (activityMind) visible.add(activityMind);
+        activeMinds = activeMinds.filter((m) => visible.has(m));
+        onlineBrains = onlineBrains.filter((b) => visible.has(b));
+      }
+
       const snapshotData = {
         event: "snapshot" as const,
         activity: recentActivity,
         conversations,
-        activeMinds: getActiveMinds(),
-        onlineBrains: getOnlineBrains(),
+        activeMinds,
+        onlineBrains,
       };
 
       // The snapshot is connection-specific (this user's conversations, unread

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -3,11 +3,17 @@ import { describe, it } from "node:test";
 import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { publish } from "../packages/daemon/src/lib/events/activity-events.js";
 import {
+  addConnection,
+  removeConnection,
+} from "../packages/daemon/src/lib/events/brain-presence.js";
+import { createConversation } from "../packages/daemon/src/lib/events/conversations.js";
+import {
   bufferEvent,
   getEventsSince,
   nextEventId,
   resetSequencer,
 } from "../packages/daemon/src/lib/events/event-sequencer.js";
+import { markIdle, onMindEvent } from "../packages/daemon/src/lib/events/mind-activity-tracker.js";
 import eventsApp from "../packages/daemon/src/web/api/v1/events.js";
 import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
@@ -333,6 +339,75 @@ describe("v1 events live activity delivery filter", () => {
       replay.some((e) => e.data.event === "activity" && e.data.mind === "live-events-bob"),
       "buffer must still record another mind's activity globally for reconnect replay",
     );
+  });
+
+  it("scopes snapshot presence to a mind's conversation participants", async () => {
+    resetSequencer();
+    // Global presence state: an unrelated active mind and an unrelated online
+    // brain, plus a partner mind that shares a conversation with the caller.
+    onMindEvent("presence-unrelated-mind", "text");
+    onMindEvent("presence-partner-mind", "text");
+    addConnection("presence-unrelated-brain");
+    try {
+      const mind = await getOrCreateMindUser("presence-scoped-mind");
+      const partner = await getOrCreateMindUser("presence-partner-mind");
+      await createConversation({ participantIds: [mind.id, partner.id] });
+      const session = await createSession(mind.id);
+
+      const stream = await openEventStream(`Bearer ${session}`);
+      await delay(200);
+      await stream.close();
+
+      const snapshot = stream.events.find((e) => e.event === "snapshot");
+      assert.ok(snapshot, "mind connection should receive a snapshot");
+      // The key case: a mind must not learn global presence.
+      assert.ok(
+        !snapshot.activeMinds.includes("presence-unrelated-mind"),
+        "mind snapshot must not expose unrelated active minds",
+      );
+      assert.ok(
+        !snapshot.onlineBrains.includes("presence-unrelated-brain"),
+        "mind snapshot must not expose unrelated online brains",
+      );
+      // But presence it is entitled to (a shared-conversation participant) stays.
+      assert.ok(
+        snapshot.activeMinds.includes("presence-partner-mind"),
+        "mind snapshot should include active minds it shares a conversation with",
+      );
+    } finally {
+      markIdle("presence-unrelated-mind");
+      markIdle("presence-partner-mind");
+      removeConnection("presence-unrelated-brain");
+    }
+  });
+
+  it("keeps global snapshot presence for a privileged connection", async () => {
+    resetSequencer();
+    onMindEvent("presence-admin-view-mind", "text");
+    addConnection("presence-admin-view-brain");
+    const prevToken = process.env.VOLUTE_DAEMON_TOKEN;
+    process.env.VOLUTE_DAEMON_TOKEN = "presence-admin-token";
+    try {
+      const stream = await openEventStream("Bearer presence-admin-token");
+      await delay(200);
+      await stream.close();
+
+      const snapshot = stream.events.find((e) => e.event === "snapshot");
+      assert.ok(snapshot, "privileged connection should receive a snapshot");
+      assert.ok(
+        snapshot.activeMinds.includes("presence-admin-view-mind"),
+        "privileged snapshot should include all active minds",
+      );
+      assert.ok(
+        snapshot.onlineBrains.includes("presence-admin-view-brain"),
+        "privileged snapshot should include all online brains",
+      );
+    } finally {
+      if (prevToken === undefined) delete process.env.VOLUTE_DAEMON_TOKEN;
+      else process.env.VOLUTE_DAEMON_TOKEN = prevToken;
+      markIdle("presence-admin-view-mind");
+      removeConnection("presence-admin-view-brain");
+    }
   });
 
   it("delivers any mind's activity live to a privileged connection", async () => {


### PR DESCRIPTION
## Summary

The connect-time snapshot on `GET /api/v1/events` returned `getActiveMinds()` and `getOnlineBrains()` unfiltered, so any authenticated mind learned the names of all currently-active minds and all online human brains (follow-up to the activity-feed gate from #346).

Minds are untrusted principals, so the snapshot now applies the same audience policy as the activity feed and live presence events:

- **Mind callers** (non-admin/system, `user_type: "mind"`) only see presence for users they share a conversation with, plus themselves. The participant set is derived from the conversations already fetched for the snapshot, so no extra queries.
- **Admin, system, and brain callers** keep the global view (the dashboard presence UI is unchanged).

Live `mind_active`/`brain_online` events were already gated for minds by the existing `activityMind` audience filter on the activity subscription; this closes the remaining snapshot leak.

## Test plan

- New test: a mind-token SSE connection's snapshot does **not** include an unrelated active mind or an unrelated online brain, but **does** include an active mind it shares a conversation with.
- New test: a privileged (daemon-token) connection's snapshot still includes global `activeMinds`/`onlineBrains`.
- Full suite: `npm test` — 1777 pass, 0 fail (includes `test/authz-coverage.test.ts`, unchanged: this route has no `/:name` param).

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)