### PR TITLE
fix: pair timeline tool results by tool_use_id

### DIFF
--- a/packages/web/src/ui/lib/tool-groups.ts
+++ b/packages/web/src/ui/lib/tool-groups.ts
@@ -50,8 +50,12 @@ export function groupToolEvents(events: HistoryMessage[]): TimelineItem[] {
       let result: HistoryMessage | null = null;
       if (id !== null) {
         // Modern event: claim the matching result by id, regardless of position.
-        result = resultsById.get(id) ?? null;
-        if (result) claimed.add(result);
+        // Skip a result a prior group already claimed so nothing renders twice.
+        const r = resultsById.get(id) ?? null;
+        if (r && !claimed.has(r)) {
+          result = r;
+          claimed.add(r);
+        }
       } else {
         // Legacy event (no id): pair with the next unclaimed tool_result
         // before the next tool_use.

--- a/packages/web/src/ui/lib/tool-groups.ts
+++ b/packages/web/src/ui/lib/tool-groups.ts
@@ -12,14 +12,32 @@ export type ToolGroup = {
 export type TimelineItem = { kind: "event"; event: HistoryMessage } | ToolGroup;
 
 /**
- * Groups sequential tool_use + tool_result pairs into ToolGroup items.
- * Non-tool events between a pair become standalone items after the group.
+ * Groups tool_use + tool_result pairs into ToolGroup items.
+ *
+ * Modern events carry ids: tool_use has `metadata.id` and tool_result has
+ * `metadata.tool_use_id`. These are paired by id regardless of position, so
+ * parallel tool calls (`use A, use B, result B, result A`) group correctly.
+ *
+ * Legacy events (pre-#388) lack `metadata.id` on the tool_use, so they fall
+ * back to the positional scan: pair with the next unclaimed tool_result before
+ * the next tool_use. Results never claimed by any group are emitted standalone
+ * so nothing disappears. Groups render at the tool_use position.
  */
 export function groupToolEvents(events: HistoryMessage[]): TimelineItem[] {
-  const items: TimelineItem[] = [];
-  let i = 0;
+  // Index tool_result events by their tool_use_id for id-based matching.
+  const resultsById = new Map<string, HistoryMessage>();
+  for (const ev of events) {
+    if (ev.type !== "tool_result") continue;
+    const id = parseMeta(ev.metadata)?.tool_use_id;
+    if (typeof id === "string" && !resultsById.has(id)) {
+      resultsById.set(id, ev);
+    }
+  }
 
-  while (i < events.length) {
+  const claimed = new Set<HistoryMessage>();
+  const items: TimelineItem[] = [];
+
+  for (let i = 0; i < events.length; i++) {
     const ev = events[i];
 
     if (ev.type === "tool_use") {
@@ -27,23 +45,24 @@ export function groupToolEvents(events: HistoryMessage[]): TimelineItem[] {
       const rawName = typeof toolMeta?.name === "string" ? toolMeta.name : "tool";
       const toolName = normalizeToolName(rawName);
       const category = getToolCategory(rawName);
+      const id = typeof toolMeta?.id === "string" ? toolMeta.id : null;
 
-      // Look ahead for the matching tool_result
-      const interleaved: HistoryMessage[] = [];
       let result: HistoryMessage | null = null;
-      let j = i + 1;
-      while (j < events.length) {
-        if (events[j].type === "tool_result") {
-          result = events[j];
-          j++;
-          break;
+      if (id !== null) {
+        // Modern event: claim the matching result by id, regardless of position.
+        result = resultsById.get(id) ?? null;
+        if (result) claimed.add(result);
+      } else {
+        // Legacy event (no id): pair with the next unclaimed tool_result
+        // before the next tool_use.
+        for (let j = i + 1; j < events.length; j++) {
+          if (events[j].type === "tool_use") break;
+          if (events[j].type === "tool_result" && !claimed.has(events[j])) {
+            result = events[j];
+            claimed.add(events[j]);
+            break;
+          }
         }
-        if (events[j].type === "tool_use") {
-          // Next tool_use without a result — stop looking
-          break;
-        }
-        interleaved.push(events[j]);
-        j++;
       }
 
       items.push({
@@ -53,16 +72,13 @@ export function groupToolEvents(events: HistoryMessage[]): TimelineItem[] {
         toolName,
         category,
       });
-
-      // Interleaved non-tool events appear after the group
-      for (const ie of interleaved) {
-        items.push({ kind: "event", event: ie });
+    } else if (ev.type === "tool_result") {
+      // Emit standalone only if no group claimed this result.
+      if (!claimed.has(ev)) {
+        items.push({ kind: "event", event: ev });
       }
-
-      i = j;
     } else {
       items.push({ kind: "event", event: ev });
-      i++;
     }
   }
 

--- a/test/tool-groups.test.ts
+++ b/test/tool-groups.test.ts
@@ -272,6 +272,72 @@ describe("groupToolEvents", () => {
     assert.equal(g2.toolResult?.id, 3);
   });
 
+  it("keeps only the first result when multiple share one tool_use_id", () => {
+    // Production shape: two Bash tool_use rows followed by extra same-id results.
+    const events = [
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"a"}' }),
+      makeEvent({ id: 2, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"b"}' }),
+      makeEvent({ id: 3, type: "tool_result", content: "out A1", metadata: '{"tool_use_id":"a"}' }),
+      makeEvent({ id: 4, type: "tool_result", content: "out A2", metadata: '{"tool_use_id":"a"}' }),
+      makeEvent({ id: 5, type: "tool_result", content: "out B", metadata: '{"tool_use_id":"b"}' }),
+    ];
+    const items = groupToolEvents(events);
+    // Two groups + the extra 'a' result standalone (nothing disappears).
+    assert.equal(items.length, 3);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult?.id, 3);
+    assert.equal(g2.toolResult?.id, 5);
+    const extra = items[2] as Extract<TimelineItem, { kind: "event" }>;
+    assert.equal(extra.kind, "event");
+    assert.equal(extra.event.id, 4);
+  });
+
+  it("legacy scan does not steal a result already claimed by a modern id-match", () => {
+    const events = [
+      // Modern pair first: result matched by id.
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Read","id":"m"}' }),
+      makeEvent({
+        id: 2,
+        type: "tool_result",
+        content: "modern out",
+        metadata: '{"tool_use_id":"m"}',
+      }),
+      // Legacy id-less tool_use: its positional scan must skip the claimed result above
+      // (it comes before) and find its own next unclaimed result.
+      makeEvent({ id: 3, type: "tool_use", content: "{}", metadata: '{"name":"Bash"}' }),
+      makeEvent({ id: 4, type: "tool_result", content: "legacy out" }),
+    ];
+    const items = groupToolEvents(events);
+    assert.equal(items.length, 2);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult?.id, 2);
+    assert.equal(g2.toolResult?.id, 4);
+  });
+
+  it("modern tool_use does not re-claim a result already taken by a legacy group", () => {
+    const events = [
+      // Legacy id-less tool_use claims the next result positionally.
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash"}' }),
+      makeEvent({
+        id: 2,
+        type: "tool_result",
+        content: "shared out",
+        metadata: '{"tool_use_id":"m"}',
+      }),
+      // Modern tool_use whose id points at the already-claimed result must not steal it.
+      makeEvent({ id: 3, type: "tool_use", content: "{}", metadata: '{"name":"Read","id":"m"}' }),
+    ];
+    const items = groupToolEvents(events);
+    assert.equal(items.length, 2);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult?.id, 2);
+    // The result is already claimed, so the modern group renders without a duplicate.
+    assert.equal(g2.toolResult, null);
+  });
+
   it("emits an orphaned result standalone", () => {
     const events = [
       makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"a"}' }),

--- a/test/tool-groups.test.ts
+++ b/test/tool-groups.test.ts
@@ -200,4 +200,96 @@ describe("groupToolEvents", () => {
     assert.equal(items[1].kind, "tool-group");
     assert.equal(items[2].kind, "event");
   });
+
+  it("pairs parallel tool calls by id (use A, use B, result B, result A)", () => {
+    const events = [
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"a"}' }),
+      makeEvent({ id: 2, type: "tool_use", content: "{}", metadata: '{"name":"Read","id":"b"}' }),
+      makeEvent({ id: 3, type: "tool_result", content: "out B", metadata: '{"tool_use_id":"b"}' }),
+      makeEvent({ id: 4, type: "tool_result", content: "out A", metadata: '{"tool_use_id":"a"}' }),
+    ];
+    const items = groupToolEvents(events);
+    assert.equal(items.length, 2);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    // Groups render at the tool_use position, results matched by id.
+    assert.equal(g1.toolUse.id, 1);
+    assert.equal(g1.toolName, "Bash");
+    assert.equal(g1.toolResult?.id, 4);
+    assert.equal(g2.toolUse.id, 2);
+    assert.equal(g2.toolName, "Read");
+    assert.equal(g2.toolResult?.id, 3);
+  });
+
+  it("matches by id even when the result precedes an intervening tool_use", () => {
+    const events = [
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"a"}' }),
+      makeEvent({ id: 2, type: "tool_use", content: "{}", metadata: '{"name":"Read","id":"b"}' }),
+      makeEvent({ id: 3, type: "tool_result", content: "out A", metadata: '{"tool_use_id":"a"}' }),
+      makeEvent({ id: 4, type: "tool_result", content: "out B", metadata: '{"tool_use_id":"b"}' }),
+    ];
+    const items = groupToolEvents(events);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult?.id, 3);
+    assert.equal(g2.toolResult?.id, 4);
+  });
+
+  it("mixes legacy (no id) and modern (id) tool_use events", () => {
+    const events = [
+      // Legacy: no id, paired positionally with the next unclaimed result.
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash"}' }),
+      makeEvent({ id: 2, type: "tool_result", content: "legacy out" }),
+      // Modern: paired by id across a reordered result stream.
+      makeEvent({ id: 3, type: "tool_use", content: "{}", metadata: '{"name":"Read","id":"m"}' }),
+      makeEvent({
+        id: 4,
+        type: "tool_result",
+        content: "modern out",
+        metadata: '{"tool_use_id":"m"}',
+      }),
+    ];
+    const items = groupToolEvents(events);
+    assert.equal(items.length, 2);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult?.id, 2);
+    assert.equal(g2.toolResult?.id, 4);
+  });
+
+  it("modern tool_use with no matching result gets null (no positional grab)", () => {
+    const events = [
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"a"}' }),
+      // Result belongs to a different (later) call by id.
+      makeEvent({ id: 2, type: "tool_use", content: "{}", metadata: '{"name":"Read","id":"b"}' }),
+      makeEvent({ id: 3, type: "tool_result", content: "out B", metadata: '{"tool_use_id":"b"}' }),
+    ];
+    const items = groupToolEvents(events);
+    assert.equal(items.length, 2);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    const g2 = items[1] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult, null);
+    assert.equal(g2.toolResult?.id, 3);
+  });
+
+  it("emits an orphaned result standalone", () => {
+    const events = [
+      makeEvent({ id: 1, type: "tool_use", content: "{}", metadata: '{"name":"Bash","id":"a"}' }),
+      makeEvent({ id: 2, type: "tool_result", content: "out A", metadata: '{"tool_use_id":"a"}' }),
+      // Result with no matching tool_use (e.g. tool_use_id "unknown").
+      makeEvent({
+        id: 3,
+        type: "tool_result",
+        content: "orphan",
+        metadata: '{"tool_use_id":"unknown"}',
+      }),
+    ];
+    const items = groupToolEvents(events);
+    assert.equal(items.length, 2);
+    const g1 = items[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g1.toolResult?.id, 2);
+    const orphan = items[1] as Extract<TimelineItem, { kind: "event" }>;
+    assert.equal(orphan.kind, "event");
+    assert.equal(orphan.event.id, 3);
+  });
 });


### PR DESCRIPTION
## Summary

Rewrites `groupToolEvents` (`packages/web/src/ui/lib/tool-groups.ts`) to pair `tool_use`/`tool_result` by id instead of sequence order, fixing mis-paired and orphaned results when a mind emits parallel tool calls (`use A, use B, result B, result A`).

- Modern events (with `metadata.id` / `tool_use_id`) match by id regardless of position.
- Legacy id-less `tool_use` rows keep the positional-scan fallback (pair with the next unclaimed result before the next `tool_use`).
- Unclaimed results are emitted standalone so nothing disappears.
- A modern `tool_use` whose result is genuinely absent returns `null` rather than positionally grabbing a later call's result — stricter than legacy, avoiding a mis-steal in streaming.

The fix is centralized in the one shared function; the three timeline consumers (TurnTimeline, SummaryNode, HistoryEvent) all call it, so no per-caller changes were needed. `MessageEntry.svelte` has its own inline ContentBlock pairing for chat rendering — a distinct path, out of scope here, left untouched.

## Review triage

Three minor findings were raised; all addressed:

- **Applied (correctness):** the modern id-based claim now checks `claimed.has()` before attaching a result, so a result already taken by an earlier legacy positional group can't be rendered twice. Previously `if (result) claimed.add(result)` never guarded against double-claiming.
- **Applied (test coverage):** added a test for multiple `tool_result` rows sharing one `tool_use_id` (the production shape: two Bash uses followed by extra same-id results) — first result pairs, extras render standalone so nothing disappears.
- **Applied (test coverage):** added two tests exercising the legacy/modern claim-skip interplay in both orderings, giving the previously-uncovered `!claimed.has(...)` guards real coverage.

## Tests

- `test/tool-groups.test.ts`: 8 new tests (5 original for this fix + 3 from review triage), all green.
- Full suite: 1931 tests passing, 0 failures. Pre-commit lint + svelte typecheck green.

Fixes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)