### PR TITLE
fix: reap live SDK sessions on mind shutdown to stop <defunct> zombies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,8 +452,10 @@ The daemon is a single privileged process (root on `--system`/Docker) that expos
 
 ```sh
 docker build -t volute .
-docker run -d -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
+docker run -d --init -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
 ```
+
+`--init` runs tini as PID 1 so orphaned mind grandchildren get reaped instead of accumulating as `<defunct>` zombies (the daemon is PID 1 otherwise and does not reap reparented orphans). The compose file sets `init: true` for the same reason.
 
 Or with docker-compose: `docker compose up -d`. The container runs with `VOLUTE_ISOLATION=user` enabled, so each mind gets its own Linux user inside the container.
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Set the model via `home/.config/config.json` (SDK config) or `home/.config/volut
 
 ```sh
 docker build -t volute .
-docker run -d -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
+docker run -d --init -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
 ```
 
 Or with docker-compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   volute:
     build: .
+    # Run an init (tini) as PID 1 so orphaned mind grandchildren (e.g. a claude
+    # SDK subprocess whose mind server was killed) get reaped instead of piling
+    # up as <defunct> zombies under the daemon. Defense-in-depth for minds still
+    # running an older template whose server doesn't reap on shutdown.
+    init: true
     ports:
       - "1618:1618"
     environment:

--- a/templates/_base/src/lib/startup.ts
+++ b/templates/_base/src/lib/startup.ts
@@ -198,7 +198,11 @@ export async function runShutdown(
   });
   try {
     await Promise.race([
-      onShutdown().catch((err) => log("server", "shutdown teardown failed:", err)),
+      // Normalize a synchronous throw into the logged/swallowed path so it can't
+      // escape runShutdown and prevent the caller's process.exit.
+      Promise.resolve()
+        .then(() => onShutdown())
+        .catch((err) => log("server", "shutdown teardown failed:", err)),
       timeout,
     ]);
   } finally {

--- a/templates/_base/src/lib/startup.ts
+++ b/templates/_base/src/lib/startup.ts
@@ -179,9 +179,46 @@ export function loadPrompts(): MindPrompts {
   }
 }
 
-export function setupShutdown(): void {
-  function shutdown() {
+/**
+ * Run the optional teardown before exit, bounded by a timeout so a wedged child
+ * (e.g. an SDK subprocess that won't exit) can't block shutdown forever. Teardown
+ * errors are logged, never thrown, so a failing hook still lets the process exit.
+ */
+export async function runShutdown(
+  onShutdown: (() => Promise<void>) | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  if (!onShutdown) return;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      log("server", `shutdown teardown timed out after ${timeoutMs}ms — exiting anyway`);
+      resolve();
+    }, timeoutMs);
+  });
+  try {
+    await Promise.race([
+      onShutdown().catch((err) => log("server", "shutdown teardown failed:", err)),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Wire SIGINT/SIGTERM to a graceful shutdown. Without `onShutdown` this exits
+ * immediately (as before); pass a teardown to reap live SDK subprocesses before
+ * exit so they aren't orphaned to PID 1 as `<defunct>` zombies. The handler is
+ * idempotent so a second signal during teardown doesn't double-run it.
+ */
+export function setupShutdown(onShutdown?: () => Promise<void>, timeoutMs = 10_000): void {
+  let shuttingDown = false;
+  async function shutdown() {
+    if (shuttingDown) return;
+    shuttingDown = true;
     log("server", "shutdown signal received");
+    await runShutdown(onShutdown, timeoutMs);
     process.exit(0);
   }
   process.on("SIGINT", shutdown);

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -22,7 +22,11 @@ import { createPreCompactHook } from "./lib/hooks/pre-compact.js";
 import { createReplyInstructionsHook } from "./lib/hooks/reply-instructions.js";
 import { log } from "./lib/logger.js";
 import { createMessageChannel } from "./lib/message-channel.js";
-import { isSessionReapable, reapSessionQuery } from "./lib/session-reaper.js";
+import {
+  isSessionReapable,
+  reapSessionQuery,
+  reapSessionsForShutdown,
+} from "./lib/session-reaper.js";
 import { createSessionStore } from "./lib/session-store.js";
 import { loadPrompts, type SubagentConfig } from "./lib/startup.js";
 import { consumeStream } from "./lib/stream-consumer.js";
@@ -69,6 +73,7 @@ export function createMind(options: {
   waitForCommits: () => Promise<void>;
   getContextInfo: () => Promise<ContextInfo>;
   getContextMessages: () => Promise<ContextMessages>;
+  reapAllSessions: () => Promise<void>;
 } {
   const autoCommit = createAutoCommitHook(options.cwd);
   const identityReload = createIdentityReloadHook(options.cwd);
@@ -569,6 +574,21 @@ export function createMind(options: {
     }
   }
 
+  /**
+   * Reap every live session's SDK subprocess on shutdown so `mind stop`/restart
+   * don't orphan `<defunct>` claude children to PID 1. Delegates the teardown to
+   * reapSessionsForShutdown; bounded externally by setupShutdown's timeout.
+   */
+  async function reapAllSessions(): Promise<void> {
+    const live = [...sessions.values()];
+    if (live.length === 0) return;
+    log("mind", `shutdown: reaping ${live.length} live SDK subprocess(es)`);
+    for (const s of live) sessions.delete(s.name);
+    await reapSessionsForShutdown(live, (name, err) =>
+      log("mind", `session "${name}": shutdown reap failed:`, err),
+    );
+  }
+
   if (idleTimeoutMs > 0) {
     log("mind", `idle session reaper: ${idleTimeoutMs / 60_000} min timeout`);
     const checkMs = Math.min(60_000, idleTimeoutMs);
@@ -746,5 +766,11 @@ export function createMind(options: {
   // instead of waiting for the first message (which adds minutes of latency).
   getOrCreateSession("main");
 
-  return { resolve, waitForCommits: autoCommit.waitForCommits, getContextInfo, getContextMessages };
+  return {
+    resolve,
+    waitForCommits: autoCommit.waitForCommits,
+    getContextInfo,
+    getContextMessages,
+    reapAllSessions,
+  };
 }

--- a/templates/claude/src/lib/session-reaper.ts
+++ b/templates/claude/src/lib/session-reaper.ts
@@ -66,3 +66,35 @@ export async function reapSessionQuery(
     onError(err);
   }
 }
+
+/** Minimal view of a live session needed to tear it down on shutdown. */
+export interface ShutdownReapable {
+  name: string;
+  /** Input iterable — closing it unwinds the stream consumer. */
+  channel: { close(): void };
+  /** The session's live SDK query, if it has one. */
+  currentQuery?: ReapableQuery;
+}
+
+/**
+ * Reap every live session's SDK subprocess on shutdown (SIGTERM/SIGINT).
+ *
+ * Unlike the idle reaper this ignores idle/reapable state — on the way out we
+ * want *all* children gone. For each session it closes the input channel so the
+ * stream consumer unwinds, then awaits `query.return()` so the CLI subprocess
+ * exits and its status is reaped, rather than being orphaned to PID 1 (the
+ * daemon, which doesn't reap reparented children) as a `<defunct>` zombie.
+ * Reaps run in parallel; a per-session failure is reported via `onError` and
+ * never rejects the batch, so one wedged child can't block the others.
+ */
+export async function reapSessionsForShutdown(
+  sessions: Iterable<ShutdownReapable>,
+  onError: (name: string, err: unknown) => void,
+): Promise<void> {
+  await Promise.all(
+    [...sessions].map(async (s) => {
+      s.channel.close();
+      await reapSessionQuery(s.currentQuery, (err) => onError(s.name, err));
+    }),
+  );
+}

--- a/templates/claude/src/server.ts
+++ b/templates/claude/src/server.ts
@@ -66,4 +66,10 @@ server.listen(port, () => {
 // Reap live SDK subprocesses on SIGTERM/SIGINT so `mind stop`/restart don't
 // orphan `<defunct>` claude children to PID 1 (the daemon, which isn't a
 // reaping init). Bounded so a wedged child can't block shutdown forever.
-setupShutdown(mind.reapAllSessions);
+// Stop accepting new messages first so a late request can't spawn a fresh
+// subprocess after reapAllSessions has snapshotted the live set (which would
+// re-orphan the very child we're reaping).
+setupShutdown(async () => {
+  server.close();
+  await mind.reapAllSessions();
+});

--- a/templates/claude/src/server.ts
+++ b/templates/claude/src/server.ts
@@ -63,4 +63,7 @@ server.listen(port, () => {
   log("server", `listening on :${actualPort}`);
 });
 
-setupShutdown();
+// Reap live SDK subprocesses on SIGTERM/SIGINT so `mind stop`/restart don't
+// orphan `<defunct>` claude children to PID 1 (the daemon, which isn't a
+// reaping init). Bounded so a wedged child can't block shutdown forever.
+setupShutdown(mind.reapAllSessions);

--- a/test/session-reaper.test.ts
+++ b/test/session-reaper.test.ts
@@ -5,6 +5,8 @@ import {
   type ReapableQuery,
   type ReapableSession,
   reapSessionQuery,
+  reapSessionsForShutdown,
+  type ShutdownReapable,
 } from "../templates/claude/src/lib/session-reaper.js";
 
 const TIMEOUT = 30 * 60_000; // 30 min
@@ -114,5 +116,84 @@ describe("reapSessionQuery", () => {
       },
     );
     assert.equal(captured, boom);
+  });
+});
+
+describe("reapSessionsForShutdown", () => {
+  function fakeSession(name: string): ShutdownReapable & {
+    closed: boolean;
+    returned: boolean;
+  } {
+    const s = {
+      name,
+      closed: false,
+      returned: false,
+      channel: {
+        close() {
+          s.closed = true;
+        },
+      },
+      currentQuery: {
+        return() {
+          s.returned = true;
+          return Promise.resolve();
+        },
+      } as ReapableQuery,
+    };
+    return s;
+  }
+
+  it("closes and reaps every live session (not just idle ones)", async () => {
+    const a = fakeSession("main");
+    const b = fakeSession("side");
+    await reapSessionsForShutdown([a, b], () => {});
+    assert.equal(a.closed, true);
+    assert.equal(a.returned, true);
+    assert.equal(b.closed, true);
+    assert.equal(b.returned, true);
+  });
+
+  it("still closes a session that has no live query", async () => {
+    const s: ShutdownReapable & { closed: boolean } = {
+      name: "main",
+      closed: false,
+      channel: {
+        close() {
+          s.closed = true;
+        },
+      },
+      currentQuery: undefined,
+    };
+    await reapSessionsForShutdown([s], () => {});
+    assert.equal(s.closed, true);
+  });
+
+  it("one wedged/failed reap doesn't block the others; errors go to onError", async () => {
+    const boom = new Error("stuck child");
+    const good = fakeSession("good");
+    const bad: ShutdownReapable & { closed: boolean } = {
+      name: "bad",
+      closed: false,
+      channel: {
+        close() {
+          bad.closed = true;
+        },
+      },
+      currentQuery: {
+        return() {
+          return Promise.reject(boom);
+        },
+      } as ReapableQuery,
+    };
+    const errors: [string, unknown][] = [];
+    await reapSessionsForShutdown([bad, good], (name, err) => errors.push([name, err]));
+    // The good session was reaped despite the bad one failing.
+    assert.equal(good.returned, true);
+    assert.equal(bad.closed, true);
+    assert.deepEqual(errors, [["bad", boom]]);
+  });
+
+  it("no-ops on an empty session set", async () => {
+    await assert.doesNotReject(() => reapSessionsForShutdown([], () => {}));
   });
 });

--- a/test/shutdown-reap.test.ts
+++ b/test/shutdown-reap.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { runShutdown } from "../templates/_base/src/lib/startup.js";
+
+describe("runShutdown", () => {
+  it("awaits the teardown before resolving", async () => {
+    let torn = false;
+    let release: () => void = () => {};
+    const teardown = () =>
+      new Promise<void>((resolve) => {
+        release = () => {
+          torn = true;
+          resolve();
+        };
+      });
+
+    let done = false;
+    const p = runShutdown(teardown, 10_000).then(() => {
+      done = true;
+    });
+
+    await Promise.resolve();
+    assert.equal(done, false, "must not resolve while teardown is pending");
+    assert.equal(torn, false);
+
+    release();
+    await p;
+    assert.equal(torn, true);
+    assert.equal(done, true);
+  });
+
+  it("resolves via timeout when the teardown wedges (bounded shutdown)", async () => {
+    // A teardown that never resolves — runShutdown must still return via timeout.
+    const teardown = () => new Promise<void>(() => {});
+    const start = Date.now();
+    await runShutdown(teardown, 20);
+    assert.ok(Date.now() - start >= 20, "should wait at least the timeout");
+  });
+
+  it("swallows teardown errors so the process can still exit", async () => {
+    const teardown = () => Promise.reject(new Error("boom"));
+    await assert.doesNotReject(() => runShutdown(teardown, 10_000));
+  });
+
+  it("no-ops when no teardown is provided", async () => {
+    await assert.doesNotReject(() => runShutdown(undefined, 10_000));
+  });
+});

--- a/test/shutdown-signal.test.ts
+++ b/test/shutdown-signal.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Guards the exact regression from #533: the SIGTERM/SIGINT handler wired by
+// setupShutdown() must run the teardown BEFORE the process exits (the bug was a
+// handler that exited without reaping), and must run it only ONCE even if a
+// second signal arrives mid-teardown (the idempotency guard). The pure-logic
+// unit tests exercise runShutdown/reapSessionsForShutdown but cannot verify that
+// an actual OS signal invokes them — this does.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const startupPath = resolve(here, "../templates/_base/src/lib/startup.ts");
+
+const workDir = mkdtempSync(resolve(tmpdir(), "shutdown-signal-"));
+const fixturePath = resolve(workDir, "fixture.ts");
+
+// A minimal mind server: wire setupShutdown() with a teardown that records each
+// invocation to a marker file, then hold the event loop open (the signal
+// listeners keep it alive). TEARDOWN_DELAY lets a second signal land mid-run.
+writeFileSync(
+  fixturePath,
+  `import { appendFileSync } from "node:fs";
+import { setupShutdown } from ${JSON.stringify(startupPath)};
+
+const marker = process.env.MARKER_FILE;
+const delayMs = Number(process.env.TEARDOWN_DELAY ?? "0");
+
+setupShutdown(async () => {
+  appendFileSync(marker, "teardown-start\\n");
+  if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+  appendFileSync(marker, "teardown-done\\n");
+});
+
+process.stdout.write("READY\\n");
+`,
+);
+
+after(() => rmSync(workDir, { recursive: true, force: true }));
+
+type Run = { code: number | null; signal: NodeJS.Signals | null; marker: string };
+
+function runFixture(
+  markerFile: string,
+  onReady: (child: ReturnType<typeof spawn>) => void,
+  env: Record<string, string> = {},
+): Promise<Run> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", fixturePath], {
+      env: { ...process.env, MARKER_FILE: markerFile, ...env },
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    let readyFired = false;
+    let buf = "";
+    child.stdout.on("data", (d: Buffer) => {
+      buf += d.toString();
+      if (!readyFired && buf.includes("READY")) {
+        readyFired = true;
+        onReady(child);
+      }
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      let marker = "";
+      try {
+        marker = readFileSync(markerFile, "utf-8");
+      } catch {
+        marker = "";
+      }
+      resolvePromise({ code, signal, marker });
+    });
+  });
+}
+
+describe("setupShutdown signal wiring", () => {
+  it("runs the teardown before exiting on SIGTERM (exit 0)", async () => {
+    const markerFile = resolve(workDir, "marker-a");
+    const run = await runFixture(markerFile, (child) => child.kill("SIGTERM"));
+    assert.equal(run.code, 0, "should exit cleanly after teardown");
+    assert.ok(
+      run.marker.includes("teardown-done"),
+      `teardown must complete before exit; marker was: ${JSON.stringify(run.marker)}`,
+    );
+  });
+
+  it("runs the teardown exactly once when a second signal arrives mid-teardown", async () => {
+    const markerFile = resolve(workDir, "marker-b");
+    const run = await runFixture(
+      markerFile,
+      (child) => {
+        // Fire two signals in quick succession while the teardown is still in
+        // its delay window — the idempotency guard must ignore the second.
+        child.kill("SIGTERM");
+        child.kill("SIGINT");
+      },
+      { TEARDOWN_DELAY: "300" },
+    );
+    assert.equal(run.code, 0);
+    const starts = run.marker.split("\n").filter((l) => l === "teardown-start").length;
+    assert.equal(
+      starts,
+      1,
+      `teardown must run exactly once; marker was: ${JSON.stringify(run.marker)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `<defunct>` zombie accumulation from #533. When a mind server was stopped or restarted, its resident Claude SDK subprocess(es) were orphaned to PID 1 (the daemon, which isn't a reaping init — and in Docker the daemon *is* PID 1), piling up as zombies.

- Wired session teardown into the mind server's SIGTERM/SIGINT handler so active SDK subprocesses are reaped before exit. `setupShutdown()` now takes an optional bounded teardown (`runShutdown` with a 10s timeout so a wedged child can't block shutdown forever).
- The claude template exposes `mind.reapAllSessions()`, which reuses the idle reaper's graceful `query.return()` path via a new `reapSessionsForShutdown()` helper — closing each session's input channel, then awaiting the SDK's cleanup so the CLI subprocess actually exits and its status is reaped.
- Added Docker `init: true` / `--init` (tini as PID 1) as defense-in-depth, so orphaned grandchildren are reaped even for minds still running an older template copy, and for the pi/codex runtimes.

