### PR TITLE
fix: ship sharp in dependencies so avatar downscaling works in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "isomorphic-dompurify": "^2.36.0",
         "libsql": "^0.5.29",
         "replicate": "^1.4.0",
+        "sharp": "^0.35.2",
         "telegraf": "^4.16.3",
         "undici": "^6.24.1",
         "zod": "^4.4.3"
@@ -46,7 +47,6 @@
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.9",
         "marked": "^18.0.5",
-        "sharp": "^0.35.2",
         "svelte": "^5.56.3",
         "svelte-check": "4.7.1",
         "tsup": "^8.5.1",
@@ -3578,7 +3578,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4541,7 +4540,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4551,7 +4549,6 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
       "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4574,7 +4571,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4591,7 +4587,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4608,7 +4603,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4625,7 +4619,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4648,7 +4641,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4671,7 +4663,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4691,7 +4682,6 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
       "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4711,7 +4701,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4731,7 +4720,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12721,7 +12709,6 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
       "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
@@ -12769,7 +12756,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -12792,7 +12778,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -12815,7 +12800,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12832,7 +12816,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12849,7 +12832,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12866,7 +12848,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12883,7 +12864,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12900,7 +12880,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12917,7 +12896,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -12934,7 +12912,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -12957,7 +12934,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -12980,7 +12956,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13003,7 +12978,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13026,7 +13000,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13049,7 +13022,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13069,7 +13041,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13086,7 +13057,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "isomorphic-dompurify": "^2.36.0",
     "libsql": "^0.5.29",
     "replicate": "^1.4.0",
+    "sharp": "^0.35.2",
     "telegraf": "^4.16.3",
     "undici": "^6.24.1",
     "zod": "^4.4.3"
@@ -94,7 +95,6 @@
     "drizzle-kit": "^0.31.10",
     "lefthook": "^2.1.9",
     "marked": "^18.0.5",
-    "sharp": "^0.35.2",
     "svelte": "^5.56.3",
     "svelte-check": "4.7.1",
     "tsup": "^8.5.1",

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -1,5 +1,5 @@
-import { readFile, realpath } from "node:fs/promises";
-import { extname, resolve } from "node:path";
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
 import { tryGetMindManager } from "../daemon/mind-manager.js";
@@ -10,6 +10,7 @@ import { onMindEvent } from "../events/mind-activity-tracker.js";
 import { findMind, getBaseName, mindDir, voluteHome } from "../mind/registry.js";
 import { readVoluteConfig } from "../mind/volute-config.js";
 import { deliveryQueue } from "../schema.js";
