### PR TITLE
fix: imagegen skill distinguishes daemon errors from missing config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,9 +124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -141,9 +138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -158,9 +152,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -175,9 +166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -781,9 +769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -801,9 +786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -821,9 +803,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -841,9 +820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1820,7 +1796,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1943,9 +1919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1953,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +1970,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +1987,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4613,9 +4574,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4633,9 +4591,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4653,9 +4608,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4673,9 +4625,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4699,9 +4648,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4725,9 +4671,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5535,9 +5478,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5555,9 +5495,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5575,9 +5512,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5595,9 +5529,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5615,9 +5546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5635,9 +5563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12901,9 +12826,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12921,9 +12843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12941,9 +12860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12961,9 +12877,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12981,9 +12894,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13001,9 +12911,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13027,9 +12934,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13053,9 +12957,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13079,9 +12980,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13105,9 +13003,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/skills/imagegen/scripts/imagegen.ts
+++ b/skills/imagegen/scripts/imagegen.ts
@@ -44,14 +44,65 @@ function getDaemonToken(): string | undefined {
   return process.env.VOLUTE_MIND_TOKEN;
 }
 
-/** Returns null only when the daemon is unreachable or imagegen is not configured. */
-async function generateViaDaemon(model: string, prompt: string): Promise<Buffer | null> {
+/**
+ * Outcome of a daemon call, distinguishing the failure modes so the mind gets an
+ * accurate diagnosis instead of a misleading "not configured" message:
+ *  - no-env      — not running under a Volute mind environment (env vars unset)
+ *  - unreachable — daemon env is set but the connection failed (daemon down)
+ *  - auth        — daemon rejected the mind's token (401/403)
+ *  - fallback    — daemon can't serve this (imagegen not configured, or old daemon)
+ */
+export type DaemonFailure =
+  | { ok: false; reason: "no-env" }
+  | { ok: false; reason: "unreachable"; detail: string }
+  | { ok: false; reason: "auth"; status: number; detail: string }
+  | { ok: false; reason: "fallback" };
+export type DaemonResult<T> = { ok: true; value: T } | DaemonFailure;
+
+async function readDaemonError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: string } | null;
+  return body?.error || `HTTP ${res.status}`;
+}
+
+/**
+ * Acts on a daemon failure: prints an informational note and returns when the
+ * caller should fall back to a direct provider (no-env / fallback), or throws a
+ * clear diagnosis for local problems that direct fallback would only mask
+ * (unreachable / auth).
+ */
+export function handleDaemonFailure(failure: DaemonFailure): void {
+  switch (failure.reason) {
+    case "no-env":
+      console.error(
+        "Not running under a Volute mind environment; falling back to direct provider.",
+      );
+      return;
+    case "unreachable":
+      throw new Error(
+        `Could not reach the Volute daemon at ${getDaemonUrl()}: ${failure.detail}. ` +
+          "The daemon may be down — this is a local connection problem, not a provider-configuration issue.",
+      );
+    case "auth":
+      throw new Error(
+        `The Volute daemon rejected this mind's token (HTTP ${failure.status}: ${failure.detail}). ` +
+          "Check VOLUTE_MIND_TOKEN — this is an authentication problem, not a provider-configuration issue.",
+      );
+    case "fallback":
+      return;
+  }
+}
+
+export async function generateViaDaemon(
+  model: string,
+  prompt: string,
+): Promise<DaemonResult<Buffer>> {
   const base = getDaemonUrl();
   const token = getDaemonToken();
-  if (!base || !token) return null;
+  if (!base || !token) return { ok: false, reason: "no-env" };
 
+  let res: Response;
   try {
-    const res = await fetch(`${base}/api/v1/system/imagegen/generate`, {
+    res = await fetch(`${base}/api/v1/system/imagegen/generate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -59,49 +110,51 @@ async function generateViaDaemon(model: string, prompt: string): Promise<Buffer 
       },
       body: JSON.stringify({ model, prompt }),
     });
-    if (!res.ok) {
-      const err = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
-        error: string;
-      };
-      // Not configured — fall back to direct Replicate
-      if (err.error?.includes("not configured") || err.error?.match(/No .* API key/)) return null;
-      throw new Error(err.error || `Daemon returned ${res.status}`);
-    }
-    return Buffer.from(await res.arrayBuffer());
   } catch (err) {
-    // Connection failure — daemon unreachable, fall back to direct
-    if (err instanceof TypeError) return null;
+    if (err instanceof TypeError) {
+      return { ok: false, reason: "unreachable", detail: err.message };
+    }
     throw err;
   }
+
+  if (res.status === 401 || res.status === 403) {
+    return { ok: false, reason: "auth", status: res.status, detail: await readDaemonError(res) };
+  }
+  if (!res.ok) {
+    const err = await readDaemonError(res);
+    // Genuinely not configured — fall back to direct provider.
+    if (/not configured/i.test(err) || /No .* API key/i.test(err)) {
+      return { ok: false, reason: "fallback" };
+    }
+    throw new Error(err);
+  }
+  return { ok: true, value: Buffer.from(await res.arrayBuffer()) };
 }
 
-/** Returns null only when the daemon is unreachable or endpoint doesn't exist. */
-async function searchViaDaemon(query: string): Promise<unknown[] | null> {
+export async function searchViaDaemon(query: string): Promise<DaemonResult<unknown[]>> {
   const base = getDaemonUrl();
   const token = getDaemonToken();
-  if (!base || !token) return null;
+  if (!base || !token) return { ok: false, reason: "no-env" };
 
+  let res: Response;
   try {
-    const res = await fetch(
+    res = await fetch(
       `${base}/api/v1/system/imagegen/models/search?q=${encodeURIComponent(query)}`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
-    if (!res.ok) {
-      // 404 = older daemon without this endpoint — fall back silently
-      if (res.status === 404) return null;
-      const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
-        error: string;
-      };
-      console.error(`daemon model search failed: ${body.error || res.status}`);
-      return null;
-    }
-    return (await res.json()) as unknown[];
   } catch (err) {
-    // Connection failure — daemon unreachable
-    if (err instanceof TypeError) return null;
-    console.error(`daemon model search error: ${err instanceof Error ? err.message : err}`);
-    return null;
+    if (err instanceof TypeError) {
+      return { ok: false, reason: "unreachable", detail: err.message };
+    }
+    throw err;
   }
+
+  if (res.status === 401 || res.status === 403) {
+    return { ok: false, reason: "auth", status: res.status, detail: await readDaemonError(res) };
+  }
+  // 404 = older daemon without this endpoint; other non-ok — fall back to direct search.
+  if (!res.ok) return { ok: false, reason: "fallback" };
+  return { ok: true, value: (await res.json()) as unknown[] };
 }
 
 async function generateDirect(model: string, prompt: string): Promise<Buffer> {
@@ -169,9 +222,13 @@ async function generate(args: string[]): Promise<void> {
 
   console.log(`generating image with ${model}...`);
 
-  // Try daemon first, fall back to direct Replicate
-  let buf = await generateViaDaemon(model, prompt);
-  if (!buf) {
+  // Try daemon first, fall back to direct Replicate.
+  const daemonRes = await generateViaDaemon(model, prompt);
+  let buf: Buffer;
+  if (daemonRes.ok) {
+    buf = daemonRes.value;
+  } else {
+    handleDaemonFailure(daemonRes); // throws for unreachable/auth; returns to fall back otherwise
     buf = await generateDirect(model, prompt);
   }
 
@@ -190,14 +247,17 @@ async function models(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Try daemon first
-  const daemonResults = await searchViaDaemon(query);
-  if (daemonResults && daemonResults.length > 0) {
-    for (const m of daemonResults as Array<{ id: string; description?: string }>) {
+  // Try daemon first.
+  const daemonRes = await searchViaDaemon(query);
+  if (daemonRes.ok && daemonRes.value.length > 0) {
+    for (const m of daemonRes.value as Array<{ id: string; description?: string }>) {
       const desc = m.description ? ` — ${m.description.slice(0, 100)}` : "";
       console.log(`${m.id}${desc}`);
     }
     return;
+  }
+  if (!daemonRes.ok) {
+    handleDaemonFailure(daemonRes); // throws for unreachable/auth; returns to fall back otherwise
   }
 
   // Fall back to direct Replicate

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -10,6 +10,11 @@ import {
   saveProviderConfig,
   setEnabledModels,
 } from "../packages/daemon/src/lib/services/imagegen.js";
+import {
+  generateViaDaemon,
+  handleDaemonFailure,
+  searchViaDaemon,
+} from "../skills/imagegen/scripts/imagegen.js";
 
 function resetImagegenConfig() {
   const config = readGlobalConfig();
@@ -240,6 +245,154 @@ describe("imagegen config", () => {
 
     it("throws on unknown provider", () => {
       assert.throws(() => parseModelId("badprovider:owner/model"), /Unknown imagegen provider/);
+    });
+  });
+});
+
+describe("imagegen skill daemon error reporting", () => {
+  const realFetch = globalThis.fetch;
+  const savedEnv = {
+    port: process.env.VOLUTE_DAEMON_PORT,
+    token: process.env.VOLUTE_MIND_TOKEN,
+  };
+
+  function setDaemonEnv(present: boolean) {
+    if (present) {
+      process.env.VOLUTE_DAEMON_PORT = "1618";
+      process.env.VOLUTE_MIND_TOKEN = "mind-token";
+    } else {
+      delete process.env.VOLUTE_DAEMON_PORT;
+      delete process.env.VOLUTE_MIND_TOKEN;
+    }
+  }
+
+  function mockFetch(fn: () => Promise<Response> | Response) {
+    globalThis.fetch = (async () => fn()) as typeof fetch;
+  }
+
+  function jsonResponse(status: number, body: unknown): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as Response;
+  }
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (savedEnv.port !== undefined) process.env.VOLUTE_DAEMON_PORT = savedEnv.port;
+    else delete process.env.VOLUTE_DAEMON_PORT;
+    if (savedEnv.token !== undefined) process.env.VOLUTE_MIND_TOKEN = savedEnv.token;
+    else delete process.env.VOLUTE_MIND_TOKEN;
+  });
+
+  describe("generateViaDaemon", () => {
+    it("reports no-env when daemon env vars are unset", async () => {
+      setDaemonEnv(false);
+      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      assert.deepEqual(res, { ok: false, reason: "no-env" });
+    });
+
+    it("reports unreachable when the connection fails", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => {
+        throw new TypeError("fetch failed");
+      });
+      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      assert.equal(res.ok, false);
+      assert.equal(res.ok === false && res.reason, "unreachable");
+    });
+
+    it("reports auth failure on 401", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(401, { error: "invalid token" }));
+      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      assert.equal(res.ok, false);
+      assert.equal(res.ok === false && res.reason, "auth");
+      assert.equal(res.ok === false && res.reason === "auth" && res.status, 401);
+    });
+
+    it("reports auth failure on 403", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(403, { error: "forbidden" }));
+      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      assert.equal(res.ok === false && res.reason, "auth");
+    });
+
+    it("reports fallback when imagegen is genuinely not configured", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(400, { error: "imagegen not configured" }));
+      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      assert.deepEqual(res, { ok: false, reason: "fallback" });
+    });
+
+    it("throws on an unexpected daemon error", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(500, { error: "boom" }));
+      await assert.rejects(generateViaDaemon("replicate:owner/model", "prompt"), /boom/);
+    });
+
+    it("returns the image buffer on success", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(200, {}));
+      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      assert.equal(res.ok, true);
+      assert.ok(res.ok && Buffer.isBuffer(res.value));
+    });
+  });
+
+  describe("searchViaDaemon", () => {
+    it("reports no-env when daemon env vars are unset", async () => {
+      setDaemonEnv(false);
+      const res = await searchViaDaemon("query");
+      assert.deepEqual(res, { ok: false, reason: "no-env" });
+    });
+
+    it("reports auth failure on 401", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(401, { error: "invalid token" }));
+      const res = await searchViaDaemon("query");
+      assert.equal(res.ok === false && res.reason, "auth");
+    });
+
+    it("reports fallback for older daemon without the endpoint (404)", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(404, { error: "not found" }));
+      const res = await searchViaDaemon("query");
+      assert.deepEqual(res, { ok: false, reason: "fallback" });
+    });
+
+    it("returns results on success", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(200, [{ id: "replicate:owner/model" }]));
+      const res = await searchViaDaemon("query");
+      assert.equal(res.ok, true);
+      assert.deepEqual(res.ok && res.value, [{ id: "replicate:owner/model" }]);
+    });
+  });
+
+  describe("handleDaemonFailure", () => {
+    it("returns (falls back) for no-env", () => {
+      assert.doesNotThrow(() => handleDaemonFailure({ ok: false, reason: "no-env" }));
+    });
+
+    it("returns (falls back) for fallback", () => {
+      assert.doesNotThrow(() => handleDaemonFailure({ ok: false, reason: "fallback" }));
+    });
+
+    it("throws a connection diagnosis for unreachable, not a config one", () => {
+      assert.throws(
+        () => handleDaemonFailure({ ok: false, reason: "unreachable", detail: "fetch failed" }),
+        /not a provider-configuration issue/,
+      );
+    });
+
+    it("throws an auth diagnosis for auth, not a config one", () => {
+      assert.throws(
+        () => handleDaemonFailure({ ok: false, reason: "auth", status: 401, detail: "bad token" }),
+        /authentication problem/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

The imagegen skill (`skills/imagegen/scripts/imagegen.ts`) collapsed four distinct daemon outcomes into one null-fallback path: env-missing, connection failure, auth rejection, and "genuinely not configured" all fell through to the direct provider, which then printed "No image generation configured. Ask an admin to set up a provider in Settings." This misdiagnosed local failures as system misconfiguration — it bit the mind "whorl" on bardo, where imagegen was fully configured but the mind couldn't reach/authenticate to the daemon (stale script using the retired `VOLUTE_DAEMON_TOKEN` var, see #465).

`generateViaDaemon`/`searchViaDaemon` now return a discriminated result:
- `no-env` — daemon env vars unset (not under a Volute mind): informational note, fall back to direct provider.
- `unreachable` — env set but connection failed: throws a clear connection diagnosis ("the daemon may be down — this is a local connection problem, not a provider-configuration issue"), no silent fallback.
- `auth` — 401/403: throws an authentication diagnosis ("check VOLUTE_MIND_TOKEN — this is an authentication problem, not a provider-configuration issue"), no silent fallback.
- `fallback` — imagegen genuinely not configured, or an older daemon (404): falls back to the direct provider, preserving the existing "ask an admin" message.

`handleDaemonFailure()` centralizes the print-or-throw decision, used by both `generate` and `models`.

## Test plan

- Added `imagegen skill daemon error reporting` describe block to `test/imagegen.test.ts` covering all outcome branches of `generateViaDaemon`, `searchViaDaemon`, and the print-vs-throw behavior of `handleDaemonFailure` (mocked `fetch`/env).
- Full suite via `npm test`: 1790 tests pass, 0 failures.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)