### PR TITLE
fix: recover timeline live view after SSE drop and bound phantom turns

### DIFF
--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -26,6 +26,7 @@ import {
   isTurnStale,
   pruneExpiredInbounds,
   reconnectDelay,
+  turnLastSeenMs,
 } from "../lib/timeline-liveness";
 import { buildTodayItems } from "../lib/timeline-today";
 import { groupToolEvents } from "../lib/tool-groups";
@@ -280,10 +281,17 @@ async function resync() {
     upsertTurnRows([...rows].reverse());
     for (const turn of turnsData) {
       if (turn.status === "active") {
-        lastEventAt.set(turn.id, Date.now());
-        fetchTurnEvents(turn.mind, { turnId: turn.id })
+        const turnId = turn.id;
+        const turnMind = turn.mind;
+        lastEventAt.set(turnId, Date.now());
+        // Mark as streaming synchronously so a newly-discovered active turn renders live,
+        // and so the completion guard below has a placeholder to observe.
+        if (!streamingEvents.has(turnId)) streamingEvents.set(turnId, []);
+        fetchTurnEvents(turnMind, { turnId })
           .then((dbEvents) => {
-            streamingEvents.set(turn.id, dbEvents);
+            // A summary/done landing mid-fetch deletes streaming state; don't resurrect it.
+            if (!streamingEvents.has(turnId)) return;
+            streamingEvents.set(turnId, dbEvents);
           })
           .catch((err) => console.warn("[TurnTimeline] Failed to resync active turn events:", err));
       } else if (streamingEvents.has(turn.id)) {
@@ -753,7 +761,7 @@ $effect(() => {
     const now = Date.now();
     for (const turn of turnsData) {
       if (turn.status !== "active") continue;
-      const seen = lastEventAt.get(turn.id) ?? new Date(turn.created_at).getTime();
+      const seen = turnLastSeenMs(turn.created_at, lastEventAt.get(turn.id));
       if (!isTurnStale(seen, now)) continue;
       lastEventAt.set(turn.id, now); // avoid refetch storms while awaiting the response
       fetchTurns({ mind: name, turnId: turn.id })

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -21,6 +21,12 @@ import { extractTextContent } from "../lib/feed-utils";
 import { formatRelativeTime } from "../lib/format";
 import { navigate } from "../lib/navigate";
 import { activeMinds } from "../lib/stores.svelte";
+import {
+  isRecentInbound,
+  isTurnStale,
+  pruneExpiredInbounds,
+  reconnectDelay,
+} from "../lib/timeline-liveness";
 import { buildTodayItems } from "../lib/timeline-today";
 import { groupToolEvents } from "../lib/tool-groups";
 import { getCategoryColor, getCategoryIcon } from "../lib/tool-names";
@@ -242,6 +248,54 @@ function handleExpand(turnId: string, expanded: boolean) {
 let scrollContainer: HTMLDivElement | undefined = $state();
 let userScrolledUp = $state(false);
 let eventSource: EventSource | null = null;
+let reconnecting = $state(false);
+let reconnectAttempts = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+// Last streaming-event time per active turn, for the staleness guard
+const lastEventAt = new Map<string, number>();
+
+function clearReconnectTimer() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) return;
+  const delay = reconnectDelay(reconnectAttempts);
+  reconnectAttempts++;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectSSE();
+  }, delay);
+}
+
+// Refetch page 1 after a reconnect and reconcile turns/streaming state so events
+// missed while disconnected are recovered (turns completed, new turns, etc.).
+async function resync() {
+  if (!name) return;
+  try {
+    const rows = await fetchTurns({ mind: name, limit: PAGE_SIZE, offset: 0 });
+    upsertTurnRows([...rows].reverse());
+    for (const turn of turnsData) {
+      if (turn.status === "active") {
+        lastEventAt.set(turn.id, Date.now());
+        fetchTurnEvents(turn.mind, { turnId: turn.id })
+          .then((dbEvents) => {
+            streamingEvents.set(turn.id, dbEvents);
+          })
+          .catch((err) => console.warn("[TurnTimeline] Failed to resync active turn events:", err));
+      } else if (streamingEvents.has(turn.id)) {
+        // Turn completed while we were disconnected — drop the stale streaming view.
+        streamingEvents.delete(turn.id);
+        lastEventAt.delete(turn.id);
+      }
+    }
+  } catch (err) {
+    console.warn("[TurnTimeline] Failed to resync after reconnect:", err);
+  }
+}
 
 function connectSSE() {
   disconnectSSE();
@@ -289,6 +343,7 @@ function connectSSE() {
         streamingEvents.set(turnId, []);
       }
       pendingInbounds = [];
+      lastEventAt.set(turnId, Date.now());
       // Fetch turn events from DB after a short delay to allow retroactive inbound tagging.
       // DB events are authoritative — replace synthetic SSE events entirely.
       // Any SSE events arriving after this .then() runs are appended normally.
@@ -306,6 +361,7 @@ function connectSSE() {
       doneFallbackTimers.delete(turnId);
       const prevStreaming = streamingEvents.get(turnId);
       streamingEvents.delete(turnId);
+      lastEventAt.delete(turnId);
       fetchTurns({ mind: name, turnId })
         .then((rows) => {
           upsertTurnRows(rows);
@@ -348,6 +404,7 @@ function connectSSE() {
       // Create new array to trigger Svelte reactivity
       const prev = streamingEvents.get(turnId)!;
       streamingEvents.set(turnId, [...prev, buildHistoryMessage(d, { turn_id: turnId })]);
+      lastEventAt.set(turnId, Date.now());
     }
 
     if (!userScrolledUp) {
@@ -356,17 +413,30 @@ function connectSSE() {
       });
     }
   };
+  es.onopen = () => {
+    clearReconnectTimer();
+    const wasReconnecting = reconnecting;
+    reconnectAttempts = 0;
+    reconnecting = false;
+    // Recover anything missed while the stream was down.
+    if (wasReconnecting) resync();
+  };
   es.onerror = () => {
+    // EventSource auto-retries transient errors (CONNECTING). A permanent close
+    // (CLOSED — e.g. a daemon restart returning an error) needs a manual reconnect
+    // with backoff, or the timeline silently stops updating until a page reload.
     if (es.readyState === EventSource.CLOSED) {
-      console.warn("[TurnTimeline] SSE connection closed permanently");
+      reconnecting = true;
+      scheduleReconnect();
     } else if (es.readyState === EventSource.CONNECTING) {
-      console.warn("[TurnTimeline] SSE reconnecting...");
+      reconnecting = true;
     }
   };
   eventSource = es;
 }
 
 function disconnectSSE() {
+  clearReconnectTimer();
   if (eventSource) {
     eventSource.close();
     eventSource = null;
@@ -393,7 +463,11 @@ async function loadTurns(offset: number) {
     if (offset === 0 && pendingInbounds.length === 0 && name) {
       fetchHistory(name, { preset: "all", limit: 10 })
         .then((recent) => {
-          const untagged = recent.filter((e) => e.type === "inbound" && !e.turn_id);
+          // Only promote recent untagged inbounds — an old inbound a stopped/sleeping
+          // mind never processed must not render as a perpetually-active turn.
+          const untagged = recent.filter(
+            (e) => e.type === "inbound" && !e.turn_id && isRecentInbound(e.created_at),
+          );
           if (untagged.length > 0 && pendingInbounds.length === 0) {
             pendingInbounds = untagged;
           }
@@ -660,9 +734,41 @@ $effect(() => {
     summariesLoaded = false;
     expandedSummaries = new SvelteMap();
     directEventsSummaries = new SvelteMap();
+    reconnecting = false;
+    reconnectAttempts = 0;
+    lastEventAt.clear();
     startScrollToBottom();
     loadTurns(0);
   }
+});
+
+// Liveness sweep: expire stale provisional inbounds and reconcile active turns that
+// the server has likely finished (converges with the server's wedged-turn sweep).
+$effect(() => {
+  const interval = setInterval(() => {
+    if (pendingInbounds.length > 0) {
+      const pruned = pruneExpiredInbounds(pendingInbounds);
+      if (pruned.length !== pendingInbounds.length) pendingInbounds = pruned;
+    }
+    const now = Date.now();
+    for (const turn of turnsData) {
+      if (turn.status !== "active") continue;
+      const seen = lastEventAt.get(turn.id) ?? new Date(turn.created_at).getTime();
+      if (!isTurnStale(seen, now)) continue;
+      lastEventAt.set(turn.id, now); // avoid refetch storms while awaiting the response
+      fetchTurns({ mind: name, turnId: turn.id })
+        .then((rows) => {
+          const fresh = rows[0];
+          if (fresh && fresh.status !== "active") {
+            streamingEvents.delete(turn.id);
+            lastEventAt.delete(turn.id);
+          }
+          upsertTurnRows(rows);
+        })
+        .catch((err) => console.warn("[TurnTimeline] Failed to check stale turn:", err));
+    }
+  }, 30_000);
+  return () => clearInterval(interval);
 });
 
 // Load summaries once turns are available
@@ -955,7 +1061,7 @@ function jumpToLatest() {
         {#if pendingInbounds.length > 0}
           <div class="turn-row">
             <div class="turn-time">
-              just now
+              {formatRelativeTime(pendingInbounds[0].created_at)}
             </div>
             <div class="turn-rail turn-rail-expanded">
               <div class="turn-dot"></div>
@@ -991,6 +1097,9 @@ function jumpToLatest() {
             </div>
             <div class="turn-body">
               <span class="mind-status-text" style:color={activeMinds.has(name) ? 'var(--accent)' : statusColor}>{name} is {statusLabel}</span>
+              {#if reconnecting}
+                <span class="reconnecting-text">reconnecting…</span>
+              {/if}
             </div>
           </div>
         {/if}
@@ -1515,6 +1624,15 @@ function jumpToLatest() {
     font-style: italic;
     line-height: 8px;
     padding-left: 20px;
+  }
+
+  .reconnecting-text {
+    display: inline-block;
+    margin-top: 6px;
+    padding-left: 20px;
+    font-size: 12px;
+    color: var(--text-2);
+    animation: pulse 1.5s infinite;
   }
   /* Scale break: two diagonal lines on the rail with labels */
   .scale-break-row {

--- a/packages/web/src/ui/lib/timeline-liveness.ts
+++ b/packages/web/src/ui/lib/timeline-liveness.ts
@@ -58,3 +58,12 @@ export const STALE_TURN_IDLE_MS = 15 * 60_000;
 export function isTurnStale(lastEventAtMs: number, now: number = Date.now()): boolean {
   return now - lastEventAtMs >= STALE_TURN_IDLE_MS;
 }
+
+/**
+ * Milliseconds of a turn's last observed activity: its last streaming event if we saw one,
+ * else its DB `created_at`. `created_at` is normalized so no-Z (UTC) DB timestamps parse
+ * correctly regardless of the browser's local offset.
+ */
+export function turnLastSeenMs(createdAt: string, lastEventAtMs?: number): number {
+  return lastEventAtMs ?? timestampMs(createdAt);
+}

--- a/packages/web/src/ui/lib/timeline-liveness.ts
+++ b/packages/web/src/ui/lib/timeline-liveness.ts
@@ -1,0 +1,60 @@
+// Pure liveness policy for the live turn timeline (TurnTimeline.svelte).
+// Kept free of Svelte/DOM so it can be unit-tested directly.
+
+import type { HistoryMessage } from "@volute/api";
+import { normalizeTimestamp } from "./format";
+
+// --- SSE reconnect backoff ---
+
+/** Backoff delays (ms) applied on successive failed reconnect attempts, capped at the last value. */
+export const RECONNECT_BACKOFF_MS = [1000, 2000, 5000, 10000];
+
+/**
+ * Delay before the next reconnect attempt.
+ * @param attempt number of reconnects already tried (0 = first retry).
+ */
+export function reconnectDelay(attempt: number): number {
+  const idx = Math.min(Math.max(attempt, 0), RECONNECT_BACKOFF_MS.length - 1);
+  return RECONNECT_BACKOFF_MS[idx];
+}
+
+// --- Provisional (pending) inbound bounds ---
+
+/** On load, an untagged inbound is only promoted to a provisional turn if newer than this. */
+export const PENDING_INBOUND_MAX_AGE_MS = 2 * 60_000;
+/** A provisional inbound with no turn_created after this long stops pretending to be active. */
+export const PENDING_INBOUND_EXPIRY_MS = 3 * 60_000;
+
+function timestampMs(dateStr: string): number {
+  return new Date(normalizeTimestamp(dateStr)).getTime();
+}
+
+/** True if an inbound is recent enough to show as a provisional active turn. */
+export function isRecentInbound(createdAt: string, now: number = Date.now()): boolean {
+  const t = timestampMs(createdAt);
+  if (Number.isNaN(t)) return false;
+  return now - t <= PENDING_INBOUND_MAX_AGE_MS;
+}
+
+/** Drop provisional inbounds older than the expiry window. */
+export function pruneExpiredInbounds(
+  inbounds: HistoryMessage[],
+  now: number = Date.now(),
+): HistoryMessage[] {
+  return inbounds.filter((ev) => {
+    const t = timestampMs(ev.created_at);
+    if (Number.isNaN(t)) return true; // keep un-parseable rather than silently dropping
+    return now - t < PENDING_INBOUND_EXPIRY_MS;
+  });
+}
+
+// --- Active-turn staleness guard ---
+
+/** Matches the server's WEDGED_TURN_IDLE_MS (summarizer.ts): a still-"active" turn idle this
+ *  long is likely finished on the server; refetch to converge instead of waiting for reload. */
+export const STALE_TURN_IDLE_MS = 15 * 60_000;
+
+/** True if an active turn's last streaming event is old enough to warrant a server refetch. */
+export function isTurnStale(lastEventAtMs: number, now: number = Date.now()): boolean {
+  return now - lastEventAtMs >= STALE_TURN_IDLE_MS;
+}

--- a/test/timeline-liveness.test.ts
+++ b/test/timeline-liveness.test.ts
@@ -10,6 +10,7 @@ import {
   RECONNECT_BACKOFF_MS,
   reconnectDelay,
   STALE_TURN_IDLE_MS,
+  turnLastSeenMs,
 } from "../packages/web/src/ui/lib/timeline-liveness";
 
 function inbound(createdAt: string, id = 1): HistoryMessage {
@@ -110,5 +111,24 @@ describe("isTurnStale", () => {
   it("is true once idle beyond the wedged-turn threshold", () => {
     assert.equal(isTurnStale(now - STALE_TURN_IDLE_MS, now), true);
     assert.equal(isTurnStale(now - (STALE_TURN_IDLE_MS + 60_000), now), true);
+  });
+});
+
+describe("turnLastSeenMs", () => {
+  const now = Date.UTC(2026, 6, 9, 12, 0, 0);
+
+  it("prefers the last streaming-event time when present", () => {
+    assert.equal(turnLastSeenMs(agoNoZ(60 * 60_000, now), now - 1000), now - 1000);
+  });
+
+  it("falls back to a normalized created_at when no event was seen", () => {
+    // No-Z (UTC) DB timestamps must parse the same as their Z counterpart, so a turn
+    // that just loaded is not miscomputed as stale (or future) by the browser's offset.
+    const withZ = new Date(now - 30_000).toISOString();
+    const withoutZ = withZ.replace("Z", "");
+    assert.equal(turnLastSeenMs(withoutZ), turnLastSeenMs(withZ));
+    assert.equal(turnLastSeenMs(withoutZ), now - 30_000);
+    // The fallback of a freshly-created turn is not stale.
+    assert.equal(isTurnStale(turnLastSeenMs(withoutZ), now), false);
   });
 });

--- a/test/timeline-liveness.test.ts
+++ b/test/timeline-liveness.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { HistoryMessage } from "@volute/api";
+import {
+  isRecentInbound,
+  isTurnStale,
+  PENDING_INBOUND_EXPIRY_MS,
+  PENDING_INBOUND_MAX_AGE_MS,
+  pruneExpiredInbounds,
+  RECONNECT_BACKOFF_MS,
+  reconnectDelay,
+  STALE_TURN_IDLE_MS,
+} from "../packages/web/src/ui/lib/timeline-liveness";
+
+function inbound(createdAt: string, id = 1): HistoryMessage {
+  return {
+    id,
+    mind: "test",
+    channel: "",
+    session: null,
+    sender: null,
+    message_id: null,
+    type: "inbound",
+    content: "hi",
+    metadata: null,
+    turn_id: null,
+    created_at: createdAt,
+  };
+}
+
+// A UTC timestamp without a Z suffix, as the DB stores them.
+function agoNoZ(ms: number, now: number): string {
+  return new Date(now - ms).toISOString().replace("Z", "");
+}
+
+describe("reconnectDelay", () => {
+  it("follows the backoff sequence and caps at the last value", () => {
+    assert.equal(reconnectDelay(0), 1000);
+    assert.equal(reconnectDelay(1), 2000);
+    assert.equal(reconnectDelay(2), 5000);
+    assert.equal(reconnectDelay(3), 10000);
+    // Caps rather than growing or indexing out of bounds.
+    assert.equal(reconnectDelay(4), 10000);
+    assert.equal(reconnectDelay(99), 10000);
+    assert.equal(reconnectDelay(RECONNECT_BACKOFF_MS.length), 10000);
+  });
+
+  it("clamps negative attempts to the first delay", () => {
+    assert.equal(reconnectDelay(-1), 1000);
+  });
+});
+
+describe("isRecentInbound", () => {
+  const now = Date.UTC(2026, 6, 9, 12, 0, 0);
+
+  it("accepts an inbound within the age cutoff", () => {
+    assert.equal(isRecentInbound(agoNoZ(30_000, now), now), true);
+    assert.equal(isRecentInbound(agoNoZ(PENDING_INBOUND_MAX_AGE_MS - 1, now), now), true);
+  });
+
+  it("rejects an inbound older than the age cutoff (phantom 'just now' guard)", () => {
+    assert.equal(isRecentInbound(agoNoZ(PENDING_INBOUND_MAX_AGE_MS + 1, now), now), false);
+    assert.equal(isRecentInbound(agoNoZ(60 * 60_000, now), now), false);
+  });
+
+  it("normalizes DB timestamps that lack a Z suffix", () => {
+    // Same instant with and without Z must classify identically.
+    const withZ = new Date(now - 30_000).toISOString();
+    const withoutZ = withZ.replace("Z", "");
+    assert.equal(isRecentInbound(withZ, now), isRecentInbound(withoutZ, now));
+  });
+
+  it("rejects an unparseable timestamp", () => {
+    assert.equal(isRecentInbound("not-a-date", now), false);
+  });
+});
+
+describe("pruneExpiredInbounds", () => {
+  const now = Date.UTC(2026, 6, 9, 12, 0, 0);
+
+  it("keeps fresh inbounds and drops expired ones", () => {
+    const fresh = inbound(agoNoZ(60_000, now), 1);
+    const expired = inbound(agoNoZ(PENDING_INBOUND_EXPIRY_MS + 1, now), 2);
+    const result = pruneExpiredInbounds([fresh, expired], now);
+    assert.deepEqual(
+      result.map((e) => e.id),
+      [1],
+    );
+  });
+
+  it("returns everything when nothing has expired", () => {
+    const items = [inbound(agoNoZ(1000, now), 1), inbound(agoNoZ(2000, now), 2)];
+    assert.equal(pruneExpiredInbounds(items, now).length, 2);
+  });
+
+  it("keeps un-parseable timestamps rather than silently dropping them", () => {
+    const bad = inbound("garbage", 9);
+    assert.equal(pruneExpiredInbounds([bad], now).length, 1);
+  });
+});
+
+describe("isTurnStale", () => {
+  const now = Date.UTC(2026, 6, 9, 12, 0, 0);
+
+  it("is false for a turn that emitted recently", () => {
+    assert.equal(isTurnStale(now - 60_000, now), false);
+    assert.equal(isTurnStale(now - (STALE_TURN_IDLE_MS - 1), now), false);
+  });
+
+  it("is true once idle beyond the wedged-turn threshold", () => {
+    assert.equal(isTurnStale(now - STALE_TURN_IDLE_MS, now), true);
+    assert.equal(isTurnStale(now - (STALE_TURN_IDLE_MS + 60_000), now), true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three liveness defects in `TurnTimeline.svelte`'s SSE-driven live view:

1. **Reconnect + resync.** `EventSource` now reconnects with backoff (1s→2s→5s→10s) on a permanent `CLOSED` and resyncs (refetch page 1, upsert turns, re-backfill/drop streaming state) so events missed while offline are recovered. A "reconnecting…" indicator shows in the status footer.
2. **Bounded provisional inbounds.** Provisional inbounds are age-bounded (~2min cutoff on load, ~3min expiry via a 30s sweep) and use real relative-time labels instead of a hardcoded "just now", killing phantom perpetually-active turns for messages a stopped/sleeping mind never processed.
3. **Staleness guard.** Active turns idle past the server's 15min wedged-turn threshold are refetched and rendered complete if the server agrees.

Policy is extracted into a pure `packages/web/src/ui/lib/timeline-liveness.ts` module with unit tests in `test/timeline-liveness.test.ts`.

## Review triage

Three reviewer findings; all genuine and addressed:

- **Wedged-turn fallback timestamp not normalized** (findings 1 & 3, same bug). The active-turn staleness sweep computed its fallback "last seen" time with raw `new Date(turn.created_at)`, bypassing `normalizeTimestamp`. DB turn rows store `created_at` as UTC without a `Z`, so this parsed in the browser's local zone — flagging fresh turns stale (UTC+) or never firing the guard (UTC-). Fixed by extracting a `turnLastSeenMs` helper into `timeline-liveness.ts` (now covered by a Z/no-Z parity unit test) and using it in the sweep.
- **resync() race re-adds streaming state to a completed turn** (finding 2). `resync()`'s active-turn refetch set `streamingEvents` without the completion guard the backfill/`turn_created` paths use, so a `summary` landing mid-fetch could delete the turn's streaming state and then have resync resurrect it — a phantom active turn until reload. Fixed by setting a synchronous placeholder and re-checking `streamingEvents.has(turnId)` before writing, mirroring the backfill pattern.

No findings were skipped.

## Testing

- `npm test` — full suite: 1936 pass, 0 fail.
- svelte-check: 0 errors (2 pre-existing warnings in `SummaryNode.svelte` / `AdminModal.svelte`, unrelated to this diff).
- Added `turnLastSeenMs` unit tests asserting Z/no-Z parity and that a freshly-created turn is not classified stale.

Fixes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)