### PR TITLE
feat: flush a sleeping mind's queued backlog as one batched turn per channel

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -11,7 +11,7 @@ import {
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { CronExpressionParser } from "cron-parser";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { sendSystemMessageDirect } from "../chat/system-chat.js";
 import { getDb } from "../db.js";
 import type { DeliveryPayload } from "../delivery/delivery-router.js";
@@ -428,9 +428,14 @@ export class SleepManager {
         } catch (err) {
           slog.warn(`failed to deliver wake summary to ${name}`, log.errorData(err));
         }
+
+        // Let the wake-summary turn finish before flushing the backlog (#382), so the
+        // summary and the per-channel batches arrive as separate, ordered turns rather
+        // than interleaving. Bounded so a stuck turn can't wedge the flush.
+        await this.waitForIdle(name, 120_000);
       }
 
-      // Flush queued messages
+      // Flush queued messages (grouped into one pre-batched turn per channel)
       const flushed = await this.flushQueuedMessages(name);
       if (flushed > 0) {
         slog.info(`flushed ${flushed} queued message(s) for ${name}`);
@@ -519,7 +524,11 @@ export class SleepManager {
   }
 
   /**
-   * Flush all queued sleep messages for a mind through the delivery manager.
+   * Flush all queued sleep messages for a mind on wake. Rows are grouped by channel
+   * and each channel group is delivered as ONE pre-batched turn (#382) — a night's
+   * backlog becomes one stack per channel, not N cold-start doorbells. Delivery is
+   * all-or-nothing per channel: a failed group's rows stay queued for the next wake,
+   * while other channels still flush.
    */
   async flushQueuedMessages(name: string): Promise<number> {
     try {
@@ -532,14 +541,15 @@ export class SleepManager {
 
       if (rows.length === 0) return 0;
 
-      let deliveredCount = 0;
+      // Parse payloads, dropping any that can never be delivered so they don't wedge
+      // the flush (or replay forever on every wake). Group survivors by channel,
+      // preserving arrival order within each channel.
+      const groups = new Map<string, { id: number; payload: DeliveryPayload }[]>();
       for (const row of rows) {
         let payload: DeliveryPayload;
         try {
           payload = JSON.parse(row.payload);
         } catch (err) {
-          // An unparseable payload can never be delivered — drop it so it doesn't wedge the
-          // rest of the flush (and replay forever on every wake).
           slog.warn(
             `dropping unparseable queued message ${row.id} for ${name}`,
             log.errorData(err),
@@ -547,19 +557,33 @@ export class SleepManager {
           await db.delete(deliveryQueue).where(eq(deliveryQueue.id, row.id));
           continue;
         }
+        const channel = payload.channel ?? "unknown";
+        if (!groups.has(channel)) groups.set(channel, []);
+        groups.get(channel)?.push({ id: row.id, payload });
+      }
 
-        const delivered = await this.deliverQueued(name, payload);
+      let deliveredCount = 0;
+      for (const [channel, items] of groups) {
+        const delivered = await this.deliverQueuedBatch(
+          name,
+          items.map((i) => i.payload),
+        );
         if (!delivered) {
-          // Delivery genuinely failed. Leave this row (and the untouched tail) queued so they
-          // retry on the next wake in order, rather than being silently dropped.
-          slog.warn(`failed to flush queued message ${row.id} for ${name}; leaving it queued`);
-          break;
+          // Whole-group failure: leave this channel's rows queued so they retry on the
+          // next wake, but keep flushing the other (independent) channels.
+          slog.warn(
+            `failed to flush ${items.length} queued message(s) on ${channel} for ${name}; leaving them queued`,
+          );
+          continue;
         }
-
-        // Delete per-row immediately after each successful delivery so a crash mid-flush
-        // replays only the undelivered tail, not the whole backlog.
-        await db.delete(deliveryQueue).where(eq(deliveryQueue.id, row.id));
-        deliveredCount++;
+        // Delete the group's rows only after a successful batch ack.
+        await db.delete(deliveryQueue).where(
+          inArray(
+            deliveryQueue.id,
+            items.map((i) => i.id),
+          ),
+        );
+        deliveredCount += items.length;
       }
 
       const state = this.states.get(name);
@@ -575,15 +599,14 @@ export class SleepManager {
   }
 
   /**
-   * Deliver one queued message on the wake path. `isFlush` skips the queue-time inbound
-   * recording (kept once, at arrival) and bypasses the sleep re-queue so the now-waking mind
-   * actually receives it. Returns whether the message was handed off to the delivery manager.
-   * Extracted as a seam so the flush loop can be unit-tested without the real delivery stack.
+   * Deliver one channel's worth of queued messages as a single pre-batched turn on
+   * the wake path. Extracted as a seam so the flush loop can be unit-tested without
+   * the real delivery stack. Returns whether the batch was handed off to the mind.
    */
-  protected async deliverQueued(name: string, payload: DeliveryPayload): Promise<boolean> {
+  protected async deliverQueuedBatch(name: string, payloads: DeliveryPayload[]): Promise<boolean> {
     // Import lazily to avoid a circular dependency with message-delivery.
-    const { deliverMessage } = await import("../delivery/message-delivery.js");
-    return deliverMessage(name, payload, { isFlush: true });
+    const { deliverBatch } = await import("../delivery/message-delivery.js");
+    return deliverBatch(name, payloads);
   }
 
   // --- Wake failure handling (#419) ---

--- a/packages/daemon/src/lib/delivery/message-delivery.ts
+++ b/packages/daemon/src/lib/delivery/message-delivery.ts
@@ -6,7 +6,12 @@ import { findMind, getBaseName } from "../mind/registry.js";
 import { activity, messages, mindHistory } from "../schema.js";
 import log from "../util/logger.js";
 import { getDeliveryManager } from "./delivery-manager.js";
-import { type DeliveryPayload, extractTextContent } from "./delivery-router.js";
+import {
+  type DeliveryPayload,
+  extractTextContent,
+  getRoutingConfig,
+  resolveRoute,
+} from "./delivery-router.js";
 
 const dlog = log.child("delivery");
 
@@ -284,6 +289,61 @@ export async function deliverMessage(
     return true;
   } catch (err) {
     dlog.warn(`unexpected error delivering to ${mindName}`, log.errorData(err));
+    return false;
+  }
+}
+
+/**
+ * Deliver a group of already-queued messages to a mind as ONE pre-batched turn —
+ * the mind-side router's `dispatchBatch` path — rather than N individual sends.
+ * Used by the wake flush (#382): a night's backlog for a channel arrives as a
+ * single `[Batch: N messages from X]` turn instead of a burst of cold-start turns.
+ *
+ * Callers group by channel, so the payloads share a channel and resolve to one
+ * session. Returns true only when the mind acks the whole batch; on any failure
+ * the caller keeps the group's rows queued for the next wake.
+ */
+export async function deliverBatch(
+  mindName: string,
+  payloads: DeliveryPayload[],
+): Promise<boolean> {
+  if (payloads.length === 0) return true;
+  try {
+    const baseName = await getBaseName(mindName);
+    const entry = await findMind(baseName);
+    if (!entry) {
+      dlog.warn(`cannot deliver batch to ${mindName}: mind not found`);
+      return false;
+    }
+
+    // Build the batch payload shape the mind-side router expects.
+    const channels: Record<string, DeliveryPayload[]> = {};
+    for (const p of payloads) {
+      const ch = p.channel ?? "unknown";
+      if (!channels[ch]) channels[ch] = [];
+      channels[ch].push(p);
+    }
+
+    // Resolve the target session from routing (payloads share a channel, so one
+    // route/session applies). An explicit payload session wins; a file route (which
+    // sleep-queued mind messages never hit) falls back to the default session.
+    const first = payloads[0];
+    const route = resolveRoute(getRoutingConfig(baseName), {
+      channel: first.channel,
+      sender: first.sender ?? undefined,
+      isDM: first.isDM,
+      participantCount: first.participantCount,
+    });
+    const session = first.session ?? (route.destination === "mind" ? route.session : "main");
+
+    const res = await fetch(`http://127.0.0.1:${entry.port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session, batch: { channels } }),
+    });
+    return res.ok;
+  } catch (err) {
+    dlog.warn(`unexpected error delivering batch to ${mindName}`, log.errorData(err));
     return false;
   }
 }

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { extractTextContent } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import {
+  deliverBatch,
   deliverMessage,
   linkToolResultToTurn,
   recordInbound,
@@ -165,6 +167,81 @@ describe("deliverMessage flush recording", () => {
       { isFlush: true },
     );
     assert.equal(ok, false);
+  });
+});
+
+describe("deliverBatch (#382)", () => {
+  const BATCH_MIND = "test-batch";
+  const BATCH_PORT = 41998;
+
+  function startMindServer(onBody: (body: any) => void, status = 200): Promise<Server> {
+    const server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        try {
+          onBody(JSON.parse(raw));
+        } catch {
+          /* ignore */
+        }
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: status === 200 }));
+      });
+    });
+    return new Promise((resolve) => server.listen(BATCH_PORT, () => resolve(server)));
+  }
+
+  afterEach(async () => {
+    await removeMind(BATCH_MIND);
+  });
+
+  it("returns true for an empty payload list without contacting the mind", async () => {
+    assert.equal(await deliverBatch(BATCH_MIND, []), true);
+  });
+
+  it("returns false when the mind is not registered", async () => {
+    const ok = await deliverBatch("no-such-mind", [
+      { channel: "@volute", sender: "x", content: "hi" },
+    ]);
+    assert.equal(ok, false);
+  });
+
+  it("POSTs one grouped batch payload per channel and returns true on ack", async () => {
+    let received: any;
+    const server = await startMindServer((b) => {
+      received = b;
+    });
+    await addMind(BATCH_MIND, BATCH_PORT);
+    try {
+      const ok = await deliverBatch(BATCH_MIND, [
+        { channel: "@volute", sender: "a", content: "one" },
+        { channel: "@volute", sender: "b", content: "two" },
+      ]);
+      assert.equal(ok, true);
+      assert.ok(received.batch, "body carries a batch payload");
+      assert.deepEqual(Object.keys(received.batch.channels), ["@volute"]);
+      assert.equal(
+        received.batch.channels["@volute"].length,
+        2,
+        "both messages in one channel batch",
+      );
+      assert.equal(typeof received.session, "string");
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it("returns false when the mind server rejects the batch", async () => {
+    const server = await startMindServer(() => {}, 500);
+    await addMind(BATCH_MIND, BATCH_PORT);
+    try {
+      const ok = await deliverBatch(BATCH_MIND, [
+        { channel: "@volute", sender: "a", content: "x" },
+      ]);
+      assert.equal(ok, false);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
   });
 });
 

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -92,14 +92,16 @@ class TestSleepManager extends SleepManager {
     return (this as any).buildTriggerWakeSummary(state);
   }
 
-  // Stub the delivery seam so flushQueuedMessages can be tested without the real delivery
-  // stack. `deliverResult` decides per-payload whether delivery "succeeds".
-  deliveredPayloads: unknown[] = [];
-  deliverResult: (payload: unknown) => boolean = () => true;
+  // Stub the batch delivery seam so flushQueuedMessages can be tested without the real
+  // delivery stack. Each call is one channel's batch; `deliverResult` decides per-batch
+  // success (keyed off the batch's first payload's channel).
+  deliveredBatches: { channel: string; payloads: any[] }[] = [];
+  deliverResult: (channel: string, payloads: any[]) => boolean = () => true;
 
-  override async deliverQueued(_name: string, payload: unknown): Promise<boolean> {
-    this.deliveredPayloads.push(payload);
-    return this.deliverResult(payload);
+  override async deliverQueuedBatch(_name: string, payloads: any[]): Promise<boolean> {
+    const channel = (payloads[0]?.channel as string) ?? "unknown";
+    this.deliveredBatches.push({ channel, payloads });
+    return this.deliverResult(channel, payloads);
   }
 
   // Expose wake-failure handling for testing
@@ -1030,15 +1032,15 @@ describe("SleepManager.flushQueuedMessages", () => {
     return `flush-mind-${process.pid}-${counter++}`;
   }
 
-  async function queue(mind: string, content: string): Promise<void> {
+  async function queue(mind: string, content: string, channel = "@volute"): Promise<void> {
     const db = await getDb();
     await db.insert(deliveryQueue).values({
       mind,
       session: "sleep",
-      channel: "@volute",
+      channel,
       sender: "volute",
       status: "sleep-queued",
-      payload: JSON.stringify({ channel: "@volute", sender: "volute", content }),
+      payload: JSON.stringify({ channel, sender: "volute", content }),
     });
   }
 
@@ -1051,7 +1053,7 @@ describe("SleepManager.flushQueuedMessages", () => {
       .all();
   }
 
-  it("delivers each queued message once and deletes delivered rows", async () => {
+  it("delivers one batch per channel and deletes delivered rows (#382)", async () => {
     const mind = uniqueMind();
     await queue(mind, "a");
     await queue(mind, "b");
@@ -1063,47 +1065,77 @@ describe("SleepManager.flushQueuedMessages", () => {
     const flushed = await sm.flushQueuedMessages(mind);
 
     assert.equal(flushed, 3);
-    assert.equal(sm.deliveredPayloads.length, 3, "each message delivered exactly once");
+    // All three share a channel → ONE batch delivery, not three.
+    assert.equal(sm.deliveredBatches.length, 1, "single channel delivered as one batch");
+    assert.equal(sm.deliveredBatches[0].payloads.length, 3, "batch carries all three messages");
+    // Arrival order preserved within the channel batch.
+    assert.deepEqual(
+      sm.deliveredBatches[0].payloads.map((p) => p.content),
+      ["a", "b", "c"],
+    );
     assert.equal((await queuedRows(mind)).length, 0, "all delivered rows deleted");
     assert.equal(sm.getState(mind).queuedMessageCount, 0);
   });
 
-  it("leaves the row queued when delivery fails (no silent drop)", async () => {
+  it("groups by channel into one batch each", async () => {
     const mind = uniqueMind();
-    await queue(mind, "a");
+    await queue(mind, "a1", "#alpha");
+    await queue(mind, "b1", "#beta");
+    await queue(mind, "a2", "#alpha");
 
     const sm = new TestSleepManager();
-    sm.deliverResult = () => false; // delivery fails
+    sm.setStateForTest(mind, sleepingState({ queuedMessageCount: 3 }));
+
+    const flushed = await sm.flushQueuedMessages(mind);
+
+    assert.equal(flushed, 3);
+    assert.equal(sm.deliveredBatches.length, 2, "two channels → two batches");
+    const alpha = sm.deliveredBatches.find((b) => b.channel === "#alpha");
+    const beta = sm.deliveredBatches.find((b) => b.channel === "#beta");
+    assert.deepEqual(
+      alpha?.payloads.map((p) => p.content),
+      ["a1", "a2"],
+    );
+    assert.deepEqual(
+      beta?.payloads.map((p) => p.content),
+      ["b1"],
+    );
+    assert.equal((await queuedRows(mind)).length, 0);
+  });
+
+  it("leaves the whole channel group queued when its batch fails (no silent drop)", async () => {
+    const mind = uniqueMind();
+    await queue(mind, "a");
+    await queue(mind, "b");
+
+    const sm = new TestSleepManager();
+    sm.deliverResult = () => false; // batch delivery fails
 
     const flushed = await sm.flushQueuedMessages(mind);
 
     assert.equal(flushed, 0);
-    assert.equal((await queuedRows(mind)).length, 1, "failed delivery must not delete the row");
+    assert.equal((await queuedRows(mind)).length, 2, "failed batch must not delete its rows");
   });
 
-  it("deletes per-row so a mid-flush failure replays only the undelivered tail", async () => {
+  it("keeps a failed channel queued while other channels flush (#382)", async () => {
     const mind = uniqueMind();
-    await queue(mind, "first");
-    await queue(mind, "second");
-    await queue(mind, "third");
+    await queue(mind, "ok1", "#good");
+    await queue(mind, "ok2", "#good");
+    await queue(mind, "bad1", "#bad");
+    await queue(mind, "bad2", "#bad");
 
     const sm = new TestSleepManager();
-    sm.setStateForTest(mind, sleepingState({ queuedMessageCount: 3 }));
-    // First delivery succeeds, then the mind "crashes" — the rest must survive.
-    let calls = 0;
-    sm.deliverResult = () => {
-      calls++;
-      return calls === 1;
-    };
+    sm.setStateForTest(mind, sleepingState({ queuedMessageCount: 4 }));
+    // Only the #bad channel's batch fails.
+    sm.deliverResult = (channel) => channel !== "#bad";
 
     const flushed = await sm.flushQueuedMessages(mind);
 
-    assert.equal(flushed, 1, "only the first row was delivered");
+    assert.equal(flushed, 2, "the good channel's two messages delivered");
     const remaining = await queuedRows(mind);
-    assert.equal(remaining.length, 2, "the undelivered tail stays queued for the next wake");
-    // The remaining rows are the tail (second, third), in order — the delivered head is gone.
+    assert.equal(remaining.length, 2, "the failed channel's rows stay queued");
     const contents = remaining.map((r) => JSON.parse(r.payload).content).sort();
-    assert.deepEqual(contents, ["second", "third"]);
+    assert.deepEqual(contents, ["bad1", "bad2"]);
     assert.equal(sm.getState(mind).queuedMessageCount, 2);
   });
 
@@ -1122,7 +1154,12 @@ describe("SleepManager.flushQueuedMessages", () => {
     const flushed = await sm.flushQueuedMessages(mind);
 
     assert.equal(flushed, 1, "the good message delivered");
-    assert.equal(sm.deliveredPayloads.length, 1, "the unparseable row never reached delivery");
+    assert.equal(sm.deliveredBatches.length, 1, "one batch delivered");
+    assert.equal(
+      sm.deliveredBatches[0].payloads.length,
+      1,
+      "the unparseable row never reached delivery",
+    );
     assert.equal((await queuedRows(mind)).length, 0, "both rows cleared from the queue");
   });
 });


### PR DESCRIPTION
Part of the core-reliability release (sleep & delivery). **Stacked on #454 — merge that first.** Final PR of the sleep-clock stack.

On wake, `flushQueuedMessages` delivered every queued row one at a time, so a night's backlog burst into N cold-start turns against a freshly-archived session. Rows are now grouped by channel and each channel group is delivered as ONE pre-batched turn via a new `deliverBatch` (the mind-side router's existing `dispatchBatch` path — `{ session, batch: { channels } }`). The flush runs strictly after the wake-summary turn (`waitForIdle`), and delivery is all-or-nothing per channel: a failed group's rows stay queued for the next wake while other channels flush.

The full sleep→queue→wake→batch assertion is left to the post-merge integration pass (an LLM-driven daemon-e2e would need API keys and be timing-flaky); the contract is covered by flush unit tests and a real-HTTP-server `deliverBatch` test.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)
