### PR TITLE
fix: clean up ephemeral session state and per-message listeners

### DIFF
--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -1192,6 +1192,12 @@ export class DeliveryManager {
       if (buffer && buffer.messages.length > 0) {
         // Session idle + messages buffered → flush after debounce
         this.scheduleBatchTimers(mind, session, bufferKey);
+      } else if (session.startsWith("new-")) {
+        // Ephemeral $new sessions get a unique name per message and never recur,
+        // so their state would accumulate forever. Reclaim it once idle. Long-lived
+        // named sessions keep their entry (bounded by routing config).
+        mindSessions.delete(session);
+        if (mindSessions.size === 0) this.sessionStates.delete(mind);
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,9 +50,9 @@ export type VoluteEvent = { messageId?: string } & (
 
 export type Listener = (event: VoluteEvent) => void;
 
-/** A handler that processes a single routed message and emits events to a listener callback. */
+/** A handler that processes a single routed message and emits events to an optional listener callback. */
 export type MessageHandler = {
-  handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener): () => void; // returns unsubscribe
+  handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener): () => void; // returns unsubscribe
 };
 
 /** Resolves a key (session name, file path, etc.) to a MessageHandler. */

--- a/templates/_base/src/lib/file-handler.ts
+++ b/templates/_base/src/lib/file-handler.ts
@@ -25,11 +25,11 @@ export function createFileHandlerResolver(cwd: string): HandlerResolver {
   const resolvedCwd = resolve(cwd);
 
   return (filePath: string): MessageHandler => ({
-    handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener): () => void {
+    handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener): () => void {
       const resolved = resolve(resolvedCwd, filePath);
       if (!resolved.startsWith(`${resolvedCwd}/`) && resolved !== resolvedCwd) {
         log("file", `rejected path traversal: ${filePath}`);
-        queueMicrotask(() => listener({ type: "done", messageId: meta.messageId }));
+        queueMicrotask(() => listener?.({ type: "done", messageId: meta.messageId }));
         return () => {};
       }
 
@@ -44,7 +44,7 @@ export function createFileHandlerResolver(cwd: string): HandlerResolver {
         }
       }
       // Emit done asynchronously so unsubscribe is assigned before listener fires
-      queueMicrotask(() => listener({ type: "done", messageId: meta.messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId: meta.messageId }));
       return () => {};
     },
   });

