### PR TITLE
fix: label a sleeping mind's next clock event wake, not sleep

### DIFF
--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -13,6 +13,14 @@ import { generateMindToken, getMindToken } from "./mind-tokens.js";
 
 const slog = log.child("scheduler");
 
+/**
+ * Cap on how late a caught-up cron fire may be delivered. A schedule whose most
+ * recent cron minute is older than this (e.g. after long daemon downtime) is
+ * skipped rather than delivered stale — a 3am dream prompt at 5pm is worse than
+ * none — but `lastFired` still advances so it fires normally next time.
+ */
+const CATCHUP_STALE_MINUTES = 10;
+
 export class Scheduler {
   private schedules = new Map<string, Schedule[]>();
   private mindDirs = new Map<string, string>(); // mindName → dir override
@@ -56,6 +64,32 @@ export class Scheduler {
       this.schedules.set(mindName, schedules);
     } else {
       this.schedules.delete(mindName);
+    }
+
+    // Reconcile lastFired bookkeeping for this mind against its authoritative
+    // schedule list. Only touch this mind's keys — other minds may not be loaded
+    // yet, so a global sweep would drop live state.
+    const epochMinute = Math.floor(Date.now() / 60000);
+    const validKeys = new Set(schedules.map((s) => `${mindName}:${s.id}`));
+    let changed = false;
+    // Prune stale entries for removed schedules (#428).
+    for (const key of this.lastFired.keys()) {
+      if (key.startsWith(`${mindName}:`) && !validKeys.has(key)) {
+        this.lastFired.delete(key);
+        changed = true;
+      }
+    }
+    // Baseline-init newly-seen schedules so catch-up never replays history (#453).
+    for (const key of validKeys) {
+      if (!this.lastFired.has(key)) {
+        this.lastFired.set(key, epochMinute);
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.saveState().catch((err) =>
+        slog.warn(`failed to persist scheduler state for ${mindName}`, log.errorData(err)),
+      );
     }
   }
 
@@ -119,11 +153,22 @@ export class Scheduler {
       }
     }
 
