### PR TITLE
fix: exclude local restic repo from backup and fix oauth-health boundary flake

### DIFF
--- a/packages/daemon/src/lib/backup/restic.ts
+++ b/packages/daemon/src/lib/backup/restic.ts
@@ -116,8 +116,27 @@ const SESSION_EXCLUDES = [
   ".mind/pi-sessions",
 ];
 
+/**
+ * When the repository is a local filesystem path, return its absolute path so
+ * the backup can exclude it. A repo that lives inside a backup root (e.g. under
+ * ~/.volute) would otherwise be backed up into itself, racing restic against
+ * its own transient pack files. Remote backends (s3:, rest:, sftp:, b2:, …)
+ * return null — nothing on the local tree to exclude.
+ */
+export function localRepoPath(config: BackupConfig): string | null {
+  const repo = config.repository;
+  if (!repo) return null;
+  // restic identifies backends by a "scheme:" prefix; a bare path or an
+  // explicit "local:" path is a local filesystem repository.
+  const scheme = /^([a-z][a-z0-9]*):/i.exec(repo);
+  if (scheme && scheme[1].toLowerCase() !== "local") return null;
+  return resolve(scheme ? repo.slice(scheme[0].length) : repo);
+}
+
 export function buildExcludePatterns(config: BackupConfig): string[] {
   const patterns = [...BASE_EXCLUDES, ...systemExcludes()];
+  const repoPath = localRepoPath(config);
+  if (repoPath) patterns.push(repoPath);
   if (!config.includeSessions) patterns.push(...SESSION_EXCLUDES);
   return patterns;
 }

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -713,10 +713,10 @@ const slog = log.child("ai-keys");
 const oauthHealth = new Map<string, { healthy: boolean; error?: string; since?: number }>();
 
 /** Check whether an OAuth token needs refresh (expired or <15 min remaining). */
