### PR TITLE
test: make webhook tests deterministic (fix flake)

### DIFF
--- a/packages/daemon/src/lib/webhook.ts
+++ b/packages/daemon/src/lib/webhook.ts
@@ -21,12 +21,17 @@ export function getAuthHeaders(): Record<string, string> {
   return headers;
 }
 
-export function fireWebhook(event: WebhookEvent): void {
+/**
+ * Fire-and-forget webhook delivery. Callers do not await the result; the
+ * returned promise (which always resolves, never rejects) exists so tests can
+ * deterministically wait for delivery to complete instead of sleeping.
+ */
+export function fireWebhook(event: WebhookEvent): Promise<void> {
   try {
     const url = getWebhookUrl();
-    if (!url) return;
+    if (!url) return Promise.resolve();
     const payload = { ...event, timestamp: event.timestamp ?? new Date().toISOString() };
-    fetch(url, {
+    return fetch(url, {
       method: "POST",
       headers: getAuthHeaders(),
       body: JSON.stringify(payload),
@@ -41,6 +46,7 @@ export function fireWebhook(event: WebhookEvent): void {
       });
   } catch (err) {
     slog.error(`webhook ${event.event} failed to serialize`, log.errorData(err));
+    return Promise.resolve();
   }
 }
 

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,62 +1,89 @@
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage, type Server } from "node:http";
-import { after, before, beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import { broadcast } from "../packages/daemon/src/lib/events/activity-events.js";
 import { fireWebhook, initWebhook } from "../packages/daemon/src/lib/webhook.js";
 
-describe("webhook", () => {
-  let server: Server;
-  let port: number;
+type Received = {
+  method: string;
+  body: string;
+  contentType: string | undefined;
+  authorization: string | undefined;
+};
+
+type TestServer = {
+  server: Server;
+  port: number;
+  received: Received[];
+  /** Resolves once the next request has been fully received. */
+  nextRequest: () => Promise<void>;
+  setStatusCode: (code: number) => void;
+};
+
+// Each test gets its own server + received array so an in-flight POST from a
+// previous test can never leak into another test's assertions.
+async function startServer(): Promise<TestServer> {
+  const received: Received[] = [];
   let statusCode = 200;
-  let received: {
-    method: string;
-    body: string;
-    contentType: string | undefined;
-    authorization: string | undefined;
-  }[];
+  let pending: (() => void) | undefined;
 
-  before(async () => {
-    received = [];
-    server = createServer((req: IncomingMessage, res) => {
-      let body = "";
-      req.on("data", (chunk: Buffer) => {
-        body += chunk.toString();
-      });
-      req.on("end", () => {
-        received.push({
-          method: req.method!,
-          body,
-          contentType: req.headers["content-type"],
-          authorization: req.headers.authorization,
-        });
-        res.writeHead(statusCode);
-        res.end();
-      });
+  const server = createServer((req: IncomingMessage, res) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
     });
-    await new Promise<void>((resolve) => {
-      server.listen(0, () => {
-        port = (server.address() as { port: number }).port;
-        resolve();
+    req.on("end", () => {
+      received.push({
+        method: req.method!,
+        body,
+        contentType: req.headers["content-type"],
+        authorization: req.headers.authorization,
       });
+      res.writeHead(statusCode);
+      res.end();
+      pending?.();
+      pending = undefined;
     });
   });
 
-  beforeEach(() => {
-    received = [];
-    statusCode = 200;
-    delete process.env.VOLUTE_WEBHOOK_URL;
-    delete process.env.VOLUTE_WEBHOOK_SECRET;
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, () => {
+      resolve((server.address() as { port: number }).port);
+    });
   });
 
-  after(() => {
+  return {
+    server,
+    port,
+    received,
+    nextRequest: () =>
+      new Promise<void>((resolve) => {
+        pending = resolve;
+      }),
+    setStatusCode: (code) => {
+      statusCode = code;
+    },
+  };
+}
+
+describe("webhook", () => {
+  let ts: TestServer;
+
+  beforeEach(async () => {
     delete process.env.VOLUTE_WEBHOOK_URL;
     delete process.env.VOLUTE_WEBHOOK_SECRET;
-    server.close();
+    ts = await startServer();
+  });
+
+  afterEach(async () => {
+    delete process.env.VOLUTE_WEBHOOK_URL;
+    delete process.env.VOLUTE_WEBHOOK_SECRET;
+    await new Promise<void>((resolve) => ts.server.close(() => resolve()));
   });
 
   it("sends POST with event data when webhook URL is set", async () => {
-    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${port}`;
-    fireWebhook({
+    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${ts.port}`;
+    await fireWebhook({
       event: "schedule_changed",
       mind: "test-mind",
       data: {
@@ -67,12 +94,10 @@ describe("webhook", () => {
       timestamp: "2026-01-01T00:00:00Z",
     });
 
-    await new Promise((r) => setTimeout(r, 200));
-
-    assert.equal(received.length, 1);
-    assert.equal(received[0].method, "POST");
-    assert.equal(received[0].contentType, "application/json");
-    const payload = JSON.parse(received[0].body);
+    assert.equal(ts.received.length, 1);
+    assert.equal(ts.received[0].method, "POST");
+    assert.equal(ts.received[0].contentType, "application/json");
+    const payload = JSON.parse(ts.received[0].body);
     assert.equal(payload.event, "schedule_changed");
     assert.equal(payload.mind, "test-mind");
     assert.equal(payload.timestamp, "2026-01-01T00:00:00Z");
@@ -82,43 +107,38 @@ describe("webhook", () => {
   });
 
   it("does nothing when webhook URL is not set", async () => {
-    fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
-    await new Promise((r) => setTimeout(r, 200));
-    assert.equal(received.length, 0);
+    await fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
+    assert.equal(ts.received.length, 0);
   });
 
   it("includes Authorization header when VOLUTE_WEBHOOK_SECRET is set", async () => {
-    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${port}`;
+    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${ts.port}`;
     process.env.VOLUTE_WEBHOOK_SECRET = "test-secret-token";
-    fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
-    await new Promise((r) => setTimeout(r, 200));
+    await fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
 
-    assert.equal(received.length, 1);
-    assert.equal(received[0].authorization, "Bearer test-secret-token");
+    assert.equal(ts.received.length, 1);
+    assert.equal(ts.received[0].authorization, "Bearer test-secret-token");
   });
 
   it("omits Authorization header when VOLUTE_WEBHOOK_SECRET is not set", async () => {
-    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${port}`;
-    fireWebhook({ event: "mind_stopped", mind: "test", data: {}, timestamp: "" });
-    await new Promise((r) => setTimeout(r, 200));
+    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${ts.port}`;
+    await fireWebhook({ event: "mind_stopped", mind: "test", data: {}, timestamp: "" });
 
-    assert.equal(received.length, 1);
-    assert.equal(received[0].authorization, undefined);
+    assert.equal(ts.received.length, 1);
+    assert.equal(ts.received[0].authorization, undefined);
   });
 
   it("does not throw on non-2xx response", async () => {
-    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${port}`;
-    statusCode = 500;
-    fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
-    await new Promise((r) => setTimeout(r, 200));
+    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${ts.port}`;
+    ts.setStatusCode(500);
+    await fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
 
-    assert.equal(received.length, 1);
+    assert.equal(ts.received.length, 1);
   });
 
   it("does not throw when webhook URL is unreachable", async () => {
     process.env.VOLUTE_WEBHOOK_URL = "http://127.0.0.1:1";
-    fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
-    await new Promise((r) => setTimeout(r, 200));
+    await fireWebhook({ event: "mind_started", mind: "test", data: {}, timestamp: "" });
     assert.ok(true);
   });
 
@@ -136,22 +156,24 @@ describe("webhook", () => {
   });
 
   it("initWebhook forwards activity events to webhook", async () => {
-    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${port}`;
+    process.env.VOLUTE_WEBHOOK_URL = `http://127.0.0.1:${ts.port}`;
     const unsub = initWebhook();
 
+    // The subscribe callback fires the webhook fire-and-forget, so wait on the
+    // server receiving the request rather than a timer.
+    const delivered = ts.nextRequest();
     broadcast({
       type: "mind_started",
       mind: "test-mind",
       summary: "Mind started",
       metadata: { port: 4100 },
     });
-
-    await new Promise((r) => setTimeout(r, 200));
+    await delivered;
 
     unsub();
 
-    assert.equal(received.length, 1);
-    const payload = JSON.parse(received[0].body);
+    assert.equal(ts.received.length, 1);
+    const payload = JSON.parse(ts.received[0].body);
     assert.equal(payload.event, "mind_started");
     assert.equal(payload.mind, "test-mind");
     assert.equal(payload.data.summary, "Mind started");


### PR DESCRIPTION
## Summary

`test/webhook.test.ts` was flaky under parallel load (`--test-concurrency=4`), failing at least three full-suite runs today and twice blocking pre-push hooks. This makes webhook delivery deterministic in the tests instead of sleep-based, eliminating the cross-test leak.

## Root cause

Webhook delivery is fire-and-forget, but the tests waited on a fixed ~200ms timer while sharing a single mutable `received` array (and env vars) across every test. Under load, a slow POST from one test could land *after* the next test's `beforeEach` reset the shared array, so a test that expected `received.length === 0` saw `1` (observed at `webhook.test.ts:87`).

## Fix

- **No shared mutable state**: each test gets its own HTTP server and its own `received` array, so an in-flight POST can never bleed into another test's assertions.
- **Deterministic delivery, no timers**: `fireWebhook` now returns its delivery promise (still fire-and-forget — it always resolves, never rejects, and every production caller ignores the return value). Direct-fire tests `await fireWebhook(...)`; the `broadcast` test awaits a per-request promise the test server resolves when the request arrives. All `setTimeout` waits are gone.

Production behavior is unchanged: `fireWebhook` remains fire-and-forget for all real callers (`schedules.ts`, `minds.ts`, `conversations.ts`), which do not await it.

## Test plan

Ran the full `npm test` suite three times (each at `--test-concurrency=4`), including two suites running concurrently to simulate contention:

- Run 1 (normal): webhook 9/9 pass.
- Run 2 (under contention, second full suite in parallel): webhook 9/9 pass.
- Run 3 (under contention): webhook 9/9 pass; suite exited 0.

The formerly-flaky "does nothing when webhook URL is not set" test now runs in sub-10ms (was a 200ms sleep) and passed in all three runs. The only non-webhook failure seen was an unrelated `backup.test.ts` test flaking under the doubled load (passed in the parallel run); pre-existing SQLITE_FULL errors in one run were an environment full-disk condition, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)