### PR TITLE
fix: spirit never replies to its own messages

### DIFF
--- a/packages/daemon/src/lib/chat/system-chat.ts
+++ b/packages/daemon/src/lib/chat/system-chat.ts
@@ -16,6 +16,32 @@ export function resetSystemDMCache(): void {
 }
 
 /**
+ * Decide whether a mind's message should trigger the system fallback reply.
+ *
+ * Only genuine two-party system DMs qualify. Channels and group DMs that include
+ * the system user are covered by fan-out to the running spirit (correctly
+ * labeled), so the utility fallback stays DM-only — this stops #system posts and
+ * group DMs from being treated as private DMs. The spirit shares the system user,
+ * so it must never be triggered to reply to its own message, which would loop.
+ */
+export function shouldGenerateSystemFallback(opts: {
+  senderIsMind: boolean;
+  hasMessage: boolean;
+  convType: string;
+  participants: { userType: string }[];
+  replyTarget: string;
+}): boolean {
+  const { senderIsMind, hasMessage, convType, participants, replyTarget } = opts;
+  if (!senderIsMind || !hasMessage) return false;
+  if (isSpiritName(replyTarget)) return false;
+  return (
+    convType === "dm" &&
+    participants.length === 2 &&
+    participants.some((p) => p.userType === "system")
+  );
+}
+
+/**
  * Ensure a DM conversation exists between the system user and a mind.
  * Caches per-mind to avoid repeated lookups.
  */
