### PR TITLE
fix: catch up missed scheduler and sleep fires; prune stale lastFired entries

### DIFF
--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -13,6 +13,14 @@ import { generateMindToken, getMindToken } from "./mind-tokens.js";
 
 const slog = log.child("scheduler");
 
+/**
+ * Cap on how late a caught-up cron fire may be delivered. A schedule whose most
+ * recent cron minute is older than this (e.g. after long daemon downtime) is
+ * skipped rather than delivered stale — a 3am dream prompt at 5pm is worse than
+ * none — but `lastFired` still advances so it fires normally next time.
+ */
+const CATCHUP_STALE_MINUTES = 10;
+
 export class Scheduler {
   private schedules = new Map<string, Schedule[]>();
   private mindDirs = new Map<string, string>(); // mindName → dir override
@@ -56,6 +64,32 @@ export class Scheduler {
       this.schedules.set(mindName, schedules);
     } else {
       this.schedules.delete(mindName);
+    }
+
+    // Reconcile lastFired bookkeeping for this mind against its authoritative
+    // schedule list. Only touch this mind's keys — other minds may not be loaded
+    // yet, so a global sweep would drop live state.
+    const epochMinute = Math.floor(Date.now() / 60000);
+    const validKeys = new Set(schedules.map((s) => `${mindName}:${s.id}`));
+    let changed = false;
+    // Prune stale entries for removed schedules (#428).
+    for (const key of this.lastFired.keys()) {
+      if (key.startsWith(`${mindName}:`) && !validKeys.has(key)) {
+        this.lastFired.delete(key);
+        changed = true;
+      }
+    }
+    // Baseline-init newly-seen schedules so catch-up never replays history (#453).
+    for (const key of validKeys) {
+      if (!this.lastFired.has(key)) {
+        this.lastFired.set(key, epochMinute);
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.saveState().catch((err) =>
+        slog.warn(`failed to persist scheduler state for ${mindName}`, log.errorData(err)),
+      );
     }
   }
 
@@ -119,11 +153,22 @@ export class Scheduler {
       }
     }
 
-    if (prevMinute === epochMinute) {
-      this.lastFired.set(key, epochMinute);
-      return true;
+    // Level-triggered catch-up: fire when the cron's most recent scheduled minute
+    // is newer than the last one we acted on — recovering fires missed while the
+    // daemon was down or a tick straddled the minute boundary. Unknown keys are
+    // baselined in loadSchedules, so this never replays history on first sight.
+    const lastFired = this.lastFired.get(key) ?? epochMinute;
+    if (prevMinute <= lastFired) return false;
+
+    // Advance regardless of whether we deliver, so a stale fire isn't retried.
+    this.lastFired.set(key, prevMinute);
+
+    // Staleness cap: skip (but don't re-attempt) a catch-up fire that's too old.
+    if (epochMinute - prevMinute > CATCHUP_STALE_MINUTES) {
+      slog.info(`skipping stale catch-up fire for ${key} (${epochMinute - prevMinute}min late)`);
+      return false;
     }
-    return false;
+    return true;
   }
 
   private async fire(mindName: string, schedule: Schedule): Promise<void> {

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -48,6 +48,13 @@ export type SleepState = {
   wakeFailures: number;
   /** Earliest time the next wake retry may run, while backing off after failures. */
   nextWakeAttemptAt: string | null;
+  /**
+   * Timestamp of the last full wake (manual `clock wake` or scheduled wake).
+   * Level-triggered sleep onset (#453) uses it to exempt a mind woken inside the
+   * current sleep window from being immediately re-slept. Persisted for awake
+   * minds so the exemption survives a daemon restart.
+   */
+  lastWakeAt: string | null;
 };
 
 type SleepStatePersisted = Record<string, SleepState>;
@@ -63,6 +70,7 @@ function defaultState(): SleepState {
     triggerWakeHistory: [],
     wakeFailures: 0,
     nextWakeAttemptAt: null,
+    lastWakeAt: null,
   };
 }
 
