### PR TITLE
ci: fix svelte-check breakage + integration-test .env ergonomics

### DIFF
--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -16,6 +16,23 @@ Docker is the canonical path for integration testing. It gives you a clean, isol
 - `ANTHROPIC_API_KEY` environment variable
 - `OPENROUTER_API_KEY` (optional, for pi-template minds using OpenRouter models)
 
+#### Credentials via `.env` (recommended)
+
+Put the keys in a `.env` file at the repo root (it's gitignored):
+
+```sh
+# .env
+ANTHROPIC_API_KEY=sk-ant-...
+OPENROUTER_API_KEY=sk-or-...   # optional
+```
+
+`test/integration-setup.sh` and `test/docker-e2e.sh` auto-source this file, so
+the keys are always available without exporting them per shell. **Without a
+key, `docker-e2e.sh` Phases 6 & 7 (real Claude round-trip) skip** and the
+live-mind integration pass can't run — so the `.env` is what makes the full
+verification campaign self-serve. If you drive minds by hand with `docker exec`,
+source it yourself first: `set -a && . .env && set +a`.
+
 ### Quick start
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "marked": "^18.0.5",
         "sharp": "^0.35.2",
         "svelte": "^5.56.3",
+        "svelte-check": "4.7.1",
         "tsup": "^8.5.1",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
@@ -1796,7 +1797,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -6307,6 +6308,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -12529,6 +12540,19 @@
         "node": ">= 18"
       }
     },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -13410,6 +13434,31 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "marked": "^18.0.5",
     "sharp": "^0.35.2",
     "svelte": "^5.56.3",
+    "svelte-check": "4.7.1",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/test/docker-e2e.sh
+++ b/test/docker-e2e.sh
@@ -7,8 +7,21 @@ set -euo pipefail
 #
 # Requirements: docker. ANTHROPIC_API_KEY is optional — when set, Phase 6/7
 # exercise a real Claude round-trip; when absent, those phases skip loudly.
+# The key is picked up from a repo-root .env if present (see below).
 #
 # Usage: bash test/docker-e2e.sh
+
+# Source .env from repo root if it exists (for API keys), matching
+# integration-setup.sh — otherwise Phase 6/7 silently skip when you forget to
+# export ANTHROPIC_API_KEY.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/.env"
+  set +a
+fi
 
 if ! command -v docker &>/dev/null; then
   echo "Error: docker is required" >&2


### PR DESCRIPTION
Two test/CI-tooling reliability fixes, found while running the v0.46.0 release verification.

## 1. Fix repo-wide CI break: pin `svelte-check` (the failing check)
CI runs `npx svelte-check`, but svelte-check isn't a declared dependency, so npx fetches the **latest** into an isolated dir. `svelte-check@4.7.2` (published 2026-07-07) crashes there at load:

```
TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')
    at new FileMap (.../svelte-check/dist/src/index.js:9013:72)
```

svelte-check declares `typescript` as a **peer dependency it doesn't bundle**, and the isolated npx fetch has no typescript to resolve against → `ts.sys` is undefined. Earlier green runs happened to fetch `4.7.1`; the fresh `4.7.2` is the regression. This breaks **every** CI run on the repo (not just this PR), and would block the release.

**Fix:** pin `svelte-check@4.7.1` (last known-good) as a root devDependency, so `npm ci` installs it against the locked `typescript` and `npx svelte-check` resolves the local bin instead of fetching latest — deterministic for CI and the lefthook pre-push hook. Verified locally: the exact CI command reports 307 files, 0 errors.

## 2. Auto-source repo-root `.env` in `docker-e2e.sh`
`docker-e2e.sh` only used `ANTHROPIC_API_KEY` if already exported, so its real Claude round-trip (Phases 6 & 7) and the live-mind integration pass silently skipped whenever the key wasn't sourced — a recurring snag during release verification. `integration-setup.sh` already auto-sources a repo-root `.env`; this mirrors that and documents the convention in `docs/integration-testing.md` (`.env` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)