### PR TITLE
fix: bound wake retries and surface wake failures

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -15,7 +15,11 @@ import { and, eq } from "drizzle-orm";
 import { sendSystemMessageDirect } from "../chat/system-chat.js";
 import { getDb } from "../db.js";
 import type { DeliveryPayload } from "../delivery/delivery-router.js";
-import { type ActivityEvent, subscribe } from "../events/activity-events.js";
+import {
+  type ActivityEvent,
+  publish as publishActivity,
+  subscribe,
+} from "../events/activity-events.js";
 import { findMind, mindDir, voluteSystemDir } from "../mind/registry.js";
 import { readVoluteConfig, resolveWakeTriggers, type SleepConfig } from "../mind/volute-config.js";
 import { getPrompt } from "../prompts.js";
@@ -23,8 +27,14 @@ import { deliveryQueue } from "../schema.js";
 import log from "../util/logger.js";
 import { getMindManager } from "./mind-manager.js";
 import { sleepMind, wakeMind } from "./mind-service.js";
+import { MIND_LEVEL_SESSION, recordNotice } from "./notices.js";
 
 const slog = log.child("sleep");
+
+/** Give up waking a mind after this many consecutive failures and mark it errored (#419). */
+const MAX_WAKE_ATTEMPTS = 5;
+/** Backoff before the next retry, indexed by (failures - 1) and capped at the last entry. */
+const WAKE_BACKOFF_MS = [60_000, 5 * 60_000, 15 * 60_000, 60 * 60_000];
 
 export type SleepState = {
   sleeping: boolean;
@@ -34,6 +44,10 @@ export type SleepState = {
   voluntaryWakeAt: string | null;
   queuedMessageCount: number;
   triggerWakeHistory: { channel: string; at: string }[];
+  /** Consecutive failed wake attempts; reset on a successful wake (#419). */
+  wakeFailures: number;
+  /** Earliest time the next wake retry may run, while backing off after failures. */
+  nextWakeAttemptAt: string | null;
 };
 
 type SleepStatePersisted = Record<string, SleepState>;
@@ -47,6 +61,8 @@ function defaultState(): SleepState {
     voluntaryWakeAt: null,
     queuedMessageCount: 0,
     triggerWakeHistory: [],
+    wakeFailures: 0,
+    nextWakeAttemptAt: null,
   };
 }
 
@@ -128,6 +144,8 @@ export class SleepManager {
         const data: SleepStatePersisted = JSON.parse(readFileSync(this.statePath, "utf-8"));
         for (const [name, state] of Object.entries(data)) {
           state.triggerWakeHistory ??= [];
+          state.wakeFailures ??= 0;
+          state.nextWakeAttemptAt ??= null;
           this.states.set(name, state);
         }
       }
@@ -318,7 +336,7 @@ export class SleepManager {
         try {
           await wakeMind(name);
         } catch (err) {
-          slog.error(`failed to wake ${name}`, log.errorData(err));
+          await this.handleWakeFailure(name, err);
           return;
         }
       }