@@ -146,6 +154,7 @@ export class SleepManager {
           state.triggerWakeHistory ??= [];
           state.wakeFailures ??= 0;
           state.nextWakeAttemptAt ??= null;
+          state.lastWakeAt ??= null;
           this.states.set(name, state);
         }
       }
@@ -157,7 +166,9 @@ export class SleepManager {
   saveState(): void {
     const data: SleepStatePersisted = {};
     for (const [name, state] of this.states) {
-      if (state.sleeping) data[name] = state;
+      // Persist sleeping states, plus awake minds that carry a lastWakeAt so the
+      // manual-wake exemption for level-triggered sleep onset survives a restart.
+      if (state.sleeping || state.lastWakeAt) data[name] = state;
     }
     try {
       writeFileSync(this.statePath, `${JSON.stringify(data, null, 2)}\n`);
@@ -621,7 +632,10 @@ export class SleepManager {
    */
   protected async markWakeErrored(name: string, err: unknown): Promise<void> {
     const detail = err instanceof Error ? err.message : String(err);
-    this.markAwake(name);
+    // The mind never woke — clear its sleep state entirely (no lastWakeAt, unlike
+    // a successful markAwake) so the tick stops retrying and nothing lingers.
+    this.states.delete(name);
+    this.saveState();
 
     slog.error(
       `${name} failed to wake ${MAX_WAKE_ATTEMPTS} times in a row; giving up and marking errored`,
@@ -664,13 +678,17 @@ export class SleepManager {
       triggerWakeHistory: [],
       wakeFailures: 0,
       nextWakeAttemptAt: null,
+      lastWakeAt: this.states.get(name)?.lastWakeAt ?? null,
     };
     this.states.set(name, state);
     this.saveState();
   }
 
   private markAwake(name: string): void {
-    this.states.delete(name);
+    // Keep a minimal awake entry recording when the mind last fully woke, so
+    // level-triggered sleep onset (#453) won't immediately re-sleep a mind woken
+    // inside its own sleep window (manual `clock wake` or a scheduled wake).
+    this.states.set(name, { ...defaultState(), lastWakeAt: new Date().toISOString() });
     this.saveState();
   }
 
@@ -687,13 +705,12 @@ export class SleepManager {
 
   private async tick(): Promise<void> {
     const now = new Date();
-    const epochMinute = Math.floor(now.getTime() / 60_000);
 
     // Iterate minds that have sleep configs or sleep state, avoiding a full registry query
     const mindNames = new Set([...this.sleepConfigs.keys(), ...this.states.keys()]);
 
     for (const name of mindNames) {
-      await this.evaluateMind(name, now, epochMinute);
+      await this.evaluateMind(name, now);
     }
   }
 
@@ -704,7 +721,7 @@ export class SleepManager {
    * removed (or never existed, e.g. a bare `clock sleep --wake-at`). Only the
    * sleep-onset check requires a running mind with an enabled schedule.
    */
-  private async evaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
+  private async evaluateMind(name: string, now: Date): Promise<void> {
     const state = this.states.get(name);
 
     if (state?.sleeping) {
@@ -737,22 +754,58 @@ export class SleepManager {
     if (!mind?.running) return;
     const config = this.getSleepConfig(name);
     if (!config?.enabled || !config.schedule) return;
-    if (this.shouldSleep(config.schedule.sleep, epochMinute)) {
+
+    if (this.shouldSleepNow(config.schedule, state?.lastWakeAt ?? null, now)) {
       this.initiateSleep(name).catch((err) =>
         slog.error(`failed to initiate sleep for ${name}`, log.errorData(err)),
       );
     }
   }
 
-  private shouldSleep(cronExpr: string, epochMinute: number): boolean {
+  /**
+   * Level-triggered sleep-onset decision: sleep whenever we're inside the nightly
+   * window, not only on the exact sleep minute — so a daemon restart or a stalled
+   * tick across the sleep minute still puts the mind to bed on the next tick.
+   *
+   * Manual-wake exemption: a full wake inside the current window (human
+   * `clock wake`, or a scheduled wake) suppresses re-sleep until the next window
+   * begins, so `volute clock wake` at 3am sticks instead of being undone a minute
+   * later.
+   */
+  shouldSleepNow(
+    schedule: { sleep: string; wake: string },
+    lastWakeAt: string | null,
+    now: Date,
+  ): boolean {
+    const { inWindow, windowStart } = this.inSleepWindow(schedule, now);
+    if (!inWindow || !windowStart) return false;
+    if (lastWakeAt && new Date(lastWakeAt) >= windowStart) return false;
+    return true;
+  }
+
+  /**
+   * Whether `now` falls inside the mind's nightly sleep window: the most recent
+   * sleep-cron fire is more recent than the most recent wake-cron fire. Returns
+   * the window start (last sleep fire) for the manual-wake exemption check.
+   */
+  inSleepWindow(
+    schedule: { sleep: string; wake: string },
+    now: Date,
+  ): { inWindow: boolean; windowStart: Date | null } {
     try {
-      const interval = CronExpressionParser.parse(cronExpr);
-      const prev = interval.prev().toDate();
-      const prevMinute = Math.floor(prev.getTime() / 60_000);
-      return prevMinute === epochMinute;
+      const prevSleep = CronExpressionParser.parse(schedule.sleep, { currentDate: now })
+        .prev()
+        .toDate();
+      const prevWake = CronExpressionParser.parse(schedule.wake, { currentDate: now })
+        .prev()
+        .toDate();
+      return { inWindow: prevSleep > prevWake, windowStart: prevSleep };
     } catch (err) {
-      slog.warn(`invalid sleep cron "${cronExpr}"`, log.errorData(err));
-      return false;
+      slog.warn(
+        `invalid sleep/wake cron "${schedule.sleep}"/"${schedule.wake}"`,
+        log.errorData(err),
+      );
+      return { inWindow: false, windowStart: null };
     }
   }
 

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -370,6 +370,101 @@ describe("scheduler fireAt", () => {
   });
 });
 
+describe("scheduler catch-up (level-triggered cron)", () => {
+  const nowMin = () => Math.floor(Date.now() / 60000);
+  const heartbeat = { id: "heartbeat", cron: "* * * * *", enabled: true };
+
+  it("fires a caught-up cron once when a minute was skipped", () => {
+    const scheduler = new TestScheduler();
+    const epochMinute = nowMin();
+    const key = "test-mind:heartbeat";
+    // Last acted-on minute is 3 minutes stale (missed ticks).
+    (scheduler as any).lastFired.set(key, epochMinute - 3);
+
+    const first = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
+    assert.equal(first, true);
+    // lastFired advances to the fired cron minute (== epochMinute for every-minute cron).
+    assert.equal((scheduler as any).lastFired.get(key), epochMinute);
+
+    // Same minute again → no double fire.
+    const second = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
+    assert.equal(second, false);
+  });
+
+  it("does not fire when already up to date this minute", () => {
+    const scheduler = new TestScheduler();
+    const epochMinute = nowMin();
+    (scheduler as any).lastFired.set("test-mind:heartbeat", epochMinute);
+    const result = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
+    assert.equal(result, false);
+  });
+
+  it("skips a stale catch-up fire but still advances lastFired", () => {
+    const scheduler = new TestScheduler();
+    const realMin = nowMin();
+    // Pretend we're evaluating 20 minutes after the cron minute (long downtime).
+    const epochMinute = realMin + 20;
+    const key = "test-mind:dream";
+    (scheduler as any).lastFired.set(key, realMin - 30);
+
+    const result = (scheduler as any).shouldFire(
+      { id: "dream", cron: "* * * * *", enabled: true },
+      epochMinute,
+      "test-mind",
+      new Map(),
+    );
+    // Too stale to deliver...
+    assert.equal(result, false);
+    // ...but lastFired advanced to the cron minute so it won't be retried.
+    assert.equal((scheduler as any).lastFired.get(key), realMin);
+  });
+});
+
+describe("scheduler loadSchedules bookkeeping", () => {
+  function writeConfig(dir: string, schedules: unknown[]) {
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(resolve(dir, "home/.config/volute.json"), JSON.stringify({ schedules }));
+  }
+
+  it("baseline-inits new schedules and prunes stale keys for the mind only (#428, #453)", () => {
+    const scheduler = new TestScheduler();
+    const dir = resolve(voluteSystemDir(), "sched-bookkeep-mind");
+    writeConfig(dir, [{ id: "heartbeat", cron: "* * * * *", message: "hi", enabled: true }]);
+
+    const lf = (scheduler as any).lastFired as Map<string, number>;
+    // Pre-seed: a stale key for this mind + a live key for another mind.
+    lf.set("sched-bookkeep-mind:old-removed", 100);
+    lf.set("other-mind:keepme", 200);
+
+    scheduler.loadSchedules("sched-bookkeep-mind", dir);
+
+    // Stale key for this mind pruned (#428).
+    assert.equal(lf.has("sched-bookkeep-mind:old-removed"), false);
+    // Other mind's key untouched — prune is per-mind only.
+    assert.equal(lf.get("other-mind:keepme"), 200);
+    // New schedule baselined to the current minute (#453) so no history replay.
+    assert.equal(lf.get("sched-bookkeep-mind:heartbeat"), Math.floor(Date.now() / 60000));
+  });
+
+  it("baseline prevents an immediate replay for a freshly loaded schedule", () => {
+    const scheduler = new TestScheduler();
+    const dir = resolve(voluteSystemDir(), "sched-fresh-mind");
+    writeConfig(dir, [{ id: "beat", cron: "* * * * *", message: "hi", enabled: true }]);
+
+    scheduler.loadSchedules("sched-fresh-mind", dir);
+
+    const epochMinute = Math.floor(Date.now() / 60000);
+    const result = (scheduler as any).shouldFire(
+      { id: "beat", cron: "* * * * *", enabled: true },
+      epochMinute,
+      "sched-fresh-mind",
+      new Map(),
+    );
+    // Baseline == epochMinute, so the current-minute cron fire is not replayed.
+    assert.equal(result, false);
+  });
+});
+
 describe("parseDuration", () => {
   // Import dynamically since it's in clock.ts — test the regex logic directly
   function parseDuration(input: string): number | null {

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -56,9 +56,20 @@ class TestSleepManager extends SleepManager {
     return null;
   }
 
-  // Expose shouldSleep for testing
-  testShouldSleep(cronExpr: string, epochMinute: number): boolean {
-    return (this as any).shouldSleep(cronExpr, epochMinute);
+  // Expose inSleepWindow / shouldSleepNow for testing
+  testInSleepWindow(
+    schedule: { sleep: string; wake: string },
+    now: Date,
+  ): { inWindow: boolean; windowStart: Date | null } {
+    return (this as any).inSleepWindow(schedule, now);
+  }
+
+  testShouldSleepNow(
+    schedule: { sleep: string; wake: string },
+    lastWakeAt: string | null,
+    now: Date,
+  ): boolean {
+    return (this as any).shouldSleepNow(schedule, lastWakeAt, now);
   }
 
   // Expose getNextWakeTime for testing
@@ -119,8 +130,8 @@ class TestSleepManager extends SleepManager {
   }
 
   // Expose evaluateMind for testing
-  testEvaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
-    return (this as any).evaluateMind(name, now, epochMinute);
+  testEvaluateMind(name: string, now: Date): Promise<void> {
+    return (this as any).evaluateMind(name, now);
   }
 }
 
@@ -135,11 +146,12 @@ function sleepingState(overrides?: Partial<SleepState>): SleepState {
     triggerWakeHistory: [],
     wakeFailures: 0,
     nextWakeAttemptAt: null,
+    lastWakeAt: null,
     ...overrides,
   };
 }
 
-function awakeState(): SleepState {
+function awakeState(overrides?: Partial<SleepState>): SleepState {
   return {
     sleeping: false,
     sleepingSince: null,
@@ -150,6 +162,8 @@ function awakeState(): SleepState {
     triggerWakeHistory: [],
     wakeFailures: 0,
     nextWakeAttemptAt: null,
+    lastWakeAt: null,
+    ...overrides,
   };
 }
 
@@ -562,15 +576,13 @@ describe("SleepManager state transitions", () => {
 // #450: waking a sleeping mind must not depend on a currently-enabled sleep
 // config — the wake times were persisted at bedtime.
 describe("SleepManager.evaluateMind wake without config", () => {
-  const epochMinute = Math.floor(Date.now() / 60_000);
-
   it("wakes a sleeping mind with a past voluntaryWakeAt even with no config", async () => {
     const sm = new TestSleepManager();
     // No sleep config set at all (getSleepConfig returns null).
     const past = new Date(Date.now() - 60_000).toISOString();
     sm.setStateForTest("test-mind", sleepingState({ voluntaryWakeAt: past }));
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, ["test-mind"]);
   });
@@ -584,7 +596,7 @@ describe("SleepManager.evaluateMind wake without config", () => {
     const past = new Date(Date.now() - 60_000).toISOString();
     sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: past }));
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, ["test-mind"]);
   });
@@ -596,7 +608,7 @@ describe("SleepManager.evaluateMind wake without config", () => {
       sleepingState({ voluntaryWakeAt: null, scheduledWakeAt: null }),
     );
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, []);
     assert.equal(sm.getState("test-mind").sleeping, true);
@@ -607,41 +619,80 @@ describe("SleepManager.evaluateMind wake without config", () => {
     const future = new Date(Date.now() + 3600_000).toISOString();
     sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: future }));
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, []);
   });
 });
 
-describe("SleepManager.shouldSleep (cron matching)", () => {
-  it("returns true when cron matches current epoch minute", () => {
-    const sm = new TestSleepManager();
-    // Use "every minute" cron — should always match
-    const now = new Date();
-    const epochMinute = Math.floor(now.getTime() / 60_000);
-    assert.equal(sm.testShouldSleep("* * * * *", epochMinute), true);
+// #453 Part 2: level-triggered sleep onset — "should this mind be asleep now"
+// rather than an exact-minute cron match.
+describe("SleepManager.inSleepWindow (level-triggered onset)", () => {
+  // Nightly window: asleep 00:00, awake 08:00.
+  const schedule = { sleep: "0 0 * * *", wake: "0 8 * * *" };
+  const at = (h: number, m = 0) => {
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  it("is in-window across the midnight-spanning night (03:00)", () => {
+    const { inWindow, windowStart } = new TestSleepManager().testInSleepWindow(schedule, at(3));
+    assert.equal(inWindow, true);
+    assert.ok(windowStart);
   });
 
-  it("returns false when cron does not match current epoch minute", () => {
-    const sm = new TestSleepManager();
-    // Use a very specific time far in the future — won't match current minute
-    // "0 0 1 1 *" = midnight Jan 1st only
-    const now = new Date();
-    const epochMinute = Math.floor(now.getTime() / 60_000);
-    // This will only match if we happen to be at midnight Jan 1st
-    if (
-      now.getMonth() !== 0 ||
-      now.getDate() !== 1 ||
-      now.getHours() !== 0 ||
-      now.getMinutes() !== 0
-    ) {
-      assert.equal(sm.testShouldSleep("0 0 1 1 *", epochMinute), false);
-    }
+  it("is out of window during the day (12:00)", () => {
+    const { inWindow } = new TestSleepManager().testInSleepWindow(schedule, at(12));
+    assert.equal(inWindow, false);
   });
 
-  it("returns false for invalid cron expression", () => {
+  it("returns not-in-window for an invalid cron", () => {
+    const { inWindow, windowStart } = new TestSleepManager().testInSleepWindow(
+      { sleep: "not-a-cron", wake: "0 8 * * *" },
+      at(3),
+    );
+    assert.equal(inWindow, false);
+    assert.equal(windowStart, null);
+  });
+});
+
+describe("SleepManager.shouldSleepNow (onset decision)", () => {
+  const schedule = { sleep: "0 0 * * *", wake: "0 8 * * *" };
+  const at = (h: number, m = 0) => {
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  it("sleeps on fresh state inside the window (daemon restart mid-window)", () => {
     const sm = new TestSleepManager();
-    assert.equal(sm.testShouldSleep("not-a-cron", 12345), false);
+    // No lastWakeAt — the mind restarted at 03:30 with no persisted awake info.
+    assert.equal(sm.testShouldSleepNow(schedule, null, at(3, 30)), true);
+  });
+
+  it("does not sleep outside the window (midday)", () => {
+    const sm = new TestSleepManager();
+    assert.equal(sm.testShouldSleepNow(schedule, null, at(12)), false);
+  });
+
+  it("exempts a mind manually woken inside the current window (no re-sleep)", () => {
+    const sm = new TestSleepManager();
+    // Woken at 03:00, evaluated at 03:30 — after the 00:00 window start.
+    const lastWakeAt = at(3).toISOString();
+    assert.equal(sm.testShouldSleepNow(schedule, lastWakeAt, at(3, 30)), false);
+  });
+
+  it("still sleeps when the last wake was before this window began", () => {
+    const sm = new TestSleepManager();
+    // Woken yesterday at 20:00, before the 00:00 window start.
+    const lastWakeAt = at(-4).toISOString(); // 20:00 previous day
+    assert.equal(sm.testShouldSleepNow(schedule, lastWakeAt, at(3, 30)), true);
+  });
+
+  it("does not sleep when the schedule cron is invalid", () => {
+    const sm = new TestSleepManager();
+    assert.equal(sm.testShouldSleepNow({ sleep: "nope", wake: "0 8 * * *" }, null, at(3)), false);
   });
 });
 
@@ -819,8 +870,19 @@ describe("SleepManager.convertTriggerToFullWake", () => {
 
     sm.convertTriggerToFullWake("test-mind");
 
-    // markAwake deletes the state, so getState returns default (not sleeping)
+    // markAwake records an awake state (lastWakeAt), so the mind is no longer sleeping
     assert.equal(sm.getState("test-mind").sleeping, false);
+  });
+
+  it("records lastWakeAt on full wake so onset can exempt it (#453)", () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest("test-mind", sleepingState({ wokenByTrigger: true }));
+
+    sm.convertTriggerToFullWake("test-mind");
+
+    const state = sm.getStateForTest("test-mind");
+    assert.ok(state?.lastWakeAt, "expected lastWakeAt to be recorded on full wake");
+    assert.equal(state?.sleeping, false);
   });
 
   it("is a no-op when sleeping but not trigger-woken", () => {


### PR DESCRIPTION
Part of the core-reliability release (sleep & delivery). **Stacked on #450 — merge that first.**

Both the scheduler and sleep-onset were edge-triggered — they fired only when the cron's previous fire minute equalled the current minute, so a fire missed during downtime or a tick straddling the minute boundary was lost forever (a missed midnight sleep cron kept a mind up all night).

- **#453 scheduler**: `shouldFire` now fires when the cron's most recent minute is newer than `lastFired` (level-triggered catch-up), with unseen keys baseline-initialized so history never replays and a ~10min staleness cap skipping (but advancing past) very-late fires.
- **#453 sleep onset**: replaced exact-minute matching with "should this mind be asleep now" (`inSleepWindow`), plus a `lastWakeAt` exemption so a manual `clock wake` inside the sleep window isn't immediately undone.
- **#428**: prune stale `lastFired` entries for removed schedules during `loadSchedules` (per-mind only).

Closes #453
Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
