### PR TITLE
fix: route the spirit's sends through the mind-sender path

### DIFF
--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -27,7 +27,7 @@ import {
   isParticipantOrOwner,
 } from "../../../lib/events/conversations.js";
 import { publish as publishMindEvent } from "../../../lib/events/mind-events.js";
-import { findMind, getBaseName, mindDir } from "../../../lib/mind/registry.js";
+import { findMind, getBaseName, resolveMindDir } from "../../../lib/mind/registry.js";
 import { readVoluteConfig } from "../../../lib/mind/volute-config.js";
 import { fixModelEscapes } from "../../../lib/util/fix-model-escapes.js";
 import log from "../../../lib/util/logger.js";
@@ -111,9 +111,14 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
     // Resolve sender: daemon token + body.sender → override, else user.username
     const senderName = user.id === 0 && body.sender ? body.sender : user.username;
 
-    // Detect if sender is a mind
+    // Detect if sender is a mind. The spirit ("volute") authenticates with its
+    // mind token but resolves to the shared system user (user_type "system"), so
+    // classify a system principal whose username is a registered mind as a mind
+    // sender too — this matches only the spirit, never a plain system principal.
     const senderIsMind =
-      (user.id === 0 && body.sender && (await findMind(body.sender))) || user.user_type === "mind";
+      (user.id === 0 && body.sender && (await findMind(body.sender))) ||
+      user.user_type === "mind" ||
+      (user.user_type === "system" && !!(await findMind(user.username)));
 
     // Track baseName and variant-aware targetName callback for the targetMind flow
     let baseName: string | undefined;
@@ -212,7 +217,7 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
 
     // Fix common model escape errors in mind-sent messages
     if (senderIsMind) {
-      const vCfg = readVoluteConfig(mindDir(baseName ?? senderName));
+      const vCfg = readVoluteConfig(await resolveMindDir(baseName ?? senderName));
       const shouldUnescapeNewlines = vCfg?.unescapeNewlines === true;
       for (const block of contentBlocks) {
         if (block.type === "text") {

--- a/test/chat-spirit-sender.test.ts
+++ b/test/chat-spirit-sender.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { getOrCreateMindUser, getOrCreateSystemUser } from "../packages/daemon/src/lib/auth.js";
+import { resetSystemDMCache } from "../packages/daemon/src/lib/chat/system-chat.js";
+import {
+  initMindManager,
+  tryGetMindManager,
+} from "../packages/daemon/src/lib/daemon/mind-manager.js";
+import {
+  generateMindToken,
+  revokeMindToken,
+} from "../packages/daemon/src/lib/daemon/mind-tokens.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { createConversation } from "../packages/daemon/src/lib/events/conversations.js";
+import { addMind, addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  conversations,
+  messages,
+  mindHistory,
+  minds,
+  users,
+} from "../packages/daemon/src/lib/schema.js";
+import { invalidateMindUserCache } from "../packages/daemon/src/web/middleware/auth.js";
+
+const TARGET_MIND = "chat-spirit-target";
+const TEST_USERNAMES = ["volute", TARGET_MIND];
+
+let convId: string;
+
+async function cleanup() {
+  resetSystemDMCache();
+  revokeMindToken("volute");
+  const db = await getDb();
+  if (convId) {
+    await db.delete(messages).where(eq(messages.conversation_id, convId));
+    await db.delete(conversations).where(eq(conversations.id, convId));
+  }
+  await db.delete(mindHistory).where(eq(mindHistory.mind, "volute"));
+  for (const username of TEST_USERNAMES) {
+    await db.delete(users).where(eq(users.username, username));
+  }
+  await db.delete(minds).where(eq(minds.name, "volute"));
+  await db.delete(minds).where(eq(minds.name, TARGET_MIND));
+}
+
+/**
+ * Set up the spirit ("volute", which reuses the shared system user), a target
+ * mind, and a two-party DM conversation between them. Returns the spirit's mind
+ * token for authenticating a send.
+ */
+async function setupSpiritDM(): Promise<{ token: string; conversationId: string }> {
+  // fan-out (invoked by the chat handler) needs a MindManager instance.
+  if (!tryGetMindManager()) initMindManager();
+
+  const systemUser = await getOrCreateSystemUser();
+  await addSpirit("volute", 4099, "claude", "/tmp/volute-spirit-sender-test");
+
+  const targetUser = await getOrCreateMindUser(TARGET_MIND);
+  await addMind(TARGET_MIND, 4177);
+
+  // Drop any cached "volute" user from a prior test so auth resolves the freshly
+  // created system user (its id must match the conversation participant).
+  invalidateMindUserCache("volute");
+
+  const conv = await createConversation({
+    participantIds: [systemUser.id, targetUser.id],
+  });
+  convId = conv.id;
+
+  const token = generateMindToken("volute");
+  return { token, conversationId: conv.id };
+}
+
+function spiritSend(app: { request: typeof fetch }, token: string, body: unknown) {
+  return app.request("http://localhost/api/v1/chat", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Origin: "http://localhost",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  } as RequestInit);
+}
+
+describe("spirit as a mind sender via POST /api/v1/chat", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("records the spirit's outbound in its own mind_history", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "hello from the spirit",
+    });
+    assert.equal(res.status, 200);
+
+    const db = await getDb();
+    const rows = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const outbound = rows.find(
+      (r) => r.type === "outbound" && r.content?.includes("hello from the spirit"),
+    );
+    assert.ok(outbound, "spirit send should be recorded as an outbound in mind_history");
+  });
+
+  it("runs the mind-sender escape fix on the spirit's message", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    // fixModelEscapes turns "\!" into "!" for mind senders only. If the spirit
+    // were still misclassified as a non-mind sender, this fix would be skipped.
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "warning\\! done",
+    });
+    assert.equal(res.status, 200);
+
+    const db = await getDb();
+    const msgs = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversation_id, conversationId))
+      .all();
+    const send = msgs.find((m) => m.sender_name === "volute");
+    assert.ok(send, "the spirit's message should be persisted");
+    assert.ok(send!.content.includes("warning! done"), "escape fix should have run");
+    assert.ok(!send!.content.includes("warning\\! done"), "raw escape should not survive");
+  });
+
+  it("does not trigger a system self-reply loop on the spirit's own send", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "anyone there?",
+    });
+    assert.equal(res.status, 200);
+
+    // The spirit shares the system user, so the DM has a system-user participant.
+    // The self-reply guard (senderIsNotSpirit) must keep generateSystemFallbackReply
+    // from firing — otherwise the system would "reply" to the spirit as itself,
+    // and the spirit would answer forever.
+    const db = await getDb();
+    const msgs = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversation_id, conversationId))
+      .all();
+    const voluteMsgs = msgs.filter((m) => m.sender_name === "volute");
+    assert.equal(voluteMsgs.length, 1, "only the spirit's send should exist — no fallback reply");
+    assert.equal(voluteMsgs[0].role, "user", "the single volute message is the send, not a reply");
+  });
+});


