### PR TITLE
fix: reap SDK subprocess on idle-session teardown (no defunct zombies)

### DIFF
--- a/templates/_base/src/lib/context-breakdown.ts
+++ b/templates/_base/src/lib/context-breakdown.ts
@@ -1,5 +1,6 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { createReadStream, readdirSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
+import { createInterface } from "node:readline";
 import type { ContextBreakdown } from "./volute-server.js";
 
 // Async tokenizer — import fires at module load; falls back to character estimation if unavailable or still loading
@@ -31,22 +32,59 @@ function countTokens(text: string): number {
 
 // --- Shared JSONL reader ---
 
-function readJsonlEntries<T>(filePath: string): T[] | null {
-  let data: string;
+// Stream-parse the transcript line-by-line instead of slurping the whole file
+// into memory. Session transcripts run to tens of MB; readFileSync + split would
+// transiently allocate several times the file size and block the event loop.
+async function readJsonlEntries<T>(filePath: string): Promise<T[] | null> {
+  const stream = createReadStream(filePath, { encoding: "utf-8" });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  const entries: T[] = [];
   try {
-    data = readFileSync(filePath, "utf-8");
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      try {
+        entries.push(JSON.parse(line));
+      } catch {}
+    }
   } catch (err: any) {
     if (err?.code !== "ENOENT") console.warn(`context-breakdown: ${filePath}:`, err?.message);
     return null;
-  }
-
-  const entries: T[] = [];
-  for (const line of data.split("\n").filter((l) => l.trim())) {
-    try {
-      entries.push(JSON.parse(line));
-    } catch {}
+  } finally {
+    rl.close();
+    stream.destroy();
   }
   return entries;
+}
+
+// --- Computed-info cache (keyed by file identity) ---
+
+// getContextInfo runs on every dashboard poll. A transcript only changes when the
+// mind takes a turn, so cache the computed breakdown keyed by (path, mtimeMs, size)
+// and serve polls between turns for free. Only the small ParsedContext is retained
+// — never the parsed messages.
+type InfoCacheEntry = { mtimeMs: number; size: number; parsed: ParsedContext | null };
+const infoCache = new Map<string, InfoCacheEntry>();
+
+export async function getCachedContextInfo(
+  filePath: string,
+  compute: () => Promise<ParsedContext | null>,
+): Promise<ParsedContext | null> {
+  let mtimeMs: number;
+  let size: number;
+  try {
+    const st = statSync(filePath);
+    mtimeMs = st.mtimeMs;
+    size = st.size;
+  } catch {
+    return null;
+  }
+  const cached = infoCache.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+    return cached.parsed;
+  }
+  const parsed = await compute();
+  infoCache.set(filePath, { mtimeMs, size, parsed });
+  return parsed;
 }
 
 // --- Claude JSONL parser ---
@@ -111,13 +149,13 @@ type SessionResult = {
   messages: ContextMessage[];
 };
 
-export function processClaudeSession(
+export async function processClaudeSession(
   filePath: string,
   systemPromptTokens: number,
   claudeMdTokens: number,
   skillDescriptionTokens: number,
-): SessionResult {
-  const entries = readJsonlEntries<ClaudeMessage>(filePath);
+): Promise<SessionResult> {
+  const entries = await readJsonlEntries<ClaudeMessage>(filePath);
   if (!entries) return { parsed: null, messages: [] };
 
   let lastContextTokens = 0;
@@ -194,22 +232,6 @@ export function processClaudeSession(
   return { parsed, messages };
 }
 
-/** @deprecated Use processClaudeSession instead */
-export function parseClaudeSessionJSONL(
-  filePath: string,
-  systemPromptTokens: number,
-  claudeMdTokens: number,
-  skillDescriptionTokens: number,
-): ParsedContext | null {
-  return processClaudeSession(filePath, systemPromptTokens, claudeMdTokens, skillDescriptionTokens)
-    .parsed;
-}
-
-/** @deprecated Use processClaudeSession instead */
-export function extractClaudeSessionMessages(filePath: string): ContextMessage[] {
-  return processClaudeSession(filePath, 0, 0, 0).messages;
-}
-
 // --- Codex JSONL parser ---
 
 type CodexEntry = {
@@ -235,13 +257,13 @@ type CodexEntry = {
 
 // --- Codex: combined parse + extract ---
 
-export function processCodexSession(
+export async function processCodexSession(
   filePath: string,
   systemPromptTokens: number,
   claudeMdTokens: number,
   skillDescriptionTokens: number,
-): SessionResult {
-  const entries = readJsonlEntries<CodexEntry>(filePath);
+): Promise<SessionResult> {
+  const entries = await readJsonlEntries<CodexEntry>(filePath);
   if (!entries) return { parsed: null, messages: [] };
 
   let lastContextTokens = 0;
@@ -322,22 +344,6 @@ export function processCodexSession(
   return { parsed, messages };
 }
 
-/** @deprecated Use processCodexSession instead */
-export function parseCodexSessionJSONL(
-  filePath: string,
-  systemPromptTokens: number,
-  claudeMdTokens: number,
-  skillDescriptionTokens: number,
-): ParsedContext | null {
-  return processCodexSession(filePath, systemPromptTokens, claudeMdTokens, skillDescriptionTokens)
-    .parsed;
-}
-
-/** @deprecated Use processCodexSession instead */
-export function extractCodexSessionMessages(filePath: string): ContextMessage[] {
-  return processCodexSession(filePath, 0, 0, 0).messages;
-}
-
 // --- Pi JSONL parser ---
 
 type PiEntry = {
@@ -360,13 +366,13 @@ type PiEntry = {
 
 // --- Pi: combined parse + extract ---
 
-export function processPiSession(
+export async function processPiSession(
   filePath: string,
   systemPromptTokens: number,
   claudeMdTokens: number,
   skillDescriptionTokens: number,
-): SessionResult {
-  const entries = readJsonlEntries<PiEntry>(filePath);
+): Promise<SessionResult> {
+  const entries = await readJsonlEntries<PiEntry>(filePath);
   if (!entries) return { parsed: null, messages: [] };
 
   let lastContextTokens = 0;
@@ -441,22 +447,6 @@ export function processPiSession(
         };
 
   return { parsed, messages };
-}
-
-/** @deprecated Use processPiSession instead */
-export function parsePiSessionJSONL(
-  filePath: string,
-  systemPromptTokens: number,
-  claudeMdTokens: number,
-  skillDescriptionTokens: number,
-): ParsedContext | null {
-  return processPiSession(filePath, systemPromptTokens, claudeMdTokens, skillDescriptionTokens)
-    .parsed;
-}
-
-/** @deprecated Use processPiSession instead */
-export function extractPiSessionMessages(filePath: string): ContextMessage[] {
-  return processPiSession(filePath, 0, 0, 0).messages;
 }
 
 // --- Preamble text readers ---

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -8,6 +8,7 @@ import {
   countSkillDescriptionTokens,
   countSystemPromptTokens,
   findClaudeSessionFile,
+  getCachedContextInfo,
   processClaudeSession,
   readSdkInstructions,
   readSkillDescriptions,
@@ -33,7 +34,7 @@ import type {
   VoluteContentPart,
   VoluteEvent,
 } from "./lib/types.js";
-import type { ContextInfo, ContextMessages } from "./lib/volute-server.js";
+import type { ContextInfo, ContextMessages, SessionContextInfo } from "./lib/volute-server.js";
 
 type Session = {
   name: string;
@@ -66,8 +67,8 @@ export function createMind(options: {
 }): {
   resolve: HandlerResolver;
   waitForCommits: () => Promise<void>;
-  getContextInfo: () => ContextInfo;
-  getContextMessages: () => ContextMessages;
+  getContextInfo: () => Promise<ContextInfo>;
+  getContextMessages: () => Promise<ContextMessages>;
 } {
   const autoCommit = createAutoCommitHook(options.cwd);
   const identityReload = createIdentityReloadHook(options.cwd);
@@ -658,51 +659,76 @@ export function createMind(options: {
   const claudeMdTokens = countSdkInstructionTokens(options.cwd);
   const skillDescTokens = countSkillDescriptionTokens([resolvePath(options.cwd, ".claude/skills")]);
 
-  function processSession(sessionName: string) {
+  function jsonlPathFor(sessionName: string): string | null {
     const sessionId = sessionStore.load(sessionName);
-    const jsonlPath = sessionId ? findClaudeSessionFile(options.cwd, sessionId) : null;
-    return jsonlPath
-      ? processClaudeSession(jsonlPath, systemPromptTokens, claudeMdTokens, skillDescTokens)
-      : null;
+    return sessionId ? findClaudeSessionFile(options.cwd, sessionId) : null;
   }
 
-  function getContextInfo(): ContextInfo {
-    return {
-      sessions: Array.from(sessions.values()).map((s) => {
-        try {
-          const result = processSession(s.name);
-          return {
-            name: s.name,
-            contextTokens: result?.parsed?.contextTokens ?? s.contextTokens,
-            contextWindow: maxContextTokens,
-            breakdown: result?.parsed?.breakdown,
-          };
-        } catch (err) {
-          log("mind", `failed to get context breakdown for session "${s.name}":`, err);
-          return { name: s.name, contextTokens: s.contextTokens, contextWindow: maxContextTokens };
-        }
-      }),
-      systemPrompt: systemPromptTokens,
-    };
+  async function getContextInfo(): Promise<ContextInfo> {
+    const infos: SessionContextInfo[] = [];
+    for (const s of sessions.values()) {
+      try {
+        const jsonlPath = jsonlPathFor(s.name);
+        // Cache the computed breakdown by file identity: polls between turns are free.
+        const parsed = jsonlPath
+          ? await getCachedContextInfo(
+              jsonlPath,
+              async () =>
+                (
+                  await processClaudeSession(
+                    jsonlPath,
+                    systemPromptTokens,
+                    claudeMdTokens,
+                    skillDescTokens,
+                  )
+                ).parsed,
+            )
+          : null;
+        infos.push({
+          name: s.name,
+          contextTokens: parsed?.contextTokens ?? s.contextTokens,
+          contextWindow: maxContextTokens,
+          breakdown: parsed?.breakdown,
+        });
+      } catch (err) {
+        log("mind", `failed to get context breakdown for session "${s.name}":`, err);
+        infos.push({
+          name: s.name,
+          contextTokens: s.contextTokens,
+          contextWindow: maxContextTokens,
+        });
+      }
+    }
+    return { sessions: infos, systemPrompt: systemPromptTokens };
   }
 
-  function getContextMessages(): ContextMessages {
+  async function getContextMessages(): Promise<ContextMessages> {
     const skillsDir = resolvePath(options.cwd, ".claude/skills");
+    const sessionMessages: ContextMessages["sessions"] = [];
+    for (const s of sessions.values()) {
+      try {
+        const jsonlPath = jsonlPathFor(s.name);
+        const result = jsonlPath
+          ? await processClaudeSession(
+              jsonlPath,
+              systemPromptTokens,
+              claudeMdTokens,
+              skillDescTokens,
+            )
+          : null;
+        sessionMessages.push({ name: s.name, messages: result?.messages ?? [] });
+      } catch (err) {
+        log("mind", `failed to extract messages for session "${s.name}":`, err);
+        sessionMessages.push({ name: s.name, messages: [] });
+      }
+    }
     return {
       preamble: {
         systemPrompt: options.systemPrompt,
         sdkInstructions: readSdkInstructions(options.cwd),
         skillDescriptions: readSkillDescriptions([skillsDir]),
       },
-      sessions: Array.from(sessions.values()).map((s) => {
-        try {
-          const result = processSession(s.name);
-          return { name: s.name, messages: result?.messages ?? [] };
-        } catch (err) {
-          log("mind", `failed to extract messages for session "${s.name}":`, err);
-          return { name: s.name, messages: [] };
-        }
-      }),
+      sessions: sessionMessages,
     };
   }
 

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -22,7 +22,7 @@ import { createPreCompactHook } from "./lib/hooks/pre-compact.js";
 import { createReplyInstructionsHook } from "./lib/hooks/reply-instructions.js";
 import { log } from "./lib/logger.js";
 import { createMessageChannel } from "./lib/message-channel.js";
-import { isSessionReapable } from "./lib/session-reaper.js";
+import { isSessionReapable, reapSessionQuery } from "./lib/session-reaper.js";
 import { createSessionStore } from "./lib/session-store.js";
 import { loadPrompts, type SubagentConfig } from "./lib/startup.js";
 import { consumeStream } from "./lib/stream-consumer.js";
@@ -545,16 +545,21 @@ export function createMind(options: {
   // transparently re-creates the session via getOrCreateSession's resume path.
   const idleTimeoutMs = (options.sessionIdleMinutes ?? 30) * 60_000;
 
-  function reapSession(session: Session) {
+  async function reapSession(session: Session) {
     log("mind", `session "${session.name}": idle — reaping SDK subprocess (resumable)`);
     // Delete first so a racing inbound message spins up a fresh resumed session
     // instead of reusing the one we're tearing down.
     sessions.delete(session.name);
     compactionTriggered.delete(session.name);
-    // Terminate the subprocess and end the input iterable so the stream consumer
-    // unwinds (its finally block also deletes from the map, now a no-op).
-    session.currentQuery?.close();
+    // End the input iterable so the stream consumer unwinds (its finally block
+    // also deletes from the map, now a no-op), then await the SDK's graceful
+    // shutdown via query.return() — unlike the fire-and-forget close(), this
+    // awaits the CLI subprocess's exit so the child is reaped instead of left
+    // as a <defunct> zombie.
     session.channel.close();
+    await reapSessionQuery(session.currentQuery, (err) =>
+      log("mind", `session "${session.name}": error reaping SDK subprocess:`, err),
+    );
     // Nothing should have raced in (isSessionReapable checked isEmpty), but if it
     // did, re-dispatch into a fresh session so no input is dropped.
     const pending = session.channel.recover();
@@ -572,7 +577,12 @@ export function createMind(options: {
       const stale = [...sessions.values()].filter((s) =>
         isSessionReapable(s, now, idleTimeoutMs, (name) => !!compactionTriggered.get(name)),
       );
-      for (const session of stale) reapSession(session);
+      // Reaps run independently; each awaits its own subprocess exit internally.
+      for (const session of stale) {
+        reapSession(session).catch((err) =>
+          log("mind", `session "${session.name}": reap failed:`, err),
+        );
+      }
     }, checkMs);
     reaper.unref?.();
   }

--- a/templates/claude/src/lib/session-reaper.ts
+++ b/templates/claude/src/lib/session-reaper.ts
@@ -35,3 +35,34 @@ export function isSessionReapable(
     now - session.lastActivityAt > idleTimeoutMs
   );
 }
+
+/** Minimal view of the SDK query needed to shut its subprocess down. */
+export interface ReapableQuery {
+  /**
+   * AsyncGenerator.return — the SDK overrides it to await its internal cleanup,
+   * which waits (bounded) for the CLI subprocess to exit.
+   */
+  return(value?: unknown): Promise<unknown>;
+}
+
+/**
+ * Tear down a reaped session's SDK subprocess and reap its exit status.
+ *
+ * `query.close()` is fire-and-forget: it kicks off cleanup but does not await the
+ * CLI subprocess's exit, so the child is left `<defunct>` (a zombie) until the
+ * mind process itself exits — PID-table growth on long-running minds with short
+ * idle timeouts. `query.return()` awaits the SDK's cleanup, which waits for the
+ * subprocess to exit, so the child's exit status is reaped. Errors are reported
+ * via `onError` (never thrown) so a teardown failure can't wedge the reaper.
+ */
+export async function reapSessionQuery(
+  query: ReapableQuery | undefined,
+  onError: (err: unknown) => void,
+): Promise<void> {
+  if (!query) return;
+  try {
+    await query.return();
+  } catch (err) {
+    onError(err);
+  }
+}

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -8,6 +8,7 @@ import {
   countSkillDescriptionTokens,
   countSystemPromptTokens,
   findCodexSessionFile,
+  getCachedContextInfo,
   processCodexSession,
   readSdkInstructions,
   readSkillDescriptions,
@@ -26,7 +27,7 @@ import type {
   VoluteContentPart,
   VoluteEvent,
 } from "./lib/types.js";
-import type { ContextInfo, ContextMessages } from "./lib/volute-server.js";
+import type { ContextInfo, ContextMessages, SessionContextInfo } from "./lib/volute-server.js";
 
 /** Minimal interface for a Codex SDK thread — typed to the methods we actually use */
 type CodexThread = {
@@ -77,8 +78,8 @@ export function createMind(options: {
   maxContextTokens?: number;
 }): {
   resolve: HandlerResolver;
-  getContextInfo: () => ContextInfo;
-  getContextMessages: () => ContextMessages;
+  getContextInfo: () => Promise<ContextInfo>;
+  getContextMessages: () => Promise<ContextMessages>;
 } {
   const sessions = new Map<string, CodexSession>();
   const prompts = loadPrompts();
@@ -623,55 +624,76 @@ export function createMind(options: {
   const claudeMdTokens = countSdkInstructionTokens(options.cwd);
   const skillDescTokens = countSkillDescriptionTokens([resolvePath(options.cwd, ".agents/skills")]);
 
-  function processSession(sessionName: string) {
+  function jsonlPathFor(sessionName: string): string | null {
     const threadId = sessionStore.load(sessionName);
-    const jsonlPath = threadId ? findCodexSessionFile(threadId, options.mindDir) : null;
-    return jsonlPath
-      ? processCodexSession(jsonlPath, systemPromptTokens, claudeMdTokens, skillDescTokens)
-      : null;
+    return threadId ? findCodexSessionFile(threadId, options.mindDir) : null;
   }
 
-  function getContextInfo(): ContextInfo {
-    return {
-      sessions: Array.from(sessions.values()).map((s) => {
-        try {
-          const result = processSession(s.name);
-          return {
-            name: s.name,
-            contextTokens: result?.parsed?.contextTokens ?? s.cumulativeInputTokens,
-            contextWindow: maxContextTokens,
-            breakdown: result?.parsed?.breakdown,
-          };
-        } catch (err) {
-          log("mind", `failed to get context breakdown for session "${s.name}":`, err);
-          return {
-            name: s.name,
-            contextTokens: s.cumulativeInputTokens,
-            contextWindow: maxContextTokens,
-          };
-        }
-      }),
-      systemPrompt: systemPromptTokens,
-    };
+  async function getContextInfo(): Promise<ContextInfo> {
+    const infos: SessionContextInfo[] = [];
+    for (const s of sessions.values()) {
+      try {
+        const jsonlPath = jsonlPathFor(s.name);
+        // Cache the computed breakdown by file identity: polls between turns are free.
+        const parsed = jsonlPath
+          ? await getCachedContextInfo(
+              jsonlPath,
+              async () =>
+                (
+                  await processCodexSession(
+                    jsonlPath,
+                    systemPromptTokens,
+                    claudeMdTokens,
+                    skillDescTokens,
+                  )
+                ).parsed,
+            )
+          : null;
+        infos.push({
+          name: s.name,
+          contextTokens: parsed?.contextTokens ?? s.cumulativeInputTokens,
+          contextWindow: maxContextTokens,
+          breakdown: parsed?.breakdown,
+        });
+      } catch (err) {
+        log("mind", `failed to get context breakdown for session "${s.name}":`, err);
+        infos.push({
+          name: s.name,
+          contextTokens: s.cumulativeInputTokens,
+          contextWindow: maxContextTokens,
+        });
+      }
+    }
+    return { sessions: infos, systemPrompt: systemPromptTokens };
   }
 
-  function getContextMessages(): ContextMessages {
+  async function getContextMessages(): Promise<ContextMessages> {
     const skillsDir = resolvePath(options.cwd, ".agents/skills");
+    const sessionMessages: ContextMessages["sessions"] = [];
+    for (const s of sessions.values()) {
+      try {
+        const jsonlPath = jsonlPathFor(s.name);
+        const result = jsonlPath
+          ? await processCodexSession(
+              jsonlPath,
+              systemPromptTokens,
+              claudeMdTokens,
+              skillDescTokens,
+            )
+          : null;
+        sessionMessages.push({ name: s.name, messages: result?.messages ?? [] });
+      } catch (err) {
+        log("mind", `failed to extract messages for session "${s.name}":`, err);
+        sessionMessages.push({ name: s.name, messages: [] });
+      }
+    }
     return {
       preamble: {
         systemPrompt: options.systemPrompt,
         sdkInstructions: readSdkInstructions(options.cwd),
         skillDescriptions: readSkillDescriptions([skillsDir]),
       },
-      sessions: Array.from(sessions.values()).map((s) => {
-        try {
-          const result = processSession(s.name);
-          return { name: s.name, messages: result?.messages ?? [] };
-        } catch (err) {
-          log("mind", `failed to extract messages for session "${s.name}":`, err);
-          return { name: s.name, messages: [] };
-        }
-      }),
+      sessions: sessionMessages,
     };
   }
 

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -16,6 +16,7 @@ import {
   countSkillDescriptionTokens,
   countSystemPromptTokens,
   findPiSessionFile,
+  getCachedContextInfo,
   processPiSession,
   readSdkInstructions,
   readSkillDescriptions,
@@ -36,7 +37,7 @@ import type {
   VoluteContentPart,
   VoluteEvent,
 } from "./lib/types.js";
-import type { ContextInfo, ContextMessages } from "./lib/volute-server.js";
+import type { ContextInfo, ContextMessages, SessionContextInfo } from "./lib/volute-server.js";
 
 type PiAgentSession = Awaited<ReturnType<typeof createAgentSession>>["session"];
 
@@ -63,8 +64,8 @@ export function createMind(options: {
   subagents?: Record<string, SubagentConfig>;
 }): {
   resolve: HandlerResolver;
-  getContextInfo: () => ContextInfo;
-  getContextMessages: () => ContextMessages;
+  getContextInfo: () => Promise<ContextInfo>;
+  getContextMessages: () => Promise<ContextMessages>;
 } {
   const sessions = new Map<string, PiSession>();
   const prompts = loadPrompts();
@@ -538,50 +539,66 @@ export function createMind(options: {
   const claudeMdTokens = countSdkInstructionTokens(options.cwd);
   const skillDescTokens = countSkillDescriptionTokens([resolvePath(options.cwd, ".pi/skills")]);
 
-  function processSession(sessionName: string) {
-    const jsonlPath = findPiSessionFile(piSessionsDir, sessionName);
-    return jsonlPath
-      ? processPiSession(jsonlPath, systemPromptTokens, claudeMdTokens, skillDescTokens)
-      : null;
+  async function getContextInfo(): Promise<ContextInfo> {
+    const infos: SessionContextInfo[] = [];
+    for (const s of sessions.values()) {
+      try {
+        const jsonlPath = findPiSessionFile(piSessionsDir, s.name);
+        // Cache the computed breakdown by file identity: polls between turns are free.
+        const parsed = jsonlPath
+          ? await getCachedContextInfo(
+              jsonlPath,
+              async () =>
+                (
+                  await processPiSession(
+                    jsonlPath,
+                    systemPromptTokens,
+                    claudeMdTokens,
+                    skillDescTokens,
+                  )
+                ).parsed,
+            )
+          : null;
+        infos.push({
+          name: s.name,
+          contextTokens: parsed?.contextTokens ?? s.contextTokens,
+          contextWindow: maxContextTokens,
+          breakdown: parsed?.breakdown,
+        });
+      } catch (err) {
+        log("mind", `failed to get context breakdown for session "${s.name}":`, err);
+        infos.push({
+          name: s.name,
+          contextTokens: s.contextTokens,
+          contextWindow: maxContextTokens,
+        });
+      }
+    }
+    return { sessions: infos, systemPrompt: systemPromptTokens };
   }
 
-  function getContextInfo(): ContextInfo {
-    return {
-      sessions: Array.from(sessions.values()).map((s) => {
-        try {
-          const result = processSession(s.name);
-          return {
-            name: s.name,
-            contextTokens: result?.parsed?.contextTokens ?? s.contextTokens,
-            contextWindow: maxContextTokens,
-            breakdown: result?.parsed?.breakdown,
-          };
-        } catch (err) {
-          log("mind", `failed to get context breakdown for session "${s.name}":`, err);
-          return { name: s.name, contextTokens: s.contextTokens, contextWindow: maxContextTokens };
-        }
-      }),
-      systemPrompt: systemPromptTokens,
-    };
-  }
-
-  function getContextMessages(): ContextMessages {
+  async function getContextMessages(): Promise<ContextMessages> {
     const skillsDir = resolvePath(options.cwd, ".pi/skills");
+    const sessionMessages: ContextMessages["sessions"] = [];
+    for (const s of sessions.values()) {
+      try {
+        const jsonlPath = findPiSessionFile(piSessionsDir, s.name);
+        const result = jsonlPath
+          ? await processPiSession(jsonlPath, systemPromptTokens, claudeMdTokens, skillDescTokens)
+          : null;
+        sessionMessages.push({ name: s.name, messages: result?.messages ?? [] });
+      } catch (err) {
+        log("mind", `failed to extract messages for session "${s.name}":`, err);
+        sessionMessages.push({ name: s.name, messages: [] });
+      }
+    }
     return {
       preamble: {
         systemPrompt: options.systemPrompt,
         sdkInstructions: readSdkInstructions(options.cwd),
         skillDescriptions: readSkillDescriptions([skillsDir]),
       },
-      sessions: Array.from(sessions.values()).map((s) => {
-        try {
-          const result = processSession(s.name);
-          return { name: s.name, messages: result?.messages ?? [] };
-        } catch (err) {
-          log("mind", `failed to extract messages for session "${s.name}":`, err);
-          return { name: s.name, messages: [] };
-        }
-      }),
+      sessions: sessionMessages,
     };
   }
 

--- a/test/context-breakdown.test.ts
+++ b/test/context-breakdown.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import {
+  getCachedContextInfo,
+  type ParsedContext,
+  processClaudeSession,
+} from "../templates/_base/src/lib/context-breakdown.js";
+
+const tmpDir = join(tmpdir(), `.volute-context-breakdown-test-${process.pid}`);
+
+// Token estimation fallback used when @anthropic-ai/tokenizer is unavailable
+// (which it is in the test environment). Lets us assert exact breakdown counts.
+const est = (s: string) => Math.round(s.length / 3.5);
+
+before(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+after(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+});
+
+describe("context-breakdown streaming parser", () => {
+  const THINK = "thinking about the problem carefully";
+  const ATEXT = "here is my considered answer";
+  const TRESULT = "the tool produced this output";
+  const UTEXT = "what is the answer to my question";
+  const TOOL_INPUT = { command: "ls -la /tmp" };
+
+  it("golden: streaming parser yields the expected ContextInfo + messages", async () => {
+    const filePath = join(tmpDir, "session-golden.jsonl");
+    // Include edge cases the old readFileSync+split path tolerated: a blank line,
+    // a malformed JSON line (skipped), and a trailing newline.
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          usage: { input_tokens: 100, cache_read_input_tokens: 50 },
+          content: [
+            { type: "thinking", thinking: THINK },
+            { type: "text", text: ATEXT },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", content: TRESULT }],
+        },
+      }),
+      "",
+      "{ this is not valid json",
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          usage: {
+            input_tokens: 200,
+            cache_creation_input_tokens: 80,
+            cache_read_input_tokens: 120,
+          },
+          content: [{ type: "tool_use", name: "Bash", input: TOOL_INPUT }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: UTEXT }] },
+      }),
+    ];
+    writeFileSync(filePath, `${lines.join("\n")}\n`);
+
+    const result = await processClaudeSession(filePath, 11, 22, 33);
+
+    const expectedParsed: ParsedContext = {
+      // Last assistant usage wins: 200 + 80 + 120
+      contextTokens: 400,
+      breakdown: {
+        systemPrompt: 11,
+        sdkInstructions: 22,
+        skillDescriptions: 33,
+        conversation: {
+          userText: est(UTEXT),
+          assistantText: est(ATEXT),
+          thinking: est(THINK),
+          toolUse: est(JSON.stringify(TOOL_INPUT)),
+          toolResult: est(TRESULT),
+        },
+      },
+    };
+    assert.deepEqual(result.parsed, expectedParsed);
+
+    assert.deepEqual(result.messages, [
+      {
+        role: "assistant",
+        blocks: [
+          { type: "thinking", text: THINK },
+          { type: "text", text: ATEXT },
+        ],
+      },
+      {
+        role: "user",
+        blocks: [{ type: "tool_result", text: TRESULT, isError: false }],
+      },
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use", name: "Bash", input: JSON.stringify(TOOL_INPUT, null, 2) }],
+      },
+      { role: "user", blocks: [{ type: "text", text: UTEXT }] },
+    ]);
+  });
+
+  it("returns empty result for a missing file", async () => {
+    const result = await processClaudeSession(join(tmpDir, "does-not-exist.jsonl"), 0, 0, 0);
+    assert.deepEqual(result, { parsed: null, messages: [] });
+  });
+});
+
+describe("getCachedContextInfo", () => {
+  it("caches by file identity: unchanged file is not re-read; a change re-parses", async () => {
+    const filePath = join(tmpDir, "cache-target.jsonl");
+    writeFileSync(filePath, "one\n");
+
+    let computeCount = 0;
+    const sentinel: ParsedContext = {
+      contextTokens: 7,
+      breakdown: {
+        systemPrompt: 0,
+        sdkInstructions: 0,
+        skillDescriptions: 0,
+        conversation: { userText: 0, assistantText: 0, thinking: 0, toolUse: 0, toolResult: 0 },
+      },
+    };
+    const compute = async () => {
+      computeCount++;
+      return sentinel;
+    };
+
+    const first = await getCachedContextInfo(filePath, compute);
+    assert.equal(computeCount, 1);
+    assert.equal(first, sentinel);
+
+    // Same file identity (mtime + size unchanged) — served from cache, no re-read.
+    const second = await getCachedContextInfo(filePath, compute);
+    assert.equal(computeCount, 1);
+    assert.equal(second, sentinel);
+
+    // Change the file (different size) — cache invalidates and re-parses.
+    writeFileSync(filePath, "one two three\n");
+    const third = await getCachedContextInfo(filePath, compute);
+    assert.equal(computeCount, 2);
+    assert.equal(third, sentinel);
+  });
+
+  it("returns null without computing for a missing file", async () => {
+    let called = false;
+    const result = await getCachedContextInfo(join(tmpDir, "nope.jsonl"), async () => {
+      called = true;
+      return null;
+    });
+    assert.equal(result, null);
+    assert.equal(called, false);
+  });
+});

--- a/test/session-reaper.test.ts
+++ b/test/session-reaper.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   isSessionReapable,
+  type ReapableQuery,
   type ReapableSession,
+  reapSessionQuery,
 } from "../templates/claude/src/lib/session-reaper.js";
 
 const TIMEOUT = 30 * 60_000; // 30 min
@@ -56,5 +58,61 @@ describe("isSessionReapable", () => {
   it("never reaps when reaping is disabled (timeout 0)", () => {
     const s = session({ lastActivityAt: 0 }); // ancient
     assert.equal(isSessionReapable(s, NOW, 0, notCompacting), false);
+  });
+});
+
+describe("reapSessionQuery", () => {
+  it("awaits query.return() so the subprocess exit is reaped (not fire-and-forget)", async () => {
+    let returned = false;
+    let resolveReturn: () => void = () => {};
+    const query: ReapableQuery = {
+      return() {
+        return new Promise<void>((resolve) => {
+          resolveReturn = () => {
+            returned = true;
+            resolve();
+          };
+        });
+      },
+    };
+
+    let done = false;
+    const p = reapSessionQuery(query, () => {}).then(() => {
+      done = true;
+    });
+
+    // return() is still pending, so reapSessionQuery must not have resolved yet.
+    await Promise.resolve();
+    assert.equal(done, false);
+    assert.equal(returned, false);
+
+    resolveReturn();
+    await p;
+    assert.equal(done, true);
+    assert.equal(returned, true);
+  });
+
+  it("no-ops when there is no query", async () => {
+    let errored = false;
+    await reapSessionQuery(undefined, () => {
+      errored = true;
+    });
+    assert.equal(errored, false);
+  });
+
+  it("reports errors via onError without throwing", async () => {
+    const boom = new Error("teardown failed");
+    let captured: unknown;
+    await reapSessionQuery(
+      {
+        return() {
+          return Promise.reject(boom);
+        },
+      },
+      (err) => {
+        captured = err;
+      },
+    );
+    assert.equal(captured, boom);
   });
 });


### PR DESCRIPTION
Part of the core-reliability release (memory footprint). **Stacked on #460 — merge that first.**

The idle-session reaper (added in #492) left a `[claude] <defunct>` zombie per reap — 17 accumulated over one integration-test session. Root cause: the SDK's `query.close()` is fire-and-forget — it kicks off cleanup but does not await the CLI subprocess's exit, so the child is left defunct until the mind process itself exits (PID-table growth on long-running minds with short idle timeouts). `query.return()` (the AsyncGenerator override) awaits the same cleanup, which waits for the subprocess to exit.

The reaper now ends the input iterable, then `await`s a new `reapSessionQuery()` helper that calls `query.return()` and reports errors without throwing (a teardown failure can't wedge the reaper). Claude-only — the codex/pi templates have no idle reaper.

The unit tests pin the behavioral contract (the reaper awaits graceful `return()` rather than fire-and-forget); a "no `<defunct>` after an idle reap" assertion belongs in the post-merge e2e pass.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
