### PR TITLE
fix: chown mind dir after all creation-time writes under user isolation

### DIFF
--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -922,9 +922,6 @@ const app = new Hono<AuthEnv>()
           "Git setup failed — variants and upgrades won't be available until git is initialized.";
       }
 
-      // Fix ownership after root git/file operations
-      await chownMindDir(dest, name);
-
       if (body.stage === "seed") {
         // Write orientation SOUL.md
         const descLine = body.description
@@ -1000,6 +997,11 @@ const app = new Hono<AuthEnv>()
           writeFileSync(resolve(dest, "home/MEMORY.md"), customMemory);
         }
       }
+
+      // Fix ownership after all root git/file operations (git objects, skill
+      // installs, and SOUL.md/MEMORY.md writes above must end up mind-owned so
+      // the mind can modify its own identity files under user isolation)
+      await chownMindDir(dest, name);
 
       // Auto-publish public key to volute.systems (non-blocking)
       publishPublicKey(name, publicKeyPem).catch((err: unknown) =>

--- a/test/docker-e2e.sh
+++ b/test/docker-e2e.sh
@@ -204,6 +204,20 @@ assert_eq "$alice_owner" "mind-alice" "/minds/alice owned by mind-alice"
 bob_owner=$(docker exec "$CONTAINER" stat -c '%U' /minds/bob)
 assert_eq "$bob_owner" "mind-bob" "/minds/bob owned by mind-bob"
 
+# Creation-time writes (skills, SOUL.md/MEMORY.md, git objects) must also be
+# handed to the mind, not just the top-level dir — the chown has to run AFTER
+# all of them. Any root-owned path here means a creation-time write escaped the
+# ownership fixup and the mind can't modify its own files.
+alice_root_owned=$(docker exec "$CONTAINER" find /minds/alice -user root -print -quit 2>/dev/null)
+if [[ -z "$alice_root_owned" ]]; then
+  pass "no root-owned files under /minds/alice"
+else
+  fail "root-owned file under /minds/alice: $alice_root_owned"
+fi
+
+alice_skills_owner=$(docker exec "$CONTAINER" stat -c '%U' /minds/alice/home/.claude/skills 2>/dev/null || echo missing)
+assert_eq "$alice_skills_owner" "mind-alice" "/minds/alice skills dir owned by mind-alice"
+
 # ─── Phase 5: Start minds ────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

The `POST /` mind-creation flow in `packages/daemon/src/web/api/minds.ts` called `chownMindDir(...)` immediately after git setup but **before** its seed `SOUL.md` write, its skill-install loop, and its custom `SOUL.md`/`MEMORY.md` writes. Under per-mind user isolation (`VOLUTE_ISOLATION=user`, i.e. Docker/system installs) those later-written files landed owned by root, so the mind — running as its own unprivileged OS user — could neither modify nor remove its own skills, and could not edit its own identity files. Its next auto-commit would also hit `EACCES` on the root-owned git objects.

This moves the post-git `chownMindDir` to **after all creation-time file writes**, matching the archive-restore and import flows in the same file, which already chown last. The early chown before `npmInstallAsMind` is kept — npm runs as the mind user and needs the directory handed over first. The change is a no-op when isolation is disabled.

This is the "likely sibling gap" flagged in PR #483, which fixed the post-creation skill routes in `mind-skills.ts`. This PR is complementary and touches `minds.ts` and `test/docker-e2e.sh` only.

I also checked the seed path (handled inline in the same `POST /` flow via `body.stage === "seed"`) — its seed `SOUL.md` write and `SEED_SKILLS` install both happen inside this flow, so the single moved chown covers them too. The archive-restore and OpenClaw-import flows were already correct (they chown after all writes).

## Test plan

- Full suite: `npm test` → 1777 pass / 0 fail.
- `npx tsc --noEmit` and `biome check` clean.
- `bash -n test/docker-e2e.sh` clean.
- Added a docker-e2e Phase 4 assertion: no root-owned files remain anywhere under the created mind dir, and its skills dir is owned by the mind user. The top-level dir was already mind-owned even with the bug (it was chowned before the later writes), so the new recursive check is what actually catches the regression. Real ownership under isolation is exercised by `test/docker-e2e.sh` Phase 4.

A unit test mirroring PR #483's chown-failure pattern isn't feasible for this flow: the create route's *first* `chownMindDir` (before `npmInstallAsMind`) would already fail under `VOLUTE_ISOLATION=user` when the `mind-<name>` OS user is absent, so the request aborts before reaching the moved chown — a failure-based observable can't isolate the ordering fix. The docker-e2e assertion, which runs with real mind users present, is the practical coverage.

Refs #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)