### PR TITLE
fix: don't throw when sending a direct system message to the spirit

### DIFF
--- a/packages/daemon/src/lib/chat/system-chat.ts
+++ b/packages/daemon/src/lib/chat/system-chat.ts
@@ -111,11 +111,21 @@ export async function sendSystemMessage(
  * Persist a system message to the conversation and mind_history, but do NOT
  * call deliverMessage. For cases where the caller POSTs directly to the mind's
  * /message endpoint (sleep manager, mind manager).
+ *
+ * When the target is the spirit ("volute"), skips conversation persistence
+ * since the spirit cannot DM itself, but still records the inbound to
+ * mind_history and returns no conversationId.
  */
 export async function sendSystemMessageDirect(
   mindName: string,
   text: string,
-): Promise<{ conversationId: string }> {
+): Promise<{ conversationId?: string }> {
+  // Spirit can't DM itself — record inbound only, no conversation persistence
+  if (isSpiritName(mindName)) {
+    await recordInbound(mindName, "@volute", "volute", text);
+    return {};
+  }
+
   const { conversationId } = await ensureSystemDM(mindName);
 
   await addMessage(conversationId, "user", "volute", [{ type: "text", text }]);

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -19,6 +19,7 @@ import {
   conversationParticipants,
   conversations,
   messages,
+  mindHistory,
   minds,
   users,
 } from "../packages/daemon/src/lib/schema.js";
@@ -32,6 +33,7 @@ async function cleanup() {
   const db = await getDb();
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
+    await db.delete(mindHistory).where(eq(mindHistory.mind, username));
   }
   await db.delete(minds).where(eq(minds.name, "volute"));
 }
@@ -130,6 +132,21 @@ describe("system messages", () => {
     assert.equal(msgs[0].sender_name, "volute");
     assert.equal(msgs[0].role, "user");
     assert.ok(msgs[0].content.includes("hello from system"));
+  });
+
+  it("sendSystemMessageDirect does not throw for the spirit and records inbound only", async () => {
+    const result = await sendSystemMessageDirect("volute", "pre-sleep context");
+
+    assert.equal(result.conversationId, undefined, "spirit gets no conversationId");
+
+    const db = await getDb();
+
+    // The inbound is recorded in mind_history even though there's no conversation
+    const history = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const inbound = history.find((h) => h.content?.includes("pre-sleep context"));
+    assert.ok(inbound, "spirit inbound should be recorded in mind_history");
+    assert.equal(inbound!.type, "inbound");
+    assert.equal(inbound!.channel, "@volute");
   });
 
   it("sendSystemMessage persists message and calls delivery pipeline", async () => {


### PR DESCRIPTION
Part of the core-reliability release (spirit correctness).

`sendSystemMessage` guards the spirit ("can't DM yourself") and skips conversation persistence for it, but its sibling `sendSystemMessageDirect` called `ensureSystemDM()` unguarded — which **throws** for the spirit. Callers hit this whenever the spirit sleeps or restarts with pending context (pre-sleep message, wake summary, restart/merge context): all three caught and continued, but logged at error level and the message was never persisted.

`sendSystemMessageDirect` now mirrors the guard via the existing `isSpiritName` helper: for the spirit it records the inbound to `mind_history` (matching `sendSystemMessage`) and returns `{ conversationId?: string }` with no id, instead of throwing. Call sites already spread `conversationId` conditionally, so no caller changes.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
