### PR TITLE
fix: make clock sleep --wake-at authoritative and preserve bedtime across trigger-wake

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -213,8 +213,12 @@ export class SleepManager {
       }
       await this.archiveSessions(name);
       state.sleeping = true;
-      state.sleepingSince = new Date().toISOString();
-      state.scheduledWakeAt = this.getNextWakeTime(this.getSleepConfig(name));
+      // Keep the original bedtime (sleepingSince) — sleep never actually ended
+      // during a trigger-wake. Only recompute the cron wake when no voluntary
+      // wake-at is pinned for the night (it stays authoritative).
+      if (!state.voluntaryWakeAt) {
+        state.scheduledWakeAt = this.getNextWakeTime(this.getSleepConfig(name));
+      }
       this.saveState();
       slog.info(`${name} returned to sleep after crashing during trigger wake`);
     } catch (err) {
@@ -651,7 +655,9 @@ export class SleepManager {
     const state: SleepState = {
       sleeping: true,
       sleepingSince: new Date().toISOString(),
-      scheduledWakeAt: this.getNextWakeTime(sleepConfig),
+      // An explicit voluntary wake-at is authoritative for the night — null out
+      // the cron wake so an earlier scheduled wake can't silently override it.
+      scheduledWakeAt: opts?.voluntaryWakeAt ? null : this.getNextWakeTime(sleepConfig),
       wokenByTrigger: false,
       voluntaryWakeAt: opts?.voluntaryWakeAt ?? null,
       queuedMessageCount: this.states.get(name)?.queuedMessageCount ?? 0,
@@ -975,9 +981,13 @@ export class SleepManager {
         .then(() => this.archiveSessions(event.mind))
         .then(() => {
           state.sleeping = true;
-          state.sleepingSince = new Date().toISOString();
-          const sleepConfig = this.getSleepConfig(event.mind);
-          state.scheduledWakeAt = this.getNextWakeTime(sleepConfig);
+          // Keep the original bedtime (sleepingSince) — sleep never actually
+          // ended during a trigger-wake. Only recompute the cron wake when no
+          // voluntary wake-at is pinned for the night (it stays authoritative).
+          if (!state.voluntaryWakeAt) {
+            const sleepConfig = this.getSleepConfig(event.mind);
+            state.scheduledWakeAt = this.getNextWakeTime(sleepConfig);
+          }
           this.saveState();
           slog.info(`${event.mind} returned to sleep`);
         })

--- a/packages/web/src/ui/components/mind/MindClock.svelte
+++ b/packages/web/src/ui/components/mind/MindClock.svelte
@@ -101,14 +101,13 @@ let rows = $derived.by(() => {
 
   // Sleep row
   if (clock.sleep?.sleeping) {
+    const effectiveWake = clock.sleep.scheduledWakeAt ?? clock.sleep.voluntaryWakeAt;
     result.push({
       id: "sleep",
       icon: "sleep",
       color: scheduleColor("sleep"),
       times: "sleeping now",
-      next: clock.sleep.scheduledWakeAt
-        ? `wake ${formatRelativeTime(clock.sleep.scheduledWakeAt)}`
-        : "",
+      next: effectiveWake ? `wake ${formatRelativeTime(effectiveWake)}` : "",
       disabled: false,
       tooltip: "",
     });
@@ -152,13 +151,12 @@ type SummaryItem = { icon: IconKind; label: string; detail: string; color: strin
 let currentItem = $derived.by((): SummaryItem | null => {
   if (!clock) return null;
   if (clock.sleep?.sleeping) {
+    const effectiveWake = clock.sleep.scheduledWakeAt ?? clock.sleep.voluntaryWakeAt;
     return {
       icon: "sleep",
       label: "Sleeping",
       color: scheduleColor("sleep"),
-      detail: clock.sleep.scheduledWakeAt
-        ? `wake ${formatRelativeTime(clock.sleep.scheduledWakeAt)}`
-        : "now",
+      detail: effectiveWake ? `wake ${formatRelativeTime(effectiveWake)}` : "now",
     };
   }
   if (activeMinds.has(name) && clock.previous?.length > 0) {

--- a/skills/volute-mind/references/sleep.md
+++ b/skills/volute-mind/references/sleep.md
@@ -31,3 +31,6 @@ You can go to sleep any time with `volute clock sleep`. Optionally set a wake ti
 ```sh
 volute clock sleep --wake-at "2025-01-15T07:00:00Z"
 ```
+
+A `--wake-at` overrides your wake schedule for that night — you will wake at the
+time you asked for, even if a scheduled wake cron would have fired earlier.

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -99,6 +99,11 @@ class TestSleepManager extends SleepManager {
   testResetWakeBackoff(name: string): void {
     (this as any).resetWakeBackoff(name);
   }
+
+  // Expose markSleeping for testing
+  testMarkSleeping(name: string, opts?: { voluntaryWakeAt?: string }): void {
+    (this as any).markSleeping(name, opts);
+  }
 }
 
 function sleepingState(overrides?: Partial<SleepState>): SleepState {
@@ -448,6 +453,91 @@ describe("SleepManager state transitions", () => {
     // Simulate incrementing
     state.queuedMessageCount++;
     assert.equal(sm.getState("test-mind").queuedMessageCount, 1);
+  });
+
+  // #451: an explicit voluntary wake-at is authoritative for the night.
+  it("markSleeping with voluntaryWakeAt nulls the cron scheduledWakeAt", () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    const wakeAt = new Date(Date.now() + 12 * 3600_000).toISOString();
+    sm.testMarkSleeping("test-mind", { voluntaryWakeAt: wakeAt });
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, wakeAt);
+  });
+
+  it("markSleeping without voluntaryWakeAt sets scheduledWakeAt from the cron", () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    sm.testMarkSleeping("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.notEqual(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, null);
+  });
+
+  // #451: a voluntary wake later than the next cron wake must not be preempted.
+  // With scheduledWakeAt null, tick()'s cron branch can never fire early.
+  it("voluntary wake later than cron leaves no scheduled cron wake to fire", () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    // Wake-at far in the future, likely later than the next 8am cron wake.
+    const wakeAt = new Date(Date.now() + 30 * 3600_000).toISOString();
+    sm.testMarkSleeping("test-mind", { voluntaryWakeAt: wakeAt });
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, wakeAt);
+  });
+
+  // #449: return-to-sleep after a trigger-wake must not reset sleepingSince.
+  it("returnToSleepAfterCrash preserves the original bedtime (sleepingSince)", async () => {
+    const sm = new TestSleepManager();
+    const bedtime = new Date(Date.now() - 8 * 3600_000).toISOString();
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ sleepingSince: bedtime, wokenByTrigger: true }),
+    );
+
+    await sm.returnToSleepAfterCrash("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.sleeping, true);
+    assert.equal(state.sleepingSince, bedtime);
+    assert.equal(state.wokenByTrigger, false);
+  });
+
+  // #451: return-to-sleep must not resurrect a cron wake when a voluntary wake
+  // is pinned for the night.
+  it("returnToSleepAfterCrash keeps scheduledWakeAt null when voluntaryWakeAt is set", async () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    const wakeAt = new Date(Date.now() + 12 * 3600_000).toISOString();
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ scheduledWakeAt: null, voluntaryWakeAt: wakeAt, wokenByTrigger: true }),
+    );
+
+    await sm.returnToSleepAfterCrash("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, wakeAt);
+  });
+
+  it("returnToSleepAfterCrash recomputes scheduledWakeAt when no voluntary wake", async () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ scheduledWakeAt: null, voluntaryWakeAt: null, wokenByTrigger: true }),
+    );
+
+    await sm.returnToSleepAfterCrash("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.notEqual(state.scheduledWakeAt, null);
   });
 });
 


### PR DESCRIPTION
Part of the core-reliability release (sleep & delivery). First of a 6-PR sleep-clock stack.

- **#451**: `volute clock sleep --wake-at <time>` is presented to minds as *the* wake time, but an earlier scheduled cron wake silently overrode it. `markSleeping` now nulls the cron `scheduledWakeAt` when a voluntary wake-at is pinned, making it authoritative; the return-to-sleep paths skip the cron recompute while a voluntary wake is set.
- **#449**: A return-to-sleep after a trigger-wake reset `sleepingSince` to the current time, so "sleeping since" and the morning wake-summary duration were wrong (a mind told it slept 45 min instead of 8 hours). Both return-to-sleep paths now preserve the original bedtime.

Closes #451
Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