-export function needsRefresh(oauth: OAuthCredentials): boolean {
+export function needsRefresh(oauth: OAuthCredentials, now: number = Date.now()): boolean {
   const expires = oauth.expires;
-  if (!expires || Date.now() >= expires) return true;
-  return expires - Date.now() < 15 * 60 * 1000;
+  if (!expires || now >= expires) return true;
+  return expires - now < 15 * 60 * 1000;
 }
 
 export async function refreshApiKeyCache(): Promise<void> {

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -48,6 +48,21 @@ describe("backup exclude patterns", () => {
     assert.ok(patterns.includes(resolve(voluteSystemDir(), "volute.db")));
   });
 
+  it("excludes a local repository so restic can't back up its repo into itself", () => {
+    const repo = resolve(voluteSystemDir(), "e2e-restic-repo");
+    const patterns = buildExcludePatterns({ repository: repo });
+    assert.ok(
+      patterns.includes(repo),
+      "a local repo inside a backup root must be excluded to avoid racing restic's own pack files",
+    );
+  });
+
+  it("does not add an exclude for a remote (non-local) repository backend", () => {
+    const patterns = buildExcludePatterns({ repository: "s3:s3.amazonaws.com/my-bucket" });
+    const base = buildExcludePatterns({});
+    assert.deepEqual(patterns, base, "remote backends have nothing on the local tree to exclude");
+  });
+
   it("writes the exclude file into the system dir", () => {
     const path = writeExcludeFile({});
     assert.ok(existsSync(path));

--- a/test/oauth-health.test.ts
+++ b/test/oauth-health.test.ts
@@ -2,51 +2,56 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { needsRefresh } from "../packages/daemon/src/web/api/system.js";
 
+// Freeze the clock so boundary cases are deterministic — otherwise the
+// milliseconds elapsed between building the fixture and reading Date.now()
+// inside needsRefresh can flip results right at the 15-minute threshold.
+const NOW = 1_700_000_000_000;
+
 describe("needsRefresh", () => {
   it("returns true when token is already expired", () => {
-    const expired = { refresh: "r", access: "a", expires: Date.now() - 1000 };
-    assert.equal(needsRefresh(expired), true);
+    const expired = { refresh: "r", access: "a", expires: NOW - 1000 };
+    assert.equal(needsRefresh(expired, NOW), true);
   });
 
   it("returns true when expires is 0", () => {
     const zero = { refresh: "r", access: "a", expires: 0 };
-    assert.equal(needsRefresh(zero), true);
+    assert.equal(needsRefresh(zero, NOW), true);
   });
 
   it("returns true when less than 15 minutes remain", () => {
     const soonExpires = {
       refresh: "r",
       access: "a",
-      expires: Date.now() + 10 * 60 * 1000, // 10 minutes
+      expires: NOW + 10 * 60 * 1000, // 10 minutes
     };
-    assert.equal(needsRefresh(soonExpires), true);
+    assert.equal(needsRefresh(soonExpires, NOW), true);
   });
 
   it("returns false when more than 15 minutes remain", () => {
     const fresh = {
       refresh: "r",
       access: "a",
-      expires: Date.now() + 30 * 60 * 1000, // 30 minutes
+      expires: NOW + 30 * 60 * 1000, // 30 minutes
     };
-    assert.equal(needsRefresh(fresh), false);
+    assert.equal(needsRefresh(fresh, NOW), false);
   });
 
-  it("returns true at exactly 15 minutes remaining", () => {
+  it("returns false at exactly 15 minutes remaining", () => {
     const exact = {
       refresh: "r",
       access: "a",
-      expires: Date.now() + 15 * 60 * 1000,
+      expires: NOW + 15 * 60 * 1000,
     };
     // At exactly 15min, remaining < 15min is false, so should return false
-    assert.equal(needsRefresh(exact), false);
+    assert.equal(needsRefresh(exact, NOW), false);
   });
 
   it("returns false when token has plenty of time", () => {
     const longLived = {
       refresh: "r",
       access: "a",
-      expires: Date.now() + 3600 * 1000, // 1 hour
+      expires: NOW + 3600 * 1000, // 1 hour
     };
-    assert.equal(needsRefresh(longLived), false);
+    assert.equal(needsRefresh(longLived, NOW), false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two tests that randomly fail CI on unrelated PRs.

### Flake 1 — `test/oauth-health.test.ts` "exactly 15 minutes remaining"
`needsRefresh()` read a fresh `Date.now()` on every call. The test built an expiry at exactly the 15-minute threshold (`Date.now() + 15min`), but the milliseconds elapsed between constructing the fixture and the internal `expires - Date.now() < 15min` check would occasionally flip the boundary, producing `AssertionError: true !== false`.

**Fix:** `needsRefresh(oauth, now = Date.now())` now takes an optional clock. Production behavior is unchanged (defaults to `Date.now()`); the test passes a frozen `NOW` constant so every boundary case is deterministic. The case title was corrected to match its actual assertion (`false` at exactly 15 minutes).

### Flake 2 — `test/daemon-e2e.test.ts` "backup API e2e"
`backupRoots()` includes `voluteHome()`, and the e2e restic repository lives at `<voluteHome>/system/e2e-restic-repo` — i.e. **inside a backup source root**. So restic archived its own repository and raced against its own transient pack files:

```
during: "archival", item: ".../system/e2e-restic-repo/data/bc/<hash>-tmp-<n>"
Warning: at least one source file could not be read
```

restic writes a temp pack file, the scan tries to read it, restic renames/removes it → "could not be read" → archival error → 500.

**Fix (production-correct):** `buildExcludePatterns()` now excludes a **local** repository path from the backup source set (via new `localRepoPath()` helper). Remote backends (`s3:`, `rest:`, `sftp:`, `b2:`, …) are detected by their `scheme:` prefix and left untouched — there's nothing on the local tree to exclude. Backing a local repo up into itself was wasteful and unsafe regardless of the test, so this is a real bug fix, not just a test workaround.

## Test plan
- `npm test` (full unit suite): **1777 pass, 0 fail** — includes the deterministic `needsRefresh` boundary cases and two new `buildExcludePatterns` cases (local repo excluded; remote backend untouched).
- `npm run test:e2e` run **3×**: backup e2e passed every time (5848ms / 4665ms / 5654ms), **50 pass, 0 fail** each. restic 0.19.0 was installed so the test actually exercised the backup path (not skipped).
- The oauth boundary is now deterministic by construction (fixed `NOW` constant — no clock read during assertion), so it cannot flip.

## Known remaining flake (not fixed here)
`test/webhook.test.ts` fails intermittently under the full parallel suite and reproduces identically on clean `origin/main` (unrelated to these two flakes). Root cause is timing/state-leak: `fireWebhook()` is fire-and-forget and each test waits a fixed 200ms before asserting `received.length === 1`, so a slow POST from one test can land in the next test's freshly-reset `received` array. A fully-safe fix would need to make delivery deterministic across both the direct-fire tests and the `broadcast`-driven test; deferred to keep this PR tight and low-risk. It passed in all runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)