### PR TITLE
fix: harden history/timeline against icon XSS and cross-mind reads

### DIFF
--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -59,6 +59,26 @@ export type DiscoveredExtensionInfo = {
 
 export type ExtensionCommandInfo = Omit<ExtensionCommand, "handler">;
 
+/**
+ * Enrich an activity event's metadata with the extension's icon/color branding and
+ * sanitize the resulting icon before it reaches the DB. Activity icons round-trip to
+ * the operator dashboard where they render as raw HTML, so the write-time sanitize is
+ * the belt-and-braces layer that keeps a malicious `metadata.icon` from becoming stored
+ * XSS even if a render-time sanitizer is ever missed.
+ */
+export function enrichActivityMetadata(
+  manifest: Pick<ExtensionManifest, "icon" | "color">,
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const enriched: Record<string, unknown> = {
+    ...metadata,
+    ...(manifest.icon && !metadata?.icon ? { icon: manifest.icon } : {}),
+    ...(manifest.color && !metadata?.color ? { color: manifest.color } : {}),
+  };
+  if (typeof enriched.icon === "string") enriched.icon = sanitizeSvgIcon(enriched.icon);
+  return enriched;
+}
+
 function toCommandInfo(cmd: ExtensionCommand): ExtensionCommandInfo {
   const { handler: _, ...info } = cmd;
   return info;
@@ -203,16 +223,9 @@ async function buildContext(
     getUser: async (id: number) => getUser(id),
     getUserByUsername: async (username: string) => getUserByUsername(username),
     publishActivity: (event) => {
-      // Inject extension icon/color into metadata so the UI can render
-      // activity cards with the correct branding without hardcoding extension IDs.
-      const metadata = {
-        ...event.metadata,
-        ...(manifest.icon && !event.metadata?.icon ? { icon: manifest.icon } : {}),
-        ...(manifest.color && !event.metadata?.color ? { color: manifest.color } : {}),
-      };
-      // Sanitize any icon (extension-provided or round-tripped from mind-derived
-      // metadata) before it reaches the DB, since the dashboard renders it raw.
-      if (typeof metadata.icon === "string") metadata.icon = sanitizeSvgIcon(metadata.icon);
+      // Inject extension icon/color branding and sanitize the icon before it reaches
+      // the DB (the dashboard renders it raw).
+      const metadata = enrichActivityMetadata(manifest, event.metadata);
       const enriched = { ...event, metadata };
       // Insert without turn linkage — when called from skill command handlers, the
       // activity is linked to the correct turn via correlation markers in tool_result.
@@ -312,12 +325,7 @@ async function loadExtension(
           const result = await cmd.handler(parsed, {
             ...context,
             publishActivity: (rawEvent) => {
-              const metadata = {
-                ...rawEvent.metadata,
-                ...(manifest.icon && !rawEvent.metadata?.icon ? { icon: manifest.icon } : {}),
-                ...(manifest.color && !rawEvent.metadata?.color ? { color: manifest.color } : {}),
-              };
-              if (typeof metadata.icon === "string") metadata.icon = sanitizeSvgIcon(metadata.icon);
+              const metadata = enrichActivityMetadata(manifest, rawEvent.metadata);
               const event = { ...rawEvent, metadata };
               activityPromises.push(
                 publish(event as Parameters<typeof publish>[0]).catch((err) => {

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -23,6 +23,7 @@ import { isIsolationEnabled, mindUserName } from "./mind/isolation.js";
 import { mindDir, voluteHome, voluteSystemDir } from "./mind/registry.js";
 import { hashSkillDir, importSkillFromDir, removeSharedSkill, sharedSkillsDir } from "./skills.js";
 import log from "./util/logger.js";
+import { sanitizeSvgIcon } from "./util/sanitize-svg.js";
 
 const VALID_EXTENSION_ID = /^[a-z0-9][a-z0-9_-]*$/;
 
@@ -204,14 +205,15 @@ async function buildContext(
     publishActivity: (event) => {
       // Inject extension icon/color into metadata so the UI can render
       // activity cards with the correct branding without hardcoding extension IDs.
-      const enriched = {
-        ...event,
-        metadata: {
-          ...event.metadata,
-          ...(manifest.icon && !event.metadata?.icon ? { icon: manifest.icon } : {}),
-          ...(manifest.color && !event.metadata?.color ? { color: manifest.color } : {}),
-        },
+      const metadata = {
+        ...event.metadata,
+        ...(manifest.icon && !event.metadata?.icon ? { icon: manifest.icon } : {}),
+        ...(manifest.color && !event.metadata?.color ? { color: manifest.color } : {}),
       };
+      // Sanitize any icon (extension-provided or round-tripped from mind-derived
+      // metadata) before it reaches the DB, since the dashboard renders it raw.
+      if (typeof metadata.icon === "string") metadata.icon = sanitizeSvgIcon(metadata.icon);
+      const enriched = { ...event, metadata };
       // Insert without turn linkage — when called from skill command handlers, the
       // activity is linked to the correct turn via correlation markers in tool_result.
       // When called from route handlers or lifecycle hooks, the record stays unlinked.
@@ -310,14 +312,13 @@ async function loadExtension(
           const result = await cmd.handler(parsed, {
             ...context,
             publishActivity: (rawEvent) => {
-              const event = {
-                ...rawEvent,
-                metadata: {
-                  ...rawEvent.metadata,
-                  ...(manifest.icon && !rawEvent.metadata?.icon ? { icon: manifest.icon } : {}),
-                  ...(manifest.color && !rawEvent.metadata?.color ? { color: manifest.color } : {}),
-                },
+              const metadata = {
+                ...rawEvent.metadata,
+                ...(manifest.icon && !rawEvent.metadata?.icon ? { icon: manifest.icon } : {}),
+                ...(manifest.color && !rawEvent.metadata?.color ? { color: manifest.color } : {}),
               };
+              if (typeof metadata.icon === "string") metadata.icon = sanitizeSvgIcon(metadata.icon);
+              const event = { ...rawEvent, metadata };
               activityPromises.push(
                 publish(event as Parameters<typeof publish>[0]).catch((err) => {
                   log.error(

--- a/packages/daemon/src/lib/util/sanitize-svg.ts
+++ b/packages/daemon/src/lib/util/sanitize-svg.ts
@@ -1,0 +1,43 @@
+import DOMPurify from "isomorphic-dompurify";
+
+/**
+ * Server-side twin of `@volute/ui`'s `sanitizeSvg`. Activity icons are stored in
+ * the `activity` table's metadata and round-tripped to the operator dashboard,
+ * where they render as raw HTML. Sanitize before the value reaches the DB so a
+ * malicious `metadata.icon` can never become stored XSS, keeping the allowlist
+ * in sync with the render-time sanitizer (belt-and-braces).
+ */
+const ALLOWED_TAGS = ["svg", "path", "circle", "rect", "line", "polyline", "polygon", "g"];
+
+const ALLOWED_ATTR = [
+  "viewBox",
+  "fill",
+  "fill-opacity",
+  "fill-rule",
+  "stroke",
+  "stroke-width",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-dasharray",
+  "stroke-opacity",
+  "opacity",
+  "d",
+  "cx",
+  "cy",
+  "r",
+  "x",
+  "y",
+  "width",
+  "height",
+  "points",
+  "transform",
+];
+
+export function sanitizeSvgIcon(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    FORBID_TAGS: ["script", "foreignObject"],
+    FORBID_ATTR: ["href", "xlink:href"],
+  });
+}

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -18,22 +18,36 @@ import log from "../../lib/util/logger.js";
 import type { AuthEnv } from "../middleware/auth.js";
 
 /**
+ * Env for the history router. `mindFilter` is resolved once by router-level
+ * middleware and read by every handler, so new routes inherit cross-mind
+ * scoping by default instead of by discipline.
+ */
+type HistoryEnv = {
+  Variables: AuthEnv["Variables"] & { mindFilter: string | undefined };
+};
+
+/**
  * Resolve the mind whose history the caller may read. Minds are untrusted:
  * a non-admin principal may only see its own history, so the client-supplied
  * `?mind=` param is ignored and forced to the caller's own (base) name.
  * Admin/system callers keep the requested filter.
  */
-async function resolveMindFilter(c: Context<AuthEnv>): Promise<string | undefined> {
+async function resolveMindFilter(c: Context<HistoryEnv>): Promise<string | undefined> {
   const user = c.get("user");
-  if (user.role === "admin" || user.role === "system") {
-    return c.req.query("mind") ?? undefined;
-  }
-  return getBaseName(user.username);
+  const privileged = user.role === "admin" || user.role === "system";
+  return privileged ? (c.req.query("mind") ?? undefined) : getBaseName(user.username);
 }
 
-const history = new Hono<AuthEnv>()
+const history = new Hono<HistoryEnv>()
+  // Backstop: compute the caller's allowed mind scope once, up front. Handlers
+  // read c.get("mindFilter") rather than each remembering to call the helper, so
+  // a future route that forgets still can't leak another mind's history.
+  .use("*", async (c, next) => {
+    c.set("mindFilter", await resolveMindFilter(c));
+    await next();
+  })
   .get("/turns", async (c) => {
-    const mindFilter = await resolveMindFilter(c);
+    const mindFilter = c.get("mindFilter");
     const turnIdFilter = c.req.query("turnId");
     const turnIdsFilter = c.req.query("turnIds");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "50", 10) || 50, 1), 200);
@@ -370,7 +384,7 @@ const history = new Hono<AuthEnv>()
     return c.json(result);
   })
   .get("/events", async (c) => {
-    const mindFilter = await resolveMindFilter(c);
+    const mindFilter = c.get("mindFilter");
 
     const stream = new ReadableStream({
       start(controller) {
@@ -432,8 +446,12 @@ const history = new Hono<AuthEnv>()
   .get("/summaries", async (c) => {
     const user = c.get("user");
     const privileged = user.role === "admin" || user.role === "system";
-    // Non-admin callers can only read their own summaries.
-    const mind = privileged ? (c.req.query("mind") ?? "_system") : await getBaseName(user.username);
+    // mindFilter is the caller's allowed scope: the requested mind for
+    // privileged callers (undefined if none), or the caller's own base name for
+    // minds. Summaries default an unscoped privileged read to the system
+    // timeline (`_system`) rather than all minds — this asymmetry is
+    // intentional and load-bearing for the system timeline view.
+    const mind = c.get("mindFilter") ?? "_system";
     const period = c.req.query("period");
     const ids = c.req.query("ids"); // comma-separated summary IDs
     const from = c.req.query("from");
@@ -509,7 +527,7 @@ const history = new Hono<AuthEnv>()
     return c.json(result);
   })
   .get("/activity", async (c) => {
-    const mind = await resolveMindFilter(c);
+    const mind = c.get("mindFilter");
     const from = c.req.query("from");
     const to = c.req.query("to");
     const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "100", 10) || 100, 1), 500);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,8 @@
     "./theme.css": "./src/theme.css",
     "./base.css": "./src/base.css",
     "./icons": "./src/icons.ts",
-    "./markdown": "./src/markdown.ts"
+    "./markdown": "./src/markdown.ts",
+    "./sanitize": "./src/sanitize.ts"
   },
   "files": [
     "src/",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,7 @@ export { default as Toggle } from "./components/Toggle.svelte";
 // Utilities
 export { icons } from "./icons.js";
 export { renderMarkdown } from "./markdown.js";
+export { sanitizeSvg } from "./sanitize.js";
 export type { TooltipOptions, TooltipPosition } from "./tooltip.js";
 // Actions
 export { tooltip } from "./tooltip.js";

--- a/packages/ui/src/sanitize.ts
+++ b/packages/ui/src/sanitize.ts
@@ -1,0 +1,54 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Static allowlist for inline SVG icons. Icons are round-tripped through the
+ * `activity` table's metadata and originate from extension code today, but the
+ * moment any extension passes mind-derived data into `metadata.icon` this
+ * becomes stored XSS in the operator's dashboard. Treat icons as untrusted at
+ * render time and permit only a static SVG shape vocabulary — no `script`,
+ * event handlers, `foreignObject`, or `href`.
+ */
+export const SVG_ICON_ALLOWED_TAGS = [
+  "svg",
+  "path",
+  "circle",
+  "rect",
+  "line",
+  "polyline",
+  "polygon",
+  "g",
+];
+
+export const SVG_ICON_ALLOWED_ATTR = [
+  "viewBox",
+  "fill",
+  "fill-opacity",
+  "fill-rule",
+  "stroke",
+  "stroke-width",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-dasharray",
+  "stroke-opacity",
+  "opacity",
+  "d",
+  "cx",
+  "cy",
+  "r",
+  "x",
+  "y",
+  "width",
+  "height",
+  "points",
+  "transform",
+];
+
+/** Sanitize an untrusted inline SVG icon string down to a static shape vocabulary. */
+export function sanitizeSvg(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: SVG_ICON_ALLOWED_TAGS,
+    ALLOWED_ATTR: SVG_ICON_ALLOWED_ATTR,
+    FORBID_TAGS: ["script", "foreignObject"],
+    FORBID_ATTR: ["href", "xlink:href"],
+  });
+}

--- a/packages/web/src/ui/components/ExtensionFeedCard.svelte
+++ b/packages/web/src/ui/components/ExtensionFeedCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { renderMarkdown } from "@volute/ui/markdown";
+import { sanitizeSvg } from "@volute/ui/sanitize";
 import { formatRelativeTime } from "../lib/format";
 
 let {
@@ -36,7 +37,7 @@ let iframeLoaded = $state(false);
 >
   <div class="feed-card-header" style:border-bottom-color="color-mix(in srgb, {cardColor} 25%, var(--border))">
     {#if icon}
-      <span class="feed-card-icon" style:color={cardColor}>{@html icon}</span>
+      <span class="feed-card-icon" style:color={cardColor}>{@html sanitizeSvg(icon)}</span>
     {/if}
     <span class="feed-card-label">{title}</span>
     {#if author}

--- a/packages/web/src/ui/components/HistoryEvent.svelte
+++ b/packages/web/src/ui/components/HistoryEvent.svelte
@@ -2,6 +2,7 @@
 import type { HistoryMessage, TurnActivity, TurnConversation } from "@volute/api";
 import { Icon, tooltip as tooltipAction } from "@volute/ui";
 import { renderMarkdown } from "@volute/ui/markdown";
+import { sanitizeSvg } from "@volute/ui/sanitize";
 import { tick } from "svelte";
 import { fetchTurnEvents } from "../lib/client";
 import { normalizeTimestamp } from "../lib/format";
@@ -214,7 +215,7 @@ async function handleClick() {
     {@const actColor = typeof actMeta?.color === "string" ? `var(--${actMeta.color})` : "var(--yellow)"}
     <div class="marker marker-icon" style:color={actColor} use:tooltipAction={{ text: tooltip, position: "left" }}>
       {#if typeof actMeta?.icon === "string"}
-        {@html actMeta.icon}
+        {@html sanitizeSvg(actMeta.icon)}
       {:else}
         <Icon kind="document-lines" />
       {/if}

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -8,6 +8,7 @@ import type {
 } from "@volute/api";
 import { Icon } from "@volute/ui";
 import { renderMarkdown } from "@volute/ui/markdown";
+import { sanitizeSvg } from "@volute/ui/sanitize";
 import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import {
   fetchHistory,
@@ -839,7 +840,7 @@ function jumpToLatest() {
                   {/each}
                   {#each turn.activities as act (act.id)}
                     {@const actColor = typeof act.metadata?.color === 'string' ? act.metadata.color : 'yellow'}
-                    {@const actIcon = typeof act.metadata?.icon === 'string' ? act.metadata.icon : ''}
+                    {@const actIcon = typeof act.metadata?.icon === 'string' ? sanitizeSvg(act.metadata.icon) : ''}
                     {@const actUrl = typeof act.metadata?.iframeUrl === 'string' ? act.metadata.iframeUrl : typeof act.metadata?.slug === 'string' ? `/minds/${typeof act.metadata?.author === 'string' ? act.metadata.author : turn.mind}/notes/${act.metadata.slug}` : ''}
                     <div class="peek-anchor">
                       <button class="peek-btn" style:color="var(--{actColor})" aria-label="View activity" onclick={(e) => { e.stopPropagation(); if (actUrl) navigate(actUrl); }}>

--- a/test/svg-icon-sanitize.test.ts
+++ b/test/svg-icon-sanitize.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 import { JSDOM } from "jsdom";
+import { enrichActivityMetadata } from "../packages/daemon/src/lib/extensions.js";
 import { sanitizeSvgIcon } from "../packages/daemon/src/lib/util/sanitize-svg.js";
 
 // The browser-side @volute/ui sanitizer runs on `dompurify`, which needs a DOM.
@@ -77,5 +78,34 @@ describe("svg icon sanitization", () => {
       "xlink:href",
       "javascript:",
     ]);
+  });
+});
+
+// The extension publishActivity enrichment is the write-time layer that keeps a
+// malicious icon out of the DB. Exercise it directly so a future refactor that drops
+// the sanitize step fails a test rather than silently disabling defense-in-depth.
+describe("extension activity metadata enrichment", () => {
+  it("sanitizes an event-supplied malicious icon before persisting", () => {
+    const out = enrichActivityMetadata(
+      { icon: undefined, color: undefined },
+      { icon: '<svg onload="alert(1)"><script>steal()</script><path d="M0 0"/></svg>' },
+    );
+    const icon = String(out.icon).toLowerCase();
+    assert.ok(!icon.includes("onload"), "strips inline handler");
+    assert.ok(!icon.includes("<script"), "strips script tag");
+    assert.ok(!icon.includes("alert"), "strips script body");
+    assert.ok(!icon.includes("steal"), "strips script body");
+    assert.ok(icon.includes("<path"), "keeps benign shape");
+  });
+
+  it("sanitizes a manifest-supplied fallback icon", () => {
+    const out = enrichActivityMetadata(
+      { icon: '<svg onload="evil()"><path d="M0 0"/></svg>', color: "purple" },
+      undefined,
+    );
+    const icon = String(out.icon).toLowerCase();
+    assert.ok(!icon.includes("onload"), "strips inline handler from manifest icon");
+    assert.ok(!icon.includes("evil"), "strips handler body");
+    assert.equal(out.color, "purple", "keeps color branding");
   });
 });

--- a/test/svg-icon-sanitize.test.ts
+++ b/test/svg-icon-sanitize.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { JSDOM } from "jsdom";
+import { sanitizeSvgIcon } from "../packages/daemon/src/lib/util/sanitize-svg.js";
+
+// The browser-side @volute/ui sanitizer runs on `dompurify`, which needs a DOM.
+// Provide one via jsdom before importing so the module initializes correctly.
+type SanitizeSvg = (html: string) => string;
+let sanitizeSvg: SanitizeSvg;
+
+before(async () => {
+  const { window } = new JSDOM("");
+  (globalThis as unknown as { window: unknown }).window = window;
+  (globalThis as unknown as { document: unknown }).document = window.document;
+  ({ sanitizeSvg } = await import("../packages/ui/src/sanitize.js"));
+});
+
+// Both the render-time (@volute/ui) and write-time (daemon) sanitizers share the
+// same allowlist, so run every case through both.
+describe("svg icon sanitization", () => {
+  function bothStrip(input: string, forbidden: string[]) {
+    for (const [name, fn] of [
+      ["sanitizeSvg", () => sanitizeSvg(input)],
+      ["sanitizeSvgIcon", () => sanitizeSvgIcon(input)],
+    ] as const) {
+      const out = fn().toLowerCase();
+      for (const bad of forbidden) {
+        assert.ok(!out.includes(bad.toLowerCase()), `${name} should strip "${bad}" from: ${out}`);
+      }
+    }
+  }
+
+  it("passes a benign icon through, preserving shape tags and attributes", () => {
+    const icon =
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2 L2 22"/><circle cx="12" cy="12" r="4"/></svg>';
+    for (const out of [sanitizeSvg(icon), sanitizeSvgIcon(icon)]) {
+      assert.ok(out.includes("<svg"), "keeps <svg>");
+      assert.ok(out.includes("<path"), "keeps <path>");
+      assert.ok(out.includes("<circle"), "keeps <circle>");
+      assert.ok(out.includes('viewBox="0 0 24 24"'), "keeps viewBox");
+      assert.ok(out.includes('d="M12 2 L2 22"'), "keeps path data");
+      assert.ok(out.includes('stroke="currentColor"'), "keeps stroke");
+    }
+  });
+
+  it("strips inline event handlers", () => {
+    bothStrip('<svg onload="alert(1)"><path d="M0 0" onclick="steal()"/></svg>', [
+      "onload",
+      "onclick",
+      "alert",
+    ]);
+  });
+
+  it("strips <script> content", () => {
+    bothStrip('<svg><script>alert(document.cookie)</script><path d="M0 0"/></svg>', [
+      "<script",
+      "alert",
+      "cookie",
+    ]);
+  });
+
+  it("strips foreignObject (HTML-in-SVG injection vector)", () => {
+    bothStrip('<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>', [
+      "foreignobject",
+      "onerror",
+      "<img",
+      "alert",
+    ]);
+  });
+
+  it("strips href / xlink:href to block javascript: navigation", () => {
+    bothStrip('<svg><a href="javascript:alert(1)"><path d="M0 0"/></a></svg>', [
+      "href",
+      "javascript:",
+    ]);
+    bothStrip('<svg><a xlink:href="javascript:alert(1)"><path d="M0 0"/></a></svg>', [
+      "xlink:href",
+      "javascript:",
+    ]);
+  });
+});

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -2,9 +2,16 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq, sql } from "drizzle-orm";
-import { createUser } from "../packages/daemon/src/lib/auth.js";
+import { createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { mindHistory, summaries, turns, users } from "../packages/daemon/src/lib/schema.js";
+import { publish as publishMindEvent } from "../packages/daemon/src/lib/events/mind-events.js";
+import {
+  activity,
+  mindHistory,
+  summaries,
+  turns,
+  users,
+} from "../packages/daemon/src/lib/schema.js";
 import { createSession, deleteSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 const TEST_USERNAME = "history-test-admin";
@@ -13,10 +20,18 @@ let sessionId: string;
 async function cleanup() {
   const db = await getDb();
   await db.delete(users).where(eq(users.username, TEST_USERNAME));
-  // Clean up test turns, history, and summaries
+  await db.delete(users).where(sql`username LIKE 'test-history-%'`);
+  // Clean up test turns, history, summaries, and activity
   await db.delete(summaries).where(sql`mind LIKE 'test-history-%'`);
   await db.delete(turns).where(sql`mind LIKE 'test-history-%'`);
   await db.delete(mindHistory).where(sql`mind LIKE 'test-history-%'`);
+  await db.delete(activity).where(sql`mind LIKE 'test-history-%'`);
+}
+
+/** Create a non-admin mind user (role "user") and return a session cookie for it. */
+async function mindSession(mindName: string): Promise<string> {
+  const user = await getOrCreateMindUser(mindName);
+  return createSession(user.id);
 }
 
 async function setupAuth(): Promise<string> {
@@ -259,5 +274,169 @@ describe("web history routes", () => {
     // We can't directly check the SQL limit, but we verify the endpoint doesn't error
     const body = await res.json();
     assert.ok(Array.isArray(body));
+  });
+
+  // ── Cross-mind isolation (non-admin callers) ──
+  //
+  // Minds are untrusted principals. A mind authenticates as a non-admin "user"
+  // whose username is its own name; the history routes must force scoping to the
+  // caller's own mind and ignore any `?mind=` / `?ids=` pointing at another mind.
+
+  it("GET /turns?mind=<other> — a mind cannot read another mind's turns", async () => {
+    const cookie = await mindSession("test-history-alice");
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    const aliceTurn = randomUUID();
+    const bobTurn = randomUUID();
+    await db.insert(turns).values([
+      { id: aliceTurn, mind: "test-history-alice", status: "complete" },
+      { id: bobTurn, mind: "test-history-bob", status: "complete" },
+    ]);
+
+    // Alice tries to read bob's turns; the ?mind= param must be ignored.
+    const res = await app.request("/api/v1/history/turns?mind=test-history-bob", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{ id: string; mind: string }>;
+    assert.ok(
+      body.every((t) => t.mind === "test-history-alice"),
+      "only the caller's own turns are returned",
+    );
+    assert.ok(!body.some((t) => t.id === bobTurn), "another mind's turn must not leak");
+  });
+
+  it("GET /activity?mind=<other> — a mind cannot read another mind's activity", async () => {
+    const cookie = await mindSession("test-history-alice");
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    await db.insert(activity).values([
+      { type: "note_created", mind: "test-history-alice", summary: "alice note" },
+      { type: "note_created", mind: "test-history-bob", summary: "bob note" },
+    ]);
+
+    const res = await app.request("/api/v1/history/activity?mind=test-history-bob", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{ mind: string; summary: string }>;
+    assert.ok(
+      body.every((a) => a.mind === "test-history-alice"),
+      "only the caller's own activity is returned",
+    );
+    assert.ok(!body.some((a) => a.summary === "bob note"), "another mind's activity must not leak");
+  });
+
+  it("GET /summaries?mind=<other> — a mind cannot read another mind's summaries", async () => {
+    const cookie = await mindSession("test-history-alice");
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    await db.insert(summaries).values([
+      {
+        mind: "test-history-alice",
+        period: "hour",
+        period_key: "2026-03-22T14",
+        content: "alice hourly",
+      },
+      {
+        mind: "test-history-bob",
+        period: "hour",
+        period_key: "2026-03-22T14",
+        content: "bob hourly",
+      },
+    ]);
+
+    const res = await app.request("/api/v1/history/summaries?period=hour&mind=test-history-bob", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{ mind: string; content: string }>;
+    assert.ok(
+      body.every((s) => s.mind === "test-history-alice"),
+      "only the caller's own summaries are returned",
+    );
+    assert.ok(
+      !body.some((s) => s.content === "bob hourly"),
+      "another mind's summary must not leak",
+    );
+  });
+
+  it("GET /summaries?ids=<other's ids> — a mind cannot fetch another mind's summaries by id", async () => {
+    const cookie = await mindSession("test-history-alice");
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    const inserted = await db
+      .insert(summaries)
+      .values([
+        {
+          mind: "test-history-alice",
+          period: "turn",
+          period_key: "alice-turn",
+          content: "alice by id",
+        },
+        {
+          mind: "test-history-bob",
+          period: "turn",
+          period_key: "bob-turn",
+          content: "bob by id",
+        },
+      ])
+      .returning({ id: summaries.id, mind: summaries.mind });
+    const aliceId = inserted.find((r) => r.mind === "test-history-alice")!.id;
+    const bobId = inserted.find((r) => r.mind === "test-history-bob")!.id;
+
+    // Requesting both ids returns only alice's row; bob's id is filtered out.
+    const res = await app.request(`/api/v1/history/summaries?ids=${aliceId},${bobId}`, {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{ id: number; mind: string }>;
+    assert.ok(
+      body.every((s) => s.mind === "test-history-alice"),
+      "only the caller's own summary is returned",
+    );
+    assert.ok(!body.some((s) => s.id === bobId), "another mind's summary id must not leak");
+  });
+
+  it("GET /events — SSE only streams the caller's own mind events", async () => {
+    const cookie = await mindSession("test-history-alice");
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await app.request("/api/v1/history/events?mind=test-history-bob", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    // The subscription registers synchronously in the stream's start(); publish
+    // bob's event first (must be filtered), then alice's (must arrive).
+    publishMindEvent("test-history-bob", {
+      mind: "test-history-bob",
+      type: "activity",
+      summary: "bob-secret",
+    } as Parameters<typeof publishMindEvent>[1]);
+    publishMindEvent("test-history-alice", {
+      mind: "test-history-alice",
+      type: "activity",
+      summary: "alice-visible",
+    } as Parameters<typeof publishMindEvent>[1]);
+
+    let received = "";
+    // Read a couple of chunks; the first data frame should be alice's event.
+    for (let i = 0; i < 3; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += decoder.decode(value, { stream: true });
+      if (received.includes("data:")) break;
+    }
+    await reader.cancel();
+
+    assert.ok(received.includes("alice-visible"), "caller's own event is streamed");
+    assert.ok(!received.includes("bob-secret"), "another mind's event must not be streamed");
   });
 });


### PR DESCRIPTION
## What

Hardens the history/timeline surface (#398) on two fronts:

**Cross-mind read isolation.** The history routes (`/turns`, `/summaries`, `/activity`, `/events`) now resolve the caller's allowed mind scope once in router-level middleware and expose it as `c.get("mindFilter")`. Minds are untrusted principals, so a non-admin caller's client-supplied `?mind=` is ignored and forced to its own base name; admin/system callers keep the requested filter. Handlers read the pre-resolved filter instead of each remembering to call the helper, so a future route inherits scoping by default rather than by discipline.

**Icon XSS defense-in-depth.** Untrusted activity/feed SVG icons are sanitized at both ends:
- **Render time** — new `sanitizeSvg` in `@volute/ui`, applied to all four `{@html icon}` sites (`HistoryEvent`, `TurnTimeline`, `ExtensionFeedCard`).
- **Write time** — server-side `sanitizeSvgIcon` (`isomorphic-dompurify`, same allowlist) runs in the extension `publishActivity` enrichment path before an icon reaches the DB, so a malicious `metadata.icon` can never become stored XSS even if a render-time sanitizer is ever missed.

## Review triage

- **Addressed (minor, defense-in-depth coverage gap):** a reviewer noted the write-time sanitization wiring in `extensions.ts` had no direct test — only the pure `sanitizeSvgIcon` function was covered. Extracted the duplicated icon/color enrichment + sanitize logic out of the two `publishActivity` closures into a single exported `enrichActivityMetadata(manifest, metadata)` helper (removing the duplication) and added two tests that drive it with event-supplied and manifest-supplied malicious icons, asserting the icon is stripped before it would be persisted.

## Tests

Added `test/svg-icon-sanitize.test.ts` (render-time + write-time sanitizer parity, plus the new enrichment-path tests) and cross-mind isolation tests in `test/web-history.test.ts` proving one mind cannot read another mind's turns/activity/summaries/SSE events. Full suite, typecheck, svelte-check, and web build all pass.

Fixes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)
