### PR TITLE
fix: withhold mind ports and dirs from non-privileged /api/minds callers

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -10,7 +10,9 @@ export type ContentBlock =
 
 export type Mind = {
   name: string;
-  port: number;
+  // Omitted for non-privileged callers (mind tokens, non-admin users); only
+  // admin/system get the port. See #503.
+  port?: number;
   created: string;
   status: "running" | "stopped" | "starting" | "sleeping";
   stage?: "seed" | "sprouted";

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -58,6 +58,7 @@ import {
   findMind,
   findVariants,
   getBaseName,
+  type MindEntry,
   mindDir,
   nextPort,
   readRegistry,
@@ -157,6 +158,42 @@ async function getMindStatus(name: string, port: number, registryRunning?: boole
     displayName: config?.profile?.displayName,
     description: config?.profile?.description,
     avatar: config?.profile?.avatar,
+  };
+}
+
+type MindStatus = Awaited<ReturnType<typeof getMindStatus>>;
+
+/** True for the daemon's own privileged principals: admin users and the system spirit. */
+function isPrivileged(c: Context<AuthEnv>): boolean {
+  const role = c.get("user").role;
+  return role === "admin" || role === "system";
+}
+
+/**
+ * Reduce a registry entry to the profile-level fields safe to hand a
+ * non-privileged caller (a mind token or a non-admin user). Registry internals —
+ * port, dir, branch, template, hash, parent, createdBy, running — are withheld:
+ * minds are untrusted principals, and a mind's own port/dir aids lateral movement
+ * (direct connections to sibling mind servers that bypass the daemon, targeted
+ * filesystem probing). Only admin/system callers get the full entry. See #503.
+ */
+function toPublicMind(
+  entry: MindEntry,
+  status: MindStatus,
+  extras: { hasPages: boolean; lastActiveAt?: string | null },
+) {
+  return {
+    name: entry.name,
+    created: entry.created,
+    stage: entry.stage,
+    mindType: entry.mindType,
+    status: status.status,
+    channels: status.channels,
+    displayName: status.displayName,
+    description: status.description,
+    avatar: status.avatar,
+    hasPages: extras.hasPages,
+    lastActiveAt: extras.lastActiveAt ?? null,
   };
 }
 
@@ -1230,16 +1267,14 @@ const app = new Hono<AuthEnv>()
       }
     }
 
+    const privileged = isPrivileged(c);
     const minds = await Promise.all(
       entries.map(async (entry) => {
         const mindStatus = await getMindStatus(entry.name, entry.port, entry.running);
         const hasPages = existsSync(resolve(mindDir(entry.name), "home", "pages"));
-        return {
-          ...entry,
-          ...mindStatus,
-          hasPages,
-          lastActiveAt: lastActiveMap.get(entry.name) ?? null,
-        };
+        const lastActiveAt = lastActiveMap.get(entry.name) ?? null;
+        if (!privileged) return toPublicMind(entry, mindStatus, { hasPages, lastActiveAt });
+        return { ...entry, ...mindStatus, hasPages, lastActiveAt };
       }),
     );
     return c.json(minds);
@@ -1254,8 +1289,15 @@ const app = new Hono<AuthEnv>()
     if (!existsSync(dir)) return c.json({ error: "Mind directory missing" }, 404);
 
     const mindStatus = await getMindStatus(name, entry.port);
+    const hasPages = existsSync(resolve(mindDir(name), "home", "pages"));
 
-    // Include variant info
+    // Non-privileged callers (minds, non-admin users) get profile-level fields
+    // only — no port/dir/branch/variants that would aid lateral movement (#503).
+    if (!isPrivileged(c)) {
+      return c.json(toPublicMind(entry, mindStatus, { hasPages }));
+    }
+
+    // Include variant info (admin/system only — variant ports/names are internal)
     const variants = await findVariants(name);
     const manager = getMindManager();
     const variantStatuses = await Promise.all(
@@ -1269,7 +1311,6 @@ const app = new Hono<AuthEnv>()
       }),
     );
 
