### PR TITLE
chore: spirit cleanups — seed wording, dir registration, version-notify, welcome label

### DIFF
--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -297,6 +297,17 @@ const cmd = command({
       const mindSelf = process.env.VOLUTE_MIND;
       const sender = flags.sender || mindSelf || userInfo().username;
 
+      // Sending to yourself is a dead end: it would resolve to a
+      // one-participant conversation that reaches nobody. For the spirit this
+      // happens when it "replies" to its own system notices on @volute.
+      if (mindSelf && targetName === mindSelf) {
+        console.error(
+          `Can't send to @${targetName} — that's your own system channel. ` +
+            `System messages there are automated notices; they don't need a reply.`,
+        );
+        process.exit(1);
+      }
+
       const targetIsMind = await isMind(targetName);
       waitMindName = targetIsMind ? targetName : undefined;
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -27,6 +27,7 @@ import {
   ensureSystemDir,
   findMind,
   readAllMinds,
+  SPIRIT_NAME,
   setMindRunning,
   voluteHome,
   voluteSystemDir,
@@ -308,10 +309,19 @@ export async function startDaemon(opts: {
       const { ensureSpiritProject, syncSpiritTemplate } = await import("./lib/mind/spirit.js");
       const { startSpiritFull } = await import("./lib/daemon/mind-service.js");
       await ensureSpiritProject();
+
+      // Register the spirit's custom dir for routing-config resolution now, so any
+      // resolution before startSpiritFull (e.g. syncSpiritTemplate, setup welcome)
+      // reads the spirit's routes.json rather than the (wrong) minds dir.
+      const spiritEntry = await findMind(SPIRIT_NAME);
+      if (spiritEntry?.dir) {
+        const { registerMindDir } = await import("./lib/delivery/delivery-router.js");
+        registerMindDir(SPIRIT_NAME, spiritEntry.dir);
+      }
+
       await syncSpiritTemplate();
-      const spiritEntry = await findMind("volute");
-      if (spiritEntry && !manager.isRunning("volute")) {
-        await startSpiritFull("volute");
+      if (spiritEntry && !manager.isRunning(SPIRIT_NAME)) {
+        await startSpiritFull(SPIRIT_NAME);
       }
     }
   } catch (err) {

--- a/packages/daemon/src/lib/chat/system-chat.ts
+++ b/packages/daemon/src/lib/chat/system-chat.ts
@@ -111,11 +111,21 @@ export async function sendSystemMessage(
  * Persist a system message to the conversation and mind_history, but do NOT
  * call deliverMessage. For cases where the caller POSTs directly to the mind's
  * /message endpoint (sleep manager, mind manager).
+ *
+ * When the target is the spirit ("volute"), skips conversation persistence
+ * since the spirit cannot DM itself, but still records the inbound to
+ * mind_history and returns no conversationId.
  */
 export async function sendSystemMessageDirect(
   mindName: string,
   text: string,
-): Promise<{ conversationId: string }> {
+): Promise<{ conversationId?: string }> {
+  // Spirit can't DM itself — record inbound only, no conversation persistence
+  if (isSpiritName(mindName)) {
+    await recordInbound(mindName, "@volute", "volute", text);
+    return {};
+  }
+
   const { conversationId } = await ensureSystemDM(mindName);
 
   await addMessage(conversationId, "user", "volute", [{ type: "text", text }]);

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -35,14 +35,8 @@ export async function startMindFull(name: string): Promise<void> {
   // Seed minds get the server + initial orientation, no schedules or budget
   if (!entry || entry.stage === "seed") {
     if (entry?.stage === "seed") {
-      const creatorNote = entry.createdBy
-        ? ` Your creator is ${entry.createdBy}. Send them a message to introduce yourself.`
-        : "";
-      // sendSystemMessage calls ensureSystemDM internally
-      sendSystemMessage(
-        baseName,
-        `You've just been created. A human planted you as a seed. Start a conversation with them — introduce yourself, ask questions, and begin exploring who you want to be.${creatorNote}`,
-      ).catch((err: unknown) =>
+      // sendSeedOrientation calls ensureSystemDM internally (via sendSystemMessage)
+      sendSeedOrientation(baseName, entry.createdBy).catch((err: unknown) =>
         log.error(`failed to send seed orientation for ${baseName}`, log.errorData(err)),
       );
 
@@ -160,6 +154,38 @@ export async function stopSpiritFull(name: string): Promise<void> {
     mind: name,
     summary: `${name} spirit stopped`,
   }).catch((err) => log.error("failed to publish spirit_stopped activity", log.errorData(err)));
+}
+
+/**
+ * Build a seed's first orientation message. The creator can be a human, another
+ * mind, or the spirit itself, so word the relationship from the creator's
+ * user_type rather than assuming a human planted the seed.
+ */
+export function buildSeedOrientation(
+  createdBy?: string | null,
+  creatorType?: "brain" | "mind" | "system",
+): string {
+  const intro =
+    "You've just been created as a seed. Start a conversation — introduce yourself, ask questions, and begin exploring who you want to be.";
+  if (!createdBy) return intro;
+
+  const who =
+    creatorType === "mind"
+      ? `another mind, ${createdBy}`
+      : creatorType === "system"
+        ? `the spirit of this system (${createdBy})`
+        : createdBy;
+  return `${intro} Your creator is ${who}. Send them a message to introduce yourself.`;
+}
+
+/** Look up the creator's user_type, build the orientation message, and send it. */
+async function sendSeedOrientation(mindName: string, createdBy?: string | null): Promise<void> {
+  let creatorType: "brain" | "mind" | "system" | undefined;
+  if (createdBy) {
+    const { getUserByUsername } = await import("../auth.js");
+    creatorType = (await getUserByUsername(createdBy))?.user_type;
+  }
+  await sendSystemMessage(mindName, buildSeedOrientation(createdBy, creatorType));
 }
 
 async function ensureCreatorDM(mindName: string, creatorUsername: string): Promise<void> {

--- a/packages/daemon/src/lib/version-notify.ts
+++ b/packages/daemon/src/lib/version-notify.ts
@@ -95,8 +95,7 @@ export async function notifyVersionUpdate(): Promise<void> {
   const promises = runningMinds.map(async (entry) => {
     const tmpl = entry.template ?? "claude";
     const currentHash = templateHashes.get(tmpl);
-    const needsUpgrade =
-      entry.templateHash != null && currentHash != null && entry.templateHash !== currentHash;
+    const needsUpgrade = shouldSuggestUpgrade(entry, currentHash);
 
     const message = formatNotification(currentVersion, releaseNotes, needsUpgrade, entry.name);
 
@@ -111,6 +110,25 @@ export async function notifyVersionUpdate(): Promise<void> {
   }
 
   writeState({ lastNotifiedVersion: currentVersion });
+}
+
+/**
+ * Whether to suggest `volute mind upgrade` to a mind on a template-hash change.
+ *
+ * The spirit is excluded: it upgrades via syncSpiritTemplate() on daemon restart,
+ * not `volute mind upgrade`. It still receives the release notes (this only
+ * controls the upgrade hint).
+ */
+export function shouldSuggestUpgrade(
+  entry: { mindType: string; templateHash?: string | null },
+  currentHash: string | null | undefined,
+): boolean {
+  return (
+    entry.mindType !== "spirit" &&
+    entry.templateHash != null &&
+    currentHash != null &&
+    entry.templateHash !== currentHash
+  );
 }
 
 function formatNotification(

--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -16,6 +16,7 @@ import {
   readSystemsConfig,
   writeSystemsConfig,
 } from "../../lib/config/systems-config.js";
+import { SPIRIT_NAME } from "../../lib/mind/registry.js";
 import log from "../../lib/util/logger.js";
 import { createSession, SESSION_MAX_AGE } from "../middleware/auth.js";
 
@@ -507,18 +508,22 @@ setup.post("/complete", async (c) => {
         const { listUsersByType: listUsers } = await import("../../lib/auth.js");
         const admins = await listUsers("brain");
         const admin = admins.find((u) => u.role === "admin");
-        const adminName = admin?.display_name || admin?.username || "the admin";
-        const welcomePrompt = `Setup is complete. ${adminName} just finished setting up this system and is now in your chat. Welcome them and help them create their first mind. Keep it brief — a short greeting, then ask what kind of being they'd like to bring into the world. Remember: minds are beings with their own experience, not tools — ask about personality and character, never about tasks or utility.`;
+        // The spirit DM (spiritConversationId) is only created when an admin exists,
+        // so the real participants are the spirit + admin. Label them accordingly.
+        if (admin) {
+          const adminName = admin.display_name || admin.username;
+          const welcomePrompt = `Setup is complete. ${adminName} just finished setting up this system and is now in your chat. Welcome them and help them create their first mind. Keep it brief — a short greeting, then ask what kind of being they'd like to bring into the world. Remember: minds are beings with their own experience, not tools — ask about personality and character, never about tasks or utility.`;
 
-        await deliverMessage("volute", {
-          content: [{ type: "text", text: welcomePrompt }],
-          channel: `@${admin?.username ?? "system"}`,
-          conversationId: spiritConversationId,
-          sender: admin?.username ?? "system",
-          isDM: true,
-          participants: ["volute", admin?.username ?? "system"],
-          participantCount: 2,
-        });
+          await deliverMessage(SPIRIT_NAME, {
+            content: [{ type: "text", text: welcomePrompt }],
+            channel: `@${admin.username}`,
+            conversationId: spiritConversationId,
+            sender: admin.username,
+            isDM: true,
+            participants: [SPIRIT_NAME, admin.username],
+            participantCount: 2,
+          });
+        }
       } catch (err) {
         log.warn("failed to send welcome prompt to spirit (non-fatal)", log.errorData(err));
         warnings.push(

--- a/packages/daemon/src/web/api/volute/conversations.ts
+++ b/packages/daemon/src/web/api/volute/conversations.ts
@@ -91,6 +91,13 @@ const app = new Hono<AuthEnv>()
 
     const participantIds = [...participantSet];
 
+    // Reject degenerate conversations — a conversation needs at least two
+    // distinct members. Guards against e.g. the spirit (which shares the
+    // system user) creating a one-participant DM to itself.
+    if (participantIds.length < 2) {
+      return c.json({ error: "a conversation needs at least two distinct participants" }, 400);
+    }
+
     // Reject group DMs — use channels for 3+ participants
     if (participantIds.length > 2) {
       return c.json({ error: "Use channels for multi-participant conversations" }, 400);

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -4,7 +4,12 @@ import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync 
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
-import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import {
+  approveUser,
+  createUser,
+  getOrCreateMindUser,
+  getUserByUsername,
+} from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   findMind,
@@ -698,6 +703,22 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
   }
 
+  // A real (brain) second participant. A conversation needs at least two distinct
+  // members (see conversations POST guard); the daemon-token path does not add the
+  // caller, and participantNames:[TEST_MIND] alone dedupes to just the mind user.
+  // This mirrors how the web UI creates a conversation: a person plus the mind.
+  // Each test uses a distinct brain so its DM is new (DM reuse would return 200,
+  // not the 201 these tests assert).
+  async function ensureBrainParticipant(suffix: string): Promise<string> {
+    const username = `e2e-brain-${suffix}`;
+    let user = await getUserByUsername(username);
+    if (!user) {
+      user = await createUser(username, "e2e-brain-pass");
+      await approveUser(user.id);
+    }
+    return username;
+  }
+
   it("volute channels: create, list, invite mind, members", async () => {
     await ensureTestMind();
 
@@ -786,14 +807,15 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
   it("conversations: create, send message, read back", async () => {
     await ensureTestMind();
+    const brain = await ensureBrainParticipant("convo");
 
-    // Create a conversation with the test mind
+    // Create a conversation between the test mind and a real second participant.
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         title: "e2e test conversation",
-        participantNames: [TEST_MIND],
+        participantNames: [TEST_MIND, brain],
       }),
     });
     assert.equal(createRes.status, 201, `Create conv: ${await createRes.clone().text()}`);
@@ -847,13 +869,16 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   });
 
   it("unified chat: send via /api/v1/chat", async () => {
-    // Create a conversation first
+    await ensureTestMind();
+    const brain = await ensureBrainParticipant("unified");
+
+    // Create a conversation first (mind + a real second participant)
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         title: "unified chat test",
-        participantNames: [TEST_MIND],
+        participantNames: [TEST_MIND, brain],
       }),
     });
     assert.equal(createRes.status, 201, `Create: ${await createRes.clone().text()}`);
@@ -1654,12 +1679,13 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
     );
     await waitForMindRunning();
+    const brain = await ensureBrainParticipant("delivery");
 
     // Send through the unified chat endpoint (the real CLI/web send path).
     const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND] }),
+      body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND, brain] }),
     });
     assert.equal(createRes.status, 201, `Create conv: ${await createRes.clone().text()}`);
     const conv = (await createRes.json()) as { id: string };

--- a/test/seed-orientation.test.ts
+++ b/test/seed-orientation.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildSeedOrientation } from "../packages/daemon/src/lib/daemon/mind-service.js";
+
+describe("buildSeedOrientation", () => {
+  it("omits the creator claim when there is no creator", () => {
+    const msg = buildSeedOrientation();
+    assert.ok(msg.includes("You've just been created as a seed"));
+    assert.ok(!msg.includes("Your creator"), "no creator line without a creator");
+    // Never assumes a human planted the seed
+    assert.ok(!msg.toLowerCase().includes("human"));
+  });
+
+  it("names a human (brain) creator plainly", () => {
+    const msg = buildSeedOrientation("alice", "brain");
+    assert.ok(msg.includes("Your creator is alice."));
+    assert.ok(!msg.toLowerCase().includes("human"));
+  });
+
+  it("words a mind creator as another mind", () => {
+    const msg = buildSeedOrientation("orchid", "mind");
+    assert.ok(msg.includes("Your creator is another mind, orchid."));
+  });
+
+  it("words the spirit (system) creator as the spirit of this system", () => {
+    const msg = buildSeedOrientation("volute", "system");
+    assert.ok(msg.includes("Your creator is the spirit of this system (volute)."));
+  });
+
+  it("falls back to the bare name when the creator type is unknown", () => {
+    const msg = buildSeedOrientation("someone");
+    assert.ok(msg.includes("Your creator is someone."));
+  });
+});

--- a/test/send-self.test.ts
+++ b/test/send-self.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, mock } from "node:test";
+import { run } from "../packages/cli/src/commands/send.js";
+
+describe("send self-DM fast-path", () => {
+  afterEach(() => {
+    mock.restoreAll();
+    delete process.env.VOLUTE_MIND;
+  });
+
+  it("errors and exits 1 when a mind sends to its own @self channel", async () => {
+    process.env.VOLUTE_MIND = "volute";
+    const exitMock = mock.method(process, "exit", () => {
+      throw new Error("exit");
+    });
+
+    const origError = console.error;
+    const errors: string[] = [];
+    console.error = (...a: unknown[]) => errors.push(a.join(" "));
+    try {
+      await run(["@volute", "reply to my own notice"]);
+    } catch {
+      // exit mock throws
+    } finally {
+      console.error = origError;
+    }
+
+    assert.equal(exitMock.mock.calls[0]?.arguments[0], 1, "should exit with 1");
+    assert.ok(
+      errors.some((e) => e.includes("your own system channel")),
+      `should explain the self-send is a dead end, got: ${errors.join(" | ")}`,
+    );
+  });
+});

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -19,6 +19,7 @@ import {
   conversationParticipants,
   conversations,
   messages,
+  mindHistory,
   minds,
   users,
 } from "../packages/daemon/src/lib/schema.js";
@@ -32,6 +33,7 @@ async function cleanup() {
   const db = await getDb();
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
+    await db.delete(mindHistory).where(eq(mindHistory.mind, username));
   }
   await db.delete(minds).where(eq(minds.name, "volute"));
 }
