### PR TITLE
chore: clock/sleep UX papercuts — trigger-wake status, 24h filter, wake-at ergonomics

### DIFF
--- a/packages/cli/src/commands/clock.ts
+++ b/packages/cli/src/commands/clock.ts
@@ -22,10 +22,16 @@ type ClockStatus = {
     schedule?: { sleep: string; wake: string };
   } | null;
   schedules: Schedule[];
-  upcoming: { id: string; at: string; type: "cron" | "timer" }[];
+  upcoming: {
+    id: string;
+    at: string;
+    type: "cron" | "timer";
+    willSkip?: boolean;
+    willQueue?: boolean;
+  }[];
 };
 
-function parseDuration(input: string): number | null {
+export function parseDuration(input: string): number | null {
   const parts = input.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/);
   if (!parts || parts[0] !== input) return null;
   const hours = parseInt(parts[1] || "0", 10);
@@ -60,8 +66,12 @@ const clockStatusCmd = command({
 
     // Sleep state
     if (status.sleep?.sleeping) {
-      const since = status.sleep.sleepingSince ? fmtTime(status.sleep.sleepingSince) : "unknown";
-      console.log(`Sleep: sleeping since ${since}`);
+      if (status.sleep.wokenByTrigger) {
+        console.log("Sleep: briefly awake (trigger) — returns to sleep when idle");
+      } else {
+        const since = status.sleep.sleepingSince ? fmtTime(status.sleep.sleepingSince) : "unknown";
+        console.log(`Sleep: sleeping since ${since}`);
+      }
       if (status.sleep.scheduledWakeAt) {
         console.log(`  Wake at: ${fmtTime(status.sleep.scheduledWakeAt)}`);
       }
@@ -89,7 +99,12 @@ const clockStatusCmd = command({
       for (const u of status.upcoming) {
         const time = fmtTime(u.at);
         const label = u.type === "timer" ? "[once]" : "[cron]";
-        console.log(`  ${u.id.padEnd(20)} ${label}  ${time}`);
+        const suffix = u.willSkip
+          ? "  [will skip: sleeping]"
+          : u.willQueue
+            ? "  [will queue: sleeping]"
+            : "";
+        console.log(`  ${u.id.padEnd(20)} ${label}  ${time}${suffix}`);
       }
     } else {
       if (!compact) console.log("");

--- a/packages/cli/src/commands/mind-sleep.ts
+++ b/packages/cli/src/commands/mind-sleep.ts
@@ -1,6 +1,35 @@
 import { command } from "../lib/command.js";
 import { daemonFetch } from "../lib/daemon-client.js";
 import { resolveMindName } from "../lib/resolve-mind-name.js";
+import { parseDuration } from "./clock.js";
+
+/**
+ * Resolve a `--wake-at` value into an ISO timestamp. Accepts a duration
+ * (`2h30m`, `45m`), a local `HH:MM` clock time (next occurrence), or an explicit
+ * date/ISO string. Returns null if the input matches none of these.
+ */
+export function resolveWakeAt(input: string, now = new Date()): string | null {
+  // Duration form: 2h30m, 45m, 1h — relative to now.
+  const durationMs = parseDuration(input);
+  if (durationMs !== null) return new Date(now.getTime() + durationMs).toISOString();
+
+  // Local HH:MM (24-hour) — next occurrence in the caller's local timezone.
+  const hm = input.match(/^(\d{1,2}):(\d{2})$/);
+  if (hm) {
+    const h = Number(hm[1]);
+    const m = Number(hm[2]);
+    if (h > 23 || m > 59) return null;
+    const d = new Date(now);
+    d.setHours(h, m, 0, 0);
+    if (d <= now) d.setDate(d.getDate() + 1); // already passed today → tomorrow
+    return d.toISOString();
+  }
+
+  // Otherwise treat as an explicit date/ISO string.
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
 
 const cmd = command({
   name: "volute clock sleep",
@@ -8,7 +37,10 @@ const cmd = command({
   args: [{ name: "name", description: "Mind to sleep (or use --mind / VOLUTE_MIND)" }],
   flags: {
     mind: { type: "string", description: "Mind name" },
-    "wake-at": { type: "string", description: "Schedule wake time" },
+    "wake-at": {
+      type: "string",
+      description: "Wake time: duration (2h30m), local HH:MM, or ISO timestamp",
+    },
   },
   run: async ({ args, flags }) => {
     const name = args.name || resolveMindName(flags as { mind?: string });
@@ -18,7 +50,18 @@ const cmd = command({
     }
 
     const body: Record<string, string> = {};
-    if (flags["wake-at"]) body.wakeAt = flags["wake-at"] as string;
+    if (flags["wake-at"]) {
+      const wakeAt = resolveWakeAt(flags["wake-at"] as string);
+      if (!wakeAt) {
+        console.error(
+          `Invalid --wake-at: ${flags["wake-at"]}\n` +
+            "Accepted forms: a duration (e.g. 2h30m, 45m), a local time (HH:MM, next " +
+            "occurrence), or an ISO timestamp (e.g. 2026-07-08T14:00:00Z).",
+        );
+        process.exit(1);
+      }
+      body.wakeAt = wakeAt;
+    }
 
     const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/sleep`, {
       method: "POST",

--- a/packages/daemon/src/web/api/schedules.ts
+++ b/packages/daemon/src/web/api/schedules.ts
@@ -18,8 +18,19 @@ function readSchedules(dir: string): Schedule[] {
   return readVoluteConfig(dir)?.schedules ?? [];
 }
 
-export type ClockEvent = { id: string; at: string; type: "cron" | "timer" };
+export type ClockEvent = {
+  id: string;
+  at: string;
+  type: "cron" | "timer";
+  /** Sleeping mind: this fire lands before wake and its whileSleeping is "skip". */
+  willSkip?: boolean;
+  /** Sleeping mind: this fire lands before wake and will be queued until wake. */
+  willQueue?: boolean;
+};
 export type ClockPrevious = { id: string; at: string };
+
+/** Only surface fires within this window in the "upcoming (next 24h)" view. */
+const UPCOMING_HORIZON_MS = 24 * 60 * 60 * 1000;
 
 /** Minimal shape of the sleep state the clock/status view needs. */
 type ClockSleepState = {
@@ -45,17 +56,39 @@ export function computeClockEvents(
   const upcoming: ClockEvent[] = [];
   const previous: ClockPrevious[] = [];
 
+  // Effective wake for a sleeping mind — favors the authoritative voluntary time
+  // (scheduledWakeAt is nulled when a --wake-at is pinned). Used to annotate which
+  // schedule fires land before wake and will be skipped/queued.
+  const effectiveWake = sleepState?.sleeping
+    ? (sleepState.scheduledWakeAt ?? sleepState.voluntaryWakeAt)
+    : null;
+  const effectiveWakeDate = effectiveWake ? new Date(effectiveWake) : null;
+
+  // Annotate a fire that lands during sleep with its while-sleeping fate.
+  const sleepFate = (s: Schedule, fireDate: Date): Partial<ClockEvent> => {
+    if (!effectiveWakeDate || fireDate >= effectiveWakeDate) return {};
+    const ws = s.whileSleeping ?? "queue";
+    if (ws === "skip") return { willSkip: true };
+    if (ws === "trigger-wake") return {}; // wakes the mind — the fire happens
+    return { willQueue: true };
+  };
+
   for (const s of schedules) {
     if (!s.enabled) continue;
     if (s.fireAt) {
       const fireDate = new Date(s.fireAt);
       if (fireDate >= now) {
-        upcoming.push({ id: s.id, at: fireDate.toISOString(), type: "timer" });
+        upcoming.push({
+          id: s.id,
+          at: fireDate.toISOString(),
+          type: "timer",
+          ...sleepFate(s, fireDate),
+        });
       }
     } else if (s.cron) {
       try {
         const next = CronExpressionParser.parse(s.cron, { currentDate: now }).next().toDate();
-        upcoming.push({ id: s.id, at: next.toISOString(), type: "cron" });
+        upcoming.push({ id: s.id, at: next.toISOString(), type: "cron", ...sleepFate(s, next) });
       } catch {
         slog.warn(`invalid cron "${s.cron}" for schedule "${s.id}"`);
       }
@@ -69,9 +102,7 @@ export function computeClockEvents(
   }
 
   if (sleepState?.sleeping) {
-    // Next event is the wake, not "sleep". Effective wake favors the authoritative
-    // voluntary time (scheduledWakeAt is nulled when a --wake-at is pinned).
-    const effectiveWake = sleepState.scheduledWakeAt ?? sleepState.voluntaryWakeAt;
+    // Next event is the wake, not "sleep".
     if (effectiveWake) {
       upcoming.push({ id: "wake", at: effectiveWake, type: "cron" });
     }
@@ -98,9 +129,15 @@ export function computeClockEvents(
     }
   }
 
-  upcoming.sort((a, b) => a.at.localeCompare(b.at));
+  // "Upcoming (next 24h)" — drop fires beyond the horizon (e.g. a weekly cron
+  // days out). Sleeping-mind currentItem shows the wake separately, so filtering
+  // the wake entry here is harmless.
+  const horizon = now.getTime() + UPCOMING_HORIZON_MS;
+  const withinHorizon = upcoming.filter((e) => new Date(e.at).getTime() <= horizon);
+
+  withinHorizon.sort((a, b) => a.at.localeCompare(b.at));
   previous.sort((a, b) => b.at.localeCompare(a.at)); // most recent first
-  return { upcoming, previous };
+  return { upcoming: withinHorizon, previous };
 }
 
 function writeSchedules(name: string, dir: string, schedules: Schedule[]): void {

--- a/packages/web/src/ui/components/mind/MindClock.svelte
+++ b/packages/web/src/ui/components/mind/MindClock.svelte
@@ -153,6 +153,14 @@ type SummaryItem = { icon: IconKind; label: string; detail: string; color: strin
 let currentItem = $derived.by((): SummaryItem | null => {
   if (!clock) return null;
   if (clock.sleep?.sleeping) {
+    if (clock.sleep.wokenByTrigger) {
+      return {
+        icon: "sleep",
+        label: "Briefly awake",
+        color: scheduleColor("wake"),
+        detail: "trigger · sleeps when idle",
+      };
+    }
     const effectiveWake = clock.sleep.scheduledWakeAt ?? clock.sleep.voluntaryWakeAt;
     return {
       icon: "sleep",

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -775,7 +775,13 @@ export interface ClockStatus {
     whileSleeping?: string;
     channel?: string;
   }[];
-  upcoming: { id: string; at: string; type: "cron" | "timer" }[];
+  upcoming: {
+    id: string;
+    at: string;
+    type: "cron" | "timer";
+    willSkip?: boolean;
+    willQueue?: boolean;
+  }[];
   previous: { id: string; at: string }[];
 }
 

--- a/skills/volute-mind/references/sleep.md
+++ b/skills/volute-mind/references/sleep.md
@@ -29,8 +29,12 @@ When trigger-woken, you get one full turn to respond, then return to sleep when 
 You can go to sleep any time with `volute clock sleep`. Optionally set a wake time:
 
 ```sh
-volute clock sleep --wake-at "2025-01-15T07:00:00Z"
+volute clock sleep --wake-at 8h          # a duration from now (2h30m, 45m, ...)
+volute clock sleep --wake-at 07:30       # local clock time, next occurrence
+volute clock sleep --wake-at "2025-01-15T07:00:00Z"   # explicit ISO timestamp
 ```
 
-A `--wake-at` overrides your wake schedule for that night — you will wake at the
-time you asked for, even if a scheduled wake cron would have fired earlier.
+`--wake-at` accepts a duration, a local `HH:MM` time (the next time it comes
+around), or an ISO timestamp — whichever is easiest. It overrides your wake
+schedule for that night: you will wake at the time you asked for, even if a
+scheduled wake cron would have fired earlier.

--- a/test/clock-events.test.ts
+++ b/test/clock-events.test.ts
@@ -112,6 +112,53 @@ describe("computeClockEvents", () => {
     assert.ok(previous.some((e) => e.id === "heartbeat"));
   });
 
+  it("annotates fires that land during sleep by their whileSleeping fate", () => {
+    const wakeAt = new Date("2026-07-07T08:00:00").toISOString();
+    const schedules: Schedule[] = [
+      // Next fire 04:00 < 08:00 wake → annotated by whileSleeping.
+      { id: "skipme", cron: "0 * * * *", message: "x", enabled: true, whileSleeping: "skip" },
+      { id: "queueme", cron: "0 * * * *", message: "x", enabled: true, whileSleeping: "queue" },
+      { id: "defaultq", cron: "0 * * * *", message: "x", enabled: true }, // defaults to queue
+      {
+        id: "wakeme",
+        cron: "0 * * * *",
+        message: "x",
+        enabled: true,
+        whileSleeping: "trigger-wake",
+      },
+      // Next fire 09:00 > 08:00 wake → not annotated.
+      { id: "afterwake", cron: "0 9 * * *", message: "x", enabled: true, whileSleeping: "skip" },
+    ];
+    const { upcoming } = computeClockEvents(
+      schedules,
+      sleepState({ scheduledWakeAt: wakeAt }),
+      null,
+      now,
+    );
+    const byId = (id: string) => upcoming.find((e) => e.id === id);
+    assert.equal(byId("skipme")?.willSkip, true);
+    assert.equal(byId("queueme")?.willQueue, true);
+    assert.equal(byId("defaultq")?.willQueue, true);
+    // trigger-wake fires actually happen → no skip/queue annotation.
+    assert.equal(byId("wakeme")?.willSkip, undefined);
+    assert.equal(byId("wakeme")?.willQueue, undefined);
+    // A fire after wake isn't affected by sleep.
+    assert.equal(byId("afterwake")?.willSkip, undefined);
+  });
+
+  it("omits fires beyond the 24h horizon", () => {
+    const schedules: Schedule[] = [
+      { id: "soon", cron: "0 * * * *", message: "x", enabled: true }, // hourly → within 24h
+      { id: "faraway", cron: "0 0 1 1 *", message: "x", enabled: true }, // Jan 1 → months out
+    ];
+    const { upcoming } = computeClockEvents(schedules, sleepState({ sleeping: false }), null, now);
+    assert.ok(upcoming.some((e) => e.id === "soon"));
+    assert.equal(
+      upcoming.some((e) => e.id === "faraway"),
+      false,
+    );
+  });
+
   it("disabled and future/past timers behave correctly", () => {
     const schedules: Schedule[] = [
       { id: "off", cron: "0 * * * *", message: "x", enabled: false },

--- a/test/mind-sleep.test.ts
+++ b/test/mind-sleep.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveWakeAt } from "../packages/cli/src/commands/mind-sleep.js";
+
+// Fixed reference time: local 03:00 on 2026-07-07.
+const now = new Date("2026-07-07T03:00:00");
+
+describe("resolveWakeAt", () => {
+  it("resolves a duration relative to now", () => {
+    const result = resolveWakeAt("2h30m", now);
+    assert.equal(result, new Date(now.getTime() + 9_000_000).toISOString());
+  });
+
+  it("resolves a minutes-only duration", () => {
+    const result = resolveWakeAt("45m", now);
+    assert.equal(result, new Date(now.getTime() + 45 * 60_000).toISOString());
+  });
+
+  it("resolves a local HH:MM later today (next occurrence)", () => {
+    const result = resolveWakeAt("07:30", now);
+    assert.ok(result);
+    const d = new Date(result as string);
+    assert.equal(d.getHours(), 7);
+    assert.equal(d.getMinutes(), 30);
+    assert.equal(d.getDate(), 7); // still today
+    assert.ok(d > now);
+  });
+
+  it("rolls a local HH:MM that already passed to tomorrow", () => {
+    const result = resolveWakeAt("01:00", now); // 01:00 < 03:00 now
+    assert.ok(result);
+    const d = new Date(result as string);
+    assert.equal(d.getHours(), 1);
+    assert.equal(d.getDate(), 8); // tomorrow
+  });
+
+  it("accepts the previously-failing bare HH:MM example (08:00)", () => {
+    const result = resolveWakeAt("08:00", now);
+    assert.ok(result);
+    const d = new Date(result as string);
+    assert.equal(d.getHours(), 8);
+    assert.ok(d > now);
+  });
+
+  it("passes through an explicit ISO timestamp", () => {
+    const iso = "2026-07-08T14:00:00Z";
+    assert.equal(resolveWakeAt(iso, now), new Date(iso).toISOString());
+  });
+
+  it("returns null for unparseable input", () => {
+    assert.equal(resolveWakeAt("nonsense", now), null);
+  });
+
+  it("returns null for an out-of-range HH:MM", () => {
+    assert.equal(resolveWakeAt("25:00", now), null);
+    assert.equal(resolveWakeAt("12:99", now), null);
+  });
+});


### PR DESCRIPTION
Part of the core-reliability release (sleep & delivery). **Stacked on #448 — merge that first.**

Clock/sleep UX papercuts from the July audit (items 1–4 of #454; items 5–8 remain open as a cosmetics follow-up, hence Refs not Closes):

1. `clock status` now shows "briefly awake (trigger)" during a trigger-wake instead of claiming "sleeping".
2. "Upcoming (next 24h)" gains an actual 24h horizon filter.
3. Fires that will be skipped/queued during sleep are annotated (`willSkip`/`willQueue`, rendered as a CLI suffix).
4. `--wake-at` now accepts a duration (`2h30m`), a local `HH:MM` (next occurrence), or an ISO timestamp, with a clearer error listing the forms; `skills/volute-mind/references/sleep.md` documents all three.

Refs #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