--- a/templates/_base/src/lib/router.ts
+++ b/templates/_base/src/lib/router.ts
@@ -191,7 +191,11 @@ export function createRouter(options: {
     instructions: string | undefined,
     sessionName: string,
   ): VoluteContentPart[] {
-    if (!instructions || instructedSessions.has(sessionName)) return content;
+    if (!instructions) return content;
+    // Ephemeral $new sessions get a unique name dispatched exactly once, so we
+    // always prepend and never track them — tracking would leak an entry per message.
+    if (sessionName.startsWith("new-")) return prependInstructions(content, instructions);
+    if (instructedSessions.has(sessionName)) return content;
     instructedSessions.add(sessionName);
     return prependInstructions(content, instructions);
   }
@@ -256,9 +260,9 @@ export function createRouter(options: {
     const messageId = generateMessageId();
     const handler = options.mindHandler(buffer.sessionName);
 
-    // Batch flushes are fire-and-forget — no HTTP response is waiting, so listener is a noop
+    // Batch flushes are fire-and-forget — no HTTP response is waiting, so no listener
     try {
-      handler.handle(content, { sessionName: buffer.sessionName, messageId }, () => {});
+      handler.handle(content, { sessionName: buffer.sessionName, messageId });
     } catch (err) {
       log("router", `error flushing batch for session ${buffer.sessionName}:`, err);
       return;
@@ -301,8 +305,6 @@ export function createRouter(options: {
     listener?: Listener,
   ): { messageId: string; unsubscribe: () => void } {
     const messageId = generateMessageId();
-    const noop = () => {};
-    const safeListener = listener ?? noop;
 
     // Expose session to child processes (daemon-client reads this for X-Volute-Session)
     process.env.VOLUTE_SESSION = session;
@@ -342,7 +344,7 @@ export function createRouter(options: {
         interrupt,
         replyInstructions: sessionConfig.replyInstructions,
       },
-      safeListener,
+      listener,
     );
     return { messageId, unsubscribe };
   }
@@ -368,7 +370,6 @@ export function createRouter(options: {
 
     const messageId = generateMessageId();
     const noop = () => {};
-    const safeListener = listener ?? noop;
 
     // Gate unmatched channels (default: gate unless explicitly disabled)
     if (!resolved.matched && config.gateUnmatched !== false) {
@@ -380,7 +381,7 @@ export function createRouter(options: {
       if (options.fileHandler) {
         const formatted = applyPrefix(content, meta);
         const fileHandler = options.fileHandler(filePath);
-        fileHandler.handle(formatted, { ...meta, messageId }, noop);
+        fileHandler.handle(formatted, { ...meta, messageId });
       }
 
       // First message from this channel — send invite notification
@@ -389,18 +390,14 @@ export function createRouter(options: {
         const notification = formatInviteNotification(meta, filePath, text);
         const notifContent: VoluteContentPart[] = [{ type: "text", text: notification }];
         const handler = options.mindHandler("main");
-        handler.handle(
-          notifContent,
-          {
-            sessionName: "main",
-            messageId: generateMessageId(),
-            interrupt: true,
-          },
-          noop,
-        );
+        handler.handle(notifContent, {
+          sessionName: "main",
+          messageId: generateMessageId(),
+          interrupt: true,
+        });
       }
 
-      queueMicrotask(() => safeListener({ type: "done", messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId }));
       return { messageId, unsubscribe: noop };
     }
 
@@ -411,7 +408,7 @@ export function createRouter(options: {
         const escaped = mindName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const pattern = new RegExp(`\\b${escaped}\\b`, "i");
         if (!pattern.test(text)) {
-          queueMicrotask(() => safeListener({ type: "done", messageId }));
+          queueMicrotask(() => listener?.({ type: "done", messageId }));
           return { messageId, unsubscribe: noop };
         }
       } else {
@@ -424,12 +421,12 @@ export function createRouter(options: {
       if (options.fileHandler) {
         const formatted = applyPrefix(content, meta);
         const handler = options.fileHandler(resolved.path);
-        const unsubscribe = handler.handle(formatted, { ...meta, messageId }, safeListener);
+        const unsubscribe = handler.handle(formatted, { ...meta, messageId }, listener);
         return { messageId, unsubscribe };
       }
       // No file handler configured — emit done and discard
       log("router", `no file handler configured — discarding file-destined message`);
-      queueMicrotask(() => safeListener({ type: "done", messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId }));
       return { messageId, unsubscribe: noop };
     }
 
@@ -473,7 +470,7 @@ export function createRouter(options: {
         scheduleBatchTimers(batchKey);
       }
 
-      queueMicrotask(() => safeListener({ type: "done", messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId }));
       return { messageId, unsubscribe: noop };
     }
 
@@ -495,7 +492,7 @@ export function createRouter(options: {
         interrupt: sessionConfig.interrupt,
         replyInstructions: sessionConfig.replyInstructions,
       },
-      safeListener,
+      listener,
     );
     return { messageId, unsubscribe };
   }
@@ -562,10 +559,9 @@ export function createRouter(options: {
 
     const messageId = generateMessageId();
     const handler = options.mindHandler(session);
-    const noop = () => {};
 
     try {
-      handler.handle(withInstructions, { sessionName: session, messageId }, noop);
+      handler.handle(withInstructions, { sessionName: session, messageId });
       log("router", `dispatched batch for session ${session}: ${allMessages.length} messages`);
     } catch (err) {
       log("router", `error dispatching batch for session ${session}:`, err);

--- a/templates/_base/src/lib/types.ts
+++ b/templates/_base/src/lib/types.ts
@@ -50,9 +50,9 @@ export type VoluteEvent = { messageId?: string } & (
 
 export type Listener = (event: VoluteEvent) => void;
 
-/** A handler that processes a single routed message and emits events to a listener callback. */
+/** A handler that processes a single routed message and emits events to an optional listener callback. */
 export type MessageHandler = {
-  handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener): () => void; // returns unsubscribe
+  handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener): () => void; // returns unsubscribe
 };
 
 /** Resolves a key (session name, file path, etc.) to a MessageHandler. */

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -478,16 +478,20 @@ export function createMind(options: {
             log("mind", `session "${session.name}": stream consumer error:`, retryErr);
             await emitError(retryErr);
             emitDone();
-            sessions.delete(session.name);
           }
         } else {
           log("mind", `session "${session.name}": stream consumer error:`, err);
           await emitError(err);
           emitDone();
-          sessions.delete(session.name);
         }
+      } finally {
+        // The stream consumer has ended (subprocess exit, error, or fresh-start
+        // abandonment) — drop the session so the sessions map doesn't retain dead
+        // entries. Matters most for ephemeral $new sessions once the idle reaper
+        // (#458) kills their subprocess, but also for any named session that ends.
+        sessions.delete(session.name);
+        log("mind", `session "${session.name}": stream consumer ended`);
       }
-      log("mind", `session "${session.name}": stream consumer ended`);
     })();
   }
 
@@ -530,14 +534,26 @@ export function createMind(options: {
 
   function createSessionHandler(sessionName: string): MessageHandler {
     return {
-      handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener): () => void {
+      handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener): () => void {
         const session = getOrCreateSession(sessionName);
 
-        // Filter listener to only receive events for this messageId
-        const filteredListener: Listener = (event) => {
-          if (event.messageId === meta.messageId) listener(event);
-        };
-        session.listeners.add(filteredListener);
+        // Only register a listener when a caller actually wants events. A per-message
+        // listener that's never removed would grow session.listeners without bound and
+        // make broadcastToSession O(messages-ever-received). The live dispatch path
+        // passes no listener, so this is usually a no-op.
+        let filteredListener: Listener | undefined;
+        if (listener) {
+          // Filter to only this messageId, and self-remove on the matching done so a
+          // caller that forgets to unsubscribe can't reintroduce the leak.
+          filteredListener = (event) => {
+            if (event.messageId !== meta.messageId) return;
+            listener(event);
+            if (event.type === "done" && filteredListener) {
+              session.listeners.delete(filteredListener);
+            }
+          };
+          session.listeners.add(filteredListener);
+        }
 
         // Track channel/sender for reply instructions
         if (meta.channel) {
@@ -567,7 +583,9 @@ export function createMind(options: {
           parent_tool_use_id: null,
         });
 
-        return () => session.listeners.delete(filteredListener);
+        return () => {
+          if (filteredListener) session.listeners.delete(filteredListener);
+        };
       },
     };
   }

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -558,13 +558,23 @@ export function createMind(options: {
 
   function createSessionHandler(sessionName: string): MessageHandler {
     return {
-      handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener): () => void {
+      handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener): () => void {
         const session = getOrCreateSession(sessionName);
 
-        const filteredListener: Listener = (event) => {
-          if (event.messageId === meta.messageId) listener(event);
-        };
-        session.listeners.add(filteredListener);
+        // Only register a listener when a caller wants events. A per-message listener
+        // that's never removed grows session.listeners without bound and makes broadcast
+        // O(messages-ever-received). The live dispatch path passes no listener.
+        let filteredListener: Listener | undefined;
+        if (listener) {
+          filteredListener = (event) => {
+            if (event.messageId !== meta.messageId) return;
+            listener(event);
+            if (event.type === "done" && filteredListener) {
+              session.listeners.delete(filteredListener);
+            }
+          };
+          session.listeners.add(filteredListener);
+        }
 
         // Track channel for reply instructions
         if (meta.channel) {
@@ -586,7 +596,9 @@ export function createMind(options: {
           broadcast(session, { type: "done" });
         });
 
-        return () => session.listeners.delete(filteredListener);
+        return () => {
+          if (filteredListener) session.listeners.delete(filteredListener);
+        };
       },
     };
   }

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -447,14 +447,23 @@ export function createMind(options: {
 
   function createSessionHandler(sessionName: string): MessageHandler {
     return {
-      handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener): () => void {
+      handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener): () => void {
         const session = getOrCreateSession(sessionName);
 
-        // Filter listener to only receive events for this messageId
-        const filteredListener: Listener = (event) => {
-          if (event.messageId === meta.messageId) listener(event);
-        };
-        session.listeners.add(filteredListener);
+        // Only register a listener when a caller wants events. A per-message listener
+        // that's never removed grows session.listeners without bound and makes broadcast
+        // O(messages-ever-received). The live dispatch path passes no listener.
+        let filteredListener: Listener | undefined;
+        if (listener) {
+          filteredListener = (event) => {
+            if (event.messageId !== meta.messageId) return;
+            listener(event);
+            if (event.type === "done" && filteredListener) {
+              session.listeners.delete(filteredListener);
+            }
+          };
+          session.listeners.add(filteredListener);
+        }
 
         // Track channel for reply instructions
         if (meta.channel) {
@@ -500,7 +509,9 @@ export function createMind(options: {
           broadcast(session, { type: "done" });
         });
 
-        return () => session.listeners.delete(filteredListener);
+        return () => {
+          if (filteredListener) session.listeners.delete(filteredListener);
+        };
       },
     };
   }

--- a/test/delivery-manager.test.ts
+++ b/test/delivery-manager.test.ts
@@ -228,6 +228,46 @@ describe("DeliveryManager", () => {
       manager = new DeliveryManager();
       assert.equal(manager.clearSessionActive("nope", "main", 10 * 60_000), false);
     });
+
+    function seedActiveSession(mgr: DeliveryManager, mind: string, session: string) {
+      const states = (mgr as any).sessionStates as Map<string, Map<string, any>>;
+      let mindSessions = states.get(mind);
+      if (!mindSessions) {
+        mindSessions = new Map();
+        states.set(mind, mindSessions);
+      }
+      mindSessions.set(session, {
+        activeCount: 1,
+        lastDeliveredAt: Date.now(),
+        lastDeliverySenders: new Set<string>(),
+        lastDeliveryChannels: new Set<string>(),
+        seenChannelProfiles: new Set<string>(),
+      });
+      return states;
+    }
+
+    it("reclaims ephemeral new-* session state when it goes idle", () => {
+      manager = new DeliveryManager();
+      const states = seedActiveSession(manager, "emind", "new-123-abc");
+      assert.equal(manager.isSessionBusy("emind", "new-123-abc"), true);
+
+      // Turn completes → decrementActive drops the ephemeral entry (and empties the mind map).
+      manager.sessionDone("emind", "new-123-abc");
+
+      assert.equal(manager.isSessionBusy("emind", "new-123-abc"), false);
+      assert.equal(states.has("emind"), false, "empty mind map should be removed too");
+    });
+
+    it("retains named session state when it goes idle", () => {
+      manager = new DeliveryManager();
+      const states = seedActiveSession(manager, "nmind", "main");
+
+      manager.sessionDone("nmind", "main");
+
+      // Long-lived named sessions keep their entry (bounded by routing config).
+      assert.ok(states.get("nmind")?.has("main"), "named session entry should be retained");
+      assert.equal(manager.isSessionBusy("nmind", "main"), false);
+    });
   });
 
   describe("new-speaker no longer interrupts (buffers instead)", () => {

--- a/test/router-invite.test.ts
+++ b/test/router-invite.test.ts
@@ -16,21 +16,21 @@ function createTestHandlers() {
   const fileCalls = new Map<string, HandlerCall[]>();
 
   const mindHandler = (session: string) => ({
-    handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener) {
+    handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener) {
       const calls = mindCalls.get(session) ?? [];
       calls.push({ content, meta });
       mindCalls.set(session, calls);
-      queueMicrotask(() => listener({ type: "done", messageId: meta.messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId: meta.messageId }));
       return () => {};
     },
   });
 
   const fileHandler = (path: string) => ({
-    handle(content: VoluteContentPart[], meta: HandlerMeta, listener: Listener) {
+    handle(content: VoluteContentPart[], meta: HandlerMeta, listener?: Listener) {
       const calls = fileCalls.get(path) ?? [];
       calls.push({ content, meta });
       fileCalls.set(path, calls);
-      queueMicrotask(() => listener({ type: "done", messageId: meta.messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId: meta.messageId }));
       return () => {};
     },
   });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -15,14 +15,24 @@ import type {
 
 function mockMindHandler(): {
   resolver: HandlerResolver;
-  calls: { sessionName: string; content: VoluteContentPart[]; meta: HandlerMeta }[];
+  calls: {
+    sessionName: string;
+    content: VoluteContentPart[];
+    meta: HandlerMeta;
+    hadListener: boolean;
+  }[];
 } {
-  const calls: { sessionName: string; content: VoluteContentPart[]; meta: HandlerMeta }[] = [];
+  const calls: {
+    sessionName: string;
+    content: VoluteContentPart[];
+    meta: HandlerMeta;
+    hadListener: boolean;
+  }[] = [];
   const resolver: HandlerResolver = (sessionName: string): MessageHandler => ({
     handle(content, meta, listener) {
-      calls.push({ sessionName, content, meta });
+      calls.push({ sessionName, content, meta, hadListener: listener !== undefined });
       // Emit done async
-      queueMicrotask(() => listener({ type: "done", messageId: meta.messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId: meta.messageId }));
       return () => {};
     },
   });
@@ -37,7 +47,7 @@ function mockFileHandler(): {
   const resolver: HandlerResolver = (path: string): MessageHandler => ({
     handle(content, meta, listener) {
       calls.push({ path, content });
-      queueMicrotask(() => listener({ type: "done", messageId: meta.messageId }));
+      queueMicrotask(() => listener?.({ type: "done", messageId: meta.messageId }));
       return () => {};
     },
   });
@@ -650,6 +660,76 @@ describe("router", () => {
     } finally {
       if (oldEnv === undefined) delete process.env.VOLUTE_MIND;
       else process.env.VOLUTE_MIND = oldEnv;
+    }
+  });
+
+  // --- Listener plumbing (leak avoidance, #459) ---
+
+  it("passes no listener to the handler when dispatched fire-and-forget", async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, "routes.json");
+    writeFileSync(configPath, JSON.stringify({ rules: [{ channel: "web", session: "main" }] }));
+
+    const mind = mockMindHandler();
+    const router = createRouter({ configPath, mindHandler: mind.resolver });
+
+    // dispatch() is the live path (daemon pre-routes) and passes no listener.
+    router.dispatch([{ type: "text", text: "hi" }], "main", { channel: "web" });
+
+    assert.equal(mind.calls.length, 1);
+    assert.equal(
+      mind.calls[0].hadListener,
+      false,
+      "handler must receive undefined (not a noop) so it won't register a per-message listener",
+    );
+  });
+
+  it("passes the listener through when one is provided", async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, "routes.json");
+    writeFileSync(configPath, JSON.stringify({ rules: [{ channel: "web", session: "main" }] }));
+
+    const mind = mockMindHandler();
+    const router = createRouter({ configPath, mindHandler: mind.resolver });
+
+    await waitForDone(router, [{ type: "text", text: "hi" }], { channel: "web" });
+
+    assert.equal(mind.calls.length, 1);
+    assert.equal(mind.calls[0].hadListener, true);
+  });
+
+  // --- Ephemeral $new instructions (leak avoidance, #463) ---
+
+  it("prepends instructions on every ephemeral $new dispatch (no per-session tracking)", async () => {
+    const dir = makeTempDir();
+    const configPath = join(dir, "routes.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        rules: [{ channel: "system:*", session: "$new" }],
+        sessions: { "new-*": { instructions: "Be brief." } },
+      }),
+    );
+
+    const mind = mockMindHandler();
+    const router = createRouter({ configPath, mindHandler: mind.resolver });
+
+    // Each $new message gets a unique session name and is dispatched exactly once, so
+    // instructions are always prepended and never tracked (which would leak an entry
+    // per message in instructedSessions).
+    await waitForDone(router, [{ type: "text", text: "a" }], { channel: "system:scheduler" });
+    await waitForDone(router, [{ type: "text", text: "b" }], { channel: "system:scheduler" });
+
+    assert.equal(mind.calls.length, 2);
+    for (const call of mind.calls) {
+      const text = call.content
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("");
+      assert.ok(
+        text.includes("[Session instructions: Be brief.]"),
+        "every ephemeral dispatch should carry instructions",
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes two memory leaks found in the July 2026 memory audit, both in the mind template server + daemon delivery path. (#458's idle-session reaper is a separate follow-up — this PR only stops the unbounded growth.)

**#463 — ephemeral `$new` session state accumulated forever.** `$new` routes expand to a unique `new-<ts>-<rand>` name per message; three structures gained an entry per ephemeral session and never released it:
- `templates/claude/src/agent.ts` — the mind's `sessions` map now deletes the session on *every* stream-consumer exit path (via a `finally`), not just on error.
- `templates/_base/src/lib/router.ts` — `instructedSessions` is no longer populated for `new-*` names. Each ephemeral name is dispatched exactly once, so always-prepending instructions is behavior-identical and needs no memory.
- `packages/daemon/src/lib/delivery/delivery-manager.ts` — `decrementActive` reclaims a `new-*` session's state once it goes idle (and drops the mind's inner map when it empties). Long-lived named sessions keep their entry (bounded by routing config).

**#459 — the mind server registered a listener per inbound message and never removed it.** `session.listeners` grew by one closure per message forever, and `broadcastToSession` iterates the whole set on every SDK event (O(messages-ever-received) CPU).
- `MessageHandler.handle`'s `listener` is now optional end-to-end (`src/types.ts` + `templates/_base/src/lib/types.ts`, `file-handler.ts`); the router passes `undefined` through instead of substituting a noop.
- The claude/codex/pi agent handlers only construct and register a `filteredListener` when a listener is actually provided, and self-remove it on the matching `done` as defense in depth. The live dispatch path passes no listener, so the common case now registers nothing.

## Test plan
- Added router unit tests: fire-and-forget dispatch passes no listener to the handler; a provided listener is passed through; ephemeral `$new` dispatches always carry instructions (no per-session tracking).
- Added delivery-manager unit tests: a `new-*` session's state is reclaimed when it goes idle; a named session's state is retained.
- Full suite green (1780/1780, 0 failures). Template typechecks (claude/pi/codex) pass via pre-commit hooks.

Closes #463
Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)