@@ -326,6 +344,9 @@ export class SleepManager {
       // Wait for health check
       const entry = await findMind(name);
       if (!entry) return;
+
+      // Wake succeeded — clear any prior failure backoff so future failures start fresh.
+      this.resetWakeBackoff(name);
 
       if (opts?.trigger) {
         // Trigger-wakes are brief interruptions — the trigger message itself
@@ -550,6 +571,79 @@ export class SleepManager {
     return deliverMessage(name, payload, { isFlush: true });
   }
 
+  // --- Wake failure handling (#419) ---
+
+  /**
+   * Record a failed wake attempt. Applies exponential backoff between retries and,
+   * after MAX_WAKE_ATTEMPTS consecutive failures, gives up and marks the mind errored
+   * rather than retrying every tick forever.
+   */
+  protected async handleWakeFailure(name: string, err: unknown): Promise<void> {
+    const state = this.states.get(name);
+    if (!state?.sleeping) return;
+
+    state.wakeFailures = (state.wakeFailures ?? 0) + 1;
+
+    if (state.wakeFailures >= MAX_WAKE_ATTEMPTS) {
+      await this.markWakeErrored(name, err);
+      return;
+    }
+
+    const backoff = WAKE_BACKOFF_MS[Math.min(state.wakeFailures - 1, WAKE_BACKOFF_MS.length - 1)];
+    state.nextWakeAttemptAt = new Date(Date.now() + backoff).toISOString();
+    this.saveState();
+    slog.warn(
+      `failed to wake ${name} (attempt ${state.wakeFailures}/${MAX_WAKE_ATTEMPTS}); retrying in ${Math.round(backoff / 60_000)}m`,
+      log.errorData(err),
+    );
+  }
+
+  /** Clear wake-failure backoff after a successful wake. */
+  private resetWakeBackoff(name: string): void {
+    const state = this.states.get(name);
+    if (!state) return;
+    if (state.wakeFailures === 0 && state.nextWakeAttemptAt === null) return;
+    state.wakeFailures = 0;
+    state.nextWakeAttemptAt = null;
+    this.saveState();
+  }
+
+  /**
+   * A mind has failed to wake too many times — it isn't asleep, it's broken.
+   * Clear the sleep state (so the tick stops retrying) and surface the failure
+   * loudly: error log, activity event for the web UI, and a mind notice so the
+   * mind learns what happened on its next successful session. A manual
+   * `volute clock wake` / `volute mind start` is the recovery path.
+   */
+  protected async markWakeErrored(name: string, err: unknown): Promise<void> {
+    const detail = err instanceof Error ? err.message : String(err);
+    this.markAwake(name);
+
+    slog.error(
+      `${name} failed to wake ${MAX_WAKE_ATTEMPTS} times in a row; giving up and marking errored`,
+      log.errorData(err),
+    );
+
+    try {
+      await publishActivity({
+        type: "mind_stopped",
+        mind: name,
+        summary: `${name} failed to wake after ${MAX_WAKE_ATTEMPTS} attempts`,
+        metadata: { error: "wake_failed", detail },
+      });
+    } catch (e) {
+      slog.error(`failed to publish wake-failure activity for ${name}`, log.errorData(e));
+    }
+
+    await recordNotice({
+      mind: name,
+      session: MIND_LEVEL_SESSION,
+      kind: "startup",
+      reason: "startup_failed",
+      detail: `Wake failed ${MAX_WAKE_ATTEMPTS} times in a row and was given up. Last error: ${detail}`,
+    });
+  }
+
   // --- Internal methods ---
 
   private markSleeping(name: string, opts?: { voluntaryWakeAt?: string }): void {
@@ -562,6 +656,8 @@ export class SleepManager {
       voluntaryWakeAt: opts?.voluntaryWakeAt ?? null,
       queuedMessageCount: this.states.get(name)?.queuedMessageCount ?? 0,
       triggerWakeHistory: [],
+      wakeFailures: 0,
+      nextWakeAttemptAt: null,
     };
     this.states.set(name, state);
     this.saveState();
@@ -600,6 +696,12 @@ export class SleepManager {
       if (!config?.enabled || !config.schedule) continue;
 
       const state = this.states.get(name);
+
+      // In wake-failure backoff — wait before retrying rather than hammering
+      // wakeMind every tick (#419).
+      if (state?.sleeping && state.nextWakeAttemptAt && now < new Date(state.nextWakeAttemptAt)) {
+        continue;
+      }
 
       // Check voluntary wake time
       if (state?.sleeping && state.voluntaryWakeAt) {

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -10,7 +10,7 @@ import {
   type SleepState,
 } from "../packages/daemon/src/lib/daemon/sleep-manager.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { deliveryQueue } from "../packages/daemon/src/lib/schema.js";
+import { activity, deliveryQueue, mindNotices } from "../packages/daemon/src/lib/schema.js";
 
 // We test the SleepManager's pure logic methods without starting the daemon.
 // The class methods like checkWakeTrigger, formatDuration, etc. are tested directly.
@@ -90,6 +90,15 @@ class TestSleepManager extends SleepManager {
     this.deliveredPayloads.push(payload);
     return this.deliverResult(payload);
   }
+
+  // Expose wake-failure handling for testing
+  testHandleWakeFailure(name: string, err: unknown): Promise<void> {
+    return (this as any).handleWakeFailure(name, err);
+  }
+
+  testResetWakeBackoff(name: string): void {
+    (this as any).resetWakeBackoff(name);
+  }
 }
 
 function sleepingState(overrides?: Partial<SleepState>): SleepState {
@@ -101,6 +110,8 @@ function sleepingState(overrides?: Partial<SleepState>): SleepState {
     voluntaryWakeAt: null,
     queuedMessageCount: 0,
     triggerWakeHistory: [],
+    wakeFailures: 0,
+    nextWakeAttemptAt: null,
     ...overrides,
   };
 }
@@ -114,6 +125,8 @@ function awakeState(): SleepState {
     voluntaryWakeAt: null,
     queuedMessageCount: 0,
     triggerWakeHistory: [],
+    wakeFailures: 0,
+    nextWakeAttemptAt: null,
   };
 }
 
@@ -887,5 +900,78 @@ describe("SleepManager.flushQueuedMessages", () => {
     assert.equal(flushed, 1, "the good message delivered");
     assert.equal(sm.deliveredPayloads.length, 1, "the unparseable row never reached delivery");
     assert.equal((await queuedRows(mind)).length, 0, "both rows cleared from the queue");
+  });
+});
+
+describe("SleepManager wake-failure handling", () => {
+  it("applies increasing backoff on consecutive failures instead of retrying every tick", async () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest("faily", sleepingState());
+    const err = new Error("boom");
+
+    await sm.testHandleWakeFailure("faily", err);
+    let state = sm.getStateForTest("faily");
+    assert.equal(state?.wakeFailures, 1);
+    assert.ok(state?.nextWakeAttemptAt, "first failure schedules a retry");
+    const wait1 = new Date(state!.nextWakeAttemptAt!).getTime() - Date.now();
+    assert.ok(wait1 > 30_000 && wait1 <= 61_000, `first backoff ~60s, got ${wait1}ms`);
+
+    await sm.testHandleWakeFailure("faily", err);
+    state = sm.getStateForTest("faily");
+    assert.equal(state?.wakeFailures, 2);
+    const wait2 = new Date(state!.nextWakeAttemptAt!).getTime() - Date.now();
+    assert.ok(wait2 > wait1, "second backoff is longer than the first");
+
+    // Still sleeping — hasn't given up yet.
+    assert.equal(sm.isSleeping("faily"), true);
+  });
+
+  it("gives up after MAX attempts, clears sleep state, and surfaces the failure", async () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest("broken", sleepingState());
+    const err = new Error("nonexistent model gpt-5.4");
+
+    for (let i = 0; i < 5; i++) {
+      await sm.testHandleWakeFailure("broken", err);
+    }
+
+    // It isn't asleep, it's broken — sleep state cleared so the tick stops retrying.
+    assert.equal(sm.isSleeping("broken"), false);
+    assert.equal(sm.getStateForTest("broken"), undefined);
+
+    const db = await getDb();
+
+    // Activity event surfaced for the web UI.
+    const events = await db.select().from(activity).where(eq(activity.mind, "broken")).all();
+    assert.ok(
+      events.some((e) => e.type === "mind_stopped" && e.summary.includes("failed to wake")),
+      "expected a mind_stopped wake-failure activity event",
+    );
+
+    // Notice recorded so the mind learns what happened on its next session.
+    const notices = await db.select().from(mindNotices).where(eq(mindNotices.mind, "broken")).all();
+    assert.ok(
+      notices.some((n) => n.kind === "startup" && n.detail.includes("gpt-5.4")),
+      "expected a startup notice carrying the wake error",
+    );
+  });
+
+  it("resetWakeBackoff clears the failure count and scheduled retry", () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest(
+      "recover",
+      sleepingState({ wakeFailures: 3, nextWakeAttemptAt: new Date().toISOString() }),
+    );
+    sm.testResetWakeBackoff("recover");
+    const state = sm.getStateForTest("recover");
+    assert.equal(state?.wakeFailures, 0);
+    assert.equal(state?.nextWakeAttemptAt, null);
+  });
+
+  it("handleWakeFailure is a no-op for a mind that is not sleeping", async () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest("awake", awakeState());
+    await sm.testHandleWakeFailure("awake", new Error("x"));
+    assert.equal(sm.getStateForTest("awake")?.wakeFailures, 0);
   });
 });