+import { type AvatarBlock, renderAvatarBlock } from "../util/avatar-image.js";
 import log from "../util/logger.js";
 import {
   type DeliveryPayload,
@@ -37,9 +38,6 @@ const REDRIVE_BATCH_LIMIT = 200;
 
 const mentionRegexCache = new Map<string, RegExp>();
 
-type AvatarBlock =
-  | { type: "text"; text: string }
-  | { type: "image"; media_type: string; data: string };
 type AvatarCacheEntry = { blocks: AvatarBlock[]; expiresAt: number };
 const avatarBlocksCache = new Map<string, AvatarCacheEntry>();
 const AVATAR_CACHE_TTL = 5 * 60 * 1000;
@@ -1070,19 +1068,6 @@ export class DeliveryManager {
 
     const blocks: AvatarBlock[] = [];
 
-    let sharpDefault: any = null;
-    try {
-      const mod = await import("sharp");
-      sharpDefault = mod.default ?? mod;
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
-        dlog.debug("sharp not available, sending full-size avatars");
-      } else {
-        dlog.warn("sharp import failed, sending full-size avatars", log.errorData(err));
-      }
-    }
-
     for (const p of participants) {
       if (!p.avatar) continue;
 
@@ -1115,33 +1100,8 @@ export class DeliveryManager {
           filePath = resolve(voluteHome(), "avatars", p.avatar);
         }
 
-        const ext = extname(filePath).toLowerCase();
-        const mimeMap: Record<string, string> = {
-          ".png": "image/png",
-          ".jpg": "image/jpeg",
-          ".jpeg": "image/jpeg",
-          ".gif": "image/gif",
-          ".webp": "image/webp",
-        };
-        const mediaType = mimeMap[ext];
-        if (!mediaType) continue;
-
-        const data = await readFile(filePath);
-        let imageData: Buffer = data;
-        if (sharpDefault) {
-          try {
-            imageData = await sharpDefault(data).resize(128, 128, { fit: "cover" }).toBuffer();
-          } catch (err) {
-            dlog.warn(
-              `avatar resize failed for ${p.username}, sending original`,
-              log.errorData(err),
-            );
-          }
-        }
-        blocks.push(
-          { type: "text", text: `[Avatar for ${p.username}]` },
-          { type: "image", media_type: mediaType, data: imageData.toString("base64") },
-        );
+        const rendered = await renderAvatarBlock(filePath, p.username);
+        if (rendered) blocks.push(...rendered);
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
         if (code !== "ENOENT") {

--- a/packages/daemon/src/lib/util/avatar-image.ts
+++ b/packages/daemon/src/lib/util/avatar-image.ts
@@ -32,24 +32,26 @@ const MIME_BY_EXT: Record<string, string> = {
   ".webp": "image/webp",
 };
 
-// Fire the "sharp missing" warning once per process rather than per avatar.
-let warnedSharpMissing = false;
+// Fire the "sharp unavailable" warning once per process rather than per avatar —
+// loadSharp() runs once per participant per delivery, so an unusable install
+// (missing package or broken native binary) would otherwise spam every message.
+let warnedSharpUnavailable = false;
 
 async function loadSharp(): Promise<any | null> {
   try {
     const mod = await import("sharp");
     return mod.default ?? mod;
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
-      if (!warnedSharpMissing) {
-        warnedSharpMissing = true;
+    if (!warnedSharpUnavailable) {
+      warnedSharpUnavailable = true;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
         alog.warn(
           "sharp is not installed — avatars will not be downscaled or inlined into mind context. Install the 'sharp' dependency to restore avatar image support.",
         );
+      } else {
+        alog.warn("sharp import failed, avatar image support disabled", log.errorData(err));
       }
-    } else {
-      alog.warn("sharp import failed, avatar image support disabled", log.errorData(err));
     }
     return null;
   }

--- a/packages/daemon/src/lib/util/avatar-image.ts
+++ b/packages/daemon/src/lib/util/avatar-image.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { extname, resolve } from "node:path";
 import { mindDir, readAllMinds, voluteHome } from "../mind/registry.js";
 import { readVoluteConfig } from "../mind/volute-config.js";
 import log from "./logger.js";
@@ -10,6 +10,31 @@ const alog = log.child("avatar-image");
 /** Max avatar dimension — covers the largest display size (96px) at retina density. */
 export const AVATAR_DIM = 256;
 
+/** Max avatar dimension for images inlined into a mind's context. */
+export const AVATAR_CONTEXT_DIM = 128;
+
+/**
+ * Hard ceiling on the base64 size of an avatar image block. A correctly resized
+ * 128×128 avatar is a few KB; anything above this means the resize regressed or
+ * was skipped, and we refuse to inline it into every participant mind's context.
+ */
+export const MAX_AVATAR_BLOCK_BYTES = 64 * 1024;
+
+export type AvatarBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; media_type: string; data: string };
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+// Fire the "sharp missing" warning once per process rather than per avatar.
+let warnedSharpMissing = false;
+
 async function loadSharp(): Promise<any | null> {
   try {
     const mod = await import("sharp");
@@ -17,9 +42,14 @@ async function loadSharp(): Promise<any | null> {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
-      alog.debug("sharp not available, keeping original avatars");
+      if (!warnedSharpMissing) {
+        warnedSharpMissing = true;
+        alog.warn(
+          "sharp is not installed — avatars will not be downscaled or inlined into mind context. Install the 'sharp' dependency to restore avatar image support.",
+        );
+      }
     } else {
-      alog.warn("sharp import failed, keeping original avatars", log.errorData(err));
+      alog.warn("sharp import failed, avatar image support disabled", log.errorData(err));
     }
     return null;
   }
@@ -104,4 +134,50 @@ export async function migrateAvatarSizes(): Promise<void> {
       }
     }
   }
+}
+
+/**
+ * Read an avatar file and render it as a `[text, image]` block pair for inlining
+ * into a mind's context, resized to AVATAR_CONTEXT_DIM.
+ *
+ * Returns null (omitting the avatar entirely) when the format is unsupported,
+ * sharp is unavailable, or the resized block would still exceed
+ * MAX_AVATAR_BLOCK_BYTES. Inlining an unbounded image into every participant's
+ * context is strictly worse than showing no avatar, so we drop the pair rather
+ * than fall back to the original bytes. File-read errors propagate to the caller.
+ */
+export async function renderAvatarBlock(
+  filePath: string,
+  label: string,
+): Promise<AvatarBlock[] | null> {
+  const ext = extname(filePath).toLowerCase();
+  const mediaType = MIME_BY_EXT[ext];
+  if (!mediaType) return null;
+
+  const sharp = await loadSharp();
+  if (!sharp) return null;
+
+  const data = await readFile(filePath);
+  let imageData: Buffer;
+  try {
+    imageData = await sharp(data, { animated: true })
+      .resize(AVATAR_CONTEXT_DIM, AVATAR_CONTEXT_DIM, { fit: "cover" })
+      .toBuffer();
+  } catch (err) {
+    alog.warn(`avatar resize failed for ${label}, omitting image`, log.errorData(err));
+    return null;
+  }
+
+  const base64 = imageData.toString("base64");
+  if (base64.length > MAX_AVATAR_BLOCK_BYTES) {
+    alog.warn(
+      `avatar for ${label} is ${base64.length} bytes after resize (> ${MAX_AVATAR_BLOCK_BYTES}), omitting image`,
+    );
+    return null;
+  }
+
+  return [
+    { type: "text", text: `[Avatar for ${label}]` },
+    { type: "image", media_type: mediaType, data: base64 },
+  ];
 }

--- a/test/avatar-image.test.ts
+++ b/test/avatar-image.test.ts
@@ -1,13 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdirSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import sharp from "sharp";
 import { voluteHome } from "../packages/daemon/src/lib/mind/registry.js";
 import {
+  AVATAR_CONTEXT_DIM,
   AVATAR_DIM,
+  MAX_AVATAR_BLOCK_BYTES,
   migrateAvatarSizes,
   normalizeAvatar,
+  renderAvatarBlock,
 } from "../packages/daemon/src/lib/util/avatar-image.js";
 import { fileEtag, isNotModified } from "../packages/daemon/src/lib/util/http-cache.js";
 
@@ -45,6 +49,52 @@ describe("normalizeAvatar", () => {
   it("returns null for non-image input", async () => {
     const result = await normalizeAvatar(Buffer.from("not an image"));
     assert.equal(result, null);
+  });
+});
+
+describe("renderAvatarBlock", () => {
+  it("resizes an oversized avatar to AVATAR_CONTEXT_DIM and stays under the block ceiling", async () => {
+    const dir = resolve(voluteHome(), "render-avatars");
+    mkdirSync(dir, { recursive: true });
+    const path = resolve(dir, "render-big.png");
+    writeFileSync(path, await makePng(1024));
+
+    const blocks = await renderAvatarBlock(path, "someone");
+    assert.ok(blocks);
+    assert.equal(blocks.length, 2);
+    assert.deepEqual(blocks[0], { type: "text", text: "[Avatar for someone]" });
+
+    const image = blocks[1];
+    assert.ok(image.type === "image");
+    assert.equal(image.media_type, "image/png");
+    assert.ok(image.data.length <= MAX_AVATAR_BLOCK_BYTES);
+
+    const meta = await sharp(Buffer.from(image.data, "base64")).metadata();
+    assert.equal(meta.width, AVATAR_CONTEXT_DIM);
+    assert.equal(meta.height, AVATAR_CONTEXT_DIM);
+  });
+
+  it("returns null for an unsupported file extension", async () => {
+    const dir = resolve(voluteHome(), "render-avatars");
+    mkdirSync(dir, { recursive: true });
+    const path = resolve(dir, "render-note.txt");
+    writeFileSync(path, "not an image");
+    assert.equal(await renderAvatarBlock(path, "someone"), null);
+  });
+});
+
+describe("sharp packaging", () => {
+  // This class of bug — an optional dep present in dev but absent in prod with a
+  // silent fallback — is invisible to every other test. sharp must ship with the
+  // published package (dependencies), not only on dev machines (devDependencies).
+  it("declares sharp as a runtime dependency, not a devDependency", () => {
+    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    assert.ok(pkg.dependencies?.sharp, "sharp must be listed in dependencies");
+    assert.ok(
+      !pkg.devDependencies?.sharp,
+      "sharp must not be in devDependencies (it no-ops silently in production)",
+    );
   });
 });
 

--- a/test/avatar-image.test.ts
+++ b/test/avatar-image.test.ts
@@ -81,6 +81,18 @@ describe("renderAvatarBlock", () => {
     writeFileSync(path, "not an image");
     assert.equal(await renderAvatarBlock(path, "someone"), null);
   });
+
+  it("returns null (omits the image) when a supported-extension file is not a real image", async () => {
+    // The regression this fix guards against: on processing failure the old code
+    // inlined the original bytes into every mind's context. renderAvatarBlock must
+    // drop the block instead. A supported extension gets past the MIME check and
+    // into sharp, which throws on the garbage bytes.
+    const dir = resolve(voluteHome(), "render-avatars");
+    mkdirSync(dir, { recursive: true });
+    const path = resolve(dir, "render-corrupt.png");
+    writeFileSync(path, "this is not a png");
+    assert.equal(await renderAvatarBlock(path, "someone"), null);
+  });
 });
 
 describe("sharp packaging", () => {


### PR DESCRIPTION
## Problem

`sharp` was listed in `devDependencies`, so it was absent from production installs of the published package. The avatar code that inlines participant images into every mind's context did `import("sharp")`, caught the `MODULE_NOT_FOUND`, and silently fell back to inlining the **full-size original bytes** — potentially megabytes of base64 — into every mind's context on every message. This class of bug (an optional dep present in dev but absent in prod, behind a silent fallback) is invisible to every other test.

## Changes

- Move `sharp` from `devDependencies` to `dependencies` (root `package.json` + refreshed `package-lock.json`) so downscaling actually runs in production.
- Refactor the two duplicate `import("sharp")` avatar loaders into a single exported `renderAvatarBlock()` in `packages/daemon/src/lib/util/avatar-image.ts`. It resizes to `AVATAR_CONTEXT_DIM` (128) and returns `null` — **omitting the avatar entirely** — when sharp is unavailable, the format is unsupported, resizing fails, or the encoded block exceeds a 64 KB ceiling (`MAX_AVATAR_BLOCK_BYTES`), rather than inlining full-size originals.
- `delivery-manager.ts` `loadAvatarBlocks()` now calls `renderAvatarBlock()` while keeping its own path-escape / symlink checks and cache.
- `loadSharp()` warns **once per process** (was debug) when sharp is unavailable.
- Tests: `renderAvatarBlock` unit tests, plus a repo-guard asserting sharp is a `dependency`, not a `devDependency`.

## Review triage

Three reviewers surfaced four findings; triage:

- **Once-per-process warning only covered the missing-module branch** (minor) — **fixed**. `loadSharp()`'s guard now covers the broken-native-binary branch too (a real risk now that sharp ships platform-specific prebuilds), so an unusable install warns once instead of once per participant per delivery.
- **Omit-on-failure path untested** (important) — **addressed**. Added a `renderAvatarBlock` test: a supported-extension file (`.png`) holding non-image bytes returns `null` (omits the block) instead of inlining the original. This exercises the exact regression contract — on processing failure, drop rather than inline full-size — for the realistic failure mode. The literal sharp-completely-absent branch is left to structural review (a trivial `return null` in `loadSharp`) plus the packaging guard test, rather than adding a test-only injection seam to production code.
- **`MAX_AVATAR_BLOCK_BYTES` ceiling drop-path untested** (minor) — **skipped**. Verified empirically that a 128×128 output is inherently a few KB; even a 200-frame noise GIF resizes to ~30 KB (sharp collapses to a single page on resize here), so the ceiling cannot be tripped by any realistic avatar. It is defense-in-depth; a deterministic fixture that trips it would be disproportionately contrived. Existing test still asserts a resized block stays under the ceiling.
- **Resize-throws catch untested** (minor) — **addressed** by the same non-image-bytes test above (a `.png` extension passes the MIME check and reaches sharp, which throws).

## Testing

Full `npm test` passes: **1927 tests, 1927 pass, 0 fail**. Targeted `test/avatar-image.test.ts` passes (10/10) including the new omit-on-failure case.

Fixes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)
