### PR TITLE
fix: sweep unbounded daemon caches (session, send-gate, avatar, SSE ring)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9,6 +9,7 @@ import { initBackupManager } from "./lib/daemon/backup-manager.js";
 import { initBridgeManager } from "./lib/daemon/bridge-manager.js";
 import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
 import { initMailPoller } from "./lib/daemon/mail-poller.js";
+import { startMaintenanceInterval } from "./lib/daemon/maintenance.js";
 import { getMindManager, initMindManager } from "./lib/daemon/mind-manager.js";
 import { startMindFull } from "./lib/daemon/mind-service.js";
 import { initScheduler } from "./lib/daemon/scheduler.js";
@@ -364,6 +365,10 @@ export async function startDaemon(opts: {
     log.warn("failed to clean expired logs", log.errorData(err));
   });
 
+  // ...and re-run that cleanup hourly so retention is actually enforced on a
+  // long-lived daemon, not just once at startup.
+  const maintenanceInterval = startMaintenanceInterval();
+
   // When the daemon rotates a provider's OAuth token, push the fresh token into
   // running minds so they don't refresh the rotating grant independently (which
   // invalidated each other and caused recurring 401s).
@@ -430,6 +435,7 @@ export async function startDaemon(opts: {
       safe("summarizer.stop", () => summarizer.stop());
       safe("backupManager.stop", () => backupManager.stop());
       safe("stopApiKeyRefresh", stopApiKeyRefresh);
+      safe("maintenanceInterval", () => clearInterval(maintenanceInterval));
       safe("delivery.dispose", () => delivery.dispose());
       await safe("bridgeManager.stopAll", () => bridgeManager.stopAll());
       await safe("manager.stopAll", () => manager.stopAll());

--- a/packages/daemon/src/lib/daemon/maintenance.ts
+++ b/packages/daemon/src/lib/daemon/maintenance.ts
@@ -1,0 +1,36 @@
+import { cleanExpiredSessions } from "../../web/middleware/auth.js";
+import { cleanExpiredLogs } from "../util/history-cleanup.js";
+import log from "../util/logger.js";
+
+/** Hourly maintenance cadence. Retention policies that only run at restart aren't policies. */
+const MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Run all daemon maintenance cleanups once. Each cleanup is guarded on its own so
+ * a transient DB error in one doesn't skip the rest (or kill the recurring interval).
+ */
+export async function runMaintenance(): Promise<void> {
+  try {
+    await cleanExpiredSessions();
+  } catch (err) {
+    log.warn("maintenance: failed to clean expired sessions", log.errorData(err));
+  }
+  try {
+    await cleanExpiredLogs();
+  } catch (err) {
+    log.warn("maintenance: failed to clean expired logs", log.errorData(err));
+  }
+}
+
+/**
+ * Start the recurring maintenance interval. Returns the timer handle so the
+ * caller can clear it during shutdown.
+ */
+export function startMaintenanceInterval(
+  intervalMs: number = MAINTENANCE_INTERVAL_MS,
+  task: () => Promise<void> = runMaintenance,
+): NodeJS.Timeout {
+  const handle = setInterval(() => void task(), intervalMs);
+  handle.unref?.();
+  return handle;
+}

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -23,7 +23,7 @@ import {
   resolveRoute,
   setRoutesChangeListener,
 } from "./delivery-router.js";
-import { onDeliveredToMind, resetTurn } from "./send-gate.js";
+import { clearMind, onDeliveredToMind, resetTurn } from "./send-gate.js";
 
 const dlog = log.child("delivery-manager");
 
@@ -454,6 +454,8 @@ export class DeliveryManager {
    */
   clearMindSessions(mindName: string): void {
     this.sessionStates.delete(mindName);
+    // Free the mind's stale-send gate state so it doesn't linger after stop.
+    clearMind(mindName);
     // Clean up any batch buffers for this mind
     const toDelete: string[] = [];
     for (const [bufferKey, buffer] of this.batchBuffers) {
@@ -1148,7 +1150,14 @@ export class DeliveryManager {
       }
     }
 
-    avatarBlocksCache.set(cacheKey, { blocks, expiresAt: Date.now() + AVATAR_CACHE_TTL });
+    // Evict expired entries on insert. The map holds base64 image blocks keyed by
+    // participant-set permutation; without this sweep every distinct membership
+    // combination leaves a permanent entry. TTL-on-read alone never frees them.
+    const now = Date.now();
+    for (const [key, entry] of avatarBlocksCache) {
+      if (entry.expiresAt <= now) avatarBlocksCache.delete(key);
+    }
+    avatarBlocksCache.set(cacheKey, { blocks, expiresAt: now + AVATAR_CACHE_TTL });
     return blocks;
   }
 

--- a/packages/daemon/src/lib/delivery/send-gate.ts
+++ b/packages/daemon/src/lib/delivery/send-gate.ts
@@ -122,16 +122,21 @@ export async function checkStaleSend(
 }
 
 /**
+ * Drop all gate state for a mind. `onDeliveredToMind` re-snapshots a fresh baseline
+ * on the next delivery, so deleting the mind's inner map is behavior-equivalent to
+ * clearing the flags — and, unlike flipping flags, keeps `state` from growing one
+ * permanent entry per conversation the mind is ever delivered into.
+ */
+export function clearMind(mindBase: string): void {
+  state.delete(mindBase);
+}
+
+/**
  * Close all open turns for a mind (called on its `done` event) so the next delivery
  * re-snapshots a fresh baseline.
  */
 export function resetTurn(mindBase: string): void {
-  const conv = state.get(mindBase);
-  if (!conv) return;
-  for (const entry of conv.values()) {
-    entry.turnOpen = false;
-    entry.heldThisTurn = false;
-  }
+  clearMind(mindBase);
 }
 
 /** Build the notice the held mind reads as its send command output. */
@@ -151,4 +156,9 @@ export function formatHoldNotice(channelLabel: string, unseen: UnseenMessage[]):
 /** Test seam: clear all gate state. */
 export function _resetAllForTest(): void {
   state.clear();
+}
+
+/** Test seam: number of minds currently holding gate state. */
+export function _stateSizeForTest(): number {
+  return state.size;
 }

--- a/packages/daemon/src/lib/events/activity-events.ts
+++ b/packages/daemon/src/lib/events/activity-events.ts
@@ -1,6 +1,8 @@
+import type { SSEActivityEvent } from "@volute/api/events";
 import { getDb } from "../db.js";
 import { activity } from "../schema.js";
 import log from "../util/logger.js";
+import { bufferEvent } from "./event-sequencer.js";
 
 export type ActivityEvent = {
   type:
@@ -26,7 +28,9 @@ export type ActivityEvent = {
   created_at?: string;
 };
 
-type Callback = (event: ActivityEvent & { id: number; created_at: string }) => void;
+// `seq` is the global sequencer id under which this event was buffered exactly once
+// (for reconnect replay); subscribers forward using it rather than re-buffering.
+type Callback = (event: ActivityEvent & { id: number; created_at: string; seq: number }) => void;
 
 const subscribers = new Set<Callback>();
 
@@ -69,9 +73,19 @@ export function broadcast(event: ActivityEvent): void {
 }
 
 function notify(event: ActivityEvent & { id: number; created_at: string }): void {
+  // Buffer once globally here, at the single publish site, so N connected clients
+  // don't each store a duplicate copy in the replay ring (which shrank the effective
+  // replay window by N×). Subscribers forward using the shared `seq`.
+  const data: SSEActivityEvent = {
+    event: "activity",
+    ...event,
+    metadata: event.metadata ?? null,
+  };
+  const seq = bufferEvent(data);
+  const delivered = { ...event, seq };
   for (const cb of subscribers) {
     try {
-      cb(event);
+      cb(delivered);
     } catch (err) {
       log.error("[activity-events] subscriber threw:", log.errorData(err));
       subscribers.delete(cb);

--- a/packages/daemon/src/lib/events/conversation-events.ts
+++ b/packages/daemon/src/lib/events/conversation-events.ts
@@ -1,4 +1,6 @@
+import type { SSEConversationEvent } from "@volute/api/events";
 import type { ContentBlock } from "./conversations.js";
+import { bufferEvent } from "./event-sequencer.js";
 
 /** In-process pub-sub for conversation events. SSE endpoint subscribes per-conversation; conversations.ts publishes when messages are added. */
 export type ConversationEvent =
@@ -12,7 +14,9 @@ export type ConversationEvent =
     }
   | { type: "typing"; senders: string[] };
 
-type Callback = (event: ConversationEvent) => void;
+// `seq` is the global sequencer id under which this event was buffered exactly once
+// (for reconnect replay); subscribers forward using it rather than re-buffering.
+type Callback = (event: ConversationEvent & { seq: number }) => void;
 
 const subscribers = new Map<string, Set<Callback>>();
 
@@ -32,9 +36,14 @@ export function subscribe(conversationId: string, callback: Callback): () => voi
 export function publish(conversationId: string, event: ConversationEvent): void {
   const set = subscribers.get(conversationId);
   if (!set) return;
+  // Buffer once globally here, at the single publish site, so N clients subscribed
+  // to this conversation don't each store a duplicate copy in the replay ring.
+  const data: SSEConversationEvent = { event: "conversation", conversationId, ...event };
+  const seq = bufferEvent(data);
+  const delivered = { ...event, seq };
   for (const cb of set) {
     try {
-      cb(event);
+      cb(delivered);
     } catch (err) {
       console.error("[conversation-events] subscriber threw:", err);
       set.delete(cb);

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -13,7 +13,7 @@ import {
   getUnreadCounts,
   listConversationsWithParticipants,
 } from "../../../lib/events/conversations.js";
-import { bufferEvent, getEventsSince, nextEventId } from "../../../lib/events/event-sequencer.js";
+import { getEventsSince, nextEventId } from "../../../lib/events/event-sequencer.js";
 import { getActiveMinds } from "../../../lib/events/mind-activity-tracker.js";
 import { getBaseName } from "../../../lib/mind/registry.js";
 import { activity } from "../../../lib/schema.js";
@@ -110,19 +110,20 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
       // mind's activity live; the buffer still records every event globally so
       // the audience filter is re-applied on reconnect replay too.
       const unsubActivity = subscribeActivity((event) => {
+        // The event was already buffered exactly once at the publish site (activity-events
+        // notify), so we forward here using its shared `seq` rather than re-buffering per
+        // connection. The audience filter still gates live delivery; reconnect replay
+        // re-applies it via getEventsSince against the globally-buffered copy.
+        if (activityMind !== undefined && event.mind !== activityMind) return;
+        const { seq, ...rest } = event;
         const data = {
           event: "activity" as const,
-          ...event,
-          metadata: event.metadata ?? null,
+          ...rest,
+          metadata: rest.metadata ?? null,
         };
-        // Buffer every event globally first so the audience filter is re-applied
-        // on reconnect replay (getEventsSince) rather than dropping events that
-        // this connection isn't entitled to see live.
-        const eventId = bufferEvent(data);
-        if (activityMind !== undefined && event.mind !== activityMind) return;
         stream
           .writeSSE({
-            id: String(eventId),
+            id: String(seq),
             data: JSON.stringify(data),
           })
           .catch((err) => {
@@ -134,11 +135,13 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
       // Subscribe to conversation events for each user conversation
       for (const conv of conversations) {
         const unsubConv = subscribeConversation(conv.id, (event) => {
-          const data = { event: "conversation" as const, conversationId: conv.id, ...event };
-          const eventId = bufferEvent(data);
+          // Buffered once at the publish site (conversation-events publish); forward
+          // using the shared `seq` instead of re-buffering per subscribed connection.
+          const { seq, ...rest } = event;
+          const data = { event: "conversation" as const, conversationId: conv.id, ...rest };
           stream
             .writeSSE({
-              id: String(eventId),
+              id: String(seq),
               data: JSON.stringify(data),
             })
             .catch((err) => {

--- a/packages/daemon/src/web/middleware/auth.ts
+++ b/packages/daemon/src/web/middleware/auth.ts
@@ -34,6 +34,9 @@ const SESSION_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 type CachedSession = { userId: number; user: User; expires: number };
 const sessionCache = new Map<string, CachedSession>();
 
+/** Test seam: direct access to the in-memory session cache. */
+export const _sessionCacheForTest = sessionCache;
+
 export function invalidateSessionCache(sessionId: string): void {
   sessionCache.delete(sessionId);
 }
@@ -63,6 +66,14 @@ export async function getSessionUserId(sessionId: string): Promise<number | unde
 }
 
 export async function cleanExpiredSessions(): Promise<void> {
+  // Sweep expired in-memory cache entries. They're only ever removed on read/logout
+  // otherwise, so every token that ever authenticated leaves a permanent entry
+  // (each holding a full User object). This runs on the daemon's maintenance timer.
+  const now = Date.now();
+  for (const [id, cached] of sessionCache) {
+    if (cached.expires <= now) sessionCache.delete(id);
+  }
+
   const db = await getDb();
   const cutoff = Date.now() - SESSION_MAX_AGE;
   await db.delete(sessions).where(lt(sessions.createdAt, cutoff));

--- a/test/conversation-events.test.ts
+++ b/test/conversation-events.test.ts
@@ -22,12 +22,14 @@ function makeEvent(
 
 describe("conversation-events", () => {
   it("subscribe + publish delivers event to callback", () => {
-    const received: ConversationEvent[] = [];
+    const received: (ConversationEvent & { seq: number })[] = [];
     const unsub = subscribe("conv-1", (e) => received.push(e));
     const event = makeEvent();
     publish("conv-1", event);
     assert.equal(received.length, 1);
-    assert.deepEqual(received[0], event);
+    const { seq, ...rest } = received[0];
+    assert.equal(typeof seq, "number", "delivered with a global sequencer id");
+    assert.deepEqual(rest, event);
     unsub();
   });
 
@@ -49,16 +51,19 @@ describe("conversation-events", () => {
   });
 
   it("multiple subscribers all receive event", () => {
-    const received1: ConversationEvent[] = [];
-    const received2: ConversationEvent[] = [];
+    const received1: (ConversationEvent & { seq: number })[] = [];
+    const received2: (ConversationEvent & { seq: number })[] = [];
     const unsub1 = subscribe("conv-4", (e) => received1.push(e));
     const unsub2 = subscribe("conv-4", (e) => received2.push(e));
     const event = makeEvent();
     publish("conv-4", event);
     assert.equal(received1.length, 1);
     assert.equal(received2.length, 1);
-    assert.deepEqual(received1[0], event);
-    assert.deepEqual(received2[0], event);
+    const strip = ({ seq, ...rest }: ConversationEvent & { seq: number }) => rest;
+    // Both subscribers get the same event, and it was buffered once (one shared seq).
+    assert.equal(received1[0].seq, received2[0].seq, "single shared sequencer id");
+    assert.deepEqual(strip(received1[0]), event);
+    assert.deepEqual(strip(received2[0]), event);
     unsub1();
     unsub2();
   });

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import {
+  runMaintenance,
+  startMaintenanceInterval,
+} from "../packages/daemon/src/lib/daemon/maintenance.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { mindHistory } from "../packages/daemon/src/lib/schema.js";
+
+function ago(ms: number): string {
+  return new Date(Date.now() - ms).toISOString().replace("T", " ").slice(0, 19);
+}
+
+describe("runMaintenance", () => {
+  it("deletes log rows older than the retention window and keeps newer ones", async () => {
+    const db = await getDb();
+    const mind = `maint-test-${process.pid}`;
+    const twoDays = 2 * 24 * 60 * 60 * 1000;
+    const oneHour = 60 * 60 * 1000;
+
+    await db.insert(mindHistory).values([
+      { mind, type: "log", content: "old", created_at: ago(twoDays) },
+      { mind, type: "log", content: "fresh", created_at: ago(oneHour) },
+      // A non-log row past the window must survive — retention only touches logs.
+      { mind, type: "message", content: "old message", created_at: ago(twoDays) },
+    ]);
+
+    await runMaintenance();
+
+    const rows = await db.select().from(mindHistory).where(eq(mindHistory.mind, mind));
+    const contents = rows.map((r) => r.content).sort();
+    assert.deepEqual(contents, ["fresh", "old message"]);
+  });
+});
+
+describe("startMaintenanceInterval", () => {
+  it("runs the maintenance task on each tick and stops once cleared", (t) => {
+    t.mock.timers.enable({ apis: ["setInterval"] });
+
+    let runs = 0;
+    const task = async () => {
+      runs++;
+    };
+    const handle = startMaintenanceInterval(1000, task);
+
+    t.mock.timers.tick(1000);
+    t.mock.timers.tick(1000);
+    assert.equal(runs, 2);
+
+    // Shutdown clears the interval: no further ticks fire the task.
+    clearInterval(handle);
+    t.mock.timers.tick(1000);
+    assert.equal(runs, 2);
+  });
+});

--- a/test/send-gate.test.ts
+++ b/test/send-gate.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, it } from "node:test";
 import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import {
   _resetAllForTest,
+  _stateSizeForTest,
   checkStaleSend,
+  clearMind,
   formatHoldNotice,
   onDeliveredToMind,
   resetTurn,
@@ -116,6 +118,26 @@ describe("send-gate stale-send hold", () => {
       true,
       "a new message in the fresh turn holds again",
     );
+  });
+
+  it("resetTurn frees the mind's state instead of leaking an entry per conversation", async () => {
+    const conv1 = await makeMindDM("gateN", "gateO");
+    const conv2 = await makeMindDM("gateN", "gateP");
+    await onDeliveredToMind("gateN", conv1);
+    await onDeliveredToMind("gateN", conv2);
+    assert.equal(_stateSizeForTest(), 1, "one mind tracked");
+
+    resetTurn("gateN");
+    assert.equal(_stateSizeForTest(), 0, "state fully freed after the turn completes");
+  });
+
+  it("clearMind drops a mind's gate state (mind stop)", async () => {
+    const conv = await makeMindDM("gateQ", "gateR");
+    await onDeliveredToMind("gateQ", conv);
+    assert.equal(_stateSizeForTest(), 1);
+
+    clearMind("gateQ");
+    assert.equal(_stateSizeForTest(), 0);
   });
 
   it("formats a readable hold notice", () => {

--- a/test/web-auth.test.ts
+++ b/test/web-auth.test.ts
@@ -5,7 +5,11 @@ import { Hono } from "hono";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { users } from "../packages/daemon/src/lib/schema.js";
 import auth from "../packages/daemon/src/web/api/auth.js";
-import { deleteSession } from "../packages/daemon/src/web/middleware/auth.js";
+import {
+  _sessionCacheForTest,
+  cleanExpiredSessions,
+  deleteSession,
+} from "../packages/daemon/src/web/middleware/auth.js";
 
 const TEST_USERNAMES = ["admin", "dupe", "loginuser", "meuser", "logoutuser"];
 
@@ -159,5 +163,28 @@ describe("web auth routes", () => {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(meRes.status, 401);
+  });
+});
+
+describe("cleanExpiredSessions cache sweep", () => {
+  it("evicts expired session-cache entries and keeps live ones", async () => {
+    const user = { id: 4242, username: "cache-sweep", role: "user" } as any;
+    _sessionCacheForTest.set("expired-sid", {
+      userId: user.id,
+      user,
+      expires: Date.now() - 1000,
+    });
+    _sessionCacheForTest.set("live-sid", {
+      userId: user.id,
+      user,
+      expires: Date.now() + 60_000,
+    });
+
+    await cleanExpiredSessions();
+
+    assert.equal(_sessionCacheForTest.has("expired-sid"), false, "expired entry swept");
+    assert.equal(_sessionCacheForTest.has("live-sid"), true, "live entry retained");
+
+    _sessionCacheForTest.delete("live-sid");
   });
 });

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -357,3 +357,41 @@ describe("v1 events live activity delivery filter", () => {
     }
   });
 });
+
+describe("v1 events replay ring buffers each event once", () => {
+  it("stores a single copy even with two subscribed clients", async () => {
+    resetSequencer();
+    const prevToken = process.env.VOLUTE_DAEMON_TOKEN;
+    process.env.VOLUTE_DAEMON_TOKEN = "ring-once-admin-token";
+    try {
+      const s1 = await openEventStream("Bearer ring-once-admin-token");
+      const s2 = await openEventStream("Bearer ring-once-admin-token");
+      await delay(200);
+
+      const before = nextEventId();
+      await publish({ type: "mind_done", mind: "ring-once-mind", summary: "ring-once-summary" });
+      await delay(200);
+      await s1.close();
+      await s2.close();
+
+      // Both clients still receive it live, each exactly once.
+      for (const s of [s1, s2]) {
+        const hits = s.events.filter(
+          (e) => e.event === "activity" && e.summary === "ring-once-summary",
+        );
+        assert.equal(hits.length, 1, "each client sees the event once live");
+      }
+
+      // But the global replay ring holds exactly one copy, not one per connected
+      // client — the regression this fix guards against. Reconnect replay still works.
+      const replay = getEventsSince(before, NO_CONVS, undefined);
+      const copies = replay.filter(
+        (e) => e.data.event === "activity" && e.data.summary === "ring-once-summary",
+      );
+      assert.equal(copies.length, 1, "event buffered exactly once globally");
+    } finally {
+      if (prevToken === undefined) delete process.env.VOLUTE_DAEMON_TOKEN;
+      else process.env.VOLUTE_DAEMON_TOKEN = prevToken;
+    }
+  });
+});


### PR DESCRIPTION
Part of the core-reliability release (memory footprint). **Stacked on #396 — merge that first.**

Sweeps four daemon-lifetime structures that grew without bound:

1. **Auth `sessionCache`** — expired entries are now swept inside `cleanExpiredSessions` (which #396 runs hourly), not just logically expired on read.
2. **Send-gate `state`** — `resetTurn` now deletes the mind's conversation entries (new `clearMind` primitive, also called on mind stop) instead of flipping flags; behavior-equivalent because `onDeliveredToMind` re-snapshots the baseline.
3. **`avatarBlocksCache`** — O(n) eviction of expired entries on insert.
4. **SSE replay ring** — each event is now buffered exactly once at its publish site with a shared `seq`; per-client subscribers forward using it instead of each re-buffering (which stored N copies per event and shrank the effective replay window N×). Live audience filtering and reconnect-replay semantics are preserved.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
