### PR TITLE
feat: back up reliably — catch up on missed fires, notify on repeated failures

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -97,7 +97,8 @@ export type ActivityEventType =
   | "note_created"
   | "brain_online"
   | "brain_offline"
-  | "profile_updated";
+  | "profile_updated"
+  | "backup_failed";
 
 export type Variant = {
   name: string;

--- a/packages/daemon/src/lib/daemon/backup-manager.ts
+++ b/packages/daemon/src/lib/daemon/backup-manager.ts
@@ -1,6 +1,8 @@
 import { CronExpressionParser } from "cron-parser";
-import { runBackup } from "../backup/backup.js";
+import { readBackupState, runBackup } from "../backup/backup.js";
 import { readGlobalConfig } from "../config/setup.js";
+import { publish as publishActivity } from "../events/activity-events.js";
+import { SPIRIT_NAME } from "../mind/registry.js";
 import log from "../util/logger.js";
 
 const blog = log.child("backup");
@@ -8,12 +10,22 @@ const blog = log.child("backup");
 export const DEFAULT_BACKUP_SCHEDULE = "0 3 * * *";
 
 /**
+ * Notify the operator on the 1st scheduled-backup failure and then every Nth
+ * consecutive one. A persistently-broken repo shouldn't spam a message every
+ * night, but a silent `lastError` in backup-state.json shouldn't sit unnoticed
+ * until restore time either. The counter resets on the next success.
+ */
+const NOTIFY_EVERY_N_FAILURES = 5;
+
+/**
  * Runs scheduled backups. Config is re-read each tick so enabling/changing the
  * schedule via the API takes effect without a daemon restart.
  */
 export class BackupManager {
   private interval: ReturnType<typeof setInterval> | null = null;
-  private lastFiredMinute = -1;
+  /** Epoch-ms of the most recent scheduled fire this process has serviced. */
+  private lastServicedFireMs = -1;
+  private consecutiveFailures = 0;
   private warnedUnconfigured = false;
 
   start(): void {
@@ -28,9 +40,16 @@ export class BackupManager {
   }
 
   /**
-   * True at most once per scheduled fire minute (records the minute it
-   * consumed), and only when backups are enabled and runnable. Not a pure
-   * predicate — a second call in the same minute returns false.
+   * True at most once per scheduled fire (records the fire it consumed), and
+   * only when backups are enabled and runnable. Not a pure predicate — a second
+   * call for the same fire returns false.
+   *
+   * Catch-up: if the machine was asleep or the daemon was down across a
+   * scheduled fire (a laptop at 3am), the fire is picked up on the next tick so
+   * long as it falls after the last successful run (`lastRun` in
+   * backup-state.json). Without an anchor (no successful backup yet) only the
+   * exact on-time minute fires, so freshly enabling backups doesn't trigger an
+   * immediate run.
    */
   isDue(now: Date = new Date()): boolean {
     const config = readGlobalConfig().backup;
@@ -45,18 +64,41 @@ export class BackupManager {
     this.warnedUnconfigured = false;
     const cron = config.schedule || DEFAULT_BACKUP_SCHEDULE;
     const epochMinute = Math.floor(now.getTime() / 60000);
-    if (epochMinute === this.lastFiredMinute) return false;
-    let prevMinute: number;
+    let prevFireMs: number;
     try {
       const interval = CronExpressionParser.parse(cron, { currentDate: now });
-      prevMinute = Math.floor(interval.prev().toDate().getTime() / 60000);
+      prevFireMs = interval.prev().toDate().getTime();
     } catch (err) {
       blog.warn(`invalid backup cron "${cron}"`, log.errorData(err));
       return false;
     }
-    if (prevMinute !== epochMinute) return false;
-    this.lastFiredMinute = epochMinute;
+
+    // Already handled this fire (dedupe within the process, incl. retries).
+    if (prevFireMs <= this.lastServicedFireMs) return false;
+
+    const lastRunMs = this.readLastRunMs();
+    // Already completed this fire (or a later one) in a prior daemon session.
+    if (lastRunMs !== null && prevFireMs <= lastRunMs) return false;
+
+    const onTime = Math.floor(prevFireMs / 60000) === epochMinute;
+    if (!onTime) {
+      // A missed fire is only a catch-up relative to a known last run; without
+      // one there's nothing to be "behind" on.
+      if (lastRunMs === null) return false;
+      blog.warn(
+        `missed scheduled backup fire at ${new Date(prevFireMs).toISOString()}; running catch-up`,
+      );
+    }
+
+    this.lastServicedFireMs = prevFireMs;
     return true;
+  }
+
+  private readLastRunMs(): number | null {
+    const lastRun = readBackupState().lastRun;
+    if (!lastRun) return null;
+    const ms = Date.parse(lastRun);
+    return Number.isNaN(ms) ? null : ms;
   }
 
   private async tick(): Promise<void> {
@@ -64,9 +106,56 @@ export class BackupManager {
     blog.info("scheduled backup starting");
     try {
       await runBackup();
+      this.recordSuccess();
     } catch (err) {
       blog.error("scheduled backup failed", log.errorData(err));
+      await this.recordFailure(err);
     }
+  }
+
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+  }
+
+  /**
+   * Track consecutive scheduled-backup failures and actively notify the operator
+   * on the 1st and then every Nth. Returns whether it notified (for tests).
+   * Notification failures are swallowed — surfacing a backup failure must never
+   * take the daemon's backup loop down with it.
+   */
+  async recordFailure(err: unknown): Promise<boolean> {
+    this.consecutiveFailures += 1;
+    const n = this.consecutiveFailures;
+    if (n !== 1 && n % NOTIFY_EVERY_N_FAILURES !== 0) return false;
+
+    const reason = err instanceof Error ? err.message : String(err);
+    const summary =
+      n === 1
+        ? `Scheduled backup failed: ${reason}`
+        : `Scheduled backup has failed ${n} times in a row: ${reason}`;
+
+    try {
+      await publishActivity({
+        type: "backup_failed",
+        mind: SPIRIT_NAME,
+        summary,
+        metadata: { consecutiveFailures: n, error: reason },
+      });
+    } catch (pubErr) {
+      blog.error("failed to publish backup-failure activity", log.errorData(pubErr));
+    }
+
+    try {
+      const { sendSystemMessage } = await import("../chat/system-chat.js");
+      await sendSystemMessage(
+        SPIRIT_NAME,
+        `${summary}\n\nBackups are not being saved. Check \`volute backup status\` and the Backups settings tab.`,
+      );
+    } catch (msgErr) {
+      blog.error("failed to send backup-failure system message", log.errorData(msgErr));
+    }
+
+    return true;
   }
 }
 

--- a/packages/daemon/src/lib/events/activity-events.ts
+++ b/packages/daemon/src/lib/events/activity-events.ts
@@ -17,7 +17,8 @@ export type ActivityEvent = {
     | "note_created"
     | "brain_online"
     | "brain_offline"
-    | "profile_updated";
+    | "profile_updated"
+    | "backup_failed";
   mind: string;
   summary: string;
   metadata?: Record<string, unknown>;

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -370,11 +370,20 @@ describe("backup API authorization", () => {
 });
 
 describe("backup manager scheduling", () => {
+  function writeLastRun(iso: string): void {
+    writeFileSync(
+      resolve(voluteSystemDir(), "backup-state.json"),
+      `${JSON.stringify({ lastRun: iso }, null, 2)}\n`,
+    );
+  }
+
   afterEach(() => {
     _resetConfigCache();
-    try {
-      unlinkSync(resolve(voluteSystemDir(), "config.json"));
-    } catch {}
+    for (const f of ["config.json", "backup-state.json"]) {
+      try {
+        unlinkSync(resolve(voluteSystemDir(), f));
+      } catch {}
+    }
     try {
       unlinkSync(secretsPath());
     } catch {}
@@ -415,6 +424,78 @@ describe("backup manager scheduling", () => {
     _resetConfigCache();
     const mgr = new BackupManager();
     assert.equal(mgr.isDue(new Date("2026-07-07T03:00:30")), false);
+  });
+
+  it("does not catch up without a prior successful run (fresh enable)", async () => {
+    const { BackupManager } = await import("../packages/daemon/src/lib/daemon/backup-manager.js");
+    const { writeGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    writeGlobalConfig({
+      backup: { repository: "/tmp/r", password: "p", enabled: true, schedule: "0 3 * * *" },
+    });
+    _resetConfigCache();
+    const mgr = new BackupManager();
+    // Well past 3am with no lastRun anchor → nothing to be behind on.
+    assert.equal(mgr.isDue(new Date("2026-07-07T08:15:00")), false);
+  });
+
+  it("catches up on a fire missed while asleep, once, when it falls after lastRun", async () => {
+    const { BackupManager } = await import("../packages/daemon/src/lib/daemon/backup-manager.js");
+    const { writeGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    writeGlobalConfig({
+      backup: { repository: "/tmp/r", password: "p", enabled: true, schedule: "0 3 * * *" },
+    });
+    _resetConfigCache();
+    // Last success was yesterday; today's 3am fire was missed (laptop asleep).
+    // Anchor in local time so it lines up with the local-time cron and `now`.
+    writeLastRun(new Date("2026-07-06T03:00:05").toISOString());
+    const mgr = new BackupManager();
+    // Daemon wakes at 08:15, well after the 03:00 fire it slept through.
+    assert.equal(mgr.isDue(new Date("2026-07-07T08:15:00")), true, "catches up on the missed fire");
+    assert.equal(
+      mgr.isDue(new Date("2026-07-07T08:16:00")),
+      false,
+      "does not re-fire the same missed fire",
+    );
+  });
+
+  it("does not catch up on a fire already covered by lastRun", async () => {
+    const { BackupManager } = await import("../packages/daemon/src/lib/daemon/backup-manager.js");
+    const { writeGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");
+    writeGlobalConfig({
+      backup: { repository: "/tmp/r", password: "p", enabled: true, schedule: "0 3 * * *" },
+    });
+    _resetConfigCache();
+    // Today's 3am fire already ran successfully (local-time anchor).
+    writeLastRun(new Date("2026-07-07T03:00:04").toISOString());
+    const mgr = new BackupManager();
+    assert.equal(mgr.isDue(new Date("2026-07-07T08:15:00")), false);
+  });
+
+  it("notifies on the 1st failure and every Nth, resetting on success", async () => {
+    const { BackupManager } = await import("../packages/daemon/src/lib/daemon/backup-manager.js");
+    const { subscribe } = await import("../packages/daemon/src/lib/events/activity-events.js");
+    const mgr = new BackupManager();
+
+    const events: string[] = [];
+    const unsubscribe = subscribe((e) => {
+      if (e.type === "backup_failed") events.push(e.summary);
+    });
+    try {
+      const err = new Error("repo unreachable");
+      // 1st notifies; 2nd–4th are throttled; 5th notifies again.
+      assert.equal(await mgr.recordFailure(err), true, "1st failure notifies");
+      assert.equal(await mgr.recordFailure(err), false);
+      assert.equal(await mgr.recordFailure(err), false);
+      assert.equal(await mgr.recordFailure(err), false);
+      assert.equal(await mgr.recordFailure(err), true, "5th consecutive failure notifies");
+      assert.equal(events.length, 2, "one activity event per notification");
+
+      // A success resets the streak, so the next failure is a fresh 1st.
+      mgr.recordSuccess();
+      assert.equal(await mgr.recordFailure(err), true, "1st failure after recovery notifies");
+    } finally {
+      unsubscribe();
+    }
   });
 });
 


### PR DESCRIPTION
Part of the core-reliability release. Makes scheduled backups survive downtime and stop failing silently.

## #455 — catch up on missed fire minutes
`BackupManager` was edge-triggered (fired only when the cron's previous fire minute equalled the current minute), so a fire missed while the machine slept (a laptop at 3am) or the daemon restarted across the boundary was lost with no record. `isDue()` now uses the cron's previous scheduled fire against the persisted `lastRun` anchor and runs the missed fire on the next tick, logging it as a catch-up. Guards prevent a per-minute retry storm (in-process `lastServicedFireMs`, since `lastRun` only advances on success) and an immediate run when backups are freshly enabled (no anchor → only the on-time minute fires).

## #456 — actively notify on repeated failures
A failed nightly backup previously only wrote a passive `lastError`. It now notifies the operator on the 1st failure and every 5th consecutive one (resetting on success) via a `backup_failed` activity event (dashboard + webhooks) and a system message to the spirit. Notification failures are swallowed so they can't take down the backup loop.

Closes #455
Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
