### PR TITLE
fix: correct turn trigger-linking and de-duplicate turn summaries

### DIFF
--- a/drizzle/0011_drop_turn_summary_event_id.sql
+++ b/drizzle/0011_drop_turn_summary_event_id.sql
@@ -1,0 +1,3 @@
+-- Drop the dead turns.summary_event_id column (superseded by summary_id, never written).
+
+ALTER TABLE `turns` DROP COLUMN `summary_event_id`;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1775500000000,
       "tag": "0010_delivery_queue_redrive",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1775600000000,
+      "tag": "0011_drop_turn_summary_event_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -155,6 +155,7 @@ export type HistoryRow = {
   session: string | null;
   content: string | null;
   metadata: string | null;
+  turn_id: string | null;
   created_at: string;
 };
 
@@ -195,6 +196,7 @@ async function gatherTurnEvents(
       session: mindHistory.session,
       content: mindHistory.content,
       metadata: mindHistory.metadata,
+      turn_id: mindHistory.turn_id,
       created_at: mindHistory.created_at,
     })
     .from(mindHistory)
@@ -220,6 +222,7 @@ async function gatherTurnEventsByTurnId(
       session: mindHistory.session,
       content: mindHistory.content,
       metadata: mindHistory.metadata,
+      turn_id: mindHistory.turn_id,
       created_at: mindHistory.created_at,
     })
     .from(mindHistory)