@@ -130,6 +132,21 @@ describe("system messages", () => {
     assert.equal(msgs[0].sender_name, "volute");
     assert.equal(msgs[0].role, "user");
     assert.ok(msgs[0].content.includes("hello from system"));
+  });
+
+  it("sendSystemMessageDirect does not throw for the spirit and records inbound only", async () => {
+    const result = await sendSystemMessageDirect("volute", "pre-sleep context");
+
+    assert.equal(result.conversationId, undefined, "spirit gets no conversationId");
+
+    const db = await getDb();
+
+    // The inbound is recorded in mind_history even though there's no conversation
+    const history = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const inbound = history.find((h) => h.content?.includes("pre-sleep context"));
+    assert.ok(inbound, "spirit inbound should be recorded in mind_history");
+    assert.equal(inbound!.type, "inbound");
+    assert.equal(inbound!.channel, "@volute");
   });
 
   it("sendSystemMessage persists message and calls delivery pipeline", async () => {

--- a/test/version-notify.test.ts
+++ b/test/version-notify.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   backfillTemplateHashes,
   notifyVersionUpdate,
+  shouldSuggestUpgrade,
 } from "../packages/daemon/src/lib/version-notify.js";
 
 const statePath = () => resolve(voluteSystemDir(), "version-notify.json");
@@ -97,5 +98,25 @@ describe("notifyVersionUpdate", () => {
     await notifyVersionUpdate();
     const state = readState();
     assert.equal(state!.lastNotifiedVersion, getCurrentVersion());
+  });
+});
+
+describe("shouldSuggestUpgrade", () => {
+  it("suggests upgrade for a regular mind whose template hash changed", () => {
+    assert.equal(shouldSuggestUpgrade({ mindType: "mind", templateHash: "old" }, "new"), true);
+  });
+
+  it("never suggests upgrade to the spirit, even on a hash change", () => {
+    // The spirit upgrades via syncSpiritTemplate() on restart, not `mind upgrade`.
+    assert.equal(shouldSuggestUpgrade({ mindType: "spirit", templateHash: "old" }, "new"), false);
+  });
+
+  it("does not suggest upgrade when the hash is unchanged", () => {
+    assert.equal(shouldSuggestUpgrade({ mindType: "mind", templateHash: "same" }, "same"), false);
+  });
+
+  it("does not suggest upgrade when a hash is missing", () => {
+    assert.equal(shouldSuggestUpgrade({ mindType: "mind", templateHash: null }, "new"), false);
+    assert.equal(shouldSuggestUpgrade({ mindType: "mind", templateHash: "old" }, null), false);
   });
 });

