### PR TITLE
fix: reject one-participant conversations so spirit self-replies fail loudly

### DIFF
--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -297,6 +297,17 @@ const cmd = command({
       const mindSelf = process.env.VOLUTE_MIND;
       const sender = flags.sender || mindSelf || userInfo().username;
 
+      // Sending to yourself is a dead end: it would resolve to a
+      // one-participant conversation that reaches nobody. For the spirit this
+      // happens when it "replies" to its own system notices on @volute.
+      if (mindSelf && targetName === mindSelf) {
+        console.error(
+          `Can't send to @${targetName} — that's your own system channel. ` +
+            `System messages there are automated notices; they don't need a reply.`,
+        );
+        process.exit(1);
+      }
+
       const targetIsMind = await isMind(targetName);
       waitMindName = targetIsMind ? targetName : undefined;
 

--- a/packages/daemon/src/lib/chat/system-chat.ts
+++ b/packages/daemon/src/lib/chat/system-chat.ts
@@ -111,11 +111,21 @@ export async function sendSystemMessage(
  * Persist a system message to the conversation and mind_history, but do NOT
  * call deliverMessage. For cases where the caller POSTs directly to the mind's
  * /message endpoint (sleep manager, mind manager).
+ *
+ * When the target is the spirit ("volute"), skips conversation persistence
+ * since the spirit cannot DM itself, but still records the inbound to
+ * mind_history and returns no conversationId.
  */
 export async function sendSystemMessageDirect(
   mindName: string,
   text: string,
-): Promise<{ conversationId: string }> {
+): Promise<{ conversationId?: string }> {
+  // Spirit can't DM itself — record inbound only, no conversation persistence
+  if (isSpiritName(mindName)) {
+    await recordInbound(mindName, "@volute", "volute", text);
+    return {};
+  }
+
   const { conversationId } = await ensureSystemDM(mindName);
 
   await addMessage(conversationId, "user", "volute", [{ type: "text", text }]);

--- a/packages/daemon/src/web/api/volute/conversations.ts
+++ b/packages/daemon/src/web/api/volute/conversations.ts
@@ -91,6 +91,13 @@ const app = new Hono<AuthEnv>()
 
     const participantIds = [...participantSet];
 
+    // Reject degenerate conversations — a conversation needs at least two
+    // distinct members. Guards against e.g. the spirit (which shares the
+    // system user) creating a one-participant DM to itself.
+    if (participantIds.length < 2) {
+      return c.json({ error: "a conversation needs at least two distinct participants" }, 400);
+    }
+
     // Reject group DMs — use channels for 3+ participants
     if (participantIds.length > 2) {
       return c.json({ error: "Use channels for multi-participant conversations" }, 400);

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -4,7 +4,12 @@ import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync 
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
-import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import {
+  approveUser,
+  createUser,
+  getOrCreateMindUser,
+  getUserByUsername,
+} from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   findMind,
@@ -698,6 +703,22 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
   }
 
+  // A real (brain) second participant. A conversation needs at least two distinct
+  // members (see conversations POST guard); the daemon-token path does not add the
+  // caller, and participantNames:[TEST_MIND] alone dedupes to just the mind user.
+  // This mirrors how the web UI creates a conversation: a person plus the mind.
+  // Each test uses a distinct brain so its DM is new (DM reuse would return 200,
+  // not the 201 these tests assert).
+  async function ensureBrainParticipant(suffix: string): Promise<string> {
+    const username = `e2e-brain-${suffix}`;
+    let user = await getUserByUsername(username);
+    if (!user) {
+      user = await createUser(username, "e2e-brain-pass");
+      await approveUser(user.id);
+    }
+    return username;
+  }
+
   it("volute channels: create, list, invite mind, members", async () => {
     await ensureTestMind();
 
@@ -786,14 +807,15 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
   it("conversations: create, send message, read back", async () => {
     await ensureTestMind();
+    const brain = await ensureBrainParticipant("convo");
 
-    // Create a conversation with the test mind
+    // Create a conversation between the test mind and a real second participant.
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         title: "e2e test conversation",
-        participantNames: [TEST_MIND],
+        participantNames: [TEST_MIND, brain],
       }),
     });
     assert.equal(createRes.status, 201, `Create conv: ${await createRes.clone().text()}`);
@@ -847,13 +869,16 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   });
 
   it("unified chat: send via /api/v1/chat", async () => {
-    // Create a conversation first
+    await ensureTestMind();
+    const brain = await ensureBrainParticipant("unified");
+
+    // Create a conversation first (mind + a real second participant)
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         title: "unified chat test",
-        participantNames: [TEST_MIND],
+        participantNames: [TEST_MIND, brain],
       }),
     });
     assert.equal(createRes.status, 201, `Create: ${await createRes.clone().text()}`);
@@ -1654,12 +1679,13 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
     );
     await waitForMindRunning();
