### PR TITLE
fix: recover pages repo from interrupted git init

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,7 @@ main() {
   install_ripgrep
 
   # Set system-wide git identity for daemon commits if not already configured
-  if ! git config --system user.name >/dev/null 2>&1; then
+  if ! git config --system user.name >/dev/null 2>&1 || ! git config --system user.email >/dev/null 2>&1; then
     git config --system user.name "Volute" && \
     git config --system user.email "volute@localhost" || \
       echo "Warning: failed to set system git config — git commits may fail."

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -15,6 +15,11 @@ import {
 const assetsDir = resolve(import.meta.dirname, "../dist/ui");
 const skillsDir = resolve(import.meta.dirname, "../skills");
 
+// Resolves once the collaborative pages repo has been initialized by
+// onDaemonStart. onMindStart awaits it so worktree-add never races ahead of
+// init (which could shell into a half-built repo or collide with its rmSync).
+let repoReady: Promise<void> | null = null;
+
 export default createExtension({
   id: "pages",
   name: "Pages",
@@ -44,7 +49,8 @@ export default createExtension({
   },
 
   onDaemonStart(ctx) {
-    ensurePagesRepo(ctx.dataDir, isolationFrom(ctx))
+    repoReady = ensurePagesRepo(ctx.dataDir, isolationFrom(ctx));
+    repoReady
       .then(() => {
         // Sync system pages from the repo to the DB so they appear in the UI.
         // Run even when the repo is empty so stale DB rows are removed.
@@ -65,8 +71,15 @@ export default createExtension({
   onMindStart(mindName, ctx) {
     const mindDir = ctx.getMindDir(mindName);
     if (!mindDir) return;
-    addPagesWorktree(mindName, mindDir, ctx.dataDir, isolationFrom(ctx)).catch((err) => {
-      console.error(`[pages] failed to add pages worktree for ${mindName}:`, err);
-    });
+    // Wait for repo init; its failures are already logged in onDaemonStart, and
+    // addPagesWorktree self-skips if the repo is still unusable.
+    (repoReady ?? Promise.resolve())
+      .catch(() => {})
+      .then(() => addPagesWorktree(mindName, mindDir, ctx.dataDir, isolationFrom(ctx)))
+      .catch((err) => {
+        console.warn(
+          `[pages] failed to add pages worktree for ${mindName}: ${(err as Error).message}`,
+        );
+      });
   },
 });

--- a/packages/extensions/pages/src/shared-pages.ts
+++ b/packages/extensions/pages/src/shared-pages.ts
@@ -42,13 +42,27 @@ function execAsync(cmd: string, args: string[]): Promise<void> {
   });
 }
 
-/** Run a git command. Adds safe.directory when isolation is enabled. */
+/**
+ * Committer identity for pages commits. `--author` on the commit calls sets the
+ * author but not the committer, so without this a host lacking a global git
+ * identity fails at the commit step (leaving a partial repo). Setting it per
+ * invocation keeps commits independent of host git config.
+ */
+const IDENTITY_ARGS = ["-c", "user.name=volute", "-c", "user.email=volute@localhost"];
+
+/**
+ * Run a git command. Adds safe.directory when isolation is enabled, and a
+ * committer identity for `commit` so commits never depend on host git config.
+ */
 function gitExec(
   args: string[],
   opts: { cwd: string },
   isolation?: IsolationInfo,
 ): Promise<string> {
-  const fullArgs = isolation?.isIsolationEnabled() ? ["-c", "safe.directory=*", ...args] : args;
+  const prefix: string[] = [];
+  if (isolation?.isIsolationEnabled()) prefix.push("-c", "safe.directory=*");
+  if (args[0] === "commit") prefix.push(...IDENTITY_ARGS);
+  const fullArgs = prefix.length ? [...prefix, ...args] : args;
   return new Promise((resolve, reject) => {
     execFileCb("git", fullArgs, { cwd: opts.cwd }, (err, stdout, stderr) => {
       if (err) {
@@ -100,24 +114,33 @@ export function pagesIsolationChownPaths(mindDir: string, wtGitDir: string | nul
   return paths;
 }
 
+/**
+ * Whether `dir` is a usable pages repo: a valid git repository with at least one
+ * commit on HEAD. A husk `.git` left by an interrupted init (e.g. only a
+ * `branches/` subdir), or a valid-but-commitless repo, both fail this probe.
+ */
+async function isRepoValid(dir: string, isolation?: IsolationInfo): Promise<boolean> {
+  try {
+    await gitExec(["rev-parse", "HEAD"], { cwd: dir }, isolation);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Idempotently initialize the collaborative pages git repo. */
 export async function ensurePagesRepo(dataDir: string, isolation?: IsolationInfo): Promise<void> {
   const dir = pagesRepoDir(dataDir);
   mkdirSync(dir, { recursive: true });
 
   if (existsSync(resolve(dir, ".git"))) {
-    try {
-      await gitExec(["rev-parse", "HEAD"], { cwd: dir }, isolation);
-      return;
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("unknown revision") || msg.includes("bad default revision")) {
-        console.warn("[pages] repo has no commits, re-initializing");
-        rmSync(resolve(dir, ".git"), { recursive: true, force: true });
-      } else {
-        throw err;
-      }
-    }
+    if (await isRepoValid(dir, isolation)) return;
+    // Any invalid or incomplete state — a husk .git from an interrupted init, or
+    // a repo with no commits — is wiped and re-initialized. The repo's content
+    // is regenerable (it's synced from minds' pages), so aggressive re-init is
+    // safe, and it self-heals boxes stuck with a broken repo on next daemon start.
+    console.warn("[pages] repo invalid or incomplete, re-initializing");
+    rmSync(resolve(dir, ".git"), { recursive: true, force: true });
   }
 
   const isIso = isolation?.isIsolationEnabled() ?? false;
@@ -147,7 +170,12 @@ export async function addPagesWorktree(
   isolation?: IsolationInfo,
 ): Promise<void> {
   const dir = pagesRepoDir(dataDir);
-  if (!existsSync(resolve(dir, ".git"))) return;
+  // Never shell into a broken repo: skip quietly and let ensurePagesRepo repair
+  // it on the next daemon start rather than failing every mind start noisily.
+  if (!(await isRepoValid(dir, isolation))) {
+    console.warn(`[pages] repo not usable, skipping worktree for ${mindName}`);
+    return;
+  }
 
   const wt = worktreePath(mindDir);
   if (existsSync(wt)) return;

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -68,6 +68,49 @@ describe("pages collaborative repo", () => {
     assert.ok(existsSync(resolve(pagesRepoDir(dataDir), ".git")));
   });
 
+  it("ensurePagesRepo repairs a husk .git left by an interrupted init", async () => {
+    // Simulate the state a killed `git init` leaves behind: a .git dir with only
+    // a branches/ subdir, no HEAD/config/objects (the bardo failure mode).
+    const repoDir = pagesRepoDir(dataDir);
+    mkdirSync(resolve(repoDir, ".git", "branches"), { recursive: true });
+
+    // Before repair, the husk is not a usable repo.
+    await assert.rejects(gitExec(["rev-parse", "HEAD"], { cwd: repoDir }));
+
+    // ensurePagesRepo should wipe the husk and re-initialize.
+    await ensurePagesRepo(dataDir);
+    await gitExec(["rev-parse", "HEAD"], { cwd: repoDir });
+
+    // And a worktree can now be added on the repaired repo.
+    const mindDir = await createFakeMind("test-pages-husk");
+    await addPagesWorktree("test-pages-husk", mindDir, dataDir);
+    assert.ok(existsSync(resolve(mindDir, "home", "pages", "_system")));
+
+    await removePagesWorktree("test-pages-husk", mindDir, dataDir);
+  });
+
+  it("addPagesWorktree skips (no throw) when the repo is a husk", async () => {
+    // A husk repo that ensurePagesRepo hasn't repaired yet: worktree-add must
+    // not shell into it and must not throw — it leaves repair for next startup.
+    const repoDir = pagesRepoDir(dataDir);
+    mkdirSync(resolve(repoDir, ".git", "branches"), { recursive: true });
+
+    const mindDir = await createFakeMind("test-pages-husk-skip");
+    await addPagesWorktree("test-pages-husk-skip", mindDir, dataDir);
+    assert.ok(!existsSync(resolve(mindDir, "home", "pages", "_system")));
+  });
+
+  it("ensurePagesRepo commits with its own identity, independent of host config", async () => {
+    await ensurePagesRepo(dataDir);
+    const repoDir = pagesRepoDir(dataDir);
+    // The init commit's committer must be the built-in identity, not whatever
+    // (if anything) the host's global git config provides.
+    const committer = (
+      await gitExec(["log", "-1", "--format=%cn <%ce>", "main"], { cwd: repoDir })
+    ).trim();
+    assert.equal(committer, "volute <volute@localhost>");
+  });
+
   it("addPagesWorktree creates worktree on mind-named branch", async () => {
     await ensurePagesRepo(dataDir);
     const mindDir = await createFakeMind("test-pages-add");


### PR DESCRIPTION
## Summary

An interrupted `git init` left the shared pages repo as a husk `.git` (on bardo, a `.git` containing only `branches/` since March). The guards trusted `existsSync(.git)` and recovery only matched "no commits" errors, so a structurally corrupt repo was **never repaired and never re-initialized** — `git worktree add` failed on every mind start, forever, silently (per-mind pages still worked, masking it). This folds in the duplicate #426.

Changes in `packages/extensions/pages/`:

- **Validate, don't stat.** New `isRepoValid()` probe (`git rev-parse HEAD` succeeds) replaces both `existsSync(.git)` checks. It covers both the husk case ("not a git repository") and the empty-but-valid-repo case ("unknown revision").
- **Repair any invalid state.** `ensurePagesRepo` re-inits on *any* validation failure instead of pattern-matching two error strings. Repo content is regenerable (synced from minds' pages), so this is safe and self-heals stuck installs (like bardo) on the next daemon start.
- **Skip, don't crash.** `addPagesWorktree` returns quietly with a one-line warn when the repo isn't usable, instead of shelling into a broken repo and throwing.
- **Sequence init before worktree-add.** `onDaemonStart` stores the init promise; `onMindStart` awaits it before adding the worktree — closes the ordering gap and the `rmSync(.git)` race.
- **Identity-independent commits.** `gitExec` now prepends `-c user.name=volute -c user.email=volute@localhost` on `commit`, so commits work without a host git identity (existing `--author` sets only the author, not the committer).
- **Quieter logs.** `onMindStart` worktree failures log `err.message` once at warn level.
- **install.sh:** its system git-identity guard now checks `user.email` too, not just `user.name`.

## Test plan

Added regression tests to `test/shared.test.ts`:
- `ensurePagesRepo` repairs a husk `.git` (only `branches/`) → `rev-parse HEAD` succeeds and a worktree can then be added.
- `addPagesWorktree` against a husk repo → no throw, no worktree left behind.
- `ensurePagesRepo` commits with the built-in committer identity (`volute <volute@localhost>`), independent of host git config.

Full suite: `npm test` → 1778/1778 pass, 0 fail. (Two earlier pre-push runs failed only on a pre-existing flaky webhook timing test under heavy multi-worktree CPU contention; the run on a quiet system passed clean.)

Closes #422
Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)