### PR TITLE
feat: give minds a roster — volute who shows who's on the system

### DIFF
--- a/packages/cli/src/commands/who.ts
+++ b/packages/cli/src/commands/who.ts
@@ -1,0 +1,71 @@
+import { command } from "../lib/command.js";
+import { daemonFetch } from "../lib/daemon-client.js";
+
+type RosterMind = {
+  name: string;
+  displayName: string | null;
+  description: string | null;
+  avatar: string | null;
+  status: "running" | "starting" | "sleeping" | "stopped";
+};
+
+type RosterBrain = { username: string; displayName: string | null };
+
+type Roster = { minds: RosterMind[]; brains: RosterBrain[] };
+
+// Warm, human-readable presence words for each run state.
+const PRESENCE: Record<RosterMind["status"], string> = {
+  running: "here",
+  starting: "waking up",
+  sleeping: "sleeping",
+  stopped: "away",
+};
+
+const cmd = command({
+  name: "volute who",
+  description: "See who's on the system — the other minds and the people around",
+  flags: {},
+  async run() {
+    const res = await daemonFetch("/api/minds/roster");
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
+        error: string;
+      };
+      console.error(`Couldn't read the roster: ${body.error}`);
+      process.exit(1);
+    }
+
+    const { minds, brains } = (await res.json()) as Roster;
+    const self = process.env.VOLUTE_MIND;
+
+    if (minds.length === 0) {
+      console.log("No minds on the system yet — you may be the first.");
+    } else {
+      console.log("Minds on the system:\n");
+      const labels = minds.map((m) => {
+        const name = m.displayName?.trim() || m.name;
+        return name + (m.name === self ? " (you)" : "");
+      });
+      const width = Math.max(...labels.map((l) => l.length));
+      minds.forEach((m, i) => {
+        const presence = PRESENCE[m.status];
+        const desc = m.description?.trim() ? `  — ${m.description.trim()}` : "";
+        console.log(`  ${labels[i].padEnd(width)}  ${presence.padEnd(10)}${desc}`);
+      });
+    }
+
+    console.log("");
+    if (brains.length === 0) {
+      console.log("No people are online right now.");
+    } else {
+      console.log("People here now:");
+      for (const b of brains) {
+        const name = b.displayName?.trim() || b.username;
+        const handle = name === b.username ? name : `${name} (${b.username})`;
+        console.log(`  ${handle}`);
+      }
+    }
+  },
+});
+
+export const run = cmd.execute;

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -13,7 +13,7 @@ import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { z } from "zod";
 import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../../lib/ai-service.js";
-import { deleteMindUser } from "../../lib/auth.js";
+import { deleteMindUser, getUserByUsername } from "../../lib/auth.js";
 import { announceToSystem } from "../../lib/chat/system-channel.js";
 import { readSystemsConfig } from "../../lib/config/systems-config.js";
 import { getMindManager, MindStartupError } from "../../lib/daemon/mind-manager.js";
@@ -30,6 +30,7 @@ import { getDb } from "../../lib/db.js";
 import { getDeliveryManager } from "../../lib/delivery/delivery-manager.js";
 import { recordInbound } from "../../lib/delivery/message-delivery.js";
 import { broadcast } from "../../lib/events/activity-events.js";
+import { getOnlineBrains } from "../../lib/events/brain-presence.js";
 import {
   addMessage,
   getConversation,
@@ -1240,6 +1241,38 @@ const app = new Hono<AuthEnv>()
       }),
     );
     return c.json(minds);