--- a/test/web-conversations.test.ts
+++ b/test/web-conversations.test.ts
@@ -38,6 +38,7 @@ const TEST_USERNAMES = [
   "other-user3",
   "group-member",
   "privacy-outsider",
+  "volute",
 ];
 
 async function cleanup() {
@@ -324,6 +325,30 @@ describe("web conversations routes", () => {
     assert.equal(res.status, 400);
     const body = await res.json();
     assert.ok(body.error.includes("channels"));
+  });
+
+  it("POST /:name/conversations — rejects a single-participant (self) conversation", async () => {
+    // The spirit shares the system user, so a "@volute" DM to itself resolves the
+    // mind user and the named participant to the same id — one distinct member.
+    const prev = process.env.VOLUTE_DAEMON_TOKEN;
+    process.env.VOLUTE_DAEMON_TOKEN = "conv-daemon-token";
+    try {
+      const app = createApp();
+      const res = await app.request("/api/minds/volute/conversations", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer conv-daemon-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ participantNames: ["volute"] }),
+      });
+      assert.equal(res.status, 400);
+      const body = await res.json();
+      assert.ok(body.error.includes("two distinct participants"), body.error);
+    } finally {
+      if (prev === undefined) delete process.env.VOLUTE_DAEMON_TOKEN;
+      else process.env.VOLUTE_DAEMON_TOKEN = prev;
+    }
   });
 
   it("POST /:name/conversations — validates participant IDs", async () => {


### PR DESCRIPTION
Part of the core-reliability release (spirit correctness). **Stacked on #432 — merge that first.** (Item 1, the `SPIRIT_NAME` constant, already landed in a prior release.)

Grab-bag of spirit/system-message cleanups from the audit:

- **Seed orientation wording** (item 2): new pure `buildSeedOrientation` words the creator by `user_type` (human / another mind / the spirit) instead of assuming "a human planted you" — spirit-assisted creation is the primary flow.
- **Spirit dir registration** (item 3): registered at daemon boot right after `ensureSpiritProject()`, so routing-config resolution before `startSpiritFull` reads the spirit's `routes.json` instead of silently falling back to the minds dir.
- **Version-notify** (item 4): `notifyVersionUpdate` no longer tells the spirit to run `volute mind upgrade` (it upgrades via `syncSpiritTemplate()` on restart); release notes still delivered. Extracted to a pure `shouldSuggestUpgrade` helper.
- **Setup welcome** (item 5): labels the DM's real participants `[spirit, admin]` and guards on an admin existing.

All reuse the existing `SPIRIT_NAME`/`isSpiritName` helpers.

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
