### PR TITLE
fix: failed variant join leaves parent files root-owned under isolation

### DIFF
--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -58,10 +58,14 @@ const cmd = command({
       },
     );
 
-    const data = (await res.json()) as { ok?: boolean; error?: string };
+    const data = (await res.json()) as { ok?: boolean; error?: string; conflicts?: string[] };
 
     if (!res.ok) {
       console.error(data.error ?? "Failed to join variant");
+      if (data.conflicts?.length) {
+        console.error("\nConflicting files:");
+        for (const file of data.conflicts) console.error(`  ${file}`);
+      }
       process.exit(1);
     }
 

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -264,6 +264,26 @@ const app = new Hono<AuthEnv>()
       } catch (err) {
         log.warn(`failed to abort merge for ${mindName}`, log.errorData(err));
       }
+      // The git ops above (auto-commit, merge, merge --abort) ran as the daemon
+      // (root). Under user isolation that leaves the parent worktree — including
+      // home/MEMORY.md and other identity files — owned root:root, so the
+      // still-running parent mind can no longer write its own files. Hand
+      // ownership back before returning.
+      try {
+        await chownMindDir(projectRoot, mindName);
+      } catch (err) {
+        log.warn(
+          `failed to restore ownership after aborted merge for ${mindName}`,
+          log.errorData(err),
+        );
+        return c.json(
+          {
+            error: `Merge failed and restoring parent ownership failed: ${err instanceof Error ? err.message : String(err)}`,
+            conflicts,
+          },
+          500,
+        );
+      }
       // Leave the variant intact so the conflict can be resolved in the variant
       // and the join retried.
       return c.json(
@@ -276,6 +296,12 @@ const app = new Hono<AuthEnv>()
     }
 
     await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