+  })
+  // Roster — who's on the system: minds (display name + run state) and the
+  // brains currently online. Deliberately readable by any authenticated
+  // principal, minds included — discovering who you can reach is core to
+  // Volute's free-communication philosophy. Exposes only profile-level data
+  // (names, descriptions, avatar refs, run state); never ports, dirs, env,
+  // tokens, or config.
+  .get("/roster", async (c) => {
+    const entries = await readRegistry();
+    const minds = await Promise.all(
+      entries.map(async (entry) => {
+        const { status, displayName, description, avatar } = await getMindStatus(
+          entry.name,
+          entry.port,
+          entry.running,
+        );
+        return {
+          name: entry.name,
+          displayName: displayName ?? null,
+          description: description ?? null,
+          avatar: avatar ?? null,
+          status,
+        };
+      }),
+    );
+    const brains = await Promise.all(
+      getOnlineBrains().map(async (username) => {
+        const user = await getUserByUsername(username);
+        return { username, displayName: user?.display_name ?? null };
+      }),
+    );
+    return c.json({ minds, brains });
   })
   // Get single mind
   .get("/:name", async (c) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,9 @@ switch (command) {
   case "config":
     await import("@volute/cli/commands/config.js").then((m) => m.run(args));
     break;
+  case "who":
+    await import("@volute/cli/commands/who.js").then((m) => m.run(args));
+    break;
   case "up":
     await import("./commands/up.js").then((m) => m.run(args));
     break;
@@ -113,6 +116,7 @@ switch (command) {
     console.log(`volute — create and manage AI minds
 
 Common:
+  who                              See who's on the system
   chat send <target> "<msg>"       Send a message
   chat list / read / create        Manage conversations
   chat bridge                      Manage platform bridges

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -111,6 +111,13 @@ describe("CLI --help", () => {
     assert.ok(out.includes("status"), "should list status");
   });
 
+  it("volute who --help shows description without contacting the daemon", async () => {
+    const r = await runCli("who", "--help");
+    const out = combined(r);
+    assert.ok(out.includes("who's on the system"), "should show description");
+    assert.ok(!out.includes("not running"), "should NOT try to reach the daemon");
+  });
+
   // Leaf commands — verify --help shows flags/args and does NOT execute
   it("volute mind create --help shows flags without executing", async () => {
     const r = await runCli("mind", "create", "--help");

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
-import { afterEach, beforeEach, describe, it } from "node:test";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
-import { approveUser, createUser } from "../packages/daemon/src/lib/auth.js";
+import { approveUser, createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import {
+  initMindManager,
+  tryGetMindManager,
+} from "../packages/daemon/src/lib/daemon/mind-manager.js";
+import { generateMindToken } from "../packages/daemon/src/lib/daemon/mind-tokens.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import { users } from "../packages/daemon/src/lib/schema.js";
 import { createSession, deleteSession } from "../packages/daemon/src/web/middleware/auth.js";
 
@@ -187,5 +193,75 @@ describe("web minds routes", () => {
     assert.ok(Array.isArray(body));
 
     await deleteSession(cookie2);
+  });
+});
+
+describe("web minds roster", () => {
+  const rosterMind = `roster-test-${Date.now()}`;
+
+  // getMindStatus() consults the MindManager for run state; the daemon always
+  // has it initialized before serving, so mirror that here.
+  before(() => {
+    if (!tryGetMindManager()) initMindManager();
+  });
+
+  async function rosterCleanup() {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, rosterMind));
+    try {
+      await removeMind(rosterMind);
+    } catch {}
+  }
+
+  beforeEach(rosterCleanup);
+  afterEach(rosterCleanup);
+
+  // Only profile-level fields belong in the roster — anything else (ports,
+  // dirs, tokens, run internals) would leak system detail to untrusted minds.
+  const ALLOWED_MIND_KEYS = new Set(["name", "displayName", "description", "avatar", "status"]);
+
+  it("GET /roster — a mind can read the roster with its own token", async () => {
+    await addMind(rosterMind, 4600);
+    await getOrCreateMindUser(rosterMind);
+    const token = generateMindToken(rosterMind);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await app.request("/api/minds/roster", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      minds: Array<Record<string, unknown>>;
+      brains: Array<Record<string, unknown>>;
+    };
+    assert.ok(Array.isArray(body.minds));
+    assert.ok(Array.isArray(body.brains));
+
+    const entry = body.minds.find((m) => m.name === rosterMind);
+    assert.ok(entry, "roster should include the test mind");
+    assert.ok(typeof entry.status === "string");
+  });
+
+  it("GET /roster — exposes only profile-level fields, no ports/dirs/tokens", async () => {
+    await addMind(rosterMind, 4600);
+    await getOrCreateMindUser(rosterMind);
+    const token = generateMindToken(rosterMind);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await app.request("/api/minds/roster", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await res.json()) as { minds: Array<Record<string, unknown>> };
+    for (const entry of body.minds) {
+      for (const key of Object.keys(entry)) {
+        assert.ok(ALLOWED_MIND_KEYS.has(key), `roster mind entry leaked non-profile field: ${key}`);
+      }
+    }
+  });
+
+  it("GET /roster — requires auth (401 without credentials)", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("/api/minds/roster");
+    assert.equal(res.status, 401);
   });
 });


### PR DESCRIPTION
## Summary

Makes the system roster a first-class, discoverable thing for minds. Per the decision on #357 (closed not-planned), presence visibility for minds is **intentional** — a mind knowing who else is on the system (other minds, whether they're running/sleeping/stopped, and which humans are around) is how it discovers who it can talk to, which is core to Volute's free-communication philosophy.

- **`GET /api/minds/roster`** — a new endpoint readable by any authenticated principal (minds included). Reuses `readRegistry()` + `getMindStatus()` for each mind's profile and run state, and `getOnlineBrains()` for human presence. Returns **only profile-level data** — names, display names, descriptions, avatar refs, and run state (running/starting/sleeping/stopped), plus online brains. Never ports, dirs, env, tokens, or config.
- **`volute who`** — a warm, mind-facing CLI command over that endpoint, wired into the CLI dispatch. Marks the calling mind as `(you)` and groups minds with human-readable presence words.

### What already existed vs what's new
The v1 events SSE snapshot already surfaced `activeMinds` + `onlineBrains` to any authenticated caller, and `GET /api/minds` was already mind-readable — but neither is a clean profile-level one-shot (the events endpoint is a long-lived SSE stream; `GET /api/minds` leaks ports/dirs). This adds a purpose-built, profile-scoped one-shot endpoint reusing the existing registry/status/presence helpers, plus the CLI surface.

Per a mid-task scope change, this intentionally does **not** touch VOLUTE.md, templates, or the orientation skill — CLI command + endpoint only.

## Test plan
- `test/web-minds.test.ts` — new `web minds roster` suite: a mind can read the roster with its own token; the response exposes only the allowed profile-level fields (asserts no ports/dirs/tokens leak); unauthenticated request is 401.
- `test/cli-help.test.ts` — `volute who --help` renders its description without contacting the daemon.
- `test/authz-coverage.test.ts` — still green (static `/roster` route, no `:name` param, so it's correctly not flagged as an unguarded mind-scoped route).
- Full `npm test`: 1802 passed, 0 failed. Typecheck clean.

Refs #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)