@@ -127,7 +153,7 @@ async function spiritWillHandle(): Promise<boolean> {
  * avoid a duplicate. Only when the spirit is stopped (and fan-out therefore
  * skipped it) does this generate a reply via the utility model.
  */
-export async function generateSystemReply(
+export async function generateSystemFallbackReply(
   conversationId: string,
   mindName: string,
   message: string,

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -5,7 +5,10 @@ import { z } from "zod";
 import { getOrCreateMindUser, getOrCreateSystemUser } from "../../../lib/auth.js";
 import { routeOutboundBridge } from "../../../lib/bridges/bridge-outbound.js";
 import { formatFileSize, stageFile, validateFilePath } from "../../../lib/chat/file-sharing.js";
-import { generateSystemReply } from "../../../lib/chat/system-chat.js";
+import {
+  generateSystemFallbackReply,
+  shouldGenerateSystemFallback,
+} from "../../../lib/chat/system-chat.js";
 import { getActiveTurnId } from "../../../lib/daemon/turn-tracker.js";
 import { extractTextContent } from "../../../lib/delivery/delivery-router.js";
 import { fanOutToMinds } from "../../../lib/delivery/fan-out.js";
@@ -324,15 +327,21 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
         : undefined,
     });
 
-    // Check if a mind is messaging a system DM — generate AI reply
+    // Generate the system fallback reply only for genuine two-party system DMs
+    // (see shouldGenerateSystemFallback for the gating rationale).
     const systemReplyTarget = baseName ?? senderName;
-    if (senderIsMind && body.message) {
-      const hasSystemUser = participants.some((p) => p.userType === "system");
-      if (hasSystemUser) {
-        generateSystemReply(conversationId!, systemReplyTarget, body.message).catch((err) =>
-          log.error(`system reply generation failed for ${systemReplyTarget}`, log.errorData(err)),
-        );
-      }
+    if (
+      shouldGenerateSystemFallback({
+        senderIsMind: !!senderIsMind,
+        hasMessage: !!body.message,
+        convType: conv.type,
+        participants,
+        replyTarget: systemReplyTarget,
+      })
+    ) {
+      generateSystemFallbackReply(conversationId!, systemReplyTarget, body.message!).catch((err) =>
+        log.error(`system reply generation failed for ${systemReplyTarget}`, log.errorData(err)),
+      );
     }
 
     return c.json({ ok: true, conversationId, outboundId });

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -27,7 +27,7 @@ import {
   isParticipantOrOwner,
 } from "../../../lib/events/conversations.js";
 import { publish as publishMindEvent } from "../../../lib/events/mind-events.js";
-import { findMind, getBaseName, mindDir } from "../../../lib/mind/registry.js";
+import { findMind, getBaseName, resolveMindDir } from "../../../lib/mind/registry.js";
 import { readVoluteConfig } from "../../../lib/mind/volute-config.js";
 import { fixModelEscapes } from "../../../lib/util/fix-model-escapes.js";
 import log from "../../../lib/util/logger.js";
@@ -111,9 +111,14 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
     // Resolve sender: daemon token + body.sender → override, else user.username
     const senderName = user.id === 0 && body.sender ? body.sender : user.username;
 
-    // Detect if sender is a mind
+    // Detect if sender is a mind. The spirit ("volute") authenticates with its
+    // mind token but resolves to the shared system user (user_type "system"), so
+    // classify a system principal whose username is a registered mind as a mind
+    // sender too — this matches only the spirit, never a plain system principal.
     const senderIsMind =
-      (user.id === 0 && body.sender && (await findMind(body.sender))) || user.user_type === "mind";
+      (user.id === 0 && body.sender && (await findMind(body.sender))) ||
+      user.user_type === "mind" ||
+      (user.user_type === "system" && !!(await findMind(user.username)));
 
     // Track baseName and variant-aware targetName callback for the targetMind flow
     let baseName: string | undefined;
@@ -212,7 +217,7 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
 
     // Fix common model escape errors in mind-sent messages
     if (senderIsMind) {
-      const vCfg = readVoluteConfig(mindDir(baseName ?? senderName));
+      const vCfg = readVoluteConfig(await resolveMindDir(baseName ?? senderName));
       const shouldUnescapeNewlines = vCfg?.unescapeNewlines === true;
       for (const block of contentBlocks) {
         if (block.type === "text") {

--- a/test/chat-spirit-sender.test.ts
+++ b/test/chat-spirit-sender.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { getOrCreateMindUser, getOrCreateSystemUser } from "../packages/daemon/src/lib/auth.js";
+import { resetSystemDMCache } from "../packages/daemon/src/lib/chat/system-chat.js";
+import {
+  initMindManager,
+  tryGetMindManager,
+} from "../packages/daemon/src/lib/daemon/mind-manager.js";
+import {
+  generateMindToken,
+  revokeMindToken,
+} from "../packages/daemon/src/lib/daemon/mind-tokens.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { createConversation } from "../packages/daemon/src/lib/events/conversations.js";
+import { addMind, addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  conversations,
+  messages,
+  mindHistory,
+  minds,
+  users,
+} from "../packages/daemon/src/lib/schema.js";
+import { invalidateMindUserCache } from "../packages/daemon/src/web/middleware/auth.js";
+
+const TARGET_MIND = "chat-spirit-target";
+const TEST_USERNAMES = ["volute", TARGET_MIND];
+
+let convId: string;
+
+async function cleanup() {
+  resetSystemDMCache();
+  revokeMindToken("volute");
+  const db = await getDb();
+  if (convId) {
+    await db.delete(messages).where(eq(messages.conversation_id, convId));
+    await db.delete(conversations).where(eq(conversations.id, convId));
+  }
+  await db.delete(mindHistory).where(eq(mindHistory.mind, "volute"));
+  for (const username of TEST_USERNAMES) {
+    await db.delete(users).where(eq(users.username, username));
+  }
+  await db.delete(minds).where(eq(minds.name, "volute"));
+  await db.delete(minds).where(eq(minds.name, TARGET_MIND));
+}
+
+/**
+ * Set up the spirit ("volute", which reuses the shared system user), a target
+ * mind, and a two-party DM conversation between them. Returns the spirit's mind
+ * token for authenticating a send.
+ */
+async function setupSpiritDM(): Promise<{ token: string; conversationId: string }> {
+  // fan-out (invoked by the chat handler) needs a MindManager instance.
+  if (!tryGetMindManager()) initMindManager();
+
+  const systemUser = await getOrCreateSystemUser();
+  await addSpirit("volute", 4099, "claude", "/tmp/volute-spirit-sender-test");
+
+  const targetUser = await getOrCreateMindUser(TARGET_MIND);
+  await addMind(TARGET_MIND, 4177);
+
+  // Drop any cached "volute" user from a prior test so auth resolves the freshly
+  // created system user (its id must match the conversation participant).
+  invalidateMindUserCache("volute");
+
+  const conv = await createConversation({
+    participantIds: [systemUser.id, targetUser.id],
+  });
+  convId = conv.id;
+
+  const token = generateMindToken("volute");
+  return { token, conversationId: conv.id };
+}
+
+function spiritSend(app: { request: typeof fetch }, token: string, body: unknown) {
+  return app.request("http://localhost/api/v1/chat", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Origin: "http://localhost",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  } as RequestInit);
+}
+
+describe("spirit as a mind sender via POST /api/v1/chat", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("records the spirit's outbound in its own mind_history", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "hello from the spirit",
+    });
+    assert.equal(res.status, 200);
+
+    const db = await getDb();
+    const rows = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const outbound = rows.find(
+      (r) => r.type === "outbound" && r.content?.includes("hello from the spirit"),
+    );
+    assert.ok(outbound, "spirit send should be recorded as an outbound in mind_history");
+  });
+
+  it("runs the mind-sender escape fix on the spirit's message", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    // fixModelEscapes turns "\!" into "!" for mind senders only. If the spirit
+    // were still misclassified as a non-mind sender, this fix would be skipped.
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "warning\\! done",
+    });
+    assert.equal(res.status, 200);
+
+    const db = await getDb();
+    const msgs = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversation_id, conversationId))
+      .all();
+    const send = msgs.find((m) => m.sender_name === "volute");
+    assert.ok(send, "the spirit's message should be persisted");
+    assert.ok(send!.content.includes("warning! done"), "escape fix should have run");
+    assert.ok(!send!.content.includes("warning\\! done"), "raw escape should not survive");
+  });
+
+  it("does not trigger a system self-reply loop on the spirit's own send", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "anyone there?",
+    });
+    assert.equal(res.status, 200);
+
+    // The spirit shares the system user, so the DM has a system-user participant.
+    // The self-reply guard (senderIsNotSpirit) must keep generateSystemFallbackReply
+    // from firing — otherwise the system would "reply" to the spirit as itself,
+    // and the spirit would answer forever.
+    const db = await getDb();
+    const msgs = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversation_id, conversationId))
+      .all();
+    const voluteMsgs = msgs.filter((m) => m.sender_name === "volute");
+    assert.equal(voluteMsgs.length, 1, "only the spirit's send should exist — no fallback reply");
+    assert.equal(voluteMsgs[0].role, "user", "the single volute message is the send, not a reply");
+  });
+});

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -3,10 +3,11 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { getOrCreateSystemUser, verifyUser } from "../packages/daemon/src/lib/auth.js";
 import {
   ensureSystemDM,
-  generateSystemReply,
+  generateSystemFallbackReply,
   resetSystemDMCache,
   sendSystemMessage,
   sendSystemMessageDirect,
+  shouldGenerateSystemFallback,
 } from "../packages/daemon/src/lib/chat/system-chat.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
