### PR TITLE
fix: wake a sleeping mind even when its sleep config is disabled or missing

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -693,52 +693,54 @@ export class SleepManager {
     const mindNames = new Set([...this.sleepConfigs.keys(), ...this.states.keys()]);
 
     for (const name of mindNames) {
-      if (!this.isSleeping(name)) {
-        const mind = await findMind(name);
-        if (!mind?.running) continue;
-      }
+      await this.evaluateMind(name, now, epochMinute);
+    }
+  }
 
-      const config = this.getSleepConfig(name);
-      if (!config?.enabled || !config.schedule) continue;
+  /**
+   * Per-mind tick evaluation. The wake checks depend only on the persisted sleep
+   * state — never on a currently-enabled sleep config — so a mind that was put to
+   * sleep with a wake time still wakes even if the schedule is later disabled or
+   * removed (or never existed, e.g. a bare `clock sleep --wake-at`). Only the
+   * sleep-onset check requires a running mind with an enabled schedule.
+   */
+  private async evaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
+    const state = this.states.get(name);
 
-      const state = this.states.get(name);
-
+    if (state?.sleeping) {
       // In wake-failure backoff — wait before retrying rather than hammering
       // wakeMind every tick (#419).
-      if (state?.sleeping && state.nextWakeAttemptAt && now < new Date(state.nextWakeAttemptAt)) {
-        continue;
+      if (state.nextWakeAttemptAt && now < new Date(state.nextWakeAttemptAt)) return;
+
+      // Voluntary wake time
+      if (state.voluntaryWakeAt && now >= new Date(state.voluntaryWakeAt)) {
+        this.initiateWake(name).catch((err) =>
+          slog.error(`failed voluntary wake for ${name}`, log.errorData(err)),
+        );
+        return;
       }
 
-      // Check voluntary wake time
-      if (state?.sleeping && state.voluntaryWakeAt) {
-        const wakeAt = new Date(state.voluntaryWakeAt);
-        if (now >= wakeAt) {
-          this.initiateWake(name).catch((err) =>
-            slog.error(`failed voluntary wake for ${name}`, log.errorData(err)),
-          );
-          continue;
-        }
+      // Scheduled wake time
+      if (state.scheduledWakeAt && now >= new Date(state.scheduledWakeAt)) {
+        this.initiateWake(name).catch((err) =>
+          slog.error(`failed scheduled wake for ${name}`, log.errorData(err)),
+        );
+        return;
       }
 
-      // Check scheduled wake time
-      if (state?.sleeping && state.scheduledWakeAt) {
-        const wakeAt = new Date(state.scheduledWakeAt);
-        if (now >= wakeAt) {
-          this.initiateWake(name).catch((err) =>
-            slog.error(`failed scheduled wake for ${name}`, log.errorData(err)),
-          );
-          continue;
-        }
-      }
+      // Sleeping but not yet time to wake (or intentionally indefinite) — done.
+      return;
+    }
 
-      // Check if it's time to sleep
-      if (!state?.sleeping) {
-        if (this.shouldSleep(config.schedule.sleep, epochMinute)) {
-          this.initiateSleep(name).catch((err) =>
-            slog.error(`failed to initiate sleep for ${name}`, log.errorData(err)),
-          );
-        }
-      }
+    // Sleep-onset — requires a running mind and an enabled schedule.
+    const mind = await findMind(name);
+    if (!mind?.running) return;
+    const config = this.getSleepConfig(name);
+    if (!config?.enabled || !config.schedule) return;
+    if (this.shouldSleep(config.schedule.sleep, epochMinute)) {
+      this.initiateSleep(name).catch((err) =>
+        slog.error(`failed to initiate sleep for ${name}`, log.errorData(err)),
+      );
     }
   }
 

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -104,6 +104,24 @@ class TestSleepManager extends SleepManager {
   testMarkSleeping(name: string, opts?: { voluntaryWakeAt?: string }): void {
     (this as any).markSleeping(name, opts);
   }
+
+  // Stub initiateWake/initiateSleep so evaluateMind can be tested without a live
+  // MindManager. Records the names it was asked to wake/sleep.
+  wakeCalls: string[] = [];
+  sleepCalls: string[] = [];
+
+  override async initiateWake(name: string): Promise<void> {
+    this.wakeCalls.push(name);
+  }
+
+  override async initiateSleep(name: string): Promise<void> {
+    this.sleepCalls.push(name);
+  }
+
+  // Expose evaluateMind for testing
+  testEvaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
+    return (this as any).evaluateMind(name, now, epochMinute);
+  }
 }
 
 function sleepingState(overrides?: Partial<SleepState>): SleepState {
@@ -538,6 +556,60 @@ describe("SleepManager state transitions", () => {
 
     const state = sm.getState("test-mind");
     assert.notEqual(state.scheduledWakeAt, null);
+  });
+});
+
+// #450: waking a sleeping mind must not depend on a currently-enabled sleep
+// config — the wake times were persisted at bedtime.
+describe("SleepManager.evaluateMind wake without config", () => {
+  const epochMinute = Math.floor(Date.now() / 60_000);
+
+  it("wakes a sleeping mind with a past voluntaryWakeAt even with no config", async () => {
+    const sm = new TestSleepManager();
+    // No sleep config set at all (getSleepConfig returns null).
+    const past = new Date(Date.now() - 60_000).toISOString();
+    sm.setStateForTest("test-mind", sleepingState({ voluntaryWakeAt: past }));
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, ["test-mind"]);
+  });
+
+  it("wakes a sleeping mind with a past scheduledWakeAt when config is disabled", async () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", {
+      enabled: false,
+      schedule: { sleep: "0 23 * * *", wake: "0 8 * * *" },
+    });
+    const past = new Date(Date.now() - 60_000).toISOString();
+    sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: past }));
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, ["test-mind"]);
+  });
+
+  it("leaves a sleeping mind asleep when it has no wake times and no config", async () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ voluntaryWakeAt: null, scheduledWakeAt: null }),
+    );
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, []);
+    assert.equal(sm.getState("test-mind").sleeping, true);
+  });
+
+  it("does not wake before the persisted wake time arrives", async () => {
+    const sm = new TestSleepManager();
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: future }));
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, []);
   });
 });
 


### PR DESCRIPTION
Part of the core-reliability release (sleep & delivery). **Stacked on #451/#449 (the first sleep PR) — merge that first.**

A mind put to sleep with a wake time (a bare `clock sleep --wake-at`, or an admin disabling the sleep schedule mid-sleep) could get stranded asleep with no automatic wake — the wake checks sat below a config-enabled guard that returned early. `SleepManager.tick()` is refactored into `evaluateMind`, where the voluntary + scheduled wake checks now run for any sleeping mind from persisted state alone; only sleep-onset requires a running mind with an enabled schedule.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