### PR DESCRIPTION
## Summary

The spirit (`volute`) authenticates with its mind token but that token resolves to the shared **system user** (`user_type: "system"`), so the unified chat handler's `senderIsMind` check — which only matched `user_type === "mind"` or the daemon-token+`body.sender` branch — never classified the spirit as a mind sender. As a result the spirit's outbound messages bypassed every mind-sender code path: `recordOutbound` (no `mind_history`, timeline showed inbounds only), turn attribution + outbound SSE, `routeOutboundBridge` (never forwarded to Discord/Slack/Telegram), `fixModelEscapes`, channel `char_limit` enforcement, and the stale-send hold.

This classifies a system principal whose username is a registered mind as a mind sender — `user.user_type === "system" && !!(await findMind(user.username))` — which matches **only** the spirit, never a plain system principal. It also switches the config read for the escape fix from `mindDir()` to `resolveMindDir()`, since the spirit lives at `~/.volute/system/spirit` (registry `dir` field), not in the minds dir.

The self-reply loop stays dead: `shouldGenerateSystemFallback()` already returns `false` when the reply target is the spirit (via `isSpiritName()`), so flipping `senderIsMind` for the spirit does not cause the system to reply to the spirit's own DMs forever.

## Stack

This is the third PR in the spirit train and lands after:
- #478 (fixes #418 — mind→spirit DMs delivered exactly once)
- #484 (fixes #430 — `shouldGenerateSystemFallback` self-reply guard, which makes this change loop-safe)

Base branch: `fix/430-spirit-self-reply-guard`.

## Test plan

New `test/chat-spirit-sender.test.ts` drives `POST /api/v1/chat` authenticated with the spirit's mind token:
- **Outbound recorded** — the spirit's send lands in its own `mind_history` as an outbound (proves it now takes the mind-sender path).
- **Escape fix runs** — `\!` is normalized to `!` in the persisted message (a mind-only transform; also exercises `resolveMindDir` for the spirit's out-of-tree dir).
- **No self-reply loop** — the spirit's own send to a system-user DM produces exactly one message (the send) and no fallback reply.

Full suite (via pre-push hook): **1785 tests, 0 failures**.

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)