### PR TITLE
fix: chown post-creation skill installs under user isolation

### DIFF
--- a/packages/daemon/src/web/api/mind-skills.ts
+++ b/packages/daemon/src/web/api/mind-skills.ts
@@ -1,6 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
+import { chownMindDir } from "../../lib/mind/isolation.js";
 import { findMind, mindDir } from "../../lib/mind/registry.js";
 import {
   installSkill,
@@ -35,6 +36,10 @@ const app = new Hono<AuthEnv>()
 
       try {
         const result = await installSkill(name, dir, skillId);
+        // installSkill writes files (and git objects) as the daemon (root under
+        // user isolation), so hand ownership to the mind — otherwise it can't
+        // modify or remove its own skill. No-op when isolation is disabled.
+        await chownMindDir(dir, name);
         return c.json({ ok: true, ...result });
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -56,6 +61,9 @@ const app = new Hono<AuthEnv>()
 
       try {
         const result = await updateSkill(name, dir, skillId);
+        // Newly written files land as root under user isolation — re-chown so
+        // the mind keeps ownership of its skill. No-op when isolation is off.
+        await chownMindDir(dir, name);
         return c.json(result);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -94,6 +102,10 @@ const app = new Hono<AuthEnv>()
 
     try {
       await uninstallSkill(name, dir, skillName);
+      // The removal commit's git objects are written as root under user
+      // isolation — re-chown so the mind's later commits don't hit EACCES.
+      // No-op when isolation is off.
+      await chownMindDir(dir, name);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return c.json({ error: msg }, 400);

--- a/test/skills-install-isolation.test.ts
+++ b/test/skills-install-isolation.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { after, afterEach, before, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, mindDir, voluteHome } from "../packages/daemon/src/lib/mind/registry.js";
+import { sessions, sharedSkills, users } from "../packages/daemon/src/lib/schema.js";
+import { importSkillFromDir } from "../packages/daemon/src/lib/skills.js";
+import mindSkillsApp from "../packages/daemon/src/web/api/mind-skills.js";
+import { type AuthEnv, authMiddleware } from "../packages/daemon/src/web/middleware/auth.js";
+import { createMindGitRepo } from "./helpers/git.js";
+
+// This file lives on its own so flipping VOLUTE_ISOLATION only affects its own
+// test process (node runs each test file in a separate process). The mind user
+// `mind-<name>` intentionally does not exist, so chownMindDir's real `chown`
+// fails — that failure is exactly the observable proving the install/update/
+// uninstall routes now hand ownership back to the mind under user isolation.
+
+const testMindName = `skill-iso-test-${Date.now()}`;
+let adminCookie: string;
+let baseRepoDir: string;
+
+const originalIsolation = process.env.VOLUTE_ISOLATION;
+
+function createApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("/*", authMiddleware);
+  app.route("/minds", mindSkillsApp);
+  return app;
+}
+
+function createSharedSkillDir(name: string): string {
+  const dir = join(voluteHome(), "tmp-iso-skill-src", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\n`,
+  );
+  return dir;
+}
+
+describe("mind skills install chowns to the mind under user isolation", () => {
+  before(async () => {
+    process.env.VOLUTE_ISOLATION = "user";
+    baseRepoDir = `${mindDir(testMindName)}-base`;
+    await createMindGitRepo(baseRepoDir);
+
+    const db = await getDb();
+    const [user] = await db
+      .insert(users)
+      .values({ username: "skill-iso-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    adminCookie = `volute_session=${sessionId}`;
+  });
+
+  after(async () => {
+    if (originalIsolation === undefined) delete process.env.VOLUTE_ISOLATION;
+    else process.env.VOLUTE_ISOLATION = originalIsolation;
+    if (existsSync(baseRepoDir)) rmSync(baseRepoDir, { recursive: true });
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "skill-iso-admin"));
+  });
+
+  beforeEach(async () => {
+    const dir = mindDir(testMindName);
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+    cpSync(baseRepoDir, dir, { recursive: true });
+    await addMind(testMindName, 4198);
+  });
+
+  afterEach(async () => {
+    const db = await getDb();
+    await db.delete(sharedSkills);
+    const dir = mindDir(testMindName);
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+    const skillsDir = join(voluteHome(), "skills");
+    if (existsSync(skillsDir)) rmSync(skillsDir, { recursive: true });
+    const tmpDir = join(voluteHome(), "tmp-iso-skill-src");
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  it("install triggers chownMindDir (fails against the absent mind user)", async () => {
+    const source = createSharedSkillDir("iso-installable");
+    await importSkillFromDir(source, "author");
+
+    const app = createApp();
+    const res = await app.request(`/minds/${testMindName}/skills/install`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: adminCookie },
+      body: JSON.stringify({ skillId: "iso-installable" }),
+    });
+
+    // The files were copied, but chownMindDir ran and failed because the
+    // `mind-<name>` OS user does not exist in the test environment. Without the
+    // ownership fix this request would succeed (200) with root-owned files.
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { error: string };
+    assert.match(body.error, /chown/i);
+  });
+});


### PR DESCRIPTION
## Summary

When a mind installs, updates, or uninstalls a skill **after creation** on a host running per-mind user isolation (`VOLUTE_ISOLATION=user`), the copied skill files and the resulting git objects were written by the daemon (root) and left owned by root. The mind — running as its own unprivileged OS user — could then neither modify nor remove its own skills, and its next auto-commit would hit `EACCES` on the root-owned `.git` objects.

Every creation-time flow (main create, archive restore, spirit bootstrap) already calls `chownMindDir(...)` after installing skills to hand ownership back to the mind. The post-creation skill routes in `mind-skills.ts` (`/install`, `/update`, `DELETE`) were the only mutating paths missing that step. This adds `chownMindDir(dir, name)` after each — a no-op when isolation is disabled.

## Test plan

- New `test/skills-install-isolation.test.ts` exercises the install route with `VOLUTE_ISOLATION=user`. The `mind-<name>` OS user intentionally doesn't exist in the test env, so the real `chown` fails — proving the route now performs the ownership step (without the fix the request would succeed with root-owned files). Kept in its own file so the env flag stays scoped to that test process.
- Full suite: `npm test` → 1776 pass / 0 fail.
- `npx tsc --noEmit` and `biome check` clean.
- Real end-to-end ownership under isolation continues to be covered by `test/docker-e2e.sh` Phase 4.

## Note for reviewers

While tracing this I noticed the main `POST /` create flow's `chownMindDir` runs *before* its skill-install loop and `SOUL.md`/`MEMORY.md` writes, so those creation-time files may also land root-owned under isolation. I left the create flow untouched to keep this PR scoped to the reported post-creation bug — flagging it as a likely sibling gap worth a separate look.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)