### PR TITLE
fix: deliver mind-to-spirit DMs exactly once

### DIFF
--- a/packages/daemon/src/lib/chat/system-chat.ts
+++ b/packages/daemon/src/lib/chat/system-chat.ts
@@ -2,7 +2,7 @@ import { aiCompleteUtility } from "../ai-service.js";
 import { getOrCreateMindUser, getOrCreateSystemUser } from "../auth.js";
 import { deliverMessage, recordInbound } from "../delivery/message-delivery.js";
 import { addMessage, createConversation, findDMConversation } from "../events/conversations.js";
-import { findMind, mindDir } from "../mind/registry.js";
+import { findMind, isSpiritName, mindDir, SPIRIT_NAME } from "../mind/registry.js";
 import { readVoluteConfig } from "../mind/volute-config.js";
 import log from "../util/logger.js";
 
@@ -59,7 +59,7 @@ export async function sendSystemMessage(
   opts?: { whileSleeping?: "skip" | "queue" | "trigger-wake"; session?: string },
 ): Promise<void> {
   // Spirit can't DM itself — deliver directly without conversation persistence
-  const isSpirit = mindName === "volute";
+  const isSpirit = isSpiritName(mindName);
   let conversationId: string | undefined;
 
   if (!isSpirit) {
@@ -99,39 +99,42 @@ export async function sendSystemMessageDirect(
 }
 
 /**
- * Check if the system spirit is running and can handle replies.
+ * Check whether the system spirit will handle the mind's DM on its own, so the
+ * AI fallback reply should be skipped. This is true when the spirit is running
+ * (fan-out has already delivered the message) or sleeping (fan-out queued it via
+ * the sleep queue, and it will reach the spirit on wake).
  */
-async function isSpiritAvailable(): Promise<boolean> {
-  const spiritEntry = await findMind("volute");
-  return !!(spiritEntry?.running && spiritEntry.mindType === "spirit");
+async function spiritWillHandle(): Promise<boolean> {
+  const spiritEntry = await findMind(SPIRIT_NAME);
+  if (spiritEntry?.running && spiritEntry.mindType === "spirit") return true;
+
+  try {
+    const { getSleepManagerIfReady } = await import("../daemon/sleep-manager.js");
+    const sm = getSleepManagerIfReady();
+    if (sm?.isSleeping(SPIRIT_NAME)) return true;
+  } catch (err) {
+    slog.debug("could not check spirit sleep state", log.errorData(err));
+  }
+
+  return false;
 }
 
 /**
- * Generate an AI-powered reply from the system user to a mind's message.
- * Routes through the system spirit when available, falls back to aiCompleteUtility.
+ * Generate an AI-powered fallback reply from the system user to a mind's message.
+ *
+ * When the spirit is running or sleeping it owns the reply — fan-out already
+ * delivered (or queued) the message to it, so this returns without delivering to
+ * avoid a duplicate. Only when the spirit is stopped (and fan-out therefore
+ * skipped it) does this generate a reply via the utility model.
  */
 export async function generateSystemReply(
   conversationId: string,
   mindName: string,
   message: string,
 ): Promise<void> {
-  // If the system spirit is running, deliver through it
-  if (await isSpiritAvailable()) {
-    try {
-      await deliverMessage("volute", {
-        content: [{ type: "text", text: message }],
-        channel: `@${mindName}`,
-        conversationId,
-        sender: mindName,
-        isDM: true,
-        participants: ["volute", mindName],
-        participantCount: 2,
-      });
-      return;
-    } catch (err) {
-      slog.warn(`failed to route to spirit, falling back to aiCompleteUtility`, log.errorData(err));
-    }
-  }
+  // The running/sleeping spirit already received the message via fan-out; don't
+  // double-deliver or double-reply.
+  if (await spiritWillHandle()) return;
 
   // Fallback: generate reply via utility model
   const entry = await findMind(mindName);

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -8,6 +8,18 @@ import { minds } from "../schema.js";
 
 export type MindType = "mind" | "spirit";
 
+/**
+ * Reserved name of the system spirit. The spirit shares the system user account
+ * (see auth.ts `getOrCreateSystemUser`), so this name is used interchangeably as
+ * the mind name, the system user's username, and the "@volute" DM channel.
+ */
+export const SPIRIT_NAME = "volute";
+
+/** True when a mind/user name is the reserved spirit name. */
+export function isSpiritName(name: string): boolean {
+  return name === SPIRIT_NAME;
+}
+
 export type MindEntry = {
   name: string;
   port: number;

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -9,11 +9,16 @@ import {
   sendSystemMessageDirect,
 } from "../packages/daemon/src/lib/chat/system-chat.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { validateMindName } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  addSpirit,
+  setMindRunning,
+  validateMindName,
+} from "../packages/daemon/src/lib/mind/registry.js";
 import {
   conversationParticipants,
   conversations,
   messages,
+  minds,
   users,
 } from "../packages/daemon/src/lib/schema.js";
 
@@ -27,6 +32,7 @@ async function cleanup() {
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
   }
+  await db.delete(minds).where(eq(minds.name, "volute"));
 }
 
 describe("system user", () => {
@@ -166,5 +172,25 @@ describe("generateSystemReply", () => {
       fallback!.content.includes("no AI model is configured"),
       "fallback should explain the issue",
     );
+  });
+
+  it("skips the fallback when the spirit is running (fan-out owns delivery)", async () => {
+    const { conversationId } = await ensureSystemDM("testmind");
+
+    // Register a running spirit — fan-out has already delivered the mind's DM to it,
+    // so generateSystemReply must not deliver or reply again (issue #418).
+    await addSpirit("volute", 4099, "claude", "/tmp/volute-spirit-test");
+    await setMindRunning("volute", true);
+
+    await generateSystemReply(conversationId, "testmind", "hello volute");
+
+    const db = await getDb();
+    const msgs = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversation_id, conversationId))
+      .all();
+    const reply = msgs.find((m) => m.role === "assistant" && m.sender_name === "volute");
+    assert.equal(reply, undefined, "should not persist any reply when the spirit is running");
   });
 });