### PR DESCRIPTION
## Summary

When a sleeping mind's wake failed, the sleep manager retried **every 60 seconds, forever, invisibly** (issue #419). A mind with a broken config — e.g. a nonexistent model — would respawn every minute indefinitely (on bardo, whorl did this for ~10 weeks) while queued messages piled up, with no operator-visible signal anywhere but the raw `mind.log`.

This adds bounded retries with backoff plus a visible failure state:

- **Per-mind failure tracking** in `SleepState` (`wakeFailures`, `nextWakeAttemptAt`), persisted via `saveState()` so a daemon restart doesn't reset the count. Back-compat defaults are filled in on `loadState`.
- **Backoff instead of every-tick retry**: after a failed `wakeMind()`, `handleWakeFailure` schedules the next attempt (1m → 5m → 15m → 60m). The tick skips wake attempts while a mind is inside its backoff window.
- **Give up after 5 consecutive failures** (`markWakeErrored`): the mind isn't asleep, it's broken — so the sleep state is cleared (stopping the retry loop), and the failure is surfaced loudly via an error-level log, a `mind_stopped` activity event (with `error: "wake_failed"` metadata) for the web UI, and a `startup` mind-notice so the mind learns what happened on its next successful session.
- **Recovery**: a successful wake (via `volute clock wake` / `volute mind start`, which bypass the tick backoff) resets the failure counter.

Scoped to the wake-retry/scheduling path only; no new DB columns or API surface changes.

## Test plan

- New unit tests in `test/sleep-manager.test.ts` covering: increasing backoff on consecutive failures, give-up after MAX attempts (sleep state cleared + activity event + notice recorded), `resetWakeBackoff`, and the not-sleeping no-op.
- `test/sleep-manager.test.ts` (67) and `test/scheduler-sleep.test.ts` (4) pass; full suite green via the pre-push hook; `tsc --noEmit` clean.

## Interaction with #476

PR #476 (`fix/417-sleep-queue-delivery`) also touches `sleep-manager.ts`, but only inside `flushQueuedMessages`/`deliverQueued`. This change lives entirely in the wake-retry/scheduling path (`initiateWake`, `tick`, new failure-handling methods, `SleepState` fields), so the two shouldn't conflict beyond trivial context around the imports. #417/#476 bounds the queue growth while this loop runs; this PR stops the loop.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)