@@ -150,7 +151,101 @@ describe("system messages", () => {
   });
 });
 
-describe("generateSystemReply", () => {
+describe("shouldGenerateSystemFallback", () => {
+  const systemDM = [{ userType: "system" }, { userType: "mind" }];
+
+  it("triggers for a two-party system DM from a mind", () => {
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: true,
+        hasMessage: true,
+        convType: "dm",
+        participants: systemDM,
+        replyTarget: "testmind",
+      }),
+      true,
+    );
+  });
+
+  it("does not trigger for a channel with a system-user participant (fan-out owns it)", () => {
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: true,
+        hasMessage: true,
+        convType: "channel",
+        participants: [{ userType: "system" }, { userType: "mind" }, { userType: "mind" }],
+        replyTarget: "testmind",
+      }),
+      false,
+    );
+  });
+
+  it("does not trigger for a group DM that includes the system user", () => {
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: true,
+        hasMessage: true,
+        convType: "dm",
+        participants: [{ userType: "system" }, { userType: "mind" }, { userType: "mind" }],
+        replyTarget: "testmind",
+      }),
+      false,
+    );
+  });
+
+  it("does not trigger when the spirit is the reply target (self-reply loop guard)", () => {
+    // The spirit shares the system user; without this guard a spirit DM to itself
+    // would trigger the system to reply to the spirit, which would reply again — loop.
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: true,
+        hasMessage: true,
+        convType: "dm",
+        participants: systemDM,
+        replyTarget: "volute",
+      }),
+      false,
+    );
+  });
+
+  it("does not trigger for a non-mind sender or an empty message", () => {
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: false,
+        hasMessage: true,
+        convType: "dm",
+        participants: systemDM,
+        replyTarget: "testmind",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: true,
+        hasMessage: false,
+        convType: "dm",
+        participants: systemDM,
+        replyTarget: "testmind",
+      }),
+      false,
+    );
+  });
+
+  it("does not trigger for a DM without a system-user participant", () => {
+    assert.equal(
+      shouldGenerateSystemFallback({
+        senderIsMind: true,
+        hasMessage: true,
+        convType: "dm",
+        participants: [{ userType: "mind" }, { userType: "mind" }],
+        replyTarget: "testmind",
+      }),
+      false,
+    );
+  });
+});
+
+describe("generateSystemFallbackReply", () => {
   beforeEach(cleanup);
   afterEach(cleanup);
 
@@ -158,7 +253,7 @@ describe("generateSystemReply", () => {
     const { conversationId } = await ensureSystemDM("testmind");
 
     // No AI model configured in test env, so aiComplete returns null
-    await generateSystemReply(conversationId, "testmind", "hello volute");
+    await generateSystemFallbackReply(conversationId, "testmind", "hello volute");
 
     const db = await getDb();
     const msgs = await db
@@ -178,11 +273,11 @@ describe("generateSystemReply", () => {
     const { conversationId } = await ensureSystemDM("testmind");
 
     // Register a running spirit — fan-out has already delivered the mind's DM to it,
-    // so generateSystemReply must not deliver or reply again (issue #418).
+    // so generateSystemFallbackReply must not deliver or reply again (issue #418).
     await addSpirit("volute", 4099, "claude", "/tmp/volute-spirit-test");
     await setMindRunning("volute", true);
 
-    await generateSystemReply(conversationId, "testmind", "hello volute");
+    await generateSystemFallbackReply(conversationId, "testmind", "hello volute");
 
     const db = await getDb();
     const msgs = await db


### PR DESCRIPTION
## Summary

Gates the system auto-reply so it fires **only for genuine two-party system DMs**, and adds the spirit self-reply guard from #430. Previously the trigger fired for *any* conversation with a system-user participant (`chat.ts`), so `#system` channel posts and group DMs were treated as private `@volute` DMs — producing duplicate/contradictory copies when the spirit was running, or a toolless utility-model reply posted into a shared channel when it was stopped.

The trigger decision is now a small pure, exported helper `shouldGenerateSystemFallback()` in `system-chat.ts`:

- fires only when `conv.type === "dm"`, exactly 2 participants, one of whom is the system user (plus the existing mind-sender + non-empty-message checks);
- **never fires when the reply target is the spirit** (which shares the system user) — this closes the infinite self-reply loop that #429 would otherwise open;
- channels and group DMs are left to fan-out to the running spirit (correctly labeled), so the utility fallback stays DM-only.

Also renames `generateSystemReply` → `generateSystemFallbackReply` now that it's fallback-only (post-#418).

**This PR also carries the #489 changes** ("route the spirit's sends through the mind-sender path"), which were merged into this branch during the stack collapse and never reached main: the spirit's sends now classify as mind-sender (`senderIsMind` includes a system principal whose username is a registered mind), get escape-fixing and `mind_history` outbound recording, and `resolveMindDir` replaces `mindDir` for config lookup. The self-reply guard here is exactly what keeps that change loop-free — #489's test "does not trigger a system self-reply loop on the spirit's own send" exercises it end to end.

## Test plan

- `npm test` targeted at `shouldGenerateSystemFallback`, `generateSystemFallbackReply`, and the spirit-sender suites — all pass (1832 total, 0 fail); full `tsc --noEmit` clean.
- New unit tests for `shouldGenerateSystemFallback`: two-party system DM triggers; channel with system participant does not; group DM does not; **spirit-as-target does not (self-reply loop guard)**; non-mind sender / empty message do not; DM without a system participant does not.
- `test/chat-spirit-sender.test.ts` (#489): outbound recording, escape fix, and the no-self-reply-loop case via POST /api/v1/chat.
- Existing fallback tests (no AI model; skip when spirit running) still pass under the new name.

## Notes

Originally stacked on #478 (`fix/418-spirit-double-delivery`), which has since been squash-merged — this branch was rebased onto main, dropping the duplicated #418 commit. Per the #429 sequencing note, #430 lands before #429 so the self-reply guard exists before the spirit starts replying to system messages.

Closes #430


🤖 Generated with [Claude Code](https://claude.com/claude-code)