+
+    // The merge and cleanup git ops ran as the daemon (root). Hand ownership of
+    // the parent worktree back to the mind user before the wrapped npm install
+    // (which runs as that user) and the restart — otherwise the tree is left
+    // root-owned under isolation. Mirrors the split/create path.
+    await chownMindDir(projectRoot, mindName);
 
     // Update template hash after upgrade merge
     if (variantName.endsWith("-upgrade") || variantName === "upgrade") {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
@@ -655,6 +655,26 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // The variant survives and is still joinable.
     assert.ok(await findMind("e2e-conflict-var"), "variant should still be registered");
     assert.ok(existsSync(created.variant.path), "variant worktree should still exist");
+
+    // The failed join must not leave root-owned files in the parent dir. Under
+    // real user isolation the merge git ops (run as the daemon) would otherwise
+    // orphan home/MEMORY.md as root:root, locking the parent mind out of its own
+    // identity files. (This harness runs the daemon as the test user, so this is
+    // a regression tripwire; the ownership-restore path itself is unit-tested in
+    // variant-join-isolation.test.ts.)
+    if (process.getuid && process.getuid() !== 0) {
+      const rootOwned: string[] = [];
+      const walk = (dir: string) => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          if (entry.name === "node_modules" || entry.name === ".git") continue;
+          const full = resolve(dir, entry.name);
+          if (statSync(full).uid === 0) rootOwned.push(full);
+          if (entry.isDirectory()) walk(full);
+        }
+      };
+      walk(parentDir);
+      assert.equal(rootOwned.length, 0, `parent dir has root-owned files: ${rootOwned.join(", ")}`);
+    }
 
     // Clean up the variant so later tests aren't affected.
     await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-conflict-var`, { method: "DELETE" });

--- a/test/variant-join-isolation.test.ts
+++ b/test/variant-join-isolation.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  addMind,
+  addVariant,
+  mindDir,
+  removeMind,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import { sessions, users } from "../packages/daemon/src/lib/schema.js";
+import { exec } from "../packages/daemon/src/lib/util/exec.js";
+import variantsApp from "../packages/daemon/src/web/api/variants.js";
+import { type AuthEnv, authMiddleware } from "../packages/daemon/src/web/middleware/auth.js";
+import { cleanGitEnv } from "./helpers/test-git-env.js";
+
+// Runs in its own file so flipping VOLUTE_ISOLATION only affects this process
+// (node runs each test file in a separate process). The `mind-<name>` OS user
+// intentionally does not exist, so chownMindDir's real `chown` fails — that
+// failure is the observable proving the failed-merge recovery path now hands
+// ownership of the parent worktree back to the mind under user isolation
+// (without it, the git ops leave the parent's files root-owned).
+
+const parentName = `vjoin-iso-${Date.now()}`;
+const variantName = `${parentName}-var`;
+const branch = variantName;
+
+let adminCookie: string;
+let parentDir: string;
+let variantDir: string;
+
+const originalIsolation = process.env.VOLUTE_ISOLATION;
+
+function createApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("/*", authMiddleware);
+  app.route("/minds", variantsApp);
+  return app;
+}
+
+describe("failed variant join restores parent ownership under user isolation", () => {
+  before(async () => {
+    process.env.VOLUTE_ISOLATION = "user";
+    const env = cleanGitEnv();
+
+    parentDir = mindDir(parentName);
+    variantDir = resolve(parentDir, ".variants", variantName);
+    if (existsSync(parentDir)) rmSync(parentDir, { recursive: true, force: true });
+    mkdirSync(parentDir, { recursive: true });
+
+    // Parent repo with a tracked file that both sides will edit conflictingly.
+    await exec("git", ["init"], { cwd: parentDir, env });
+    await exec("git", ["config", "user.email", "test@test.com"], { cwd: parentDir, env });
+    await exec("git", ["config", "user.name", "Test"], { cwd: parentDir, env });
+    writeFileSync(resolve(parentDir, "MEMORY.md"), "base\n");
+    await exec("git", ["add", "-A"], { cwd: parentDir, env });
+    await exec("git", ["commit", "-m", "init"], { cwd: parentDir, env });
+
+    // Variant worktree on its own branch, with a conflicting edit.
+    await exec("git", ["worktree", "add", "-b", branch, variantDir], { cwd: parentDir, env });
+    writeFileSync(resolve(variantDir, "MEMORY.md"), "variant version\n");
+    await exec("git", ["commit", "-am", "variant edit"], { cwd: variantDir, env });
+
+    // Parent (main) makes a conflicting edit to the same file.
+    writeFileSync(resolve(parentDir, "MEMORY.md"), "parent version\n");
+    await exec("git", ["commit", "-am", "parent edit"], { cwd: parentDir, env });
+
+    await addMind(parentName, 4196);
+    await addVariant(variantName, parentName, 4197, variantDir, branch);
+
+    const db = await getDb();
+    const [user] = await db
+      .insert(users)
+      .values({ username: "vjoin-iso-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    adminCookie = `volute_session=${sessionId}`;
+  });
+
+  after(async () => {
+    if (originalIsolation === undefined) delete process.env.VOLUTE_ISOLATION;
+    else process.env.VOLUTE_ISOLATION = originalIsolation;
+    if (existsSync(variantDir)) rmSync(variantDir, { recursive: true, force: true });
+    if (existsSync(parentDir)) rmSync(parentDir, { recursive: true, force: true });
+    await removeMind(variantName);
+    await removeMind(parentName);
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "vjoin-iso-admin"));
+  });
+
+  it("aborts the conflicting merge and triggers chownMindDir (fails against the absent mind user)", async () => {
+    const app = createApp();
+    const res = await app.request(`/minds/${parentName}/variants/${variantName}/merge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: adminCookie },
+      body: JSON.stringify({ skipVerify: true }),
+    });
+
+    // The merge conflicts and is aborted, then chownMindDir runs to hand the
+    // parent worktree back to the mind user. That chown fails because the
+    // `mind-<name>` OS user does not exist here — proving ownership restore is
+    // wired into the failed-join path. Its conflict list still surfaces.
+    assert.equal(res.status, 500);
+    const body = (await res.json()) as { error: string; conflicts?: string[] };
+    assert.match(body.error, /chown/i);
+    assert.ok(
+      body.conflicts?.includes("MEMORY.md"),
+      `expected MEMORY.md in conflicts: ${JSON.stringify(body.conflicts)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

The variant-join merge handler (`packages/daemon/src/web/api/variants.ts`) runs all its `gitExec` calls as the daemon (root), unwrapped — unlike the create/split path, which chowns before the wrapped `npm install`. Under `VOLUTE_ISOLATION=user`, the auto-commit / `git merge` / `git merge --abort` (the abort added by #475) write into the parent worktree as root.

- **Failed join** (merge conflict → abort): left the parent mind dir — ~91 files including `home/MEMORY.md` — owned `root:root`. The parent mind stays running through a failed join, so it could no longer write its own identity files.
- **Successful join** masked the same issue only because it restarts the mind, which re-chowns.

## Live-test evidence

Observed during integration testing under user isolation: after a merge-conflict join, `home/MEMORY.md` and the rest of the parent dir were `root:root`, locking the still-running parent out of its identity files.

## Fix

- Call `chownMindDir(projectRoot, mindName)` in **both** the failed-merge recovery branch (after `git merge --abort`, before returning the conflict) and the success path (right after `cleanupVariant`, before the wrapped `npm install` — mirroring the split/create path). No join outcome now leaves root-owned files in the mind dir.
- CLI `volute mind join` now surfaces the `conflicts[]` file list from the merge-failure response instead of discarding it, so the user is told which files collided.

## Test plan

- New unit test `test/variant-join-isolation.test.ts` (pattern from `test/skills-install-isolation.test.ts`): with `VOLUTE_ISOLATION=user` and the `mind-<name>` OS user intentionally absent, a conflicting join returns 500 with an error matching `/chown/i` and the conflict list — proving the ownership-restore step now runs in the failed-join path.
- Extended the #475 daemon-e2e conflict test to assert no root-owned files remain under the parent dir after a failed join (regression tripwire; the harness runs the daemon as the test user).
- `npm test`: 1851 pass / 0 fail. `npm run test:e2e`: 51 pass / 0 fail.

Refs #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)