@@ -343,23 +346,40 @@ export async function summarizeTurn(
 
   if (events.length === 0) return;
 
+  // Resolve the turn this summary belongs to. When called without an explicit `turnId`
+  // (completeTurn returned undefined because a wedged-turn sweep already completed the turn),
+  // reuse the turn_id the events already carry so the summary keys on the turn UUID and
+  // dedupes — instead of minting a "<mind>-<doneId>" key that produces a SECOND summary for
+  // the same turn (see #395).
+  const effectiveTurnId = turnId ?? events.find((ev) => ev.turn_id)?.turn_id ?? undefined;
+
+  // If a summary for this turn already exists (the sweep summarized it first), stop here —
+  // this also short-circuits the redundant AI call.
+  if (effectiveTurnId && (await summaryExists(mind, "turn", effectiveTurnId))) return;
+
   // Detect interrupted turns
   const substantiveTypes = new Set(["text", "outbound", "tool_use", "tool_result", "thinking"]);
   const hasSubstantiveOutput = events.some((ev) => substantiveTypes.has(ev.type));
   if (!hasSubstantiveOutput) {
     sLog.info(
-      `skipping summary for interrupted turn ${turnId ?? "(no turn)"} (no substantive output)`,
+      `skipping summary for interrupted turn ${effectiveTurnId ?? "(no turn)"} (no substantive output)`,
     );
-    if (turnId) {
+    if (effectiveTurnId) {
       try {
         const db = await getDb();
         await db
           .update(mindHistory)
           .set({ turn_id: null })
-          .where(and(eq(mindHistory.turn_id, turnId), eq(mindHistory.type, "inbound")));
-        await db.update(messages).set({ turn_id: null }).where(eq(messages.turn_id, turnId));
+          .where(and(eq(mindHistory.turn_id, effectiveTurnId), eq(mindHistory.type, "inbound")));
+        await db
+          .update(messages)
+          .set({ turn_id: null })
+          .where(eq(messages.turn_id, effectiveTurnId));
+        // The turn produced nothing — no output, no summary. Delete the row so it can't come
+        // back from /history/turns as a junk "(no summary)" orphan (see #395).
+        await db.delete(turns).where(eq(turns.id, effectiveTurnId));
       } catch (err) {
-        sLog.error(`failed to un-tag events for interrupted turn ${turnId}`, log.errorData(err));
+        sLog.error(`failed to clean up interrupted turn ${effectiveTurnId}`, log.errorData(err));
       }
     }
     return;
@@ -408,7 +428,7 @@ export async function summarizeTurn(
   };
 
   // Write to unified summaries table
-  const periodKey = turnId ?? `${mind}-${doneId}`;
+  const periodKey = effectiveTurnId ?? `${mind}-${doneId}`;
   const db = await getDb();
   let summaryId: number | undefined;
   try {
@@ -449,9 +469,9 @@ export async function summarizeTurn(
   }
 
   // Link summary back to turn
-  if (turnId && summaryId != null) {
-    setSummaryId(turnId, summaryId).catch((err) => {
-      sLog.error(`failed to link summary to turn ${turnId}`, log.errorData(err));
+  if (effectiveTurnId && summaryId != null) {
+    setSummaryId(effectiveTurnId, summaryId).catch((err) => {
+      sLog.error(`failed to link summary to turn ${effectiveTurnId}`, log.errorData(err));
     });
   }
 
@@ -463,7 +483,7 @@ export async function summarizeTurn(
     channel,
     content: summaryText,
     metadata,
-    turnId,
+    turnId: effectiveTurnId,
   });
 }
 
@@ -841,11 +861,7 @@ async function processMonth(periodKey: string): Promise<void> {
   }
 }
 
-async function summaryExists(
-  mind: string,
-  period: TimerPeriod,
-  periodKey: string,
-): Promise<boolean> {
+async function summaryExists(mind: string, period: Period, periodKey: string): Promise<boolean> {
   const db = await getDb();
   const row = await db
     .select({ id: summaries.id })

--- a/packages/daemon/src/lib/daemon/turn-lifecycle.ts
+++ b/packages/daemon/src/lib/daemon/turn-lifecycle.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
 import { getDb } from "../db.js";
 import { getDeliveryManager } from "../delivery/delivery-manager.js";
@@ -79,32 +79,61 @@ function markDeliveredOnCleanTurn(mind: string, session?: string | null): void {
 
 /**
  * Link the inbound message(s) that triggered a turn to that turn, and set the turn's
- * `trigger_event_id`. Session-scoped replacement for the removed time-window heuristic:
- * a turn is per-session and this only tags inbound events on the turn's own channel that
- * are still untagged, so it's deterministic (no 60s window, no id-range guessing).
+ * `trigger_event_id`. Runs once, at turn creation.
+ *
+ * Two failure modes this guards against (see #403):
+ *
+ * 1. **Channel race.** The turn-creating event (`thinking`/`text`/…) only carries a channel
+ *    once the template's message→channel mapping is established — a timing race. When it's
+ *    absent we fall back to the turn's `session`, which is channel-shaped for the default
+ *    routes (`session = ${channel}`, so a DM session *is* the `@handle` slug). A session that
+ *    isn't a channel slug (e.g. the `main` default) simply matches no inbound rows — a safe
+ *    no-op rather than a mis-tag.
+ * 2. **Unbounded sweep.** We only claim untagged inbounds that arrived at/after the previous
+ *    turn on this session was created. Without that bound a late turn hoovers stale inbounds
+ *    that belonged to (or were abandoned by) an earlier turn. Inbounds older than the bound
+ *    stay untagged — they genuinely never got their own turn.
  */
-async function linkPendingInbound(mind: string, turnId: string, channel?: string): Promise<void> {
-  // Channel is required to prevent cross-session tagging: without it a turn on one
-  // session could steal inbound events meant for a different session/channel.
-  if (!channel) return;
+async function linkPendingInbound(
+  mind: string,
+  turnId: string,
+  channel: string | undefined,
+  session: string | undefined,
+): Promise<void> {
+  const scopeChannel = channel ?? session;
+  if (!scopeChannel) return;
   const db = await getDb();
-  const recent = await db
+
+  // Lower-bound the sweep by the previous turn on this session (assignSession has already
+  // written this turn's `session`, so `id != turnId` excludes it from the max).
+  let lowerBound: string | undefined;
+  if (session) {
+    const prev = await db
+      .select({ max: sql<string | null>`max(${turns.created_at})` })
+      .from(turns)
+      .where(and(eq(turns.mind, mind), eq(turns.session, session), sql`${turns.id} != ${turnId}`))
+      .get();
+    lowerBound = prev?.max ?? undefined;
+  }
+
+  const conditions = [
+    eq(mindHistory.mind, mind),
+    eq(mindHistory.type, "inbound"),
+    sql`${mindHistory.turn_id} IS NULL`,
+    eq(mindHistory.channel, scopeChannel),
+  ];
+  if (lowerBound) conditions.push(gte(mindHistory.created_at, lowerBound));
+
+  const pending = await db
     .select({ id: mindHistory.id })
     .from(mindHistory)
-    .where(
-      and(
-        eq(mindHistory.mind, mind),
-        eq(mindHistory.type, "inbound"),
-        sql`${mindHistory.turn_id} IS NULL`,
-        eq(mindHistory.channel, channel),
-      ),
-    )
-    .orderBy(desc(mindHistory.id))
-    .limit(5);
-  if (recent.length === 0) return;
-  const ids = recent.map((r) => r.id);
+    .where(and(...conditions))
+    .orderBy(mindHistory.id);
+  if (pending.length === 0) return;
+  const ids = pending.map((r) => r.id);
   await db.update(mindHistory).set({ turn_id: turnId }).where(inArray(mindHistory.id, ids));
-  await db.update(turns).set({ trigger_event_id: recent[0].id }).where(eq(turns.id, turnId));
+  // Trigger is the earliest inbound in the window — the message that started the turn.
+  await db.update(turns).set({ trigger_event_id: ids[0] }).where(eq(turns.id, turnId));
 }
 
 /**
@@ -139,7 +168,7 @@ export async function handleMindEvent(
       if (event.session) await assignSession(mind, turnId, event.session);
       // Link the triggering inbound(s) and set the turn's trigger_event_id.
       try {
-        await linkPendingInbound(mind, turnId, event.channel);
+        await linkPendingInbound(mind, turnId, event.channel, event.session);
       } catch (err) {
         llog.warn(
           `failed to link trigger inbound for turn ${turnId} (mind: ${mind})`,

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -58,7 +58,6 @@ export const turns = sqliteTable(
     mind: text("mind").notNull(),
     session: text("session"),
     trigger_event_id: integer("trigger_event_id"),
-    summary_event_id: integer("summary_event_id"),
     summary_id: integer("summary_id"),
     status: text("status").notNull().default("active"),
     created_at: text("created_at").notNull().default(sql`(datetime('now'))`),

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -93,7 +93,9 @@ const history = new Hono<AuthEnv>()
           sql`${mindHistory.type} IN ('inbound', 'outbound')`,
         ),
       )
-      .orderBy(mindHistory.created_at);
+      // id tiebreaker: created_at is second-resolution, so a same-second inbound/outbound
+      // pair would otherwise flip and read as an answer-before-question exchange (#403).
+      .orderBy(mindHistory.created_at, mindHistory.id);
 
     // Group all events by turn and channel
     type ConvEvent = {

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -152,7 +152,9 @@ const history = new Hono<AuthEnv>()
       .select()
       .from(activity)
       .where(inArray(activity.turn_id, turnIds))
-      .orderBy(activity.created_at);
+      // id tiebreaker: created_at is second-resolution, so same-second activities within a
+      // turn would otherwise flip order (#403 — same missing tiebreaker as the message pairs).
+      .orderBy(activity.created_at, activity.id);
 
     const activitiesByTurn = new Map<string, typeof activityRows>();
     for (const a of activityRows) {

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -161,6 +161,11 @@ let loadingChildren = new SvelteSet<number>();
 // For single-turn hours: expand directly to raw events instead of showing the turn summary
 let directEventsSummaries = $state(new SvelteMap<number, HistoryMessage[]>());
 
+// A turn summary's period_key is the turn UUID. Legacy "<mind>-<doneId>" keys can't be
+// resolved to turn events, so the direct-events drill-down must skip them (see #395).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isTurnUuid = (key: string): boolean => UUID_RE.test(key);
+
 // --- Streaming events for active turns ---
 let streamingEvents = $state(new SvelteMap<string, HistoryMessage[]>());
 let nextSyntheticId = -1;
@@ -499,15 +504,21 @@ async function toggleSummaryExpand(summary: SummaryRow) {
 
       if (sourceIds.length > 0) {
         const turnSummaryRows = await fetchSummaryByIds(sourceIds);
-        const turnIds = turnSummaryRows.map((s) => s.period_key);
+        const uuidRows = turnSummaryRows.filter((s) => isTurnUuid(s.period_key));
 
-        if (turnIds.length === 1) {
-          const events = await fetchTurnEvents(turnSummaryRows[0].mind, {
-            turnId: turnIds[0],
+        if (uuidRows.length < turnSummaryRows.length) {
+          // One or more legacy keys can't be resolved to turns — render the summary rows
+          // themselves rather than an empty drill-down.
+          expandedSummaries.set(summary.id, turnSummaryRows);
+        } else if (uuidRows.length === 1) {
+          const events = await fetchTurnEvents(uuidRows[0].mind, {
+            turnId: uuidRows[0].period_key,
           });
           directEventsSummaries.set(summary.id, events);
-        } else if (turnIds.length > 0) {
-          const turns: TurnRow[] = await fetchTurns({ turnIds: turnIds });
+        } else if (uuidRows.length > 0) {
+          const turns: TurnRow[] = await fetchTurns({
+            turnIds: uuidRows.map((s) => s.period_key),
+          });
           turns.sort((a, b) => a.created_at.localeCompare(b.created_at));
           expandedSummaries.set(summary.id, turns);
         } else {

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import { describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
 import {
@@ -262,6 +263,96 @@ describe("summarizer", () => {
         .from(summaries)
         .where(and(eq(summaries.mind, mind3), eq(summaries.period, "turn")));
       assert.equal(rows.length, 0, "no summary should be inserted for empty turn");
+    });
+  });
+
+  // ── Wedged / interrupted turns (#395) ──
+
+  describe("summarizeTurn: wedged/interrupted", () => {
+    it("does not duplicate a summary when done arrives after a wedged-turn sweep", async () => {
+      const mind = "test-wedged-dedupe";
+      const session = "wd1";
+      const turnId = randomUUID();
+      const db = await getDb();
+      await db.insert(turns).values({ id: turnId, mind, session, status: "active" });
+      await db.insert(mindHistory).values({
+        mind,
+        type: "inbound",
+        session,
+        channel: "@c",
+        content: "hi",
+        turn_id: turnId,
+      });
+      await db.insert(mindHistory).values({
+        mind,
+        type: "text",
+        session,
+        content: "hello back",
+        turn_id: turnId,
+      });
+      const doneResult = await db
+        .insert(mindHistory)
+        .values({ mind, type: "done", session, turn_id: turnId })
+        .returning({ id: mindHistory.id });
+      const doneId = doneResult[0].id;
+
+      // The sweep summarizes the wedged turn under period_key = <turn uuid>.
+      await summarizeTurn(mind, session, "@c", doneId, turnId);
+      // Then the real `done` fires: completeTurn returned undefined, so no turnId is passed.
+      // The old fallback keyed on "<mind>-<doneId>" and produced a SECOND summary.
+      await summarizeTurn(mind, session, "@c", doneId, undefined);
+
+      const rows = await db
+        .select()
+        .from(summaries)
+        .where(and(eq(summaries.mind, mind), eq(summaries.period, "turn")));
+      assert.equal(rows.length, 1, "exactly one summary should exist for the turn");
+      assert.equal(rows[0].period_key, turnId, "summary must be keyed by the turn uuid");
+
+      await clearMind(mind);
+    });
+
+    it("deletes the turn row for an interrupted turn (no substantive output)", async () => {
+      const mind = "test-interrupted-delete";
+      const session = "id1";
+      const turnId = randomUUID();
+      const db = await getDb();
+      await db.insert(turns).values({ id: turnId, mind, session, status: "active" });
+      const inbound = await db
+        .insert(mindHistory)
+        .values({
+          mind,
+          type: "inbound",
+          session,
+          channel: "@c",
+          content: "you there?",
+          turn_id: turnId,
+        })
+        .returning({ id: mindHistory.id });
+      const doneResult = await db
+        .insert(mindHistory)
+        .values({ mind, type: "done", session, turn_id: turnId })
+        .returning({ id: mindHistory.id });
+
+      await summarizeTurn(mind, session, "@c", doneResult[0].id, turnId);
+
+      const summaryRows = await db
+        .select()
+        .from(summaries)
+        .where(and(eq(summaries.mind, mind), eq(summaries.period, "turn")));
+      assert.equal(summaryRows.length, 0, "no summary for an output-less turn");
+
+      const inboundRow = await db
+        .select()
+        .from(mindHistory)
+        .where(eq(mindHistory.id, inbound[0].id))
+        .get();
+      assert.equal(inboundRow!.turn_id, null, "inbound should be un-tagged");
+
+      const turnRow = await db.select().from(turns).where(eq(turns.id, turnId)).get();
+      assert.equal(turnRow, undefined, "the orphaned turn row must be deleted");
+
+      await clearMind(mind);
     });
   });
 

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -354,6 +354,53 @@ describe("summarizer", () => {
 
       await clearMind(mind);
     });
+
+    it("deletes an interrupted turn resolved via events' turn_id when called with turnId=undefined", async () => {
+      // The #395 path: completeTurn returned undefined (a wedged-turn sweep already ran), so
+      // `done` fires summarizeTurn with no explicit turnId. The id must be recovered from the
+      // events' own turn_id column, then the output-less turn deleted.
+      const mind = "test-interrupted-from-events";
+      const session = "ie1";
+      const turnId = randomUUID();
+      const db = await getDb();
+      await db.insert(turns).values({ id: turnId, mind, session, status: "active" });
+      const inbound = await db
+        .insert(mindHistory)
+        .values({
+          mind,
+          type: "inbound",
+          session,
+          channel: "@c",
+          content: "still there?",
+          turn_id: turnId,
+        })
+        .returning({ id: mindHistory.id });
+      const doneResult = await db
+        .insert(mindHistory)
+        .values({ mind, type: "done", session, turn_id: turnId })
+        .returning({ id: mindHistory.id });
+
+      // No explicit turnId — it must be resolved from the events' turn_id.
+      await summarizeTurn(mind, session, "@c", doneResult[0].id, undefined);
+
+      const summaryRows = await db
+        .select()
+        .from(summaries)
+        .where(and(eq(summaries.mind, mind), eq(summaries.period, "turn")));
+      assert.equal(summaryRows.length, 0, "no summary for an output-less turn");
+
+      const inboundRow = await db
+        .select()
+        .from(mindHistory)
+        .where(eq(mindHistory.id, inbound[0].id))
+        .get();
+      assert.equal(inboundRow!.turn_id, null, "inbound should be un-tagged");
+
+      const turnRow = await db.select().from(turns).where(eq(turns.id, turnId)).get();
+      assert.equal(turnRow, undefined, "turn resolved from events must be deleted");
+
+      await clearMind(mind);
+    });
   });
 
   // ── Transcript building ──

--- a/test/turn-lifecycle.test.ts
+++ b/test/turn-lifecycle.test.ts
@@ -262,6 +262,140 @@ describe("turn-lifecycle: mid-turn inbound tagging", () => {
   });
 });
 
+describe("turn-lifecycle: trigger linking (#403)", () => {
+  it("links the trigger when the turn-creating event carries no channel (session fallback)", async () => {
+    const mind = "tl-channelless-trigger";
+    // Inbound arrives on the @alice DM (session is channel-shaped: session === channel).
+    const inboundId = await recordInbound(mind, "@alice", "alice", "hello~");
+    // The turn is created by a channel-less `thinking` event — the template's
+    // message→channel mapping hasn't been established yet (the race in #403).
+    const { turnId } = await handleMindEvent(mind, {
+      type: "thinking",
+      session: "@alice",
+      content: "let me look",
+    });
+    assert.ok(turnId);
+
+    const db = await getDb();
+    const inbound = await db.select().from(mindHistory).where(eq(mindHistory.id, inboundId!)).get();
+    assert.equal(inbound!.turn_id, turnId, "inbound should be tagged despite the missing channel");
+    const turn = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(turn!.trigger_event_id, inboundId, "trigger should resolve via the session");
+    await cleanup(mind);
+  });
+
+  it("does not claim inbounds that predate the previous turn on the session (bounded sweep)", async () => {
+    const mind = "tl-bounded-sweep";
+    const db = await getDb();
+    // A prior turn on the @alice session, created at 01:00.
+    const priorTurn = "00000000-0000-0000-0000-000000000001";
+    await db.insert(turns).values({
+      id: priorTurn,
+      mind,
+      session: "@alice",
+      status: "complete",
+      created_at: "2020-01-01 01:00:00",
+    });
+    // A stale inbound that arrived BEFORE the prior turn and was never claimed — it must
+    // stay untagged rather than be hoovered by the next turn.
+    const stale = await db
+      .insert(mindHistory)
+      .values({
+        mind,
+        type: "inbound",
+        channel: "@alice",
+        sender: "alice",
+        content: "old ping",
+        created_at: "2020-01-01 00:30:00",
+      })
+      .returning({ id: mindHistory.id });
+    // A fresh inbound that arrived after the prior turn — this one belongs to the new turn.
+    const fresh = await db
+      .insert(mindHistory)
+      .values({
+        mind,
+        type: "inbound",
+        channel: "@alice",
+        sender: "alice",
+        content: "new ping",
+        created_at: "2020-01-01 02:00:00",
+      })
+      .returning({ id: mindHistory.id });
+
+    // The new turn is created channel-less (session fallback) on @alice.
+    const { turnId } = await handleMindEvent(mind, {
+      type: "thinking",
+      session: "@alice",
+      content: "on it",
+    });
+    assert.ok(turnId);
+
+    const staleRow = await db
+      .select()
+      .from(mindHistory)
+      .where(eq(mindHistory.id, stale[0].id))
+      .get();
+    const freshRow = await db
+      .select()
+      .from(mindHistory)
+      .where(eq(mindHistory.id, fresh[0].id))
+      .get();
+    assert.equal(staleRow!.turn_id, null, "stale pre-prior-turn inbound must stay untagged");
+    assert.equal(freshRow!.turn_id, turnId, "fresh inbound must be tagged to the new turn");
+    const turn = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(
+      turn!.trigger_event_id,
+      fresh[0].id,
+      "trigger is the fresh inbound, not the stale",
+    );
+    await cleanup(mind);
+  });
+
+  it("each turn owns exactly its own inbounds across two turns (pip scenario)", async () => {
+    const mind = "tl-pip-scenario";
+    // Turn A: three inbounds arrive, then a channel-less first event opens the turn.
+    const a1 = await recordInbound(mind, "@pip", "pip", "hello~ seeing skills?");
+    const a2 = await recordInbound(mind, "@pip", "pip", "hello again");
+    const a3 = await recordInbound(mind, "@pip", "pip", "ping");
+    const { turnId: turnA } = await handleMindEvent(mind, {
+      type: "thinking",
+      session: "@pip",
+      content: "checking",
+    });
+    assert.ok(turnA);
+    await handleMindEvent(mind, {
+      type: "text",
+      session: "@pip",
+      channel: "@pip",
+      content: "fixed — all nine skills",
+    });
+    await handleMindEvent(mind, { type: "done", session: "@pip" });
+
+    // Turn B: a later inbound + turn. It must not re-claim turn A's inbounds.
+    const b1 = await recordInbound(mind, "@pip", "pip", "thanks!");
+    const { turnId: turnB } = await handleMindEvent(mind, {
+      type: "thinking",
+      session: "@pip",
+      content: "you're welcome",
+    });
+    assert.ok(turnB);
+    assert.notEqual(turnA, turnB);
+
+    const db = await getDb();
+    for (const id of [a1, a2, a3]) {
+      const row = await db.select().from(mindHistory).where(eq(mindHistory.id, id!)).get();
+      assert.equal(row!.turn_id, turnA, `inbound ${id} should belong to turn A`);
+    }
+    const bRow = await db.select().from(mindHistory).where(eq(mindHistory.id, b1!)).get();
+    assert.equal(bRow!.turn_id, turnB, "the later inbound should belong to turn B");
+    const tA = await db.select().from(turns).where(eq(turns.id, turnA!)).get();
+    const tB = await db.select().from(turns).where(eq(turns.id, turnB!)).get();
+    assert.equal(tA!.trigger_event_id, a1, "turn A trigger is its first inbound");
+    assert.equal(tB!.trigger_event_id, b1, "turn B trigger is its own inbound");
+    await cleanup(mind);
+  });
+});
+
 describe("turn-lifecycle: concurrent sessions", () => {
   const mind = "tl-concurrent";
   afterEach(() => cleanup(mind));

--- a/test/turn-lifecycle.test.ts
+++ b/test/turn-lifecycle.test.ts
@@ -351,6 +351,28 @@ describe("turn-lifecycle: trigger linking (#403)", () => {
     await cleanup(mind);
   });
 
+  it("a channel-less turn on a non-channel-shaped session claims nothing (no cross-channel over-reach)", async () => {
+    const mind = "tl-nonchannel-session";
+    // Session is a plain name (e.g. the `main` default), NOT a channel slug. An untagged
+    // inbound sits on an unrelated channel. The session→channel fallback scopes the sweep
+    // to channel === "main", which matches no inbound — the safety property the removed
+    // `if (!channel) return` guard used to provide now rests on channel-equality.
+    const orphan = await recordInbound(mind, "@bob", "bob", "unrelated ping");
+    const { turnId } = await handleMindEvent(mind, {
+      type: "thinking",
+      session: "main",
+      content: "thinking to myself",
+    });
+    assert.ok(turnId);
+
+    const db = await getDb();
+    const row = await db.select().from(mindHistory).where(eq(mindHistory.id, orphan!)).get();
+    assert.equal(row!.turn_id, null, "inbound on a different channel must stay untagged");
+    const turn = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(turn!.trigger_event_id, null, "trigger must stay null — nothing was claimed");
+    await cleanup(mind);
+  });
+
   it("each turn owns exactly its own inbounds across two turns (pip scenario)", async () => {
     const mind = "tl-pip-scenario";
     // Turn A: three inbounds arrive, then a channel-less first event opens the turn.

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -138,6 +138,53 @@ describe("web history routes", () => {
     assert.equal(body[0].summary, "Test summary content");
   });
 
+  it("GET /api/v1/history/turns — orders same-second messages by id (#403)", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    const turnId = randomUUID();
+    await db.insert(turns).values({
+      id: turnId,
+      mind: "test-history-mind1",
+      status: "complete",
+    });
+    // Question and answer share the exact same created_at second. The inbound is recorded
+    // first (lower id); without the id tiebreaker the pair could flip and read as an
+    // answer-before-question exchange.
+    const ts = "2020-06-01 12:00:00";
+    await db.insert(mindHistory).values({
+      mind: "test-history-mind1",
+      type: "inbound",
+      channel: "@alice",
+      sender: "alice",
+      content: "question?",
+      turn_id: turnId,
+      created_at: ts,
+    });
+    await db.insert(mindHistory).values({
+      mind: "test-history-mind1",
+      type: "outbound",
+      channel: "@alice",
+      content: "answer.",
+      turn_id: turnId,
+      created_at: ts,
+    });
+
+    const res = await app.request(`/api/v1/history/turns?turnId=${turnId}`, {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{
+      conversations: Array<{ messages: Array<{ role: string }> }>;
+    }>;
+    assert.equal(body.length, 1);
+    const messages = body[0].conversations[0].messages;
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].role, "user", "the question (lower id) must come first");
+    assert.equal(messages[1].role, "assistant", "the answer (higher id) must come second");
+  });
+
   it("GET /api/v1/history/turns — requires auth", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const res = await app.request("/api/v1/history/turns");


### PR DESCRIPTION
Fixes two coupled turn-tracking bugs.

## #403 — turn trigger-linking

- `linkPendingInbound` (`turn-lifecycle.ts`) now falls back to the turn's **session** as the channel scope when the creating event carries no channel (defeats the message→channel mapping timing race), and **bounds the untagged-inbound sweep to the previous turn on the same session** so a late turn no longer hoovers stale inbounds abandoned by an earlier turn (the 40-minute over-collection symptom).
- `/history/turns`: added an `id` tiebreaker to the inbound/outbound message ordering — `created_at` is second-resolution, so a same-second question/answer pair could otherwise flip and read as an answer-before-question exchange. The same tiebreaker was added to the per-turn **activity** ordering for consistency (review follow-up).

## #395 — duplicate turn summaries

- `summarizeTurn` (`summarizer.ts`) resolves the effective turn id from the events' `turn_id` and short-circuits via `summaryExists`, killing the `"<mind>-<doneId>"` duplicate-summary path when `completeTurn` returned undefined (a wedged-turn sweep already completed the turn).
- Interrupted, output-less turns now delete their `turns` row (and un-tag their inbound/messages) so they can't resurface from `/history/turns` as junk "(no summary)" orphans.
- `summaryExists` broadened to accept the `"turn"` period.
- Dropped the dead `turns.summary_event_id` column (schema + migration `0011_drop_turn_summary_event_id.sql`, applied on next daemon start).
- Frontend guard in `TurnTimeline.svelte` skips legacy non-uuid `period_key`s in the single-turn drill-down.

## Review triage

Six review findings were considered:

- **Applied — activity ordering tiebreaker** (`history.ts`): the #403 plan asked to check sibling history queries; the per-turn activity query still ordered by `created_at` alone. Added `activity.id` as a tiebreaker.
- **Applied — test hardening**: added a negative test locking in the anti-cross-channel invariant the session-to-channel fallback rests on (a channel-less turn on a non-channel-shaped session claims nothing), and a test covering the #395 `effectiveTurnId`-resolved-from-events deletion path (`summarizeTurn(..., undefined)`).
- **Skipped — "unbounded sweep when session is absent / on a session's first turn"** (raised three times): the sessionless-with-channel path is **not reachable** — substantive events are emitted per-session (`emit(session, ...)`), so a turn-creating event always carries a session. The only remaining no-lower-bound case is a session's genuine **first** turn, which has no prior turn to steal inbounds from, so claiming untagged inbounds there is correct attribution rather than the cross-turn over-collection #403 fixed (this behaviour is exercised by the multi-inbound "pip scenario" test). Adding a naive time/count bound would risk dropping legitimately-queued sleep/wake backlog on a first turn, so the deliberate minimal design was kept.

## Testing

Full suite green: **1931 tests, 0 failures** (`npm test`). Pre-push hook re-ran the full suite + `svelte-check`, both passed.

Fixes #403
Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
