### PR TITLE
fix: reap idle sessions to release SDK subprocess memory

### DIFF
--- a/templates/_base/src/lib/startup.ts
+++ b/templates/_base/src/lib/startup.ts
@@ -28,6 +28,8 @@ export type MindConfig = {
   logLevel?: "error" | "warn" | "info" | "debug";
   compactionMessage?: string;
   compaction?: { maxContextTokens?: number };
+  /** Idle minutes before a session's SDK subprocess is reaped. 0 disables. Default 30. */
+  sessionIdleMinutes?: number;
   subagents?: Record<string, SubagentConfig>;
   // Template-specific config fields (claude, pi, codex)
   maxThinkingTokens?: number;

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -21,6 +21,7 @@ import { createPreCompactHook } from "./lib/hooks/pre-compact.js";
 import { createReplyInstructionsHook } from "./lib/hooks/reply-instructions.js";
 import { log } from "./lib/logger.js";
 import { createMessageChannel } from "./lib/message-channel.js";
+import { isSessionReapable } from "./lib/session-reaper.js";
 import { createSessionStore } from "./lib/session-store.js";
 import { loadPrompts, type SubagentConfig } from "./lib/startup.js";
 import { consumeStream } from "./lib/stream-consumer.js";
@@ -45,6 +46,8 @@ type Session = {
   replyInstructionsFired: boolean;
   replyInstructionsMode: "once" | "always" | "never";
   contextTokens: number;
+  /** Last inbound message or completed turn — drives idle reaping. */
+  lastActivityAt: number;
 };
 
 export function createMind(options: {
@@ -58,6 +61,8 @@ export function createMind(options: {
   maxContextTokens?: number;
   subagents?: Record<string, SubagentConfig>;
   onIdentityReload?: () => Promise<void>;
+  /** Idle minutes before a session's SDK subprocess is reaped. 0 disables. Default 30. */
+  sessionIdleMinutes?: number;
 }): {
   resolve: HandlerResolver;
   waitForCommits: () => Promise<void>;
@@ -320,6 +325,7 @@ export function createMind(options: {
           // This turn's message is fully processed — drop it from the channel's
           // in-flight set so a later compaction abort won't re-feed it.
           session.channel.ack();
+          session.lastActivityAt = Date.now();
           await autoCommit.flushFileChanges();
           const wasCompacting = compactionTriggered.get(session.name);
           compactionTriggered.set(session.name, false);
@@ -508,6 +514,7 @@ export function createMind(options: {
       replyInstructionsFired: false,
       replyInstructionsMode: "once",
       contextTokens: 0,
+      lastActivityAt: Date.now(),
     };
     sessions.set(name, session);
 
@@ -528,6 +535,45 @@ export function createMind(options: {
 
     startSession(session, savedSessionId);
     return session;
+  }
+
+  // --- Idle session reaping ---
+  // Each session holds a resident SDK subprocess (~250MB) for its whole life.
+  // After the idle timeout, shut the subprocess down while keeping the session
+  // resumable: the session id is persisted, so the next inbound message
+  // transparently re-creates the session via getOrCreateSession's resume path.
+  const idleTimeoutMs = (options.sessionIdleMinutes ?? 30) * 60_000;
+
+  function reapSession(session: Session) {
+    log("mind", `session "${session.name}": idle — reaping SDK subprocess (resumable)`);
+    // Delete first so a racing inbound message spins up a fresh resumed session
+    // instead of reusing the one we're tearing down.
+    sessions.delete(session.name);
+    compactionTriggered.delete(session.name);
+    // Terminate the subprocess and end the input iterable so the stream consumer
+    // unwinds (its finally block also deletes from the map, now a no-op).
+    session.currentQuery?.close();
+    session.channel.close();
+    // Nothing should have raced in (isSessionReapable checked isEmpty), but if it
+    // did, re-dispatch into a fresh session so no input is dropped.
+    const pending = session.channel.recover();
+    if (pending.length > 0) {
+      const fresh = getOrCreateSession(session.name);
+      for (const msg of pending) fresh.channel.push(msg);
+    }
+  }
+
+  if (idleTimeoutMs > 0) {
+    log("mind", `idle session reaper: ${idleTimeoutMs / 60_000} min timeout`);
+    const checkMs = Math.min(60_000, idleTimeoutMs);
+    const reaper = setInterval(() => {
+      const now = Date.now();
+      const stale = [...sessions.values()].filter((s) =>
+        isSessionReapable(s, now, idleTimeoutMs, (name) => !!compactionTriggered.get(name)),
+      );
+      for (const session of stale) reapSession(session);
+    }, checkMs);
+    reaper.unref?.();
   }
 
   // --- MessageHandler implementation ---
@@ -575,6 +621,7 @@ export function createMind(options: {
         }
 
         // Push message into SDK
+        session.lastActivityAt = Date.now();
         session.messageIds.push(meta.messageId);
         session.channel.push({
           type: "user",

--- a/templates/claude/src/lib/message-channel.ts
+++ b/templates/claude/src/lib/message-channel.ts
@@ -11,6 +11,14 @@ export type MessageChannel = {
    * compaction abort so in-flight input is never lost.
    */
   recover: () => SDKUserMessage[];
+  /**
+   * Terminate the input iterable: resolve any pending `next()` with `done: true`
+   * and make subsequent `next()` calls return done. The SDK sees end-of-input and
+   * shuts the query down. Used by the idle reaper to release the SDK subprocess.
+   */
+  close: () => void;
+  /** True when nothing is queued or in flight (no pending work). */
+  isEmpty: () => boolean;
   iterable: AsyncIterable<SDKUserMessage>;
 };
 
@@ -23,6 +31,7 @@ export function createMessageChannel(): MessageChannel {
   // re-feed the unprocessed ones instead of dropping them.
   const inFlight: SDKUserMessage[] = [];
   let resolve: ((value: IteratorResult<SDKUserMessage>) => void) | null = null;
+  let closed = false;
 
   function deliver(msg: SDKUserMessage): IteratorResult<SDKUserMessage> {
     inFlight.push(msg);
@@ -52,10 +61,24 @@ export function createMessageChannel(): MessageChannel {
       }
       return [...inFlight.splice(0), ...queue.splice(0)];
     },
+    close() {
+      closed = true;
+      if (resolve) {
+        const r = resolve;
+        resolve = null;
+        r({ value: undefined as any, done: true });
+      }
+    },
+    isEmpty() {
+      return queue.length === 0 && inFlight.length === 0;
+    },
     iterable: {
       [Symbol.asyncIterator]() {
         return {
           next(): Promise<IteratorResult<SDKUserMessage>> {
+            if (closed) {
+              return Promise.resolve({ value: undefined as any, done: true });
+            }
             if (queue.length > 0) {
               return Promise.resolve(deliver(queue.shift()!));
             }

--- a/templates/claude/src/lib/session-reaper.ts
+++ b/templates/claude/src/lib/session-reaper.ts
@@ -1,0 +1,37 @@
+/**
+ * Idle-session reaping decision logic.
+ *
+ * Each mind session keeps a resident Claude SDK subprocess alive for as long as
+ * the session lives. When a session has been idle past the configured timeout it
+ * can be reaped — its subprocess shut down — while staying resumable, since the
+ * session id is persisted and the next inbound message re-creates it via resume.
+ */
+
+export interface ReapableSession {
+  name: string;
+  /** Timestamp (ms) of the last inbound message or completed turn. */
+  lastActivityAt: number;
+  /** Set while a turn is in progress; undefined between turns. */
+  currentMessageId?: string;
+  channel: { isEmpty(): boolean };
+}
+
+/**
+ * A session is reapable only when it has been idle longer than the timeout and
+ * has no work in progress: no turn running, no queued/in-flight input, and not
+ * mid-compaction (which owns its own abort/resume lifecycle).
+ */
+export function isSessionReapable(
+  session: ReapableSession,
+  now: number,
+  idleTimeoutMs: number,
+  isCompacting: (name: string) => boolean,
+): boolean {
+  if (idleTimeoutMs <= 0) return false;
+  return (
+    session.currentMessageId === undefined &&
+    session.channel.isEmpty() &&
+    !isCompacting(session.name) &&
+    now - session.lastActivityAt > idleTimeoutMs
+  );
+}

--- a/templates/claude/src/server.ts
+++ b/templates/claude/src/server.ts
@@ -33,6 +33,7 @@ const mind = createMind({
   sessionsDir,
   compactionMessage: config.compactionMessage,
   maxContextTokens: config.compaction?.maxContextTokens,
+  sessionIdleMinutes: config.sessionIdleMinutes,
   subagents: config.subagents,
   onIdentityReload: async () => {
     log("server", "identity file changed — restarting to reload");

--- a/test/message-channel.test.ts
+++ b/test/message-channel.test.ts
@@ -130,6 +130,65 @@ describe("createMessageChannel", () => {
     });
   });
 
+  describe("isEmpty()", () => {
+    it("is true for a fresh channel", () => {
+      assert.equal(createMessageChannel().isEmpty(), true);
+    });
+
+    it("is false while a message is queued", () => {
+      const ch = createMessageChannel();
+      ch.push(msg("queued"));
+      assert.equal(ch.isEmpty(), false);
+    });
+
+    it("is false while a delivered message is unacked (in flight)", async () => {
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+      const pending = iter.next();
+      ch.push(msg("inflight"));
+      await pending;
+      assert.equal(ch.isEmpty(), false);
+    });
+
+    it("is true again after the in-flight message is acked", async () => {
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+      const pending = iter.next();
+      ch.push(msg("done"));
+      await pending;
+      ch.ack();
+      assert.equal(ch.isEmpty(), true);
+    });
+  });
+
+  describe("close()", () => {
+    it("resolves a pending next() with done:true", async () => {
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+      const waiting = iter.next();
+      ch.close();
+      const result = await waiting;
+      assert.equal(result.done, true);
+    });
+
+    it("makes subsequent next() calls return done", async () => {
+      const ch = createMessageChannel();
+      ch.close();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+      const result = await iter.next();
+      assert.equal(result.done, true);
+    });
+
+    it("leaves queued messages recoverable so nothing is dropped on reap", async () => {
+      // Mirrors the reaper: a message that raced in before close() must still be
+      // recoverable for re-dispatch into a fresh resumed session.
+      const ch = createMessageChannel();
+      ch.push(msg("raced"));
+      ch.close();
+      assert.deepEqual(ch.recover().map(text), ["raced"]);
+    });
+  });
+
   describe("ack()", () => {
     it("excludes an acknowledged message from recovery", async () => {
       const ch = createMessageChannel();

--- a/test/session-reaper.test.ts
+++ b/test/session-reaper.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isSessionReapable,
+  type ReapableSession,
+} from "../templates/claude/src/lib/session-reaper.js";
+
+const TIMEOUT = 30 * 60_000; // 30 min
+const NOW = 1_000_000_000;
+
+function session(overrides: Partial<ReapableSession> & { empty?: boolean } = {}): ReapableSession {
+  const { empty = true, ...rest } = overrides;
+  return {
+    name: "main",
+    lastActivityAt: NOW - TIMEOUT - 1, // idle past the timeout by default
+    currentMessageId: undefined,
+    channel: { isEmpty: () => empty },
+    ...rest,
+  };
+}
+
+const notCompacting = () => false;
+
+describe("isSessionReapable", () => {
+  it("reaps a session idle past the timeout", () => {
+    assert.equal(isSessionReapable(session(), NOW, TIMEOUT, notCompacting), true);
+  });
+
+  it("does not reap when activity is recent (timer reset)", () => {
+    const s = session({ lastActivityAt: NOW - 60_000 }); // active 1 min ago
+    assert.equal(isSessionReapable(s, NOW, TIMEOUT, notCompacting), false);
+  });
+
+  it("does not reap exactly at the boundary (strictly greater required)", () => {
+    const s = session({ lastActivityAt: NOW - TIMEOUT });
+    assert.equal(isSessionReapable(s, NOW, TIMEOUT, notCompacting), false);
+  });
+
+  it("does not reap a session mid-turn", () => {
+    const s = session({ currentMessageId: "m1" });
+    assert.equal(isSessionReapable(s, NOW, TIMEOUT, notCompacting), false);
+  });
+
+  it("does not reap a session with queued/in-flight input", () => {
+    const s = session({ empty: false });
+    assert.equal(isSessionReapable(s, NOW, TIMEOUT, notCompacting), false);
+  });
+
+  it("does not reap a session mid-compaction", () => {
+    assert.equal(
+      isSessionReapable(session(), NOW, TIMEOUT, () => true),
+      false,
+    );
+  });
+
+  it("never reaps when reaping is disabled (timeout 0)", () => {
+    const s = session({ lastActivityAt: 0 }); // ancient
+    assert.equal(isSessionReapable(s, NOW, 0, notCompacting), false);
+  });
+});


### PR DESCRIPTION
## Summary

Idle mind sessions in the claude template kept their Claude Agent SDK subprocess resident indefinitely (~250MB RSS each) — on bardo this was ~2.5GB of idle memory. This adds an idle-session reaper: after a configurable idle period, an ephemeral/idle session's SDK subprocess is shut down cleanly while the session stays resumable.

- **Idle timeout**: default 30 min, configurable per mind via `sessionIdleMinutes` in `home/.config/config.json` (`0` disables). Threaded `startup.ts` (`MindConfig`) → `server.ts` → `createMind`.
- **All sessions are reapable, including `main`.** The startup pre-warm of `main` stays, so restarts are instant; it just gets reaped later if idle.
- **Reap keeps the session resumable.** The session id is already persisted on every `onSessionId`, and `getOrCreateSession` already resumes from the session store — so the next inbound message transparently re-creates the session via `resume`. Reaping never deletes the persisted session id.
- **Reap sequence** (in `agent.ts`): `sessions.delete(name)` first (so a racing inbound spins up a fresh resumed session), then `currentQuery.close()` (SDK-documented subprocess teardown) + `channel.close()`, then `channel.recover()` re-dispatches any raced messages into a fresh session so nothing is dropped. The stream consumer's `finally` (from #487) also drops the dead map entry.
- **Guards**: a session is only reaped when idle past the timeout AND no turn in progress (`currentMessageId === undefined`) AND `channel.isEmpty()` AND not mid-compaction. Activity (inbound message push, completed turn) resets `lastActivityAt`.
- **`message-channel.ts`**: added `close()` (resolve pending `next()` with `done`, subsequent `next()` return done) and `isEmpty()` (no queued/in-flight work).
- The reap decision is extracted to a pure `isSessionReapable()` in `lib/session-reaper.ts` for testability.

## Test plan

- `test/session-reaper.test.ts` (new): idle → reapable, recent activity → not (timer reset), boundary (strictly-greater), mid-turn → not, non-empty channel → not, mid-compaction → not, disabled (timeout 0) → never.
- `test/message-channel.test.ts` (extended): `isEmpty()` across fresh/queued/in-flight/acked states; `close()` resolves pending `next()` with done, makes subsequent `next()` return done, and leaves queued messages recoverable for re-dispatch on reap.
- Full `npm test` green; template typecheck (claude/pi/codex) green via pre-commit hook.

## Stacking

Built on #487 (`fix/463-459-session-listener-leaks`), which reworked session-state cleanup in this area and was squash-merged to main. This PR is rebased onto `origin/main`; its diff contains only the reaper work.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)