### PR TITLE
fix: run history/session cleanup hourly, not just at daemon startup

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9,6 +9,7 @@ import { initBackupManager } from "./lib/daemon/backup-manager.js";
 import { initBridgeManager } from "./lib/daemon/bridge-manager.js";
 import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
 import { initMailPoller } from "./lib/daemon/mail-poller.js";
+import { startMaintenanceInterval } from "./lib/daemon/maintenance.js";
 import { getMindManager, initMindManager } from "./lib/daemon/mind-manager.js";
 import { startMindFull } from "./lib/daemon/mind-service.js";
 import { initScheduler } from "./lib/daemon/scheduler.js";
@@ -364,6 +365,10 @@ export async function startDaemon(opts: {
     log.warn("failed to clean expired logs", log.errorData(err));
   });
 
+  // ...and re-run that cleanup hourly so retention is actually enforced on a
+  // long-lived daemon, not just once at startup.
+  const maintenanceInterval = startMaintenanceInterval();
+
   // When the daemon rotates a provider's OAuth token, push the fresh token into
   // running minds so they don't refresh the rotating grant independently (which
   // invalidated each other and caused recurring 401s).
@@ -430,6 +435,7 @@ export async function startDaemon(opts: {
       safe("summarizer.stop", () => summarizer.stop());
       safe("backupManager.stop", () => backupManager.stop());
       safe("stopApiKeyRefresh", stopApiKeyRefresh);
+      safe("maintenanceInterval", () => clearInterval(maintenanceInterval));
       safe("delivery.dispose", () => delivery.dispose());
       await safe("bridgeManager.stopAll", () => bridgeManager.stopAll());
       await safe("manager.stopAll", () => manager.stopAll());

--- a/packages/daemon/src/lib/daemon/maintenance.ts
+++ b/packages/daemon/src/lib/daemon/maintenance.ts
@@ -1,0 +1,36 @@
+import { cleanExpiredSessions } from "../../web/middleware/auth.js";
+import { cleanExpiredLogs } from "../util/history-cleanup.js";
+import log from "../util/logger.js";
+
+/** Hourly maintenance cadence. Retention policies that only run at restart aren't policies. */
+const MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Run all daemon maintenance cleanups once. Each cleanup is guarded on its own so
+ * a transient DB error in one doesn't skip the rest (or kill the recurring interval).
+ */
+export async function runMaintenance(): Promise<void> {
+  try {
+    await cleanExpiredSessions();
+  } catch (err) {
+    log.warn("maintenance: failed to clean expired sessions", log.errorData(err));
+  }
+  try {
+    await cleanExpiredLogs();
+  } catch (err) {
+    log.warn("maintenance: failed to clean expired logs", log.errorData(err));
+  }
+}
+
+/**
+ * Start the recurring maintenance interval. Returns the timer handle so the
+ * caller can clear it during shutdown.
+ */
+export function startMaintenanceInterval(
+  intervalMs: number = MAINTENANCE_INTERVAL_MS,
+  task: () => Promise<void> = runMaintenance,
+): NodeJS.Timeout {
+  const handle = setInterval(() => void task(), intervalMs);
+  handle.unref?.();
+  return handle;
+}

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import {
+  runMaintenance,
+  startMaintenanceInterval,
+} from "../packages/daemon/src/lib/daemon/maintenance.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { mindHistory } from "../packages/daemon/src/lib/schema.js";
+
+function ago(ms: number): string {
+  return new Date(Date.now() - ms).toISOString().replace("T", " ").slice(0, 19);
+}
+
+describe("runMaintenance", () => {
+  it("deletes log rows older than the retention window and keeps newer ones", async () => {
+    const db = await getDb();
+    const mind = `maint-test-${process.pid}`;
+    const twoDays = 2 * 24 * 60 * 60 * 1000;
+    const oneHour = 60 * 60 * 1000;
+
+    await db.insert(mindHistory).values([
+      { mind, type: "log", content: "old", created_at: ago(twoDays) },
+      { mind, type: "log", content: "fresh", created_at: ago(oneHour) },
+      // A non-log row past the window must survive — retention only touches logs.
+      { mind, type: "message", content: "old message", created_at: ago(twoDays) },
+    ]);
+
+    await runMaintenance();
+
+    const rows = await db.select().from(mindHistory).where(eq(mindHistory.mind, mind));
+    const contents = rows.map((r) => r.content).sort();
+    assert.deepEqual(contents, ["fresh", "old message"]);
+  });
+});
+
+describe("startMaintenanceInterval", () => {
+  it("runs the maintenance task on each tick and stops once cleared", (t) => {
+    t.mock.timers.enable({ apis: ["setInterval"] });
+
+    let runs = 0;
+    const task = async () => {
+      runs++;
+    };
+    const handle = startMaintenanceInterval(1000, task);
+
+    t.mock.timers.tick(1000);
+    t.mock.timers.tick(1000);
+    assert.equal(runs, 2);
+
+    // Shutdown clears the interval: no further ticks fire the task.
+    clearInterval(handle);
+    t.mock.timers.tick(1000);
+    assert.equal(runs, 2);
+  });
+});


### PR DESCRIPTION
Part of the core-reliability release (memory footprint).

`cleanExpiredLogs()` and `cleanExpiredSessions()` ran exactly once, at daemon startup. The 24h log-retention policy was therefore never enforced on an always-on deployment (Docker, systemd) — `type='log'` rows in `mind_history` accumulated unboundedly until the next restart. This adds an hourly maintenance interval (`maintenance.ts`) that re-runs both cleanups, each independently guarded so a transient DB error can't kill the interval or skip the other cleanup. The startup run is kept; the interval is cleared on shutdown.

This is branch 1 of the daemon-memory stack; #462 (unbounded cache sweep) builds on the `cleanExpiredSessions` hook this adds.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