+    const brain = await ensureBrainParticipant("delivery");
 
     // Send through the unified chat endpoint (the real CLI/web send path).
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND] }),
+      body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND, brain] }),
     });
     assert.equal(createRes.status, 201, `Create conv: ${await createRes.clone().text()}`);
     const conv = (await createRes.json()) as { id: string };

--- a/test/send-self.test.ts
+++ b/test/send-self.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, mock } from "node:test";
+import { run } from "../packages/cli/src/commands/send.js";
+
+describe("send self-DM fast-path", () => {
+  afterEach(() => {
+    mock.restoreAll();
+    delete process.env.VOLUTE_MIND;
+  });
+
+  it("errors and exits 1 when a mind sends to its own @self channel", async () => {
+    process.env.VOLUTE_MIND = "volute";
+    const exitMock = mock.method(process, "exit", () => {
+      throw new Error("exit");
+    });
+
+    const origError = console.error;
+    const errors: string[] = [];
+    console.error = (...a: unknown[]) => errors.push(a.join(" "));
+    try {
+      await run(["@volute", "reply to my own notice"]);
+    } catch {
+      // exit mock throws
+    } finally {
+      console.error = origError;
+    }
+
+    assert.equal(exitMock.mock.calls[0]?.arguments[0], 1, "should exit with 1");
+    assert.ok(
+      errors.some((e) => e.includes("your own system channel")),
+      `should explain the self-send is a dead end, got: ${errors.join(" | ")}`,
+    );
+  });
+});

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -19,6 +19,7 @@ import {
   conversationParticipants,
   conversations,
   messages,
+  mindHistory,
   minds,
   users,
 } from "../packages/daemon/src/lib/schema.js";
@@ -32,6 +33,7 @@ async function cleanup() {
   const db = await getDb();
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
+    await db.delete(mindHistory).where(eq(mindHistory.mind, username));
   }
   await db.delete(minds).where(eq(minds.name, "volute"));
 }
@@ -130,6 +132,21 @@ describe("system messages", () => {
     assert.equal(msgs[0].sender_name, "volute");
     assert.equal(msgs[0].role, "user");
     assert.ok(msgs[0].content.includes("hello from system"));
+  });
+
+  it("sendSystemMessageDirect does not throw for the spirit and records inbound only", async () => {
+    const result = await sendSystemMessageDirect("volute", "pre-sleep context");
+
+    assert.equal(result.conversationId, undefined, "spirit gets no conversationId");
+
+    const db = await getDb();
+
+    // The inbound is recorded in mind_history even though there's no conversation
+    const history = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const inbound = history.find((h) => h.content?.includes("pre-sleep context"));
+    assert.ok(inbound, "spirit inbound should be recorded in mind_history");
+    assert.equal(inbound!.type, "inbound");
+    assert.equal(inbound!.channel, "@volute");
   });
 
   it("sendSystemMessage persists message and calls delivery pipeline", async () => {

--- a/test/web-conversations.test.ts
+++ b/test/web-conversations.test.ts
@@ -38,6 +38,7 @@ const TEST_USERNAMES = [
   "other-user3",
   "group-member",
   "privacy-outsider",
+  "volute",
 ];
 
 async function cleanup() {
@@ -324,6 +325,30 @@ describe("web conversations routes", () => {
     assert.equal(res.status, 400);
     const body = await res.json();
     assert.ok(body.error.includes("channels"));
+  });
+
+  it("POST /:name/conversations — rejects a single-participant (self) conversation", async () => {
+    // The spirit shares the system user, so a "@volute" DM to itself resolves the
+    // mind user and the named participant to the same id — one distinct member.
+    const prev = process.env.VOLUTE_DAEMON_TOKEN;
+    process.env.VOLUTE_DAEMON_TOKEN = "conv-daemon-token";
+    try {
+      const app = createApp();
+      const res = await app.request("/api/minds/volute/conversations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer conv-daemon-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ participantNames: ["volute"] }),
+      });
+      assert.equal(res.status, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes("two distinct participants"), body.error);
+    } finally {
+      if (prev === undefined) delete process.env.VOLUTE_DAEMON_TOKEN;
+      else process.env.VOLUTE_DAEMON_TOKEN = prev;
+    }
   });
 
   it("POST /:name/conversations — validates participant IDs", async () => {


### PR DESCRIPTION
Part of the core-reliability release (spirit correctness). **Stacked on #431 — merge that first.**

When the spirit replied to its own system messages, the reply vanished into a one-participant conversation — with a success message. System messages reach the spirit as if from itself (`@volute`), so following the standard reply instructions resolved to a conversation whose participant set deduped to a single member, created anyway, then fanned out to nobody.

- **API guard**: the conversations POST now rejects a resolved participant set with fewer than 2 distinct members → 400 "a conversation needs at least two distinct participants" (also covers any user creating a conversation with only themselves).
- **CLI fast-path**: `send.ts` errors early when a mind's resolved DM target is itself, explaining that `@volute` is its own system channel and automated notices don't need a reply.

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
