### PR TITLE
perf: spawn mind servers without the tsx wrapper process

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -398,22 +398,12 @@ export class MindManager {
       env.HOME = resolve(dir, "home");
     }
 
-    // When VOLUTE_NODE_PATH is set (e.g. Electron bundled Node), use it to run tsx explicitly
-    const customNode = process.env.VOLUTE_NODE_PATH;
-    let baseBin: string;
-    let baseArgs: string[];
-    if (customNode) {
-      baseBin = customNode;
-      baseArgs = [
-        resolve(dir, "node_modules", ".bin", "tsx"),
-        "src/server.ts",
-        "--port",
-        String(port),
-      ];
-    } else {
-      baseBin = resolve(dir, "node_modules", ".bin", "tsx");
-      baseArgs = ["src/server.ts", "--port", String(port)];
-    }
+    // Run node directly with tsx as an import loader instead of the tsx bin
+    // shim, which would fork a second node process (~60MB RSS) that does
+    // nothing. VOLUTE_NODE_PATH (e.g. Electron bundled Node) overrides the
+    // node binary. The bare `tsx` specifier resolves against the spawn cwd.
+    const baseBin = process.env.VOLUTE_NODE_PATH ?? process.execPath;
+    const baseArgs = ["--import", "tsx", "src/server.ts", "--port", String(port)];
     let spawnCmd: string;
     let spawnArgs: string[];
     if (isIsolationEnabled()) {
@@ -722,7 +712,7 @@ export class MindManager {
         resolve();
       });
       try {
-        // Kill the entire process group (tsx + node child)
+        // Kill the entire process group (node + any children it spawns)
         process.kill(-child.pid!, "SIGTERM");
       } catch {
         clearTimeout(killTimer);

--- a/packages/daemon/src/lib/mind/spawn-server.ts
+++ b/packages/daemon/src/lib/mind/spawn-server.ts
@@ -7,12 +7,8 @@ import { isSandboxEnabled, wrapForSandbox } from "./sandbox.js";
 
 type SpawnResult = { child: ChildProcess; actualPort: number } | null;
 
-function tsxBin(cwd: string): string {
-  return resolve(cwd, "node_modules", ".bin", "tsx");
-}
-
 /**
- * Spawn `tsx src/server.ts --port <port>` in the given path and wait for it to be listening.
+ * Spawn `node --import tsx src/server.ts --port <port>` in the given path and wait for it to be listening.
  *
  * In detached mode: spawns with stdout/stderr going to a log file. The child survives parent exit.
  * Use this when the CLI will exit immediately after (e.g. `volute fork`).
@@ -29,8 +25,11 @@ export async function spawnServer(
   port: number,
   options?: { detached?: boolean; logDir?: string; mindName?: string; template?: string },
 ): Promise<SpawnResult> {
-  let cmd = tsxBin(cwd);
-  let args = ["src/server.ts", "--port", String(port)];
+  // Run node directly with tsx as an import loader rather than the tsx bin
+  // shim, which forks a second idle node process (~60MB RSS). The bare `tsx`
+  // specifier resolves against the spawn cwd (the mind directory).
+  let cmd = process.env.VOLUTE_NODE_PATH ?? process.execPath;
+  let args = ["--import", "tsx", "src/server.ts", "--port", String(port)];
   if (options?.mindName) {
     if (isIsolationEnabled()) {
       [cmd, args] = await wrapForIsolation(cmd, args, options.mindName);


### PR DESCRIPTION
Part of the core-reliability release (memory footprint).

Mind and variant servers were spawned via the `tsx` bin shim, which forks a second node process (~60MB RSS per mind) that does nothing afterward — ~310MB on a 10-mind host. They now spawn node directly with tsx as an import loader (`node --import tsx src/server.ts`), dropping the wrapper. The bare `tsx` specifier still resolves against the spawn cwd (the mind dir), so per-mind tsx resolution is unchanged.

Verified: isolation (`runuser`) and sandbox wrappers pass `[cmd, ...args]` through unchanged; the process-group kill still tears down the detached group (one fewer member); the Electron `VOLUTE_NODE_PATH` path still resolves tsx from the mind cwd. Daemon e2e (51/51) passes unchanged.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