### PR DESCRIPTION
## Summary

When a mind DMs the spirit (`@volute`), the message was delivered to the running spirit **twice** through two independent paths in the chat send handler:

1. `fanOutToMinds()` — the spirit shares the system user, whose participant row (`userType === "system"`, username `volute`) matches the running spirit, so fan-out delivers.
2. `generateSystemReply()` — when the spirit was available, its spirit branch called `deliverMessage("volute", …)` again with the same content.

Both recorded an inbound row and both hit the spirit's server, which batched them into one turn containing the message twice — so the spirit replied twice (production evidence in #418).

This makes **fan-out the single delivery owner**:

- `generateSystemReply()` now returns without delivering when the spirit is **running** (fan-out already delivered) or **sleeping** (fan-out queued the message via the sleep queue; the AI fallback would otherwise reply now *and* the spirit again on wake — the sleeping-spirit edge case from the issue's plan).
- The `aiCompleteUtility` fallback is kept only for a **stopped** spirit, which fan-out skips (it only targets running/sleeping minds).

Per #437 item 1, the hardcoded `"volute"` spirit-name checks touched by this change are centralized into a shared `SPIRIT_NAME` constant + `isSpiritName()` helper in `packages/daemon/src/lib/mind/registry.ts`, used in `system-chat.ts`. (Remaining call sites elsewhere are left for the #437 PR.)

Scope note: the broader spirit self-reply gating (#430) and reply-loop guard (#429) are follow-ups that build on this.

## Test plan

- New unit test: `generateSystemReply` with a running spirit registered → no reply delivered/persisted (fan-out owns delivery).
- Existing test retained: spirit stopped + no AI model → fallback reply persisted.
- `test/system-chat.test.ts` 12/12 pass; related `system-channel`/`message-delivery`/`delivery-manager` suites (56 tests) pass; full suite ran green in the pre-push hook.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)