-    if (prevMinute === epochMinute) {
-      this.lastFired.set(key, epochMinute);
-      return true;
+    // Level-triggered catch-up: fire when the cron's most recent scheduled minute
+    // is newer than the last one we acted on — recovering fires missed while the
+    // daemon was down or a tick straddled the minute boundary. Unknown keys are
+    // baselined in loadSchedules, so this never replays history on first sight.
+    const lastFired = this.lastFired.get(key) ?? epochMinute;
+    if (prevMinute <= lastFired) return false;
+
+    // Advance regardless of whether we deliver, so a stale fire isn't retried.
+    this.lastFired.set(key, prevMinute);
+
+    // Staleness cap: skip (but don't re-attempt) a catch-up fire that's too old.
+    if (epochMinute - prevMinute > CATCHUP_STALE_MINUTES) {
+      slog.info(`skipping stale catch-up fire for ${key} (${epochMinute - prevMinute}min late)`);
+      return false;
     }
-    return false;
+    return true;
   }
 
   private async fire(mindName: string, schedule: Schedule): Promise<void> {

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -213,8 +213,12 @@ export class SleepManager {
       }
       await this.archiveSessions(name);
       state.sleeping = true;
-      state.sleepingSince = new Date().toISOString();
-      state.scheduledWakeAt = this.getNextWakeTime(this.getSleepConfig(name));
+      // Keep the original bedtime (sleepingSince) — sleep never actually ended
+      // during a trigger-wake. Only recompute the cron wake when no voluntary
+      // wake-at is pinned for the night (it stays authoritative).
+      if (!state.voluntaryWakeAt) {
+        state.scheduledWakeAt = this.getNextWakeTime(this.getSleepConfig(name));
+      }
       this.saveState();
       slog.info(`${name} returned to sleep after crashing during trigger wake`);
     } catch (err) {
@@ -651,7 +655,9 @@ export class SleepManager {
     const state: SleepState = {
       sleeping: true,
       sleepingSince: new Date().toISOString(),
-      scheduledWakeAt: this.getNextWakeTime(sleepConfig),
+      // An explicit voluntary wake-at is authoritative for the night — null out
+      // the cron wake so an earlier scheduled wake can't silently override it.
+      scheduledWakeAt: opts?.voluntaryWakeAt ? null : this.getNextWakeTime(sleepConfig),
       wokenByTrigger: false,
       voluntaryWakeAt: opts?.voluntaryWakeAt ?? null,
       queuedMessageCount: this.states.get(name)?.queuedMessageCount ?? 0,
@@ -975,9 +981,13 @@ export class SleepManager {
         .then(() => this.archiveSessions(event.mind))
         .then(() => {
           state.sleeping = true;
-          state.sleepingSince = new Date().toISOString();
-          const sleepConfig = this.getSleepConfig(event.mind);
-          state.scheduledWakeAt = this.getNextWakeTime(sleepConfig);
+          // Keep the original bedtime (sleepingSince) — sleep never actually
+          // ended during a trigger-wake. Only recompute the cron wake when no
+          // voluntary wake-at is pinned for the night (it stays authoritative).
+          if (!state.voluntaryWakeAt) {
+            const sleepConfig = this.getSleepConfig(event.mind);
+            state.scheduledWakeAt = this.getNextWakeTime(sleepConfig);
+          }
           this.saveState();
           slog.info(`${event.mind} returned to sleep`);
         })

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -693,52 +693,54 @@ export class SleepManager {
     const mindNames = new Set([...this.sleepConfigs.keys(), ...this.states.keys()]);
 
     for (const name of mindNames) {
-      if (!this.isSleeping(name)) {
-        const mind = await findMind(name);
-        if (!mind?.running) continue;
-      }
+      await this.evaluateMind(name, now, epochMinute);
+    }
+  }
 
-      const config = this.getSleepConfig(name);
-      if (!config?.enabled || !config.schedule) continue;
+  /**
+   * Per-mind tick evaluation. The wake checks depend only on the persisted sleep
+   * state — never on a currently-enabled sleep config — so a mind that was put to
+   * sleep with a wake time still wakes even if the schedule is later disabled or
+   * removed (or never existed, e.g. a bare `clock sleep --wake-at`). Only the
+   * sleep-onset check requires a running mind with an enabled schedule.
+   */
+  private async evaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
+    const state = this.states.get(name);
 
-      const state = this.states.get(name);
-
+    if (state?.sleeping) {
       // In wake-failure backoff — wait before retrying rather than hammering
       // wakeMind every tick (#419).
-      if (state?.sleeping && state.nextWakeAttemptAt && now < new Date(state.nextWakeAttemptAt)) {
-        continue;
+      if (state.nextWakeAttemptAt && now < new Date(state.nextWakeAttemptAt)) return;
+
+      // Voluntary wake time
+      if (state.voluntaryWakeAt && now >= new Date(state.voluntaryWakeAt)) {
+        this.initiateWake(name).catch((err) =>
+          slog.error(`failed voluntary wake for ${name}`, log.errorData(err)),
+        );
+        return;
       }
 
-      // Check voluntary wake time
-      if (state?.sleeping && state.voluntaryWakeAt) {
-        const wakeAt = new Date(state.voluntaryWakeAt);
-        if (now >= wakeAt) {
-          this.initiateWake(name).catch((err) =>
-            slog.error(`failed voluntary wake for ${name}`, log.errorData(err)),
-          );
-          continue;
-        }
+      // Scheduled wake time
+      if (state.scheduledWakeAt && now >= new Date(state.scheduledWakeAt)) {
+        this.initiateWake(name).catch((err) =>
+          slog.error(`failed scheduled wake for ${name}`, log.errorData(err)),
+        );
+        return;
       }
 
-      // Check scheduled wake time
-      if (state?.sleeping && state.scheduledWakeAt) {
-        const wakeAt = new Date(state.scheduledWakeAt);
-        if (now >= wakeAt) {
-          this.initiateWake(name).catch((err) =>
-            slog.error(`failed scheduled wake for ${name}`, log.errorData(err)),
-          );
-          continue;
-        }
-      }
+      // Sleeping but not yet time to wake (or intentionally indefinite) — done.
+      return;
+    }
 
-      // Check if it's time to sleep
-      if (!state?.sleeping) {
-        if (this.shouldSleep(config.schedule.sleep, epochMinute)) {
-          this.initiateSleep(name).catch((err) =>
-            slog.error(`failed to initiate sleep for ${name}`, log.errorData(err)),
-          );
-        }
-      }
+    // Sleep-onset — requires a running mind and an enabled schedule.
+    const mind = await findMind(name);
+    if (!mind?.running) return;
+    const config = this.getSleepConfig(name);
+    if (!config?.enabled || !config.schedule) return;
+    if (this.shouldSleep(config.schedule.sleep, epochMinute)) {
+      this.initiateSleep(name).catch((err) =>
+        slog.error(`failed to initiate sleep for ${name}`, log.errorData(err)),
+      );
     }
   }
 

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -48,6 +48,13 @@ export type SleepState = {
   wakeFailures: number;
   /** Earliest time the next wake retry may run, while backing off after failures. */
   nextWakeAttemptAt: string | null;
+  /**
+   * Timestamp of the last full wake (manual `clock wake` or scheduled wake).
+   * Level-triggered sleep onset (#453) uses it to exempt a mind woken inside the
+   * current sleep window from being immediately re-slept. Persisted for awake
+   * minds so the exemption survives a daemon restart.
+   */
+  lastWakeAt: string | null;
 };
 
 type SleepStatePersisted = Record<string, SleepState>;
@@ -63,6 +70,7 @@ function defaultState(): SleepState {
     triggerWakeHistory: [],
     wakeFailures: 0,
     nextWakeAttemptAt: null,
+    lastWakeAt: null,
   };
 }
 
@@ -146,6 +154,7 @@ export class SleepManager {
           state.triggerWakeHistory ??= [];
           state.wakeFailures ??= 0;
           state.nextWakeAttemptAt ??= null;
+          state.lastWakeAt ??= null;
           this.states.set(name, state);
         }
       }
@@ -157,7 +166,9 @@ export class SleepManager {
   saveState(): void {
     const data: SleepStatePersisted = {};
     for (const [name, state] of this.states) {
-      if (state.sleeping) data[name] = state;
+      // Persist sleeping states, plus awake minds that carry a lastWakeAt so the
+      // manual-wake exemption for level-triggered sleep onset survives a restart.
+      if (state.sleeping || state.lastWakeAt) data[name] = state;
     }
     try {
       writeFileSync(this.statePath, `${JSON.stringify(data, null, 2)}\n`);
@@ -621,7 +632,10 @@ export class SleepManager {
    */
   protected async markWakeErrored(name: string, err: unknown): Promise<void> {
     const detail = err instanceof Error ? err.message : String(err);
-    this.markAwake(name);
+    // The mind never woke — clear its sleep state entirely (no lastWakeAt, unlike
+    // a successful markAwake) so the tick stops retrying and nothing lingers.
+    this.states.delete(name);
+    this.saveState();
 
     slog.error(
       `${name} failed to wake ${MAX_WAKE_ATTEMPTS} times in a row; giving up and marking errored`,
@@ -664,13 +678,17 @@ export class SleepManager {
       triggerWakeHistory: [],
       wakeFailures: 0,
       nextWakeAttemptAt: null,
+      lastWakeAt: this.states.get(name)?.lastWakeAt ?? null,
     };
     this.states.set(name, state);
     this.saveState();
   }
 
   private markAwake(name: string): void {
-    this.states.delete(name);
+    // Keep a minimal awake entry recording when the mind last fully woke, so
+    // level-triggered sleep onset (#453) won't immediately re-sleep a mind woken
+    // inside its own sleep window (manual `clock wake` or a scheduled wake).
+    this.states.set(name, { ...defaultState(), lastWakeAt: new Date().toISOString() });
     this.saveState();
   }
 
@@ -687,13 +705,12 @@ export class SleepManager {
 
   private async tick(): Promise<void> {
     const now = new Date();
-    const epochMinute = Math.floor(now.getTime() / 60_000);
 
     // Iterate minds that have sleep configs or sleep state, avoiding a full registry query
     const mindNames = new Set([...this.sleepConfigs.keys(), ...this.states.keys()]);
 
     for (const name of mindNames) {
-      await this.evaluateMind(name, now, epochMinute);
+      await this.evaluateMind(name, now);
     }
   }
 
@@ -704,7 +721,7 @@ export class SleepManager {
    * removed (or never existed, e.g. a bare `clock sleep --wake-at`). Only the
    * sleep-onset check requires a running mind with an enabled schedule.
    */
-  private async evaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
+  private async evaluateMind(name: string, now: Date): Promise<void> {
     const state = this.states.get(name);
 
     if (state?.sleeping) {
@@ -737,22 +754,58 @@ export class SleepManager {
     if (!mind?.running) return;
     const config = this.getSleepConfig(name);
     if (!config?.enabled || !config.schedule) return;
-    if (this.shouldSleep(config.schedule.sleep, epochMinute)) {
+
+    if (this.shouldSleepNow(config.schedule, state?.lastWakeAt ?? null, now)) {
       this.initiateSleep(name).catch((err) =>
         slog.error(`failed to initiate sleep for ${name}`, log.errorData(err)),
       );
     }
   }
 
-  private shouldSleep(cronExpr: string, epochMinute: number): boolean {
+  /**
+   * Level-triggered sleep-onset decision: sleep whenever we're inside the nightly
+   * window, not only on the exact sleep minute — so a daemon restart or a stalled
+   * tick across the sleep minute still puts the mind to bed on the next tick.
+   *
+   * Manual-wake exemption: a full wake inside the current window (human
+   * `clock wake`, or a scheduled wake) suppresses re-sleep until the next window
+   * begins, so `volute clock wake` at 3am sticks instead of being undone a minute
+   * later.
+   */
+  shouldSleepNow(
+    schedule: { sleep: string; wake: string },
+    lastWakeAt: string | null,
+    now: Date,
+  ): boolean {
+    const { inWindow, windowStart } = this.inSleepWindow(schedule, now);
+    if (!inWindow || !windowStart) return false;
+    if (lastWakeAt && new Date(lastWakeAt) >= windowStart) return false;
+    return true;
+  }
+
+  /**
+   * Whether `now` falls inside the mind's nightly sleep window: the most recent
+   * sleep-cron fire is more recent than the most recent wake-cron fire. Returns
+   * the window start (last sleep fire) for the manual-wake exemption check.
+   */
+  inSleepWindow(
+    schedule: { sleep: string; wake: string },
+    now: Date,
+  ): { inWindow: boolean; windowStart: Date | null } {
     try {
-      const interval = CronExpressionParser.parse(cronExpr);
-      const prev = interval.prev().toDate();
-      const prevMinute = Math.floor(prev.getTime() / 60_000);
-      return prevMinute === epochMinute;
+      const prevSleep = CronExpressionParser.parse(schedule.sleep, { currentDate: now })
+        .prev()
+        .toDate();
+      const prevWake = CronExpressionParser.parse(schedule.wake, { currentDate: now })
+        .prev()
+        .toDate();
+      return { inWindow: prevSleep > prevWake, windowStart: prevSleep };
     } catch (err) {
-      slog.warn(`invalid sleep cron "${cronExpr}"`, log.errorData(err));
-      return false;
+      slog.warn(
+        `invalid sleep/wake cron "${schedule.sleep}"/"${schedule.wake}"`,
+        log.errorData(err),
+      );
+      return { inWindow: false, windowStart: null };
     }
   }
 

--- a/packages/daemon/src/web/api/schedules.ts
+++ b/packages/daemon/src/web/api/schedules.ts
@@ -18,6 +18,91 @@ function readSchedules(dir: string): Schedule[] {
   return readVoluteConfig(dir)?.schedules ?? [];
 }
 
+export type ClockEvent = { id: string; at: string; type: "cron" | "timer" };
+export type ClockPrevious = { id: string; at: string };
+
+/** Minimal shape of the sleep state the clock/status view needs. */
+type ClockSleepState = {
+  sleeping: boolean;
+  scheduledWakeAt: string | null;
+  voluntaryWakeAt: string | null;
+  sleepingSince: string | null;
+};
+
+/**
+ * Compute the `upcoming` / `previous` clock events shown in the dashboard and
+ * `volute clock status`. Sleep/wake are surfaced with honest labels: a sleeping
+ * mind's next event is its `wake` (at the effective wake time — a voluntary
+ * `--wake-at` is authoritative), and an awake mind's most recent sleep event is
+ * the `wake` that ended the last night. The next sleep onset stays `sleep`.
+ */
+export function computeClockEvents(
+  schedules: Schedule[],
+  sleepState: ClockSleepState | null,
+  sleepConfig: { enabled?: boolean; schedule?: { sleep: string; wake: string } } | null,
+  now: Date,
+): { upcoming: ClockEvent[]; previous: ClockPrevious[] } {
+  const upcoming: ClockEvent[] = [];
+  const previous: ClockPrevious[] = [];
+
+  for (const s of schedules) {
+    if (!s.enabled) continue;
+    if (s.fireAt) {
+      const fireDate = new Date(s.fireAt);
+      if (fireDate >= now) {
+        upcoming.push({ id: s.id, at: fireDate.toISOString(), type: "timer" });
+      }
+    } else if (s.cron) {
+      try {
+        const next = CronExpressionParser.parse(s.cron, { currentDate: now }).next().toDate();
+        upcoming.push({ id: s.id, at: next.toISOString(), type: "cron" });
+      } catch {
+        slog.warn(`invalid cron "${s.cron}" for schedule "${s.id}"`);
+      }
+      try {
+        const prev = CronExpressionParser.parse(s.cron, { currentDate: now }).prev().toDate();
+        previous.push({ id: s.id, at: prev.toISOString() });
+      } catch {
+        // ignore — prev() can fail for some expressions
+      }
+    }
+  }
+
+  if (sleepState?.sleeping) {
+    // Next event is the wake, not "sleep". Effective wake favors the authoritative
+    // voluntary time (scheduledWakeAt is nulled when a --wake-at is pinned).
+    const effectiveWake = sleepState.scheduledWakeAt ?? sleepState.voluntaryWakeAt;
+    if (effectiveWake) {
+      upcoming.push({ id: "wake", at: effectiveWake, type: "cron" });
+    }
+    if (sleepState.sleepingSince) {
+      previous.push({ id: "sleep", at: sleepState.sleepingSince });
+    }
+  } else if (sleepConfig?.enabled && sleepConfig.schedule) {
+    try {
+      const nextSleep = CronExpressionParser.parse(sleepConfig.schedule.sleep, { currentDate: now })
+        .next()
+        .toDate();
+      upcoming.push({ id: "sleep", at: nextSleep.toISOString(), type: "cron" });
+    } catch {
+      /* ignore */
+    }
+    // Previous sleep-related event is the wake that ended the last night.
+    try {
+      const prevWake = CronExpressionParser.parse(sleepConfig.schedule.wake, { currentDate: now })
+        .prev()
+        .toDate();
+      previous.push({ id: "wake", at: prevWake.toISOString() });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  upcoming.sort((a, b) => a.at.localeCompare(b.at));
+  previous.sort((a, b) => b.at.localeCompare(a.at)); // most recent first
+  return { upcoming, previous };
+}
+
 function writeSchedules(name: string, dir: string, schedules: Schedule[]): void {
   const config = readVoluteConfig(dir) ?? {};
   config.schedules = schedules.length > 0 ? schedules : undefined;
@@ -44,63 +129,9 @@ const app = new Hono<AuthEnv>()
     const sleepConfig = sleepManager?.getSleepConfig(name) ?? null;
     const schedules = readSchedules(dir);
 
-    // Compute upcoming and previous schedule fires
+    // Compute upcoming and previous schedule fires (incl. honest sleep/wake labels)
     const now = new Date();
-    const upcoming: { id: string; at: string; type: "cron" | "timer" }[] = [];
-    const previous: { id: string; at: string }[] = [];
-
-    for (const s of schedules) {
-      if (!s.enabled) continue;
-      if (s.fireAt) {
-        const fireDate = new Date(s.fireAt);
-        if (fireDate >= now) {
-          upcoming.push({ id: s.id, at: fireDate.toISOString(), type: "timer" });
-        }
-      } else if (s.cron) {
-        try {
-          const interval = CronExpressionParser.parse(s.cron);
-          const next = interval.next().toDate();
-          upcoming.push({ id: s.id, at: next.toISOString(), type: "cron" });
-        } catch {
-          slog.warn(`invalid cron "${s.cron}" for schedule "${s.id}" of ${name}`);
-        }
-        try {
-          const prevInterval = CronExpressionParser.parse(s.cron);
-          const prev = prevInterval.prev().toDate();
-          previous.push({ id: s.id, at: prev.toISOString() });
-        } catch {
-          // ignore — prev() can fail for some expressions
-        }
-      }
-    }
-    // Include sleep in upcoming and previous
-    if (sleepState?.sleeping) {
-      if (sleepState.scheduledWakeAt) {
-        upcoming.push({ id: "sleep", at: sleepState.scheduledWakeAt, type: "cron" as const });
-      }
-      if (sleepState.sleepingSince) {
-        previous.push({ id: "sleep", at: sleepState.sleepingSince });
-      }
-    } else if (sleepConfig?.enabled && sleepConfig.schedule) {
-      try {
-        const sleepInterval = CronExpressionParser.parse(sleepConfig.schedule.sleep);
-        const nextSleep = sleepInterval.next().toDate();
-        upcoming.push({ id: "sleep", at: nextSleep.toISOString(), type: "cron" as const });
-      } catch {
-        /* ignore */
-      }
-      // Use wake cron for previous — shows when sleep ended, not when it started
-      try {
-        const prevWakeInterval = CronExpressionParser.parse(sleepConfig.schedule.wake);
-        const prevWake = prevWakeInterval.prev().toDate();
-        previous.push({ id: "sleep", at: prevWake.toISOString() });
-      } catch {
-        /* ignore */
-      }
-    }
-
-    upcoming.sort((a, b) => a.at.localeCompare(b.at));
-    previous.sort((a, b) => b.at.localeCompare(a.at)); // most recent first
+    const { upcoming, previous } = computeClockEvents(schedules, sleepState, sleepConfig, now);
 
     return c.json({ sleep: sleepState, sleepConfig, schedules, upcoming, previous });
   })

--- a/packages/web/src/ui/components/mind/MindClock.svelte
+++ b/packages/web/src/ui/components/mind/MindClock.svelte
@@ -14,6 +14,7 @@ const BUILTIN_COLORS: Record<string, string> = {
   dream: "var(--purple)",
   dreaming: "var(--purple)",
   sleep: "var(--blue)",
+  wake: "var(--blue)",
 };
 
 let { name }: { name: string } = $props();
@@ -37,6 +38,7 @@ function scheduleIcon(id: string): IconKind {
   if (lower === "heartbeat" || lower === "pulse") return "heartbeat";
   if (lower === "dream" || lower === "dreaming") return "dream";
   if (lower === "sleep") return "sleep";
+  if (lower === "wake") return "sleep";
   return "clock";
 }
 
@@ -185,7 +187,8 @@ let currentItem = $derived.by((): SummaryItem | null => {
 
 let nextItem = $derived.by((): SummaryItem | null => {
   if (!clock) return null;
-  const next = clock.upcoming[0];
+  const skipWake = clock.sleep?.sleeping;
+  const next = clock.upcoming.find((u) => !(skipWake && u.id === "wake"));
   if (!next) return null;
   return {
     icon: scheduleIcon(next.id),

--- a/packages/web/src/ui/components/mind/MindClock.svelte
+++ b/packages/web/src/ui/components/mind/MindClock.svelte
@@ -101,14 +101,13 @@ let rows = $derived.by(() => {
 
   // Sleep row
   if (clock.sleep?.sleeping) {
+    const effectiveWake = clock.sleep.scheduledWakeAt ?? clock.sleep.voluntaryWakeAt;
     result.push({
       id: "sleep",
       icon: "sleep",
       color: scheduleColor("sleep"),
       times: "sleeping now",
-      next: clock.sleep.scheduledWakeAt
-        ? `wake ${formatRelativeTime(clock.sleep.scheduledWakeAt)}`
-        : "",
+      next: effectiveWake ? `wake ${formatRelativeTime(effectiveWake)}` : "",
       disabled: false,
       tooltip: "",
     });
@@ -152,13 +151,12 @@ type SummaryItem = { icon: IconKind; label: string; detail: string; color: strin
 let currentItem = $derived.by((): SummaryItem | null => {
   if (!clock) return null;
   if (clock.sleep?.sleeping) {
+    const effectiveWake = clock.sleep.scheduledWakeAt ?? clock.sleep.voluntaryWakeAt;
     return {
       icon: "sleep",
       label: "Sleeping",
       color: scheduleColor("sleep"),
-      detail: clock.sleep.scheduledWakeAt
-        ? `wake ${formatRelativeTime(clock.sleep.scheduledWakeAt)}`
-        : "now",
+      detail: effectiveWake ? `wake ${formatRelativeTime(effectiveWake)}` : "now",
     };
   }
   if (activeMinds.has(name) && clock.previous?.length > 0) {

--- a/skills/volute-mind/references/sleep.md
+++ b/skills/volute-mind/references/sleep.md
@@ -31,3 +31,6 @@ You can go to sleep any time with `volute clock sleep`. Optionally set a wake ti
 ```sh
 volute clock sleep --wake-at "2025-01-15T07:00:00Z"
 ```
+
+A `--wake-at` overrides your wake schedule for that night — you will wake at the
+time you asked for, even if a scheduled wake cron would have fired earlier.

--- a/test/clock-events.test.ts
+++ b/test/clock-events.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
+import { computeClockEvents } from "../packages/daemon/src/web/api/schedules.js";
+
+const now = new Date("2026-07-07T03:00:00");
+
+function sleepState(overrides: Record<string, unknown> = {}) {
+  return {
+    sleeping: true,
+    scheduledWakeAt: null,
+    voluntaryWakeAt: null,
+    sleepingSince: null,
+    ...overrides,
+  };
+}
+
+describe("computeClockEvents", () => {
+  it("sleeping mind: next event is 'wake' (not 'sleep'), previous is 'sleep'", () => {
+    const wakeAt = new Date("2026-07-07T08:00:00").toISOString();
+    const since = new Date("2026-07-07T00:00:00").toISOString();
+    const { upcoming, previous } = computeClockEvents(
+      [],
+      sleepState({ scheduledWakeAt: wakeAt, sleepingSince: since }),
+      { enabled: true, schedule: { sleep: "0 0 * * *", wake: "0 8 * * *" } },
+      now,
+    );
+
+    // Upcoming holds the wake at the scheduled wake time — never a "sleep" entry.
+    assert.deepEqual(
+      upcoming.find((e) => e.id === "wake"),
+      { id: "wake", at: wakeAt, type: "cron" },
+    );
+    assert.equal(
+      upcoming.some((e) => e.id === "sleep"),
+      false,
+    );
+    // Previous correctly labels when sleep began.
+    assert.deepEqual(
+      previous.find((e) => e.id === "sleep"),
+      { id: "sleep", at: since },
+    );
+  });
+
+  it("sleeping mind: 'wake' uses the authoritative voluntaryWakeAt when scheduled is null", () => {
+    const voluntary = new Date("2026-07-07T14:00:00").toISOString();
+    const { upcoming } = computeClockEvents(
+      [],
+      sleepState({ scheduledWakeAt: null, voluntaryWakeAt: voluntary }),
+      null,
+      now,
+    );
+    assert.deepEqual(
+      upcoming.find((e) => e.id === "wake"),
+      { id: "wake", at: voluntary, type: "cron" },
+    );
+  });
+
+  it("awake mind with sleep enabled: upcoming 'sleep', previous 'wake' (not 'sleep')", () => {
+    const { upcoming, previous } = computeClockEvents(
+      [],
+      sleepState({ sleeping: false }),
+      { enabled: true, schedule: { sleep: "0 0 * * *", wake: "0 8 * * *" } },
+      now,
+    );
+
+    // Next sleep onset is still labeled "sleep".
+    const nextSleep = upcoming.find((e) => e.id === "sleep");
+    assert.ok(nextSleep, "expected an upcoming sleep event");
+    assert.equal(nextSleep?.type, "cron");
+
+    // The most recent sleep-related event is the wake that ended the last night.
+    assert.ok(
+      previous.some((e) => e.id === "wake"),
+      "expected a previous 'wake' event",
+    );
+    // It must NOT be mislabeled "sleep".
+    assert.equal(
+      previous.some((e) => e.id === "sleep"),
+      false,
+    );
+  });
+
+  it("awake mind with sleep disabled: no sleep/wake events", () => {
+    const { upcoming, previous } = computeClockEvents(
+      [],
+      sleepState({ sleeping: false }),
+      { enabled: false, schedule: { sleep: "0 0 * * *", wake: "0 8 * * *" } },
+      now,
+    );
+    assert.equal(
+      upcoming.some((e) => e.id === "sleep" || e.id === "wake"),
+      false,
+    );
+    assert.equal(
+      previous.some((e) => e.id === "sleep" || e.id === "wake"),
+      false,
+    );
+  });
+
+  it("regular cron schedules appear in both upcoming and previous under their own id", () => {
+    const schedules: Schedule[] = [
+      { id: "heartbeat", cron: "0 * * * *", message: "beat", enabled: true },
+    ];
+    const { upcoming, previous } = computeClockEvents(
+      schedules,
+      sleepState({ sleeping: false }),
+      null,
+      now,
+    );
+    assert.ok(upcoming.some((e) => e.id === "heartbeat" && e.type === "cron"));
+    assert.ok(previous.some((e) => e.id === "heartbeat"));
+  });
+
+  it("disabled and future/past timers behave correctly", () => {
+    const schedules: Schedule[] = [
+      { id: "off", cron: "0 * * * *", message: "x", enabled: false },
+      {
+        id: "future",
+        fireAt: new Date(now.getTime() + 3600_000).toISOString(),
+        message: "later",
+        enabled: true,
+      },
+      {
+        id: "past",
+        fireAt: new Date(now.getTime() - 3600_000).toISOString(),
+        message: "gone",
+        enabled: true,
+      },
+    ];
+    const { upcoming } = computeClockEvents(schedules, sleepState({ sleeping: false }), null, now);
+    assert.equal(
+      upcoming.some((e) => e.id === "off"),
+      false,
+    ); // disabled skipped
+    assert.ok(upcoming.some((e) => e.id === "future" && e.type === "timer")); // future timer shown
+    assert.equal(
+      upcoming.some((e) => e.id === "past"),
+      false,
+    ); // past timer not upcoming
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -370,6 +370,101 @@ describe("scheduler fireAt", () => {
   });
 });
 
+describe("scheduler catch-up (level-triggered cron)", () => {
+  const nowMin = () => Math.floor(Date.now() / 60000);
+  const heartbeat = { id: "heartbeat", cron: "* * * * *", enabled: true };
+
+  it("fires a caught-up cron once when a minute was skipped", () => {
+    const scheduler = new TestScheduler();
+    const epochMinute = nowMin();
+    const key = "test-mind:heartbeat";
+    // Last acted-on minute is 3 minutes stale (missed ticks).
+    (scheduler as any).lastFired.set(key, epochMinute - 3);
+
+    const first = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
+    assert.equal(first, true);
+    // lastFired advances to the fired cron minute (== epochMinute for every-minute cron).
+    assert.equal((scheduler as any).lastFired.get(key), epochMinute);
+
+    // Same minute again → no double fire.
+    const second = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
+    assert.equal(second, false);
+  });
+
+  it("does not fire when already up to date this minute", () => {
+    const scheduler = new TestScheduler();
+    const epochMinute = nowMin();
+    (scheduler as any).lastFired.set("test-mind:heartbeat", epochMinute);
+    const result = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
+    assert.equal(result, false);
+  });
+
+  it("skips a stale catch-up fire but still advances lastFired", () => {
+    const scheduler = new TestScheduler();
+    const realMin = nowMin();
+    // Pretend we're evaluating 20 minutes after the cron minute (long downtime).
+    const epochMinute = realMin + 20;
+    const key = "test-mind:dream";
+    (scheduler as any).lastFired.set(key, realMin - 30);
+
+    const result = (scheduler as any).shouldFire(
+      { id: "dream", cron: "* * * * *", enabled: true },
+      epochMinute,
+      "test-mind",
+      new Map(),
+    );
+    // Too stale to deliver...
+    assert.equal(result, false);
+    // ...but lastFired advanced to the cron minute so it won't be retried.
+    assert.equal((scheduler as any).lastFired.get(key), realMin);
+  });
+});
+
+describe("scheduler loadSchedules bookkeeping", () => {
+  function writeConfig(dir: string, schedules: unknown[]) {
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(resolve(dir, "home/.config/volute.json"), JSON.stringify({ schedules }));
+  }
+
+  it("baseline-inits new schedules and prunes stale keys for the mind only (#428, #453)", () => {
+    const scheduler = new TestScheduler();
+    const dir = resolve(voluteSystemDir(), "sched-bookkeep-mind");
+    writeConfig(dir, [{ id: "heartbeat", cron: "* * * * *", message: "hi", enabled: true }]);
+
+    const lf = (scheduler as any).lastFired as Map<string, number>;
+    // Pre-seed: a stale key for this mind + a live key for another mind.
+    lf.set("sched-bookkeep-mind:old-removed", 100);
+    lf.set("other-mind:keepme", 200);
+
+    scheduler.loadSchedules("sched-bookkeep-mind", dir);
+
+    // Stale key for this mind pruned (#428).
+    assert.equal(lf.has("sched-bookkeep-mind:old-removed"), false);
+    // Other mind's key untouched — prune is per-mind only.
+    assert.equal(lf.get("other-mind:keepme"), 200);
+    // New schedule baselined to the current minute (#453) so no history replay.
+    assert.equal(lf.get("sched-bookkeep-mind:heartbeat"), Math.floor(Date.now() / 60000));
+  });
+
+  it("baseline prevents an immediate replay for a freshly loaded schedule", () => {
+    const scheduler = new TestScheduler();
+    const dir = resolve(voluteSystemDir(), "sched-fresh-mind");
+    writeConfig(dir, [{ id: "beat", cron: "* * * * *", message: "hi", enabled: true }]);
+
+    scheduler.loadSchedules("sched-fresh-mind", dir);
+
+    const epochMinute = Math.floor(Date.now() / 60000);
+    const result = (scheduler as any).shouldFire(
+      { id: "beat", cron: "* * * * *", enabled: true },
+      epochMinute,
+      "sched-fresh-mind",
+      new Map(),
+    );
+    // Baseline == epochMinute, so the current-minute cron fire is not replayed.
+    assert.equal(result, false);
+  });
+});
+
 describe("parseDuration", () => {
   // Import dynamically since it's in clock.ts — test the regex logic directly
   function parseDuration(input: string): number | null {

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -104,6 +104,24 @@ class TestSleepManager extends SleepManager {
   testMarkSleeping(name: string, opts?: { voluntaryWakeAt?: string }): void {
     (this as any).markSleeping(name, opts);
   }
+
+  // Stub initiateWake/initiateSleep so evaluateMind can be tested without a live
+  // MindManager. Records the names it was asked to wake/sleep.
+  wakeCalls: string[] = [];
+  sleepCalls: string[] = [];
+
+  override async initiateWake(name: string): Promise<void> {
+    this.wakeCalls.push(name);
+  }
+
+  override async initiateSleep(name: string): Promise<void> {
+    this.sleepCalls.push(name);
+  }
+
+  // Expose evaluateMind for testing
+  testEvaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
+    return (this as any).evaluateMind(name, now, epochMinute);
+  }
 }
 
 function sleepingState(overrides?: Partial<SleepState>): SleepState {
@@ -538,6 +556,60 @@ describe("SleepManager state transitions", () => {
 
     const state = sm.getState("test-mind");
     assert.notEqual(state.scheduledWakeAt, null);
+  });
+});
+
+// #450: waking a sleeping mind must not depend on a currently-enabled sleep
+// config — the wake times were persisted at bedtime.
+describe("SleepManager.evaluateMind wake without config", () => {
+  const epochMinute = Math.floor(Date.now() / 60_000);
+
+  it("wakes a sleeping mind with a past voluntaryWakeAt even with no config", async () => {
+    const sm = new TestSleepManager();
+    // No sleep config set at all (getSleepConfig returns null).
+    const past = new Date(Date.now() - 60_000).toISOString();
+    sm.setStateForTest("test-mind", sleepingState({ voluntaryWakeAt: past }));
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, ["test-mind"]);
+  });
+
+  it("wakes a sleeping mind with a past scheduledWakeAt when config is disabled", async () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", {
+      enabled: false,
+      schedule: { sleep: "0 23 * * *", wake: "0 8 * * *" },
+    });
+    const past = new Date(Date.now() - 60_000).toISOString();
+    sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: past }));
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, ["test-mind"]);
+  });
+
+  it("leaves a sleeping mind asleep when it has no wake times and no config", async () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ voluntaryWakeAt: null, scheduledWakeAt: null }),
+    );
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, []);
+    assert.equal(sm.getState("test-mind").sleeping, true);
+  });
+
+  it("does not wake before the persisted wake time arrives", async () => {
+    const sm = new TestSleepManager();
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: future }));
+
+    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+
+    assert.deepEqual(sm.wakeCalls, []);
   });
 });
 

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -99,6 +99,11 @@ class TestSleepManager extends SleepManager {
   testResetWakeBackoff(name: string): void {
     (this as any).resetWakeBackoff(name);
   }
+
+  // Expose markSleeping for testing
+  testMarkSleeping(name: string, opts?: { voluntaryWakeAt?: string }): void {
+    (this as any).markSleeping(name, opts);
+  }
 }
 
 function sleepingState(overrides?: Partial<SleepState>): SleepState {
@@ -448,6 +453,91 @@ describe("SleepManager state transitions", () => {
     // Simulate incrementing
     state.queuedMessageCount++;
     assert.equal(sm.getState("test-mind").queuedMessageCount, 1);
+  });
+
+  // #451: an explicit voluntary wake-at is authoritative for the night.
+  it("markSleeping with voluntaryWakeAt nulls the cron scheduledWakeAt", () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    const wakeAt = new Date(Date.now() + 12 * 3600_000).toISOString();
+    sm.testMarkSleeping("test-mind", { voluntaryWakeAt: wakeAt });
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, wakeAt);
+  });
+
+  it("markSleeping without voluntaryWakeAt sets scheduledWakeAt from the cron", () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    sm.testMarkSleeping("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.notEqual(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, null);
+  });
+
+  // #451: a voluntary wake later than the next cron wake must not be preempted.
+  // With scheduledWakeAt null, tick()'s cron branch can never fire early.
+  it("voluntary wake later than cron leaves no scheduled cron wake to fire", () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    // Wake-at far in the future, likely later than the next 8am cron wake.
+    const wakeAt = new Date(Date.now() + 30 * 3600_000).toISOString();
+    sm.testMarkSleeping("test-mind", { voluntaryWakeAt: wakeAt });
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, wakeAt);
+  });
+
+  // #449: return-to-sleep after a trigger-wake must not reset sleepingSince.
+  it("returnToSleepAfterCrash preserves the original bedtime (sleepingSince)", async () => {
+    const sm = new TestSleepManager();
+    const bedtime = new Date(Date.now() - 8 * 3600_000).toISOString();
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ sleepingSince: bedtime, wokenByTrigger: true }),
+    );
+
+    await sm.returnToSleepAfterCrash("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.sleeping, true);
+    assert.equal(state.sleepingSince, bedtime);
+    assert.equal(state.wokenByTrigger, false);
+  });
+
+  // #451: return-to-sleep must not resurrect a cron wake when a voluntary wake
+  // is pinned for the night.
+  it("returnToSleepAfterCrash keeps scheduledWakeAt null when voluntaryWakeAt is set", async () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    const wakeAt = new Date(Date.now() + 12 * 3600_000).toISOString();
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ scheduledWakeAt: null, voluntaryWakeAt: wakeAt, wokenByTrigger: true }),
+    );
+
+    await sm.returnToSleepAfterCrash("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.equal(state.scheduledWakeAt, null);
+    assert.equal(state.voluntaryWakeAt, wakeAt);
+  });
+
+  it("returnToSleepAfterCrash recomputes scheduledWakeAt when no voluntary wake", async () => {
+    const sm = new TestSleepManager();
+    sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });
+    sm.setStateForTest(
+      "test-mind",
+      sleepingState({ scheduledWakeAt: null, voluntaryWakeAt: null, wokenByTrigger: true }),
+    );
+
+    await sm.returnToSleepAfterCrash("test-mind");
+
+    const state = sm.getState("test-mind");
+    assert.notEqual(state.scheduledWakeAt, null);
   });
 });
 

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -56,9 +56,20 @@ class TestSleepManager extends SleepManager {
     return null;
   }
 
-  // Expose shouldSleep for testing
-  testShouldSleep(cronExpr: string, epochMinute: number): boolean {
-    return (this as any).shouldSleep(cronExpr, epochMinute);
+  // Expose inSleepWindow / shouldSleepNow for testing
+  testInSleepWindow(
+    schedule: { sleep: string; wake: string },
+    now: Date,
+  ): { inWindow: boolean; windowStart: Date | null } {
+    return (this as any).inSleepWindow(schedule, now);
+  }
+
+  testShouldSleepNow(
+    schedule: { sleep: string; wake: string },
+    lastWakeAt: string | null,
+    now: Date,
+  ): boolean {
+    return (this as any).shouldSleepNow(schedule, lastWakeAt, now);
   }
 
   // Expose getNextWakeTime for testing
@@ -119,8 +130,8 @@ class TestSleepManager extends SleepManager {
   }
 
   // Expose evaluateMind for testing
-  testEvaluateMind(name: string, now: Date, epochMinute: number): Promise<void> {
-    return (this as any).evaluateMind(name, now, epochMinute);
+  testEvaluateMind(name: string, now: Date): Promise<void> {
+    return (this as any).evaluateMind(name, now);
   }
 }
 
@@ -135,11 +146,12 @@ function sleepingState(overrides?: Partial<SleepState>): SleepState {
     triggerWakeHistory: [],
     wakeFailures: 0,
     nextWakeAttemptAt: null,
+    lastWakeAt: null,
     ...overrides,
   };
 }
 
-function awakeState(): SleepState {
+function awakeState(overrides?: Partial<SleepState>): SleepState {
   return {
     sleeping: false,
     sleepingSince: null,
@@ -150,6 +162,8 @@ function awakeState(): SleepState {
     triggerWakeHistory: [],
     wakeFailures: 0,
     nextWakeAttemptAt: null,
+    lastWakeAt: null,
+    ...overrides,
   };
 }
 
@@ -562,15 +576,13 @@ describe("SleepManager state transitions", () => {
 // #450: waking a sleeping mind must not depend on a currently-enabled sleep
 // config — the wake times were persisted at bedtime.
 describe("SleepManager.evaluateMind wake without config", () => {
-  const epochMinute = Math.floor(Date.now() / 60_000);
-
   it("wakes a sleeping mind with a past voluntaryWakeAt even with no config", async () => {
     const sm = new TestSleepManager();
     // No sleep config set at all (getSleepConfig returns null).
     const past = new Date(Date.now() - 60_000).toISOString();
     sm.setStateForTest("test-mind", sleepingState({ voluntaryWakeAt: past }));
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, ["test-mind"]);
   });
@@ -584,7 +596,7 @@ describe("SleepManager.evaluateMind wake without config", () => {
     const past = new Date(Date.now() - 60_000).toISOString();
     sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: past }));
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, ["test-mind"]);
   });
@@ -596,7 +608,7 @@ describe("SleepManager.evaluateMind wake without config", () => {
       sleepingState({ voluntaryWakeAt: null, scheduledWakeAt: null }),
     );
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, []);
     assert.equal(sm.getState("test-mind").sleeping, true);
@@ -607,41 +619,80 @@ describe("SleepManager.evaluateMind wake without config", () => {
     const future = new Date(Date.now() + 3600_000).toISOString();
     sm.setStateForTest("test-mind", sleepingState({ scheduledWakeAt: future }));
 
-    await sm.testEvaluateMind("test-mind", new Date(), epochMinute);
+    await sm.testEvaluateMind("test-mind", new Date());
 
     assert.deepEqual(sm.wakeCalls, []);
   });
 });
 
-describe("SleepManager.shouldSleep (cron matching)", () => {
-  it("returns true when cron matches current epoch minute", () => {
-    const sm = new TestSleepManager();
-    // Use "every minute" cron — should always match
-    const now = new Date();
-    const epochMinute = Math.floor(now.getTime() / 60_000);
-    assert.equal(sm.testShouldSleep("* * * * *", epochMinute), true);
+// #453 Part 2: level-triggered sleep onset — "should this mind be asleep now"
+// rather than an exact-minute cron match.
+describe("SleepManager.inSleepWindow (level-triggered onset)", () => {
+  // Nightly window: asleep 00:00, awake 08:00.
+  const schedule = { sleep: "0 0 * * *", wake: "0 8 * * *" };
+  const at = (h: number, m = 0) => {
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  it("is in-window across the midnight-spanning night (03:00)", () => {
+    const { inWindow, windowStart } = new TestSleepManager().testInSleepWindow(schedule, at(3));
+    assert.equal(inWindow, true);
+    assert.ok(windowStart);
   });
 
-  it("returns false when cron does not match current epoch minute", () => {
-    const sm = new TestSleepManager();
-    // Use a very specific time far in the future — won't match current minute
-    // "0 0 1 1 *" = midnight Jan 1st only
-    const now = new Date();
-    const epochMinute = Math.floor(now.getTime() / 60_000);
-    // This will only match if we happen to be at midnight Jan 1st
-    if (
-      now.getMonth() !== 0 ||
-      now.getDate() !== 1 ||
-      now.getHours() !== 0 ||
-      now.getMinutes() !== 0
-    ) {
-      assert.equal(sm.testShouldSleep("0 0 1 1 *", epochMinute), false);
-    }
+  it("is out of window during the day (12:00)", () => {
+    const { inWindow } = new TestSleepManager().testInSleepWindow(schedule, at(12));
+    assert.equal(inWindow, false);
   });
 
-  it("returns false for invalid cron expression", () => {
+  it("returns not-in-window for an invalid cron", () => {
+    const { inWindow, windowStart } = new TestSleepManager().testInSleepWindow(
+      { sleep: "not-a-cron", wake: "0 8 * * *" },
+      at(3),
+    );
+    assert.equal(inWindow, false);
+    assert.equal(windowStart, null);
+  });
+});
+
+describe("SleepManager.shouldSleepNow (onset decision)", () => {
+  const schedule = { sleep: "0 0 * * *", wake: "0 8 * * *" };
+  const at = (h: number, m = 0) => {
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  it("sleeps on fresh state inside the window (daemon restart mid-window)", () => {
     const sm = new TestSleepManager();
-    assert.equal(sm.testShouldSleep("not-a-cron", 12345), false);
+    // No lastWakeAt — the mind restarted at 03:30 with no persisted awake info.
+    assert.equal(sm.testShouldSleepNow(schedule, null, at(3, 30)), true);
+  });
+
+  it("does not sleep outside the window (midday)", () => {
+    const sm = new TestSleepManager();
+    assert.equal(sm.testShouldSleepNow(schedule, null, at(12)), false);
+  });
+
+  it("exempts a mind manually woken inside the current window (no re-sleep)", () => {
+    const sm = new TestSleepManager();
+    // Woken at 03:00, evaluated at 03:30 — after the 00:00 window start.
+    const lastWakeAt = at(3).toISOString();
+    assert.equal(sm.testShouldSleepNow(schedule, lastWakeAt, at(3, 30)), false);
+  });
+
+  it("still sleeps when the last wake was before this window began", () => {
+    const sm = new TestSleepManager();
+    // Woken yesterday at 20:00, before the 00:00 window start.
+    const lastWakeAt = at(-4).toISOString(); // 20:00 previous day
+    assert.equal(sm.testShouldSleepNow(schedule, lastWakeAt, at(3, 30)), true);
+  });
+
+  it("does not sleep when the schedule cron is invalid", () => {
+    const sm = new TestSleepManager();
+    assert.equal(sm.testShouldSleepNow({ sleep: "nope", wake: "0 8 * * *" }, null, at(3)), false);
   });
 });
 
@@ -819,8 +870,19 @@ describe("SleepManager.convertTriggerToFullWake", () => {
 
     sm.convertTriggerToFullWake("test-mind");
 
-    // markAwake deletes the state, so getState returns default (not sleeping)
+    // markAwake records an awake state (lastWakeAt), so the mind is no longer sleeping
     assert.equal(sm.getState("test-mind").sleeping, false);
+  });
+
+  it("records lastWakeAt on full wake so onset can exempt it (#453)", () => {
+    const sm = new TestSleepManager();
+    sm.setStateForTest("test-mind", sleepingState({ wokenByTrigger: true }));
+
+    sm.convertTriggerToFullWake("test-mind");
+
+    const state = sm.getStateForTest("test-mind");
+    assert.ok(state?.lastWakeAt, "expected lastWakeAt to be recorded on full wake");
+    assert.equal(state?.sleeping, false);
   });
 
   it("is a no-op when sleeping but not trigger-woken", () => {


### PR DESCRIPTION
Part of the core-reliability release (sleep & delivery). **Stacked on #453/#428 — merge that first.**

The clock/status view pushed a sleeping mind's **wake** timestamp into `upcoming` labeled `sleep`, so the dashboard showed "Sleeping (wake in 7m) · sleep in 7m" and the CLI listed the wake time under `sleep`. The awake branch had the mirror bug in `previous` (prev-wake labeled `sleep`).

The upcoming/previous computation is extracted into a pure, tested `computeClockEvents`: a sleeping mind's next event is now `wake` at the effective wake time (voluntary authoritative), and an awake mind's most recent sleep-related event is the `wake` that ended the night. `MindClock.svelte` gets a `wake` color/icon and de-duplicates the wake row against the "Sleeping · wake in X" summary.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