## Scope

- Only the claude template's server (the default, and the one that reproduced in #533) reaps on shutdown. The pi and codex templates use different runtimes and are left unchanged; the Docker `--init` defense covers orphan reaping for them and for older-template minds. If pi/codex are later confirmed to leak, they can wire the same `setupShutdown(callback)` hook.
- Bare-metal/systemd installs were already fine (systemd is a real reaping init); the zombie problem is Docker-specific because the daemon runs as PID 1 there. Both the per-process fix and `init: true` address it.

## Review triage

Applied:
- **Reap-window race (minor):** the HTTP server now closes before `reapAllSessions()` snapshots the live set, so a late `/message` can't spawn a fresh subprocess that escapes the reap and gets re-orphaned.
- **Sync-throw hardening (minor):** `runShutdown` normalizes a synchronous throw from `onShutdown` into its logged/swallowed path so it can't prevent `process.exit`.
- **Missing wiring test (important):** added `test/shutdown-signal.test.ts`, a subprocess test that a real SIGTERM/SIGINT runs the teardown *before* exit (exit 0) and runs it *exactly once* when a second signal lands mid-teardown (idempotency guard). This guards the exact #533 regression the pure-logic unit tests can't reach.

Skipped:
- **e2e orphan-child assertion (minor):** a daemon-e2e test asserting a stopped mind leaves no live child PID would be heavyweight and PID/timing-flaky under `--test-concurrency`. The new subprocess wiring test plus the `runShutdown` / `reapSessionsForShutdown` unit tests are an adequate guard.

## Tests

Full `npm test`: 1933 tests, 1933 pass, 0 fail (confirmed across multiple clean runs). Template typecheck (claude/pi/codex) passes. One intermittent `--test-force-exit` tail artifact in untouched web test files under `--test-concurrency=4` is a pre-existing concurrency flake (passes fail-0 on re-run) and is unrelated to this change.

Fixes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)