### PR TITLE
feat: heal missing timeline summaries and render un-summarized turns

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -922,10 +922,11 @@ async function backfill(): Promise<void> {
 
 /**
  * Regenerate any period summary that has child material but no summary row of its own.
- * `needed` maps periodKey → the minds that have child summaries for that key. A key with
- * any mind missing its summary is (re)processed; `process` re-derives minds and is
- * idempotent (summaryExists + the unique (mind, period, period_key) index), so this is
- * safe to run repeatedly.
+ * `needed` maps periodKey → the minds that have child summaries for that key. A key is
+ * (re)processed when any mind is missing its summary OR the `_system` rollup is missing
+ * (per-mind children exist ⇒ a system rollup should too; `process` calls `summarizeSystem`).
+ * `process` re-derives minds and is idempotent (summaryExists + the unique
+ * (mind, period, period_key) index), so this is safe to run repeatedly.
  */
 async function healMissing(
   period: TimerPeriod,
@@ -942,11 +943,14 @@ async function healMissing(
   const have = new Set(existing.map((r) => `${r.mind}|${r.period_key}`));
 
   for (const [key, minds] of needed) {
-    let gap = false;
-    for (const mind of minds) {
-      if (!have.has(`${mind}|${key}`)) {
-        gap = true;
-        break;
+    // A missing system rollup is itself a gap even when every per-mind summary exists.
+    let gap = !have.has(`${SYSTEM_MIND}|${key}`);
+    if (!gap) {
+      for (const mind of minds) {
+        if (!have.has(`${mind}|${key}`)) {
+          gap = true;
+          break;
+        }
       }
     }
     if (!gap) continue;

--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -111,6 +111,11 @@ function utcDateTimeStr(d: Date): string {
   return d.toISOString().replace("T", " ").slice(0, 19);
 }
 
+/** Parse a "YYYY-MM-DD HH:MM:SS" UTC datetime string (as stored via datetime('now')). */
+function parseUtcDateTime(s: string): Date {
+  return new Date(`${s.replace(" ", "T")}Z`);
+}
+
 export function getTimeRange(
   periodKey: string,
   period: TimerPeriod,
@@ -913,6 +918,137 @@ async function backfill(): Promise<void> {
   }
 }
 
+// ── Gap reconciliation ──
+
+/**
+ * Regenerate any period summary that has child material but no summary row of its own.
+ * `needed` maps periodKey → the minds that have child summaries for that key. A key with
+ * any mind missing its summary is (re)processed; `process` re-derives minds and is
+ * idempotent (summaryExists + the unique (mind, period, period_key) index), so this is
+ * safe to run repeatedly.
+ */
+async function healMissing(
+  period: TimerPeriod,
+  needed: Map<string, Set<string>>,
+  process: (key: string) => Promise<void>,
+): Promise<void> {
+  if (needed.size === 0) return;
+  const db = await getDb();
+  const keys = [...needed.keys()];
+  const existing = await db
+    .select({ mind: summaries.mind, period_key: summaries.period_key })
+    .from(summaries)
+    .where(and(eq(summaries.period, period), inArray(summaries.period_key, keys)));
+  const have = new Set(existing.map((r) => `${r.mind}|${r.period_key}`));
+
+  for (const [key, minds] of needed) {
+    let gap = false;
+    for (const mind of minds) {
+      if (!have.has(`${mind}|${key}`)) {
+        gap = true;
+        break;
+      }
+    }
+    if (!gap) continue;
+    try {
+      await process(key);
+    } catch (err) {
+      sLog.error(`reconcile ${period} ${key} failed`, log.errorData(err));
+    }
+  }
+}
+
+function addNeeded(map: Map<string, Set<string>>, key: string, mind: string): void {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  set.add(mind);
+}
+
+/**
+ * Heal historical gaps left by summarizer errors or daemon downtime: any period with child
+ * summaries but no summary of its own gets regenerated. Runs every tick, bounded to a recent
+ * lookback so silent gaps self-heal within a tick rather than staying invisible forever.
+ * The current in-progress period (hour/day/week/month) is skipped — those are summarized on
+ * rollover by the normal tick. Exported for testing.
+ */
+export async function reconcileMissingSummaries(lookbackDays = 7): Promise<void> {
+  const db = await getDb();
+  const now = new Date();
+  const windowStart = new Date(now);
+  windowStart.setDate(windowStart.getDate() - lookbackDays);
+
+  const currentHourKey = getPeriodKey(now, "hour");
+  const currentDayKey = getPeriodKey(now, "day");
+  const currentWeekKey = getPeriodKey(now, "week");
+  const currentMonthKey = getPeriodKey(now, "month");
+  const cutoffDayKey = getPeriodKey(windowStart, "day");
+
+  // ── Hours: turn summaries whose local hour lacks an hour summary ──
+  const turnRows = await db
+    .select({ mind: summaries.mind, created_at: summaries.created_at })
+    .from(summaries)
+    .where(
+      and(
+        eq(summaries.period, "turn"),
+        gte(summaries.created_at, utcDateTimeStr(windowStart)),
+        sql`${summaries.mind} != ${SYSTEM_MIND}`,
+      ),
+    );
+  const neededHours = new Map<string, Set<string>>();
+  for (const r of turnRows) {
+    const key = getPeriodKey(parseUtcDateTime(r.created_at), "hour");
+    if (key === currentHourKey) continue;
+    addNeeded(neededHours, key, r.mind);
+  }
+  await healMissing("hour", neededHours, processHour);
+
+  // ── Days: hour summaries whose day lacks a day summary ──
+  const hourRows = await db
+    .select({ mind: summaries.mind, period_key: summaries.period_key })
+    .from(summaries)
+    .where(
+      and(
+        eq(summaries.period, "hour"),
+        gte(summaries.period_key, cutoffDayKey),
+        sql`${summaries.mind} != ${SYSTEM_MIND}`,
+      ),
+    );
+  const neededDays = new Map<string, Set<string>>();
+  for (const r of hourRows) {
+    const key = r.period_key.slice(0, 10);
+    if (key === currentDayKey) continue;
+    addNeeded(neededDays, key, r.mind);
+  }
+  await healMissing("day", neededDays, processDay);
+
+  // ── Weeks & months: day summaries whose week/month lacks a summary ──
+  // Re-query day summaries so freshly-healed days are considered.
+  const dayRows = await db
+    .select({ mind: summaries.mind, period_key: summaries.period_key })
+    .from(summaries)
+    .where(
+      and(
+        eq(summaries.period, "day"),
+        gte(summaries.period_key, cutoffDayKey),
+        sql`${summaries.mind} != ${SYSTEM_MIND}`,
+      ),
+    );
+  const neededWeeks = new Map<string, Set<string>>();
+  const neededMonths = new Map<string, Set<string>>();
+  for (const r of dayRows) {
+    const d = new Date(`${r.period_key}T00:00:00`);
+    const weekKey = getPeriodKey(d, "week");
+    if (weekKey !== currentWeekKey) addNeeded(neededWeeks, weekKey, r.mind);
+    const monthKey = r.period_key.slice(0, 7);
+    if (monthKey !== currentMonthKey) addNeeded(neededMonths, monthKey, r.mind);
+  }
+  await healMissing("week", neededWeeks, processWeek);
+  await healMissing("month", neededMonths, processMonth);
+}
+
 // ── Summarizer class ──
 
 export class Summarizer {
@@ -940,6 +1076,7 @@ export class Summarizer {
       }
 
       await reconcileWedgedTurns(WEDGED_TURN_IDLE_MS);
+      await reconcileMissingSummaries();
 
       const now = new Date();
       const currentHourKey = getPeriodKey(now, "hour");

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -17,9 +17,10 @@ import {
   fetchTurns,
 } from "../lib/client";
 import { extractTextContent } from "../lib/feed-utils";
-import { formatRelativeTime, normalizeTimestamp } from "../lib/format";
+import { formatRelativeTime } from "../lib/format";
 import { navigate } from "../lib/navigate";
 import { activeMinds } from "../lib/stores.svelte";
+import { buildTodayItems } from "../lib/timeline-today";
 import { groupToolEvents } from "../lib/tool-groups";
 import { getCategoryColor, getCategoryIcon } from "../lib/tool-names";
 import ToolGroupComponent from "./chat/ToolGroup.svelte";
@@ -566,17 +567,6 @@ let timelineItems = $derived.by(() => {
   const items: TimelineItem[] = [];
   const now = new Date();
 
-  // Show turns individually if they completed during or after the current hour.
-  // Use the turn's completion time (summary_meta.to_time) rather than created_at,
-  // because a turn that started in the previous hour but completed in the current
-  // hour won't be included in the previous hour's summary (race condition).
-  const currentHourStart = new Date(now);
-  currentHourStart.setMinutes(0, 0, 0);
-  const hourCutoffMs = currentHourStart.getTime();
-
-  // But also include any turns from today that don't have an hourly summary yet
-  // (i.e., turns from the current in-progress hour)
-
   // Monthly summaries (oldest)
   for (const s of monthSummaries) items.push({ kind: "summary", summary: s });
 
@@ -591,36 +581,23 @@ let timelineItems = $derived.by(() => {
   // Daily summaries
   for (const s of daySummaries) items.push({ kind: "summary", summary: s });
 
-  // Separator before hourly
-  if ((daySummaries.length > 0 || items.length > 0) && hourSummaries.length > 0) {
+  // Today section: hour summaries interleaved chronologically with individual turns.
+  // Turns render individually when active/current-hour, or when they fall in an
+  // earlier-today hour that has no hour summary yet — so a missing summary degrades
+  // to more detail instead of a silent gap.
+  const todayItems = buildTodayItems({
+    now,
+    hourSummaries,
+    turnsData,
+    isActive: (t) => t.status === "active" || streamingEvents.has(t.id),
+  });
+
+  // Separator before the today section
+  if (items.length > 0 && todayItems.length > 0) {
     items.push({ kind: "separator", above: "earlier this week", below: "today" });
   }
 
-  // Hourly summaries
-  for (const s of hourSummaries) items.push({ kind: "summary", summary: s });
-
-  // Only turns that completed during/after the current hour (or active turns).
-  // Use to_time (completion time) from summary metadata when available, since a
-  // turn that started in the previous hour but completed in the current hour
-  // won't be covered by the previous hour's summary.
-  const recentTurns = turnsData.filter((t) => {
-    if (t.status === "active" || streamingEvents.has(t.id)) return true;
-    const toTime = (t.summary_meta as Record<string, unknown> | null)?.to_time as
-      | string
-      | undefined;
-    const timeStr = toTime ?? t.created_at;
-    const turnTime = new Date(normalizeTimestamp(timeStr)).getTime();
-    return turnTime >= hourCutoffMs;
-  });
-
-  // Separator before turns
-  if (items.length > 0 && recentTurns.length > 0) {
-    items.push({ kind: "separator", above: "earlier today", below: "this hour" });
-  }
-
-  for (const t of recentTurns) {
-    items.push({ kind: "turn", turn: t });
-  }
+  for (const t of todayItems) items.push(t);
 
   return items;
 });

--- a/packages/web/src/ui/lib/timeline-today.ts
+++ b/packages/web/src/ui/lib/timeline-today.ts
@@ -1,0 +1,78 @@
+import type { SummaryRow, TurnRow } from "@volute/api";
+
+// Builds the chronological "today" section of the turn timeline: hour summaries
+// interleaved with individual turn rows. Turns render individually when they are
+// active/current-hour, or when they fall in an earlier-today hour that has NO hour
+// summary yet (summarizer lag/failure). This makes a missing summary degrade to
+// "more detail" instead of a silent gap.
+
+export type TodayItem = { kind: "summary"; summary: SummaryRow } | { kind: "turn"; turn: TurnRow };
+
+function normalizeTs(s: string): string {
+  return s.endsWith("Z") ? s : `${s}Z`;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** Local-time hour key ("YYYY-MM-DDTHH") for a date, matching summary period_keys. */
+function localHourKey(d: Date): string {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}T${pad2(d.getHours())}`;
+}
+
+/** Completion time (ms) for a turn: to_time from summary metadata, else created_at. */
+function turnCompletionMs(turn: TurnRow): number {
+  const toTime = (turn.summary_meta as Record<string, unknown> | null)?.to_time as
+    | string
+    | undefined;
+  return new Date(normalizeTs(toTime ?? turn.created_at)).getTime();
+}
+
+/** Local hour-start (ms) for an hour summary period_key. */
+function hourSummaryMs(periodKey: string): number {
+  return new Date(`${periodKey.slice(0, 10)}T${periodKey.slice(11, 13)}:00:00`).getTime();
+}
+
+export function buildTodayItems(opts: {
+  now: Date;
+  hourSummaries: SummaryRow[];
+  turnsData: TurnRow[];
+  isActive: (turn: TurnRow) => boolean;
+}): TodayItem[] {
+  const { now, hourSummaries, turnsData, isActive } = opts;
+
+  const currentHourStart = new Date(now);
+  currentHourStart.setMinutes(0, 0, 0);
+  const currentHourMs = currentHourStart.getTime();
+
+  const todayStartMs = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+
+  const coveredHours = new Set(hourSummaries.map((s) => s.period_key));
+
+  const sortable: { sort: number; item: TodayItem }[] = [];
+
+  for (const s of hourSummaries) {
+    sortable.push({ sort: hourSummaryMs(s.period_key), item: { kind: "summary", summary: s } });
+  }
+
+  for (const t of turnsData) {
+    const ms = turnCompletionMs(t);
+    if (isActive(t)) {
+      // Active turns are live; sort into the current hour region regardless of start time.
+      sortable.push({ sort: Math.max(ms, currentHourMs), item: { kind: "turn", turn: t } });
+      continue;
+    }
+    if (ms >= currentHourMs) {
+      // Current, in-progress hour — no hour summary exists yet.
+      sortable.push({ sort: ms, item: { kind: "turn", turn: t } });
+    } else if (ms >= todayStartMs && !coveredHours.has(localHourKey(new Date(ms)))) {
+      // Earlier today, but this hour has no summary → show the turn individually.
+      sortable.push({ sort: ms, item: { kind: "turn", turn: t } });
+    }
+    // Otherwise the turn is covered by an existing hour/day summary — omit it here.
+  }
+
+  sortable.sort((a, b) => a.sort - b.sort);
+  return sortable.map((x) => x.item);
+}

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -8,6 +8,7 @@ import {
   getTimeRange,
   type HistoryRow,
   type Period,
+  reconcileMissingSummaries,
   reconcileWedgedTurns,
   summarizePeriod,
   summarizeTurn,
@@ -471,6 +472,131 @@ describe("summarizer", () => {
       assert.ok(row, "monthly summary should exist");
       const meta = JSON.parse(row!.metadata!);
       assert.equal(meta.source_count, 3);
+    });
+  });
+
+  describe("reconcileMissingSummaries", () => {
+    const utcFmt = (d: Date) => d.toISOString().replace("T", " ").slice(0, 19);
+
+    async function countSummaries(mind: string, period: Period): Promise<number> {
+      const db = await getDb();
+      const rows = await db
+        .select({ id: summaries.id })
+        .from(summaries)
+        .where(and(eq(summaries.mind, mind), eq(summaries.period, period)));
+      return rows.length;
+    }
+
+    it("heals a missing hour + day summary from orphaned turn summaries", async () => {
+      const mind = "reconcile-gap-mind";
+      const db = await getDb();
+
+      // Two turn summaries in the same hour yesterday, with no hour/day rollup.
+      const base = new Date();
+      base.setDate(base.getDate() - 1);
+      base.setHours(10, 10, 0, 0);
+      const hourKey = getPeriodKey(base, "hour");
+      const dayKey = getPeriodKey(base, "day");
+
+      await db.insert(summaries).values([
+        {
+          mind,
+          period: "turn",
+          period_key: `${mind}-t1`,
+          content: "I read a file.",
+          metadata: JSON.stringify({ deterministic: true }),
+          created_at: utcFmt(base),
+        },
+        {
+          mind,
+          period: "turn",
+          period_key: `${mind}-t2`,
+          content: "I updated the journal.",
+          metadata: JSON.stringify({ deterministic: true }),
+          created_at: utcFmt(new Date(base.getTime() + 5 * 60_000)),
+        },
+      ]);
+
+      // Precondition: no hour/day summary yet.
+      assert.equal(await countSummaries(mind, "hour"), 0);
+      assert.equal(await countSummaries(mind, "day"), 0);
+
+      await reconcileMissingSummaries();
+
+      const hourRow = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, mind),
+            eq(summaries.period, "hour"),
+            eq(summaries.period_key, hourKey),
+          ),
+        )
+        .get();
+      assert.ok(hourRow, "missing hour summary should be generated");
+
+      const dayRow = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, mind),
+            eq(summaries.period, "day"),
+            eq(summaries.period_key, dayKey),
+          ),
+        )
+        .get();
+      assert.ok(dayRow, "missing day summary should be generated");
+
+      // Idempotent: a second pass adds nothing.
+      const hourCount = await countSummaries(mind, "hour");
+      const dayCount = await countSummaries(mind, "day");
+      await reconcileMissingSummaries();
+      assert.equal(await countSummaries(mind, "hour"), hourCount, "no duplicate hour summaries");
+      assert.equal(await countSummaries(mind, "day"), dayCount, "no duplicate day summaries");
+    });
+
+    it("heals a missing week summary from an orphaned previous-week day summary", async () => {
+      const mind = "reconcile-week-mind";
+      const db = await getDb();
+
+      // The most recent day that is NOT in the current ISO week (1..7 days ago),
+      // so it is inside the 7-day lookback but the week is not the in-progress one.
+      const now = new Date();
+      const daysSinceMonday = (now.getDay() + 6) % 7; // 0 = Monday .. 6 = Sunday
+      const prevWeekSunday = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() - daysSinceMonday - 1,
+      );
+      const dayKey = getPeriodKey(prevWeekSunday, "day");
+      const weekKey = getPeriodKey(prevWeekSunday, "week");
+
+      await db.insert(summaries).values({
+        mind,
+        period: "day",
+        period_key: dayKey,
+        content: "A full day of work.",
+        metadata: JSON.stringify({ deterministic: true }),
+      });
+
+      assert.equal(await countSummaries(mind, "week"), 0);
+
+      await reconcileMissingSummaries();
+
+      const weekRow = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, mind),
+            eq(summaries.period, "week"),
+            eq(summaries.period_key, weekKey),
+          ),
+        )
+        .get();
+      assert.ok(weekRow, "missing week summary should be generated");
     });
   });
 

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -10,6 +10,7 @@ import {
   type Period,
   reconcileMissingSummaries,
   reconcileWedgedTurns,
+  SYSTEM_MIND,
   summarizePeriod,
   summarizeTurn,
 } from "../packages/daemon/src/lib/daemon/summarizer.js";
@@ -597,6 +598,147 @@ describe("summarizer", () => {
         )
         .get();
       assert.ok(weekRow, "missing week summary should be generated");
+    });
+
+    it("heals a missing system rollup even when all per-mind summaries exist", async () => {
+      const mind = "reconcile-sysgap-mind";
+      const db = await getDb();
+
+      // A per-mind hour summary already exists (with a turn in range) but the
+      // `_system` rollup for that same hour is missing — a system insert that
+      // failed once must still self-heal.
+      const base = new Date();
+      base.setDate(base.getDate() - 1);
+      base.setHours(9, 15, 0, 0);
+      const hourKey = getPeriodKey(base, "hour");
+
+      await db.insert(summaries).values([
+        {
+          mind,
+          period: "turn",
+          period_key: `${mind}-sysgap-t1`,
+          content: "I did some work.",
+          metadata: JSON.stringify({ deterministic: true }),
+          created_at: utcFmt(base),
+        },
+        {
+          mind,
+          period: "hour",
+          period_key: hourKey,
+          content: "An hour of work.",
+          metadata: JSON.stringify({ deterministic: true }),
+        },
+      ]);
+
+      const before = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, SYSTEM_MIND),
+            eq(summaries.period, "hour"),
+            eq(summaries.period_key, hourKey),
+          ),
+        )
+        .get();
+      assert.equal(before, undefined, "system rollup should not exist yet");
+
+      await reconcileMissingSummaries();
+
+      const sysRow = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, SYSTEM_MIND),
+            eq(summaries.period, "hour"),
+            eq(summaries.period_key, hourKey),
+          ),
+        )
+        .get();
+      assert.ok(sysRow, "missing system hour rollup should be healed");
+    });
+
+    it("skips the in-progress current hour and day", async () => {
+      const db = await getDb();
+      const now = new Date();
+      const currentHourKey = getPeriodKey(now, "hour");
+      const currentDayKey = getPeriodKey(now, "day");
+
+      // Mind A: a turn summary in the current hour → its hour must NOT be summarized.
+      const mindA = "reconcile-current-hour-mind";
+      await db.insert(summaries).values({
+        mind: mindA,
+        period: "turn",
+        period_key: `${mindA}-cur`,
+        content: "still going.",
+        metadata: JSON.stringify({ deterministic: true }),
+        created_at: utcFmt(now),
+      });
+
+      // Mind B: an hour summary in today's current hour → the current day must NOT
+      // be summarized (day is still in progress).
+      const mindB = "reconcile-current-day-mind";
+      await db.insert(summaries).values({
+        mind: mindB,
+        period: "hour",
+        period_key: currentHourKey,
+        content: "an hour today.",
+        metadata: JSON.stringify({ deterministic: true }),
+      });
+
+      await reconcileMissingSummaries();
+
+      assert.equal(
+        await countSummaries(mindA, "hour"),
+        0,
+        "current in-progress hour must not be summarized",
+      );
+
+      const dayRow = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, mindB),
+            eq(summaries.period, "day"),
+            eq(summaries.period_key, currentDayKey),
+          ),
+        )
+        .get();
+      assert.equal(dayRow, undefined, "current in-progress day must not be summarized");
+    });
+
+    it("leaves material older than the lookback window alone", async () => {
+      const mind = "reconcile-old-mind";
+      const db = await getDb();
+
+      // A turn summary 8 days ago — outside the 7-day reconciliation window.
+      const old = new Date();
+      old.setDate(old.getDate() - 8);
+      old.setHours(10, 0, 0, 0);
+
+      await db.insert(summaries).values({
+        mind,
+        period: "turn",
+        period_key: `${mind}-old`,
+        content: "old work.",
+        metadata: JSON.stringify({ deterministic: true }),
+        created_at: utcFmt(old),
+      });
+
+      await reconcileMissingSummaries();
+
+      assert.equal(
+        await countSummaries(mind, "hour"),
+        0,
+        "out-of-window material must not be summarized (hour)",
+      );
+      assert.equal(
+        await countSummaries(mind, "day"),
+        0,
+        "out-of-window material must not be summarized (day)",
+      );
     });
   });
 

--- a/test/timeline-today.test.ts
+++ b/test/timeline-today.test.ts
@@ -93,6 +93,37 @@ describe("buildTodayItems", () => {
     );
   });
 
+  it("buckets a turn by completion time, not start (cross-hour turn)", () => {
+    // Started 10:55 (hour 10 is summarized) but completed 11:05 (hour 11 has no
+    // summary). It must bucket to the completion hour and render individually,
+    // not vanish into hour 10's summary.
+    const startTs = localTimeStr(10, 55);
+    const endTs = localTimeStr(11, 5);
+    const crossHourTurn: TurnRow = {
+      id: "cross",
+      mind: "m",
+      summary: "did a thing",
+      summary_meta: { to_time: endTs },
+      status: "complete",
+      created_at: startTs,
+      trigger: null,
+      conversations: [],
+      activities: [],
+    };
+    const items = buildTodayItems({
+      now: NOW,
+      hourSummaries: [hourSummary(10)],
+      turnsData: [crossHourTurn],
+      isActive: noneActive,
+    });
+    assert.deepEqual(
+      items.map((i) =>
+        i.kind === "summary" ? `s:${i.summary.period_key.slice(-2)}` : `t:${i.turn.id}`,
+      ),
+      ["s:10", "t:cross"],
+    );
+  });
+
   it("always shows active turns and sorts them last", () => {
     const items = buildTodayItems({
       now: NOW,

--- a/test/timeline-today.test.ts
+++ b/test/timeline-today.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { SummaryRow, TurnRow } from "@volute/api";
+import { buildTodayItems } from "../packages/web/src/ui/lib/timeline-today.js";
+
+// A fixed "now": 2026-07-09 13:30 local time.
+const NOW = new Date(2026, 6, 9, 13, 30, 0);
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** Build a local UTC-ish "YYYY-MM-DD HH:MM:SS" string for a local wall-clock time today. */
+function localTimeStr(hour: number, minute: number): string {
+  const d = new Date(NOW.getFullYear(), NOW.getMonth(), NOW.getDate(), hour, minute, 0);
+  // Turn timestamps are stored UTC without a Z; buildTodayItems appends Z, so emit UTC.
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function hourSummary(hour: number): SummaryRow {
+  const key = `${NOW.getFullYear()}-${pad2(NOW.getMonth() + 1)}-${pad2(NOW.getDate())}T${pad2(hour)}`;
+  return {
+    id: 1000 + hour,
+    mind: "m",
+    period: "hour",
+    period_key: key,
+    content: `hour ${hour}`,
+    metadata: null,
+    created_at: localTimeStr(hour, 0),
+  };
+}
+
+function turn(id: string, completedHour: number, completedMin: number, active = false): TurnRow {
+  const ts = localTimeStr(completedHour, completedMin);
+  return {
+    id,
+    mind: "m",
+    summary: active ? null : "did a thing",
+    summary_meta: active ? null : { to_time: ts },
+    status: active ? "active" : "complete",
+    created_at: ts,
+    trigger: null,
+    conversations: [],
+    activities: [],
+  };
+}
+
+describe("buildTodayItems", () => {
+  const noneActive = () => false;
+
+  it("hides turns whose hour already has a summary", () => {
+    const items = buildTodayItems({
+      now: NOW,
+      hourSummaries: [hourSummary(10)],
+      turnsData: [turn("a", 10, 15)],
+      isActive: noneActive,
+    });
+    // Only the hour summary; the covered turn is folded into it.
+    assert.deepEqual(
+      items.map((i) =>
+        i.kind === "summary" ? `s:${i.summary.period_key.slice(-2)}` : `t:${i.turn.id}`,
+      ),
+      ["s:10"],
+    );
+  });
+
+  it("renders uncovered-hour turns individually, in chronological position", () => {
+    // Hours 10 and 12 have summaries; turns at 11:xx do not → they must slot between.
+    const items = buildTodayItems({
+      now: NOW,
+      hourSummaries: [hourSummary(12), hourSummary(10)],
+      turnsData: [turn("t11a", 11, 5), turn("t11b", 11, 40)],
+      isActive: noneActive,
+    });
+    assert.deepEqual(
+      items.map((i) =>
+        i.kind === "summary" ? `s:${i.summary.period_key.slice(-2)}` : `t:${i.turn.id}`,
+      ),
+      ["s:10", "t:t11a", "t:t11b", "s:12"],
+    );
+  });
+
+  it("always shows current-hour turns even with no summary", () => {
+    const items = buildTodayItems({
+      now: NOW,
+      hourSummaries: [],
+      turnsData: [turn("cur", 13, 10)],
+      isActive: noneActive,
+    });
+    assert.deepEqual(
+      items.map((i) => (i.kind === "turn" ? i.turn.id : "s")),
+      ["cur"],
+    );
+  });
+
+  it("always shows active turns and sorts them last", () => {
+    const items = buildTodayItems({
+      now: NOW,
+      hourSummaries: [hourSummary(10)],
+      turnsData: [turn("live", 13, 20, true), turn("t11", 11, 0)],
+      isActive: (t) => t.status === "active",
+    });
+    const ids = items.map((i) => (i.kind === "summary" ? "s:10" : `t:${i.turn.id}`));
+    assert.deepEqual(ids, ["s:10", "t:t11", "t:live"]);
+  });
+});


### PR DESCRIPTION
## What

Closes silent gaps in the activity timeline: summaries that never got generated (summarizer errors, daemon downtime) or that lag behind now degrade to visible detail instead of vanishing.

### Backend — `reconcileMissingSummaries()`
A new step on the summarizer tick regenerates any hour/day/week/month summary that has child material but no summary of its own. It runs every tick, bounded to a 7-day lookback, skips the in-progress period (summarized on rollover), re-derives minds, and is idempotent (`summaryExists` + the unique `(mind, period, period_key)` index), so it self-heals within a tick without duplicating work.

### Frontend — `buildTodayItems()`
The timeline's "today" section is now a pure helper that interleaves hour summaries with individual turn rows chronologically. When a turn's hour has no summary yet, the turn renders individually (bucketed by *completion* time, not start, so a turn that spans an hour boundary lands under the hour it actually finished in). A missing summary therefore reads as "more detail," never a gap.

## Review triage

Addressed the review findings:

- **Missing `_system` rollup could stay a permanent gap** (finding 1): `healMissing` now treats an absent `_system` summary as a gap even when every per-mind summary already exists, so a system insert that failed once still self-heals rather than leaving a permanent hour-level gap. Previously the system rollup was only regenerated as a side effect of a per-mind gap.
- **Cross-hour bucketing not exercised** (finding 2): added a `buildTodayItems` test where a turn starts in a summarized hour but completes in an uncovered one, asserting it buckets to the completion hour and renders individually — locks the `to_time`-vs-`created_at` distinction against regression.
- **Current in-progress period skip not locked** (finding 3): added a summarizer test asserting the current hour and current day are never summarized by reconcile.
- **7-day lookback bound not locked** (finding 4): added a test seeding an orphaned turn summary 8 days ago and asserting reconcile leaves it alone.

## Known limitations / follow-ups

- Issue item 3 (a dedicated "N turns (not yet summarized)" day-gap row) was intentionally left out: backend reconcile self-heals day gaps within a 5-min tick and the frontend already renders un-summarized *today* turns individually, so a new expandable render kind exceeded the tight scope. Flagged as a follow-up.
- Week/month reconciliation is bounded to the same 7-day lookback, so it only heals recent weeks/months whose day rows fall in that window; older tiers still rely on the first-tick backfill (4 weeks / 3 months).

## Testing

- Full suite: **1898 tests, 0 failures**
- `tsc --noEmit`: clean
- svelte-check + web build: pass (unchanged from implementation)
- Targeted `summarizer` + `timeline-today` suites: 42 pass

Fixes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
