### PR TITLE
fix(scheduler): default schedule fires to queue while sleeping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,9 +124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -141,9 +138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -158,9 +152,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -175,9 +166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -781,9 +769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -801,9 +786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -821,9 +803,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -841,9 +820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1820,7 +1796,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1943,9 +1919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1953,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +1970,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +1987,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4613,9 +4574,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4633,9 +4591,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4653,9 +4608,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4673,9 +4625,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4699,9 +4648,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4725,9 +4671,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5535,9 +5478,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5555,9 +5495,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5575,9 +5512,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5595,9 +5529,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5615,9 +5546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5635,9 +5563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12901,9 +12826,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12921,9 +12843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12941,9 +12860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12961,9 +12877,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12981,9 +12894,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13001,9 +12911,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13027,9 +12934,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13053,9 +12957,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13079,9 +12980,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13105,9 +13003,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -148,7 +148,9 @@ export class Scheduler {
       }
 
       await this.deliverSystem(mindName, `[${schedule.id}] ${text}`, {
-        whileSleeping: schedule.whileSleeping,
+        // Default schedule fires to "queue" while asleep so an unadorned cron
+        // schedule doesn't inherit the DM wake-trigger fallback and wake the mind.
+        whileSleeping: schedule.whileSleeping ?? "queue",
         session: schedule.session,
       });
       slog.info(`fired "${schedule.id}" for ${mindName}`);

--- a/skills/volute-mind/SKILL.md
+++ b/skills/volute-mind/SKILL.md
@@ -81,8 +81,12 @@ volute clock add --id morning-check --cron "0 9 * * *" --message "morning check"
 ```
 
 - `skip` — silently skip when sleeping
-- `queue` — queue for delivery on wake
+- `queue` — queue for delivery on wake (**default** when `--while-sleeping` is unset)
 - `trigger-wake` — briefly wake you, then return to sleep when idle
+
+By default a schedule that fires while you sleep is queued and delivered when you wake — it won't wake you. Set `--while-sleeping trigger-wake` on a schedule if you want it to wake you.
+
+Schedule messages arrive from sender `volute` with the schedule id as a `[prefix]` in the text (e.g. `[dream] dream time`), so a `wakeTriggers.senders` glob can never match a schedule id — that's dead config. Use `--while-sleeping trigger-wake` on the schedule instead.
 
 ## Sleep
 

--- a/test/scheduler-sleep.test.ts
+++ b/test/scheduler-sleep.test.ts
@@ -25,7 +25,7 @@ class TestScheduler extends Scheduler {
 }
 
 describe("scheduler whileSleeping", () => {
-  it("delivers message with whileSleeping undefined by default", async () => {
+  it("defaults whileSleeping to queue when unset", async () => {
     const scheduler = new TestScheduler();
     await (scheduler as any).fire("test-mind", {
       id: "no-flag",
@@ -34,7 +34,7 @@ describe("scheduler whileSleeping", () => {
       enabled: true,
     });
     assert.equal(scheduler.systemDeliveries.length, 1);
-    assert.equal(scheduler.systemDeliveries[0].opts?.whileSleeping, undefined);
+    assert.equal(scheduler.systemDeliveries[0].opts?.whileSleeping, "queue");
   });
 
   it("passes whileSleeping: skip to delivery", async () => {


### PR DESCRIPTION
## Summary

A mind with a sleep schedule was trigger-woken by **every** schedule that fired during its sleep window, even schedules that never asked for it. Root cause: when `whileSleeping` is unset, `Scheduler.fire()` passed `undefined` through to delivery, and `resolveSleepAction()` treats an unset `whileSleeping` as "defer to the mind's wake triggers". Since schedule fires are delivered as DMs from `volute` and the default `wakeTriggers.dms` is enabled, an unadorned cron schedule behaved like `trigger-wake` for nearly every mind.

This defaults schedule deliveries to `whileSleeping: "queue"` at the scheduler layer (`scheduler.ts` `fire()`). Only schedule-originated messages change; organic DMs/mentions keep their wake-trigger semantics, so `resolveSleepAction()` is deliberately left untouched.

Also updates the `volute-mind` skill "Sleep behavior" docs to state the `queue` default and to note that `wakeTriggers.senders` globs can never match a schedule id (schedule messages come from sender `volute` with the id as a `[prefix]`) — use `--while-sleeping trigger-wake` instead.

## Test plan

- `test/scheduler-sleep.test.ts` — updated the first test to expect `whileSleeping: "queue"` when unset; the explicit `skip`/`queue`/`trigger-wake` pass-through tests are unchanged. All 4 pass.
- `test/message-delivery.test.ts` (`resolveSleepAction` table) unchanged.
- Full suite ran green in the pre-push hook.

## Interaction with in-flight PRs

Per the issue's sequencing note, this lands with/after #417's coalescing (defaulting to `queue` increases queued schedule fires, which #417 bounds). This change is confined to `scheduler.ts` and does not touch `deliverMessage` (#476) or `flushQueuedMessages`/`SleepState` (#480), so there are no code conflicts.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)