### PR TITLE
test: fix integration-setup leaving volute un-setup

### DIFF
--- a/test/integration-setup.sh
+++ b/test/integration-setup.sh
@@ -139,10 +139,15 @@ if [[ -z "$TOKEN" ]]; then
   exit 1
 fi
 
-# Write setup config so CLI commands work inside the container
+# Write setup config so CLI commands work inside the container. The `setupCompleted`
+# field is what `isSetupComplete()` checks; the container entrypoint never runs
+# `volute setup`, and `migrateSetupCompleted()` only runs at daemon startup (after
+# config.json already exists), so we must write the flag explicitly. config.json was
+# absent when the daemon started, so its config cache is empty and this fresh write
+# is picked up without a daemon restart.
 echo "Writing setup config..."
 docker exec "$CONTAINER" sh -c \
-  'mkdir -p /data/system && echo '"'"'{"setup":{"type":"system","isolation":"user"}}'"'"' > /data/system/config.json'
+  'mkdir -p /data/system && echo '"'"'{"setup":{"type":"system","isolation":"user"},"setupCompleted":true}'"'"' > /data/system/config.json'
 
 # Create a test user account (first user auto-becomes admin)
 echo "Creating test user account..."
@@ -263,10 +268,10 @@ echo "  # Shorthand"
 echo "  $VEXEC status"
 echo ""
 echo "  # Seed a mind"
-echo "  $VEXEC seed my-mind --template claude --model claude-sonnet-4-6"
+echo "  $VEXEC seed create my-mind --template claude --model claude-sonnet-4-6"
 echo ""
 echo "  # Send a message and wait for the response"
-echo "  $VEXEC send @my-mind \"hello, who are you?\" --wait"
+echo "  $VEXEC chat send @my-mind \"hello, who are you?\" --wait"
 echo ""
 echo "Teardown: bash test/integration-teardown.sh"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Root cause

`test/integration-setup.sh` wrote `/data/system/config.json` as
`{"setup":{"type":"system","isolation":"user"}}` — omitting the `setupCompleted`
flag that `isSetupComplete()` actually checks (`packages/daemon/src/lib/config/setup.ts`).
The daemon's `migrateSetupCompleted()` (which back-fills the flag) runs only at
daemon startup, but the script writes the config *after* the daemon is already
healthy. Result: `setupCompleted` was never set, and every subsequent CLI command
aborted with "Volute is not set up. Run 'volute setup' first."

The fix writes `"setupCompleted":true` into the config explicitly, mirroring the
approach PR #494 took for `test/docker-e2e.sh`. `config.json` is absent when the
daemon starts, so the daemon's config cache is empty and the fresh write is picked
up without a daemon restart.

Also corrected stale command forms in the script's printed help:
- `volute seed my-mind ...` → `volute seed create my-mind ...`
- `volute send @my-mind ...` → `volute chat send @my-mind ...`

(`--wait` was verified as a valid `chat send` flag and left as-is.)

## Test plan

Ran end-to-end against a real Docker container (keys sourced from `.env`):

1. `bash test/integration-setup.sh` — completes clean.
2. `docker exec <c> volute mind list` → "No minds configured" (no setup error).
3. `docker exec <c> volute seed create my-mind --template claude --model claude-sonnet-4-6` → seeds successfully.
4. `docker exec <c> volute mind list` → shows `my-mind: running (seed)`.

All with **no manual config patching**. Then `bash test/integration-teardown.sh` cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)