-    const hasPages = existsSync(resolve(mindDir(name), "home", "pages"));
     return c.json({ ...entry, ...mindStatus, variants: variantStatuses, hasPages });
   })
   // Context info — proxy to mind's /context endpoint

--- a/packages/web/src/ui/components/mind/MindCard.svelte
+++ b/packages/web/src/ui/components/mind/MindCard.svelte
@@ -31,7 +31,9 @@ let { mind }: { mind: Mind } = $props();
     <p class="description">{mind.description}</p>
   {/if}
   <div class="meta">
-    <span>:{mind.port}</span>
+    {#if mind.port}
+      <span>:{mind.port}</span>
+    {/if}
     {#each mind.channels.filter(ch => ch.name !== "web" && ch.status === "connected") as ch}
       <span class="channel-badge">{ch.displayName || ch.name}</span>
     {/each}

--- a/test/authz-coverage.test.ts
+++ b/test/authz-coverage.test.ts
@@ -34,7 +34,9 @@ const AUTHZ_EXEMPT: Record<string, string> = {
   "files.ts GET /:name/avatar": "serves the mind's public profile avatar image",
   "mind-skills.ts GET /:name/skills": "lists installed skills (capability metadata, no secrets)",
   "variants.ts GET /:name/variants": "variant existence/status, same info as GET /:name",
-  "minds.ts GET /:name": "existence/status/public profile (display name, description, avatar)",
+  "minds.ts GET /:name":
+    "in-handler authz: non-privileged callers get existence/status/public profile only; " +
+    "port/dir/branch/variants (full registry entry) reserved for admin/system (#503)",
 
   // --- In-handler authorization (participant/owner/self checks) ---
   "minds.ts GET /:name/conversations":

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -805,6 +805,56 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(patched.settings?.description, "set by member");
   });
 
+  it("GET /api/minds withholds port/dir from non-privileged (mind) callers (#503)", async () => {
+    await ensureTestMind();
+
+    // A mind principal (untrusted): resolves to a role:"user", user_type:"mind" account.
+    const mindUser = await getOrCreateMindUser("e2e-authz-mind-503");
+    const mindSession = await createSession(mindUser.id);
+    const asMind = (path: string): Promise<Response> => {
+      const headers = new Headers();
+      headers.set("Authorization", `Bearer ${mindSession}`);
+      headers.set("Origin", BASE_URL);
+      return fetch(`${BASE_URL}${path}`, { headers });
+    };
+
+    // Registry internals that aid lateral movement / fs probing — must never
+    // reach a mind token.
+    const SENSITIVE = ["port", "dir", "branch", "template", "templateHash", "parent", "createdBy"];
+
+    // List: a mind caller gets profile-level fields only.
+    const mindList = await asMind("/api/minds");
+    assert.equal(mindList.status, 200);
+    const minds = (await mindList.json()) as Record<string, unknown>[];
+    const mine = minds.find((m) => m.name === TEST_MIND);
+    assert.ok(mine, `expected ${TEST_MIND} in mind-facing list`);
+    for (const f of SENSITIVE) {
+      assert.ok(!(f in mine), `mind list leaked "${f}": ${JSON.stringify(mine)}`);
+    }
+    assert.ok("status" in mine && "channels" in mine, "reduced entry keeps profile/status fields");
+
+    // Detail: same reduction, and no variants array (variant ports are internal).
+    const mindDetail = await asMind(`/api/minds/${TEST_MIND}`);
+    assert.equal(mindDetail.status, 200);
+    const detail = (await mindDetail.json()) as Record<string, unknown>;
+    for (const f of [...SENSITIVE, "variants"]) {
+      assert.ok(!(f in detail), `mind detail leaked "${f}": ${JSON.stringify(detail)}`);
+    }
+
+    // Admin (daemon token) still gets the full entry, including port.
+    const adminList = await daemonRequest("/api/minds");
+    const adminMinds = (await adminList.json()) as Record<string, unknown>[];
+    const adminMine = adminMinds.find((m) => m.name === TEST_MIND);
+    assert.ok(
+      adminMine && typeof adminMine.port === "number",
+      "admin list must still include port",
+    );
+
+    const adminDetail = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const adminDetailBody = (await adminDetail.json()) as Record<string, unknown>;
+    assert.equal(typeof adminDetailBody.port, "number", "admin detail must still include port");
+  });
+
   it("conversations: create, send message, read back", async () => {
     await ensureTestMind();
     const brain = await ensureBrainParticipant("convo");

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -840,6 +840,13 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     for (const f of [...SENSITIVE, "variants"]) {
       assert.ok(!(f in detail), `mind detail leaked "${f}": ${JSON.stringify(detail)}`);
     }
+    // Positively lock the reduced contract: the profile-level fields the UI/CLI
+    // consume must survive toPublicMind()'s hand-maintained allowlist. Only
+    // always-present fields are asserted — displayName/description/avatar come
+    // from an optional profile and JSON drops undefined-valued keys.
+    for (const f of ["name", "status", "channels", "stage", "hasPages", "lastActiveAt"]) {
+      assert.ok(f in detail, `reduced detail dropped "${f}": ${JSON.stringify(detail)}`);
+    }
 
     // Admin (daemon token) still gets the full entry, including port.
     const adminList = await daemonRequest("/api/minds");
@@ -853,6 +860,12 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const adminDetail = await daemonRequest(`/api/minds/${TEST_MIND}`);
     const adminDetailBody = (await adminDetail.json()) as Record<string, unknown>;
     assert.equal(typeof adminDetailBody.port, "number", "admin detail must still include port");
+    // The other half of the preserved behavior: admins keep the variants array
+    // that minds are denied.
+    assert.ok(
+      Array.isArray(adminDetailBody.variants),
+      "admin detail must still include variants array",
+    );
   });
 
   it("conversations: create, send message, read back", async () => {


### PR DESCRIPTION
## Summary

`GET /api/minds` and `GET /api/minds/:name` returned the full registry entry — including `port`, `dir`, `branch`, `template`, `parent`, `createdBy`, and variant ports — to **any** authenticated caller. Minds are untrusted principals (a mind token resolves to a non-admin `role: "user"` account), so a mind could read every sibling mind's port and directory, aiding lateral movement: direct connections to sibling mind servers that bypass the daemon, and targeted filesystem probing.

This filters both responses by caller privilege:

- **Non-privileged callers** (mind tokens, non-admin users) now receive only a profile-level view via a new `toPublicMind()` helper: `name`, `created`, `stage`, `mindType`, `status`, `channels`, `displayName`, `description`, `avatar`, `hasPages`, `lastActiveAt`.
- **Admin/system callers** still get the full registry entry, including `port`, `dir`, `branch`, and the `variants` array.

`isPrivileged()` gates on `role === "admin" || role === "system"`.

## Changes

- `packages/daemon/src/web/api/minds.ts` — `toPublicMind()` allowlist helper + `isPrivileged()` gate applied to the list and detail routes.
- `packages/api/src/types.ts` — `Mind.port` made optional (omitted for non-privileged callers).
- `packages/web/src/ui/components/mind/MindCard.svelte` — guard the port display when `port` is absent.
- `test/authz-coverage.test.ts` — updated the `GET /:name` exemption note to document the in-handler privilege split.
- `test/daemon-e2e.test.ts` — new test verifying the leak is closed for mind callers and preserved for admins.

## Review triage

Two minor review findings, both addressed (test-only strengthening):

- **Reduced view had no positive assertion** — the e2e test only asserted sensitive fields were *absent*. Added positive assertions that the reduced detail view keeps the profile-level fields the UI/CLI consume (`name`, `status`, `channels`, `stage`, `hasPages`, `lastActiveAt`). `displayName`/`description`/`avatar` are intentionally not asserted: they come from an optional profile and `c.json()` drops `undefined`-valued keys, so asserting them would be flaky for a profile-less test mind.
- **Admin `variants` preservation was unchecked** — added an assertion that the admin detail response still includes the `variants` array (the other half of the behavior deliberately withheld from minds).

## Test evidence

- Full unit suite: `npm test` → 1923 pass, 0 fail.
- Targeted e2e: `test/daemon-e2e.test.ts` #503 test → pass.
- Pre-push hook re-ran svelte-check + the full test suite → pass.

Fixes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
