### PR TITLE
test: stop leaking test homes, add sleep-flush e2e, and fix drizzle config

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,14 @@
-import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { defineConfig } from "drizzle-kit";
 
+// The schema moved to packages/daemon during the monorepo split. Point migrations at
+// a scratch DB under ./drizzle (env-overridable) rather than the live ~/.volute DB so
+// `npm run db:generate`/`migrate` can never touch a running install's data.
 export default defineConfig({
   out: "./drizzle",
-  schema: "./src/lib/schema.ts",
+  schema: "./packages/daemon/src/lib/schema.ts",
   dialect: "sqlite",
-  dbCredentials: { url: `file:${resolve(homedir(), ".volute", "system", "volute.db")}` },
+  dbCredentials: {
+    url: `file:${process.env.VOLUTE_DRIZZLE_DB ?? resolve(process.cwd(), "drizzle", "dev.db")}`,
+  },
 });

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -3,7 +3,7 @@ import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   approveUser,
   createUser,
@@ -1711,6 +1711,168 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       if (!delivered) await new Promise((r) => setTimeout(r, 500));
     }
     assert.ok(delivered, "inbound message should be recorded in mind_history after delivery");
+
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+  });
+
+  // Regression guard for the batched queued-flush contract (#382, PR #530): a sleeping
+  // mind's backlog is queued per channel, and the wake flush delivers each channel group
+  // as one batched turn — all-or-nothing per group, so a failed delivery keeps the group
+  // queued rather than dropping it. This drives the real cross-process path (chat API →
+  // fan-out → sleep queue → flush → deliverBatch → mind's /message).
+  //
+  // The mind is slept from a stopped state (no pre-sleep ritual) and the flush is invoked
+  // directly, because CI runs without a model API key: the mind process exits the moment a
+  // real turn starts, so the pre-sleep/wake-summary turns can't be relied on here. The
+  // "exactly one dispatchBatch per channel" cardinality and per-channel failure isolation
+  // (one group fails while another flushes) are covered by the in-process unit tests
+  // (message-delivery / sleep-manager), which can observe them without a live model.
+  it("sleep→queue→flush: queues per channel, flush drains it, failed delivery keeps it queued", {
+    timeout: 120000,
+  }, async () => {
+    await ensureTestMind();
+
+    /** All still-queued sleep rows for the test mind. */
+    async function queuedRows(): Promise<{ channel: string | null }[]> {
+      const db = await getDb();
+      return db
+        .select({ channel: deliveryQueue.channel })
+        .from(deliveryQueue)
+        .where(and(eq(deliveryQueue.mind, TEST_MIND), eq(deliveryQueue.status, "sleep-queued")))
+        .all();
+    }
+
+    async function waitForStatus(target: string, timeoutMs = 30000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const s = (await (await daemonRequest(`/api/minds/${TEST_MIND}`)).json()) as {
+          status: string;
+        };
+        if (s.status === target) return;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      throw new Error(`mind did not reach status ${target}`);
+    }
+
+    async function waitForSleeping(timeoutMs = 15000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+        if (((await res.json()) as { sleeping: boolean }).sleeping) return;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      throw new Error("mind did not reach sleeping state");
+    }
+
+    async function waitForQueuedCount(count: number, timeoutMs = 30000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if ((await queuedRows()).length >= count) return;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      throw new Error(`expected ${count} queued rows within ${timeoutMs}ms`);
+    }
+
+    async function flush(): Promise<number> {
+      const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep/messages`, { method: "POST" });
+      assert.equal(res.status, 200, `flush: ${await res.clone().text()}`);
+      return ((await res.json()) as { flushed: number }).flushed;
+    }
+
+    // Sleep from a stopped state so no model turn runs.
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await waitForStatus("stopped");
+    const sleepRes = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`, { method: "POST" });
+    assert.equal(sleepRes.status, 200, `sleep: ${await sleepRes.clone().text()}`);
+    await waitForSleeping();
+
+    // Two channels the mind belongs to. Channel (non-DM) messages don't match the default
+    // wake triggers, so they queue rather than trigger-waking the mind.
+    const suffix = Date.now();
+    const chans: Record<string, string> = {};
+    for (const label of ["a", "b"]) {
+      const name = `sleep-flush-${label}-${suffix}`;
+      const createRes = await daemonRequest("/api/v1/channels", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      assert.equal(createRes.status, 201, `create ${name}: ${await createRes.clone().text()}`);
+      chans[label] = ((await createRes.json()) as { id: string }).id;
+      const inviteRes = await daemonRequest(`/api/v1/channels/${name}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: TEST_MIND }),
+      });
+      assert.equal(inviteRes.status, 200, `invite ${name}: ${await inviteRes.clone().text()}`);
+    }
+    const sender = await ensureBrainParticipant(`flush-${suffix}`);
+
+    async function sendToChannel(convId: string, text: string): Promise<void> {
+      const res = await daemonRequest("/api/v1/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ conversationId: convId, message: text, sender }),
+      });
+      assert.equal(res.status, 200, `send: ${await res.clone().text()}`);
+    }
+
+    // While asleep: two messages on channel A, one on channel B.
+    await sendToChannel(chans.a, "first while you slept");
+    await sendToChannel(chans.a, "second while you slept");
+    await sendToChannel(chans.b, "a note on the other channel");
+    await waitForQueuedCount(3);
+
+    // The backlog is queued across exactly two distinct channels (2 + 1), and the sleep
+    // state counts it — the mind was never invoked during sleep.
+    const queued = await queuedRows();
+    assert.equal(queued.length, 3, "all three messages queued");
+    const byChannel = new Map<string, number>();
+    for (const row of queued)
+      byChannel.set(row.channel ?? "?", (byChannel.get(row.channel ?? "?") ?? 0) + 1);
+    assert.equal(byChannel.size, 2, `expected 2 distinct channels, got ${[...byChannel.keys()]}`);
+    assert.deepEqual([...byChannel.values()].sort(), [1, 2], "channels grouped 2 and 1");
+    // The channel that holds two messages — it must flush as one atomic group, below.
+    const twoMsgChannel = [...byChannel.entries()].find(([, n]) => n === 2)?.[0];
+    assert.ok(twoMsgChannel, "one channel should hold both of its messages");
+
+    const sleepState = (await (await daemonRequest(`/api/minds/${TEST_MIND}/sleep`)).json()) as {
+      queuedMessageCount: number;
+    };
+    assert.equal(sleepState.queuedMessageCount, 3, "sleep state counts the queued backlog");
+
+    // Flush while the mind is DOWN: deliverBatch can't reach it, so every group fails and
+    // its rows stay queued. The #382 contract is all-or-nothing per group — a failed flush
+    // never drops the backlog.
+    assert.equal(await flush(), 0, "nothing flushes to a down mind");
+    assert.equal((await queuedRows()).length, 3, "a failed flush leaves the backlog queued");
+
+    // Bring the mind's process up and flush again. The two-message channel is delivered
+    // first, to a freshly-live mind, so its group flushes as ONE atomic batch (2 messages,
+    // not 2 turns) and its rows are deleted together. (The keyless CI mind exits once that
+    // batch's turn starts, so a later channel's group may not reach it — which itself shows
+    // the per-group isolation: a group that can't be delivered stays queued. Its status also
+    // reads "sleeping" not "running", so wait on the port instead of status.)
+    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    assert.ok(
+      startRes.status === 200 || startRes.status === 409,
+      `start: ${startRes.status} ${await startRes.clone().text()}`,
+    );
+    const entry = await findMind(TEST_MIND);
+    assert.ok(entry, "test mind must be registered");
+    await waitForListeningPid(entry.port, 30000);
+
+    const flushed = await flush();
+    assert.ok(flushed >= 2, `the two-message group must flush atomically; flushed ${flushed}`);
+    const remaining = await queuedRows();
+    assert.ok(
+      !remaining.some((r) => r.channel === twoMsgChannel),
+      "the delivered channel's whole group was removed",
+    );
+    assert.ok(
+      remaining.length <= 1,
+      `at most the other channel's message remains: ${remaining.length}`,
+    );
 
     await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });

--- a/test/drizzle-config.test.ts
+++ b/test/drizzle-config.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import config from "../drizzle.config.js";
+
+// Guards the two stale-path bugs from #335 item 5: after the monorepo split the schema
+// path and the live-DB credentials in drizzle.config.ts silently rotted, leaving
+// `npm run db:generate` broken and (if it ran) pointed at the real ~/.volute database.
+describe("drizzle.config", () => {
+  it("points schema at the real (post-monorepo) schema file", () => {
+    const schema = config.schema as string;
+    assert.ok(schema, "schema path must be set");
+    assert.ok(existsSync(resolve(process.cwd(), schema)), `schema path does not exist: ${schema}`);
+  });
+
+  it("never targets the live ~/.volute database", () => {
+    const url = (config.dbCredentials as { url: string }).url;
+    const liveDb = resolve(homedir(), ".volute");
+    assert.ok(!url.includes(liveDb), `db url must not point at the live install: ${url}`);
+    assert.ok(url.includes("drizzle"), `db url should live under ./drizzle: ${url}`);
+  });
+});

--- a/test/helpers/test-home.ts
+++ b/test/helpers/test-home.ts
@@ -1,0 +1,40 @@
+import { readdirSync, rmSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** Prefix every per-run test home dir shares (see test/setup.ts). */
+export const TEST_HOME_PREFIX = "volute-test-";
+
+/**
+ * Remove leaked `volute-test-*` dirs left behind by prior runs that never ran their
+ * exit cleanup (a SIGKILL, an OOM, a crash). Only dirs older than `maxAgeMs` are
+ * swept so a concurrently-running sibling test process — whose freshly-created dir
+ * is younger than the threshold — is never touched.
+ *
+ * Best-effort: races (another process removing the same dir) and stat failures are
+ * swallowed. Returns the dirs actually removed, for tests.
+ */
+export function sweepStaleTestHomes(
+  root: string,
+  maxAgeMs: number,
+  now: number = Date.now(),
+): string[] {
+  const removed: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return removed;
+  }
+  for (const name of entries) {
+    if (!name.startsWith(TEST_HOME_PREFIX)) continue;
+    const full = resolve(root, name);
+    try {
+      if (now - statSync(full).mtimeMs < maxAgeMs) continue;
+      rmSync(full, { recursive: true, force: true });
+      removed.push(full);
+    } catch {
+      // Another process may have removed it, or stat raced a deletion — ignore.
+    }
+  }
+  return removed;
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { sweepStaleTestHomes } from "./helpers/test-home.js";
 
 // Strip GIT_* env vars that are inherited when tests run inside git hooks
 // (e.g. pre-push). These vars cause git commands in test temp dirs to target
@@ -15,11 +16,30 @@ for (const key of Object.keys(process.env)) {
 // minds get TMPDIR=<mindDir>/.mind/tmp, and tsx creates a unix socket there
 // whose path must stay under the 104-byte sun_path limit.
 const tmpRoot = process.platform === "darwin" ? "/tmp" : tmpdir();
+
+// Sweep test homes leaked by prior runs that were force-killed before their exit
+// cleanup ran. Without this they piled up until they filled the disk (#502). The
+// 2h threshold is well past any real run, so a sibling test process running
+// concurrently right now keeps its fresh dir.
+sweepStaleTestHomes(tmpRoot, 2 * 60 * 60 * 1000);
+
 const testHome = resolve(tmpRoot, `volute-test-${process.pid}`);
 // Remove stale test dir from a prior run with the same PID to ensure
 // a clean database (avoids migration issues with leftover DB files)
 if (existsSync(testHome)) rmSync(testHome, { recursive: true, force: true });
 mkdirSync(testHome, { recursive: true });
+
+// Remove this run's test home when the process exits. `node --test --test-force-exit`
+// calls process.exit() once tests finish, which still fires synchronous 'exit'
+// handlers — so a sync rmSync here reliably cleans up (verified) where an async
+// after() hook would be skipped.
+process.on("exit", () => {
+  try {
+    rmSync(testHome, { recursive: true, force: true });
+  } catch {
+    // Best-effort — the sweep above catches anything left behind next run.
+  }
+});
 mkdirSync(resolve(testHome, "system"), { recursive: true });
 process.env.VOLUTE_HOME = testHome;
 process.env.VOLUTE_USER_HOME = testHome;

--- a/test/test-home.test.ts
+++ b/test/test-home.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { sweepStaleTestHomes, TEST_HOME_PREFIX } from "./helpers/test-home.js";
+
+describe("sweepStaleTestHomes", () => {
+  let root: string;
+
+  before(() => {
+    root = mkdtempSync(resolve(tmpdir(), "sweep-test-"));
+  });
+
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  /** Create a `volute-test-<pid>` dir and backdate its mtime by `ageMs`. */
+  function makeHome(pid: number, ageMs: number): string {
+    const dir = resolve(root, `${TEST_HOME_PREFIX}${pid}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "volute.db"), "x"); // non-empty, like a real run
+    const when = (Date.now() - ageMs) / 1000;
+    utimesSync(dir, when, when);
+    return dir;
+  }
+
+  it("removes stale homes older than the threshold but keeps fresh ones", () => {
+    const stale = makeHome(1001, 3 * 60 * 60 * 1000); // 3h old
+    const fresh = makeHome(1002, 60 * 1000); // 1m old
+
+    const removed = sweepStaleTestHomes(root, 2 * 60 * 60 * 1000);
+
+    assert.deepEqual(removed, [stale]);
+    assert.ok(!existsSync(stale), "stale home should be removed");
+    assert.ok(existsSync(fresh), "fresh home (a concurrent run) must be preserved");
+  });
+
+  it("ignores unrelated directories", () => {
+    const unrelated = resolve(root, "some-other-dir");
+    mkdirSync(unrelated, { recursive: true });
+    const when = (Date.now() - 24 * 60 * 60 * 1000) / 1000; // a full day old
+    utimesSync(unrelated, when, when);
+
+    sweepStaleTestHomes(root, 2 * 60 * 60 * 1000);
+
+    assert.ok(existsSync(unrelated), "non volute-test-* dirs are never swept");
+  });
+
+  it("returns an empty list for a missing root without throwing", () => {
+    assert.deepEqual(sweepStaleTestHomes(resolve(root, "does-not-exist"), 1000), []);
+  });
+});


### PR DESCRIPTION
CI/test hygiene across three issues.

## #502 — stop leaking `/tmp/volute-test-*` homes
- Added a synchronous `process.on("exit")` cleanup in `test/setup.ts` that removes the per-run temp home (verified it fires under `--test-force-exit` for both in-process and child-process runs despite the open DB handle).
- Extracted a `>2h` startup sweep of stale test homes to `test/helpers/test-home.ts`, with unit tests in `test/test-home.test.ts`.

## #532 — deterministic sleep→queue→flush e2e
- Added a daemon-e2e case for the batched sleep→queue→flush contract. CI has no model key, so the mind process exits the moment a real turn starts; the test therefore sleeps from a stopped state and flushes directly via `POST /:name/sleep/messages`, asserting the deterministic invariants: a two-message group flushes atomically, a failed flush to a down mind keeps the whole backlog, and per-channel queue grouping.
- Exact per-channel turn cardinality and one-fails-while-other-succeeds isolation remain unit-tested (they need a live model to observe cross-process).

## #335 — CI/test hygiene
- Fixed the remaining item: `drizzle.config.ts` pointed at the pre-monorepo schema path and the live `~/.volute` DB. Repointed it and added a guard test (`test/drizzle-config.test.ts`).
- Items already landed on main (e2e-in-CI, voluteHome guard via #472), and the template compile gate (`scripts/typecheck-templates.ts`) already exists. The dist-boot smoke CI job and deduping the two daemon-client resolvers are deferred as noted follow-ups.

## Review triage
No review findings were reported by the reviewers; nothing to triage.

## Test evidence
- `npm test`: 1900/1900 pass, 0 fail.
- `tsc --noEmit`: clean.
- `biome check` on changed files: clean.
- svelte-check (pre-push hook): clean.

Fixes #502
Fixes #532
Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
