### PR TITLE
fix: bound provisional meta-summaries and render summaries as markdown

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -519,29 +519,122 @@ function getScopeInstruction(mind: string): string {
   return 'Write in first person as the mind who performed the actions (e.g. "I explored...", "I worked on...").';
 }
 
+// ── Deterministic fallback bounding & provisional retry ──
+
+/**
+ * Week/month deterministic fallbacks are an *index* of their children, not a verbatim
+ * concatenation: one bounded line per child, capped in total. This keeps a failed AI call
+ * from producing a 100k+ char blob that then poisons the next period's rollup.
+ */
+const DIGEST_CHILD_CHARS = 200;
+const DIGEST_MAX_CHARS = 4000;
+const DIGEST_NOTICE = "(auto-generated digest — AI summary pending)";
+
+/** When rolling per-mind summaries into a _system summary, cap each child fed to the AI. */
+const ROLLUP_CHILD_CHARS = 2000;
+
+/**
+ * A deterministic week/month summary is *provisional*: the summarizer retries it on later
+ * ticks (replacing the row on AI success) until it heals or the budget runs out. This bounds
+ * the "one transient AI outage scars a month forever" failure mode and heals existing blobs.
+ */
+const PROVISIONAL_MAX_ATTEMPTS = 5;
+const PROVISIONAL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+type ChildEntry = { key: string; text: string };
+
+function truncateChars(text: string, max: number): string {
+  const t = text.trim();
+  return t.length > max ? `${t.slice(0, max).trimEnd()}…` : t;
+}
+
+/** First sentence (or first ~200 chars) of a child summary, whitespace-flattened. */
+function digestLine(text: string): string {
+  const flat = text.trim().replace(/\s+/g, " ");
+  const match = flat.match(/^.*?[.!?](?=\s|$)/);
+  const line = match ? match[0] : flat;
+  return line.length > DIGEST_CHILD_CHARS
+    ? `${line.slice(0, DIGEST_CHILD_CHARS).trimEnd()}…`
+    : line;
+}
+
+function buildBoundedDigest(entries: ChildEntry[], period: TimerPeriod, periodKey: string): string {
+  const label = period === "week" ? `Week ${periodKey}` : periodKey;
+  const header = `${label} ${DIGEST_NOTICE}`;
+  const lines: string[] = [];
+  let total = header.length + 2;
+  for (let i = 0; i < entries.length; i++) {
+    const line = `${entries[i].key}: ${digestLine(entries[i].text)}`;
+    if (lines.length > 0 && total + line.length + 1 > DIGEST_MAX_CHARS) {
+      lines.push(`…and ${entries.length - i} more`);
+      break;
+    }
+    lines.push(line);
+    total += line.length + 1;
+  }
+  return `${header}\n\n${lines.join("\n")}`;
+}
+
 function buildPeriodicDeterministicSummary(
-  sources: string[],
+  entries: ChildEntry[],
   period: TimerPeriod,
   periodKey: string,
 ): string {
-  if (sources.length === 0) return "";
+  if (entries.length === 0) return "";
   switch (period) {
     case "hour":
-      return `Activity during ${periodKey.slice(11)}:00: ${sources.join(" ")}`;
+      return `Activity during ${periodKey.slice(11)}:00: ${entries.map((e) => e.text).join(" ")}`;
     case "day":
-      return `Activity on ${periodKey}:\n\n${sources.join("\n\n")}`;
+      return `Activity on ${periodKey}:\n\n${entries.map((e) => e.text).join("\n\n")}`;
     case "week":
-      return `Week ${periodKey} summary:\n\n${sources.join("\n\n")}`;
     case "month":
-      return `${periodKey} summary:\n\n${sources.join("\n\n")}`;
+      return buildBoundedDigest(entries, period, periodKey);
   }
+}
+
+function parseMeta(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Whether an existing deterministic week/month row should be retried. True while it's a
+ * provisional (deterministic) week/month summary that hasn't exhausted its attempt budget or
+ * aged out of the retry window. Rows written before this feature (no `attempts`/
+ * `first_attempt_at`) are treated as fresh, so upgrades heal them.
+ */
+function shouldRetry(period: TimerPeriod, meta: Record<string, unknown>): boolean {
+  if (period !== "week" && period !== "month") return false;
+  if (meta.deterministic !== true) return false;
+  const attempts = typeof meta.attempts === "number" ? meta.attempts : 0;
+  if (attempts >= PROVISIONAL_MAX_ATTEMPTS) return false;
+  const first = typeof meta.first_attempt_at === "string" ? Date.parse(meta.first_attempt_at) : NaN;
+  if (!Number.isNaN(first) && Date.now() - first > PROVISIONAL_WINDOW_MS) return false;
+  return true;
+}
+
+/** Fold retry-budget bookkeeping into a provisional (deterministic) week/month row's metadata. */
+function trackProvisionalAttempt(
+  metadata: Record<string, unknown>,
+  prev: Record<string, unknown> | null,
+): void {
+  const prevAttempts = prev && typeof prev.attempts === "number" ? prev.attempts : 0;
+  metadata.attempts = prevAttempts + 1;
+  metadata.first_attempt_at =
+    prev && typeof prev.first_attempt_at === "string"
+      ? prev.first_attempt_at
+      : new Date().toISOString();
 }
 
 async function gatherChildSummaries(
   mind: string,
   period: TimerPeriod,
   periodKey: string,
-): Promise<{ texts: string[]; sourceIds: number[] }> {
+): Promise<{ texts: string[]; sourceIds: number[]; keys: string[] }> {
   const db = await getDb();
   const childPeriod = getChildPeriod(period);
 
@@ -550,7 +643,7 @@ async function gatherChildSummaries(
     // so we filter by created_at time range instead
     const { start, end } = getTimeRange(periodKey, "hour");
     const rows = await db
-      .select({ id: summaries.id, content: summaries.content })
+      .select({ id: summaries.id, content: summaries.content, key: summaries.period_key })
       .from(summaries)
       .where(
         and(
@@ -564,13 +657,14 @@ async function gatherChildSummaries(
     return {
       texts: rows.map((r) => r.content),
       sourceIds: rows.map((r) => r.id),
+      keys: rows.map((r) => r.key),
     };
   }
 
   if (period === "day") {
     // Day reads hourly summaries whose period_key starts with the day
     const rows = await db
-      .select({ id: summaries.id, content: summaries.content })
+      .select({ id: summaries.id, content: summaries.content, key: summaries.period_key })
       .from(summaries)
       .where(
         and(
@@ -583,6 +677,7 @@ async function gatherChildSummaries(
     return {
       texts: rows.map((r) => r.content),
       sourceIds: rows.map((r) => r.id),
+      keys: rows.map((r) => r.key),
     };
   }
 
@@ -591,7 +686,7 @@ async function gatherChildSummaries(
   const startKey = start.slice(0, 10);
   const endKey = end.slice(0, 10);
   const rows = await db
-    .select({ id: summaries.id, content: summaries.content })
+    .select({ id: summaries.id, content: summaries.content, key: summaries.period_key })
     .from(summaries)
     .where(
       and(
@@ -605,6 +700,7 @@ async function gatherChildSummaries(
   return {
     texts: rows.map((r) => r.content),
     sourceIds: rows.map((r) => r.id),
+    keys: rows.map((r) => r.key),
   };
 }
 
@@ -612,17 +708,32 @@ export async function summarizePeriod(
   mind: string,
   period: TimerPeriod,
   periodKey: string,
+  complete: typeof aiCompleteUtility = aiCompleteUtility,
 ): Promise<boolean> {
-  if (await summaryExists(mind, period, periodKey)) return false;
-
   const db = await getDb();
+  const existing = await db
+    .select({ id: summaries.id, metadata: summaries.metadata })
+    .from(summaries)
+    .where(
+      and(
+        eq(summaries.mind, mind),
+        eq(summaries.period, period),
+        eq(summaries.period_key, periodKey),
+      ),
+    )
+    .get();
+  const existingMeta = existing ? parseMeta(existing.metadata) : null;
+  // A finished summary is skipped, but a provisional (deterministic) week/month is retried.
+  if (existing && !shouldRetry(period, existingMeta as Record<string, unknown>)) return false;
+
   const sources = await gatherChildSummaries(mind, period, periodKey);
   if (sources.texts.length === 0) return false;
 
   // If there's only one child summary, promote it directly instead of
   // generating a redundant wrapper. E.g. an hour with one turn doesn't
   // need a separate hourly summary — the turn summary *is* the hourly summary.
-  if (sources.texts.length === 1) {
+  // (Only for fresh summaries; a provisional retry falls through to the AI path.)
+  if (!existing && sources.texts.length === 1) {
     try {
       await db
         .insert(summaries)
@@ -650,6 +761,7 @@ export async function summarizePeriod(
     return true;
   }
 
+  const entries: ChildEntry[] = sources.texts.map((text, i) => ({ key: sources.keys[i], text }));
   const promptKey = `meta_summary_${period}` as const;
   const scopeInstruction = getScopeInstruction(mind);
   const systemPrompt = await getPrompt(promptKey, { scope_instruction: scopeInstruction });
@@ -658,32 +770,40 @@ export async function summarizePeriod(
   let content: string;
   let deterministic: boolean;
 
-  const aiResult = await aiCompleteUtility(systemPrompt, userMessage);
-  if (aiResult) {
-    content = aiResult;
-    deterministic = false;
-  } else {
-    content = buildPeriodicDeterministicSummary(sources.texts, period, periodKey);
-    deterministic = true;
-  }
-
   const metadata: Record<string, unknown> = {
-    deterministic,
     source_count: sources.texts.length,
     source_ids: sources.sourceIds,
   };
 
+  const aiResult = await complete(systemPrompt, userMessage);
+  if (aiResult) {
+    content = aiResult;
+    deterministic = false;
+  } else {
+    content = buildPeriodicDeterministicSummary(entries, period, periodKey);
+    deterministic = true;
+    if (period === "week" || period === "month") trackProvisionalAttempt(metadata, existingMeta);
+  }
+  metadata.deterministic = deterministic;
+
   try {
-    await db
-      .insert(summaries)
-      .values({
-        mind,
-        period,
-        period_key: periodKey,
-        content,
-        metadata: JSON.stringify(metadata),
-      })
-      .onConflictDoNothing();
+    if (existing) {
+      await db
+        .update(summaries)
+        .set({ content, metadata: JSON.stringify(metadata) })
+        .where(eq(summaries.id, existing.id));
+    } else {
+      await db
+        .insert(summaries)
+        .values({
+          mind,
+          period,
+          period_key: periodKey,
+          content,
+          metadata: JSON.stringify(metadata),
+        })
+        .onConflictDoNothing();
+    }
   } catch (err) {
     sLog.error(
       `failed to persist ${period} summary for ${mind} (${periodKey})`,
@@ -700,10 +820,26 @@ export async function summarizePeriod(
 
 // ── System-level summaries ──
 
-export async function summarizeSystem(period: TimerPeriod, periodKey: string): Promise<void> {
-  if (await summaryExists(SYSTEM_MIND, period, periodKey)) return;
-
+export async function summarizeSystem(
+  period: TimerPeriod,
+  periodKey: string,
+  complete: typeof aiCompleteUtility = aiCompleteUtility,
+): Promise<void> {
   const db = await getDb();
+  const existing = await db
+    .select({ id: summaries.id, metadata: summaries.metadata })
+    .from(summaries)
+    .where(
+      and(
+        eq(summaries.mind, SYSTEM_MIND),
+        eq(summaries.period, period),
+        eq(summaries.period_key, periodKey),
+      ),
+    )
+    .get();
+  const existingMeta = existing ? parseMeta(existing.metadata) : null;
+  if (existing && !shouldRetry(period, existingMeta as Record<string, unknown>)) return;
+
   const rows = await db
     .select({ mind: summaries.mind, content: summaries.content })
     .from(summaries)
@@ -719,7 +855,13 @@ export async function summarizeSystem(period: TimerPeriod, periodKey: string): P
   if (rows.length === 0) return;
 
   const minds = [...new Set(rows.map((r) => r.mind))];
-  const texts = rows.map((r) => `[${r.mind}] ${r.content}`);
+  // Cap each child so one pathological per-mind summary can't blow up the rollup's AI input
+  // (or its deterministic fallback).
+  const entries: ChildEntry[] = rows.map((r) => ({
+    key: r.mind,
+    text: truncateChars(r.content, ROLLUP_CHILD_CHARS),
+  }));
+  const texts = entries.map((e) => `[${e.key}] ${e.text}`);
 
   const promptKey = `meta_summary_${period}` as const;
   const scopeInstruction = getScopeInstruction(SYSTEM_MIND);
@@ -729,28 +871,74 @@ export async function summarizeSystem(period: TimerPeriod, periodKey: string): P
   let content: string;
   let deterministic: boolean;
 
-  const aiResult = await aiCompleteUtility(systemPrompt, userMessage);
+  const metadata: Record<string, unknown> = { minds, source_count: rows.length };
+
+  const aiResult = await complete(systemPrompt, userMessage);
   if (aiResult) {
     content = aiResult;
     deterministic = false;
   } else {
-    content = buildPeriodicDeterministicSummary(texts, period, periodKey);
+    content = buildPeriodicDeterministicSummary(entries, period, periodKey);
     deterministic = true;
+    if (period === "week" || period === "month") trackProvisionalAttempt(metadata, existingMeta);
   }
+  metadata.deterministic = deterministic;
 
   try {
-    await db
-      .insert(summaries)
-      .values({
-        mind: SYSTEM_MIND,
-        period,
-        period_key: periodKey,
-        content,
-        metadata: JSON.stringify({ deterministic, minds, source_count: rows.length }),
-      })
-      .onConflictDoNothing();
+    if (existing) {
+      await db
+        .update(summaries)
+        .set({ content, metadata: JSON.stringify(metadata) })
+        .where(eq(summaries.id, existing.id));
+    } else {
+      await db
+        .insert(summaries)
+        .values({
+          mind: SYSTEM_MIND,
+          period,
+          period_key: periodKey,
+          content,
+          metadata: JSON.stringify(metadata),
+        })
+        .onConflictDoNothing();
+    }
   } catch (err) {
     sLog.error(`failed to persist system ${period} summary (${periodKey})`, log.errorData(err));
+  }
+}
+
+/**
+ * Retry provisional (deterministic) week/month summaries that the tick guards would otherwise
+ * skip. Per-mind summaries are healed before `_system` so the rollup sees the improved children.
+ */
+export async function repairProvisionalSummaries(
+  complete: typeof aiCompleteUtility = aiCompleteUtility,
+): Promise<void> {
+  const db = await getDb();
+  const rows = await db
+    .select({
+      mind: summaries.mind,
+      period: summaries.period,
+      period_key: summaries.period_key,
+      metadata: summaries.metadata,
+    })
+    .from(summaries)
+    .where(inArray(summaries.period, ["week", "month"]));
+  const due = rows.filter((r) => shouldRetry(r.period as TimerPeriod, parseMeta(r.metadata)));
+  due.sort((a, b) => (a.mind === SYSTEM_MIND ? 1 : 0) - (b.mind === SYSTEM_MIND ? 1 : 0));
+  for (const r of due) {
+    try {
+      if (r.mind === SYSTEM_MIND) {
+        await summarizeSystem(r.period as TimerPeriod, r.period_key, complete);
+      } else {
+        await summarizePeriod(r.mind, r.period as TimerPeriod, r.period_key, complete);
+      }
+    } catch (err) {
+      sLog.error(
+        `failed to repair provisional ${r.period} summary for ${r.mind} (${r.period_key})`,
+        log.errorData(err),
+      );
+    }
   }
 }
 
@@ -1124,6 +1312,9 @@ export class Summarizer {
       if (!(await summaryExists(SYSTEM_MIND, "month", prevMonthKey))) {
         await processMonth(prevMonthKey);
       }
+
+      // Re-attempt provisional (deterministic) week/month summaries the guards above skip.
+      await repairProvisionalSummaries();
     } catch (err) {
       sLog.error("tick failed", log.errorData(err));
     }

--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -540,6 +540,14 @@ const ROLLUP_CHILD_CHARS = 2000;
  */
 const PROVISIONAL_MAX_ATTEMPTS = 5;
 const PROVISIONAL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * Minimum spacing between provisional retries. The summarizer tick runs every 5 minutes and
+ * `repairProvisionalSummaries` retries every due row on each tick, so without spacing the whole
+ * attempt budget would burn in ~25 minutes — the 7-day window would never bind and any AI outage
+ * longer than that would scar the summary permanently. Spacing the attempts (~1.4 days apart) makes
+ * the budget genuinely span the window, so the row heals whenever the AI recovers within a week.
+ */
+const PROVISIONAL_RETRY_BACKOFF_MS = PROVISIONAL_WINDOW_MS / PROVISIONAL_MAX_ATTEMPTS;
 
 type ChildEntry = { key: string; text: string };
 
@@ -614,6 +622,11 @@ function shouldRetry(period: TimerPeriod, meta: Record<string, unknown>): boolea
   if (attempts >= PROVISIONAL_MAX_ATTEMPTS) return false;
   const first = typeof meta.first_attempt_at === "string" ? Date.parse(meta.first_attempt_at) : NaN;
   if (!Number.isNaN(first) && Date.now() - first > PROVISIONAL_WINDOW_MS) return false;
+  // Space attempts across the window so the tick cadence can't burn the whole budget in minutes.
+  // A row with no `last_attempt_at` (a pre-feature blob, or one never retried) is eligible
+  // immediately — so upgrades heal on the next tick and only repeated *failures* get backed off.
+  const last = typeof meta.last_attempt_at === "string" ? Date.parse(meta.last_attempt_at) : NaN;
+  if (!Number.isNaN(last) && Date.now() - last < PROVISIONAL_RETRY_BACKOFF_MS) return false;
   return true;
 }
 
@@ -628,6 +641,7 @@ function trackProvisionalAttempt(
     prev && typeof prev.first_attempt_at === "string"
       ? prev.first_attempt_at
       : new Date().toISOString();
+  metadata.last_attempt_at = new Date().toISOString();
 }
 
 async function gatherChildSummaries(

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -170,14 +170,14 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
   },
   meta_summary_week: {
     content:
-      "Summarize the following daily summaries from a single week into a reflective overview (~500-800 words). ${scope_instruction} Identify recurring patterns and themes across days, note growth or evolution in thinking, highlight significant accomplishments and relationships, and flag unresolved threads. The text below contains daily summaries — synthesize them into a weekly reflection.",
+      "Distill the following daily summaries from a single week into a reflective overview. ${scope_instruction} Open with a short overview, then use markdown headers (## Heading) for a few themed sections covering recurring patterns, growth in thinking, significant accomplishments and relationships, and any unresolved threads. Prefer omission over completeness — this is an orientation aid, not a record; the daily summaries hold the detail. Use markdown for structure. Hard cap: 600 words. The text below contains daily summaries — synthesize, don't concatenate.",
     description: "System prompt for weekly meta-summaries",
     variables: ["scope_instruction"],
     category: "system",
   },
   meta_summary_month: {
     content:
-      "Summarize the following daily summaries from a single month into a comprehensive narrative (~800-1500 words). ${scope_instruction} Paint the big picture: major milestones and accomplishments, how perspectives or identity evolved, key relationships and interactions, recurring themes, and the overall trajectory. The text below contains daily summaries — compose them into a monthly narrative.",
+      "Distill the following daily summaries from a single month into a brief orientation aid. ${scope_instruction} Open with a 3-5 sentence overview, then use markdown headers (## Heading) for a few short themed sections covering major milestones, how perspectives or identity evolved, key relationships, and recurring themes. Prefer omission over completeness — this is an orientation aid, not a record; the weekly and daily summaries hold the detail. Use markdown for structure. Hard cap: 800 words. The text below contains daily summaries — synthesize, don't concatenate.",
     description: "System prompt for monthly meta-summaries",
     variables: ["scope_instruction"],
     category: "system",

--- a/packages/web/src/ui/components/SummaryNode.svelte
+++ b/packages/web/src/ui/components/SummaryNode.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { HistoryMessage, SummaryRow, TurnRow } from "@volute/api";
 import { Icon } from "@volute/ui";
+import { renderMarkdown } from "@volute/ui/markdown";
 import type { SvelteMap } from "svelte/reactivity";
 import { groupToolEvents } from "../lib/tool-groups";
 import { getCategoryColor, getCategoryIcon } from "../lib/tool-names";
@@ -46,6 +47,16 @@ function collapseExpandedChild() {
     (c) => "period" in c && (expandedSummaries.has(c.id) || directEventsSummaries.has(c.id)),
   );
   if (expanded && "period" in expanded) toggleSummaryExpand(expanded as SummaryRow);
+}
+
+// Clamped previews render as plain text, so strip leading markdown sigils (headers,
+// emphasis, list bullets) that would otherwise show up literally in the 3-line clamp.
+function plainPreview(text: string): string {
+  return text
+    .replace(/^\s*#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/(\*\*|__|\*|_|`)/g, "")
+    .trim();
 }
 </script>
 
@@ -95,7 +106,7 @@ function collapseExpandedChild() {
               <div class="summary-child-body">
                 {#if !childExpanded}
                   <span class="summary-child-time">{formatPeriodTime(childSummary.period, childSummary.period_key)}</span>
-                  <span class="summary-text">{childSummary.content}</span>
+                  <span class="summary-text">{plainPreview(childSummary.content)}</span>
                 {/if}
               </div>
             </div>
@@ -140,9 +151,11 @@ function collapseExpandedChild() {
       {/if}
     {/snippet}
     {#snippet footer()}
-      <button class="summary-expand-collapse" onclick={(e) => e.stopPropagation()}>
-        <span class="summary-text">{summary.content}</span>
-      </button>
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="summary-expand-collapse" onclick={(e) => e.stopPropagation()}>
+        <div class="summary-full markdown-body">{@html renderMarkdown(summary.content)}</div>
+      </div>
     {/snippet}
   </TimelineBranch>
 {:else}
@@ -150,7 +163,7 @@ function collapseExpandedChild() {
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="summary-collapsed" onclick={() => toggleSummaryExpand(summary)}>
     <span class="summary-collapsed-time">{formatPeriodTime(summary.period, summary.period_key)}</span>
-    <span class="summary-text">{summary.content}</span>
+    <span class="summary-text">{plainPreview(summary.content)}</span>
   </div>
 {/if}
 
@@ -182,6 +195,14 @@ function collapseExpandedChild() {
     text-align: left;
     font: inherit;
     color: inherit;
+  }
+  /* Expanded long-form summaries are prose: render markdown, and cap tall
+     week/month narratives with internal scroll so they don't push the rest
+     of the timeline off-screen. */
+  .summary-full {
+    font-size: 13px;
+    max-height: 420px;
+    overflow-y: auto;
   }
   .summary-expand-collapse::before {
     content: "";

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -11,6 +11,7 @@ import {
   type Period,
   reconcileMissingSummaries,
   reconcileWedgedTurns,
+  repairProvisionalSummaries,
   SYSTEM_MIND,
   summarizePeriod,
   summarizeTurn,
@@ -877,6 +878,164 @@ describe("summarizer", () => {
         0,
         "out-of-window material must not be summarized (day)",
       );
+    });
+  });
+
+  // ── Provisional fallback bounding + repair (#404) ──
+
+  describe("provisional meta-summaries", () => {
+    async function insertSummary(
+      mind: string,
+      period: Period,
+      periodKey: string,
+      content: string,
+      metadata?: Record<string, unknown>,
+    ) {
+      const db = await getDb();
+      await db.insert(summaries).values({
+        mind,
+        period,
+        period_key: periodKey,
+        content,
+        metadata: JSON.stringify(metadata ?? { deterministic: true }),
+      });
+    }
+
+    async function getSummary(mind: string, period: Period, periodKey: string) {
+      const db = await getDb();
+      return db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, mind),
+            eq(summaries.period, period),
+            eq(summaries.period_key, periodKey),
+          ),
+        )
+        .get();
+    }
+
+    const failAi = async () => null;
+
+    it("bounds the month deterministic fallback to an index instead of concatenating", async () => {
+      const mind = "bounded-fallback-mind";
+      const child = `${"lorem ipsum ".repeat(500)}Done.`; // ~6k chars each
+      assert.ok(child.length > 5000);
+      for (let d = 1; d <= 30; d++) {
+        const key = `2026-04-${String(d).padStart(2, "0")}`;
+        await insertSummary(mind, "day", key, `Day ${d}: ${child}`);
+      }
+
+      const generated = await summarizePeriod(mind, "month", "2026-04", failAi);
+      assert.equal(generated, true);
+
+      const row = await getSummary(mind, "month", "2026-04");
+      assert.ok(row, "month summary should exist");
+      // The bounded digest must be far smaller than even a single child's verbatim content.
+      assert.ok(row!.content.length < 5000, `digest too large: ${row!.content.length}`);
+      assert.match(row!.content, /AI summary pending/);
+      assert.match(row!.content, /2026-04-01:/);
+      const meta = JSON.parse(row!.metadata!);
+      assert.equal(meta.deterministic, true);
+      assert.equal(meta.attempts, 1);
+    });
+
+    it("retries a provisional row and replaces it when the AI later succeeds", async () => {
+      const mind = "retry-heal-mind";
+      await insertSummary(mind, "day", "2026-04-05", "Monday: I did things.");
+      await insertSummary(mind, "day", "2026-04-06", "Tuesday: I did more.");
+
+      const first = await summarizePeriod(mind, "month", "2026-04", failAi);
+      assert.equal(first, true);
+      const provisional = await getSummary(mind, "month", "2026-04");
+      assert.equal(JSON.parse(provisional!.metadata!).deterministic, true);
+
+      const healed = "# April\n\nA steady, productive month.";
+      const second = await summarizePeriod(mind, "month", "2026-04", async () => healed);
+      assert.equal(second, true);
+
+      const row = await getSummary(mind, "month", "2026-04");
+      assert.equal(row!.content, healed);
+      assert.equal(JSON.parse(row!.metadata!).deterministic, false);
+
+      // Upsert, not duplicate insert.
+      const db = await getDb();
+      const all = await db
+        .select()
+        .from(summaries)
+        .where(
+          and(
+            eq(summaries.mind, mind),
+            eq(summaries.period, "month"),
+            eq(summaries.period_key, "2026-04"),
+          ),
+        );
+      assert.equal(all.length, 1);
+    });
+
+    it("stops retrying once the attempt budget is exhausted", async () => {
+      const mind = "budget-exhausted-mind";
+      await insertSummary(mind, "day", "2026-04-05", "A day.");
+      await insertSummary(mind, "month", "2026-04", "old blob", {
+        deterministic: true,
+        attempts: 5,
+      });
+
+      const generated = await summarizePeriod(mind, "month", "2026-04", async () => "healed");
+      assert.equal(generated, false, "budget-exhausted row should not be retried");
+
+      const row = await getSummary(mind, "month", "2026-04");
+      assert.equal(row!.content, "old blob", "row must be left untouched");
+    });
+
+    it("stops retrying once the retry window has elapsed", async () => {
+      const mind = "window-elapsed-mind";
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+      await insertSummary(mind, "day", "2026-04-05", "A day.");
+      await insertSummary(mind, "month", "2026-04", "old blob", {
+        deterministic: true,
+        attempts: 1,
+        first_attempt_at: eightDaysAgo,
+      });
+
+      const generated = await summarizePeriod(mind, "month", "2026-04", async () => "healed");
+      assert.equal(generated, false, "aged-out row should not be retried");
+      const row = await getSummary(mind, "month", "2026-04");
+      assert.equal(row!.content, "old blob");
+    });
+
+    it("truncates an oversized child before building the _system rollup", async () => {
+      const key = "2026-05-10T09";
+      const huge = "x".repeat(5000);
+      await insertSummary("sys-child-a", "hour", key, "short child.");
+      await insertSummary("sys-child-b", "hour", key, huge);
+
+      await summarizeSystem("hour", key, failAi);
+
+      const row = await getSummary("_system", "hour", key);
+      assert.ok(row, "_system hour summary should exist");
+      // The 5000-char child must have been capped (ROLLUP_CHILD_CHARS = 2000).
+      assert.ok(row!.content.length < 4500, `rollup too large: ${row!.content.length}`);
+      assert.ok(!row!.content.includes(huge), "oversized child must not appear verbatim");
+    });
+
+    it("repairProvisionalSummaries heals per-mind and _system rows", async () => {
+      const mind = "repair-mind";
+      await insertSummary(mind, "day", "2026-06-01", "Day one.");
+      await insertSummary(mind, "day", "2026-06-02", "Day two.");
+      await insertSummary(mind, "month", "2026-06", "per-mind blob", { deterministic: true });
+      await insertSummary("_system", "month", "2026-06", "system blob", { deterministic: true });
+
+      await repairProvisionalSummaries(async () => "HEALED");
+
+      const mindRow = await getSummary(mind, "month", "2026-06");
+      assert.equal(mindRow!.content, "HEALED");
+      assert.equal(JSON.parse(mindRow!.metadata!).deterministic, false);
+
+      const sysRow = await getSummary("_system", "month", "2026-06");
+      assert.equal(sysRow!.content, "HEALED");
+      assert.equal(JSON.parse(sysRow!.metadata!).deterministic, false);
     });
   });
 

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -14,6 +14,7 @@ import {
   repairProvisionalSummaries,
   SYSTEM_MIND,
   summarizePeriod,
+  summarizeSystem,
   summarizeTurn,
 } from "../packages/daemon/src/lib/daemon/summarizer.js";
 import {
@@ -916,6 +917,19 @@ describe("summarizer", () => {
         .get();
     }
 
+    // Push a provisional row's last_attempt_at into the past so the retry-spacing guard lets the
+    // next attempt through — the test-time stand-in for the ~1.4 days between real ticks.
+    async function agePastBackoff(mind: string, period: Period, periodKey: string) {
+      const db = await getDb();
+      const row = await getSummary(mind, period, periodKey);
+      const meta = JSON.parse(row!.metadata!);
+      meta.last_attempt_at = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      await db
+        .update(summaries)
+        .set({ metadata: JSON.stringify(meta) })
+        .where(eq(summaries.id, row!.id));
+    }
+
     const failAi = async () => null;
 
     it("bounds the month deterministic fallback to an index instead of concatenating", async () => {
@@ -951,6 +965,8 @@ describe("summarizer", () => {
       const provisional = await getSummary(mind, "month", "2026-04");
       assert.equal(JSON.parse(provisional!.metadata!).deterministic, true);
 
+      // A later tick (past the retry-spacing backoff) finds the AI healthy and heals the row.
+      await agePastBackoff(mind, "month", "2026-04");
       const healed = "# April\n\nA steady, productive month.";
       const second = await summarizePeriod(mind, "month", "2026-04", async () => healed);
       assert.equal(second, true);
@@ -1003,6 +1019,82 @@ describe("summarizer", () => {
       assert.equal(generated, false, "aged-out row should not be retried");
       const row = await getSummary(mind, "month", "2026-04");
       assert.equal(row!.content, "old blob");
+    });
+
+    it("does not retry a provisional again within the backoff interval", async () => {
+      const mind = "backoff-spacing-mind";
+      // Two children so the period isn't promoted from a single child (which skips the fallback).
+      await insertSummary(mind, "day", "2026-04-05", "A day.");
+      await insertSummary(mind, "day", "2026-04-06", "Another day.");
+
+      const first = await summarizePeriod(mind, "month", "2026-04", failAi);
+      assert.equal(first, true);
+      assert.equal(JSON.parse((await getSummary(mind, "month", "2026-04"))!.metadata!).attempts, 1);
+
+      // A retry on the very next tick (well within the backoff) must be skipped — otherwise the
+      // 5-minute tick cadence would burn the whole attempt budget in minutes.
+      const second = await summarizePeriod(mind, "month", "2026-04", async () => "healed");
+      assert.equal(second, false, "should not retry within the backoff interval");
+      const row = await getSummary(mind, "month", "2026-04");
+      assert.equal(JSON.parse(row!.metadata!).deterministic, true, "must stay provisional");
+      assert.equal(JSON.parse(row!.metadata!).attempts, 1, "attempts must not increment");
+    });
+
+    it("spaces attempts across the window and gives up only after the budget", async () => {
+      const mind = "spaced-budget-mind";
+      // Two children so the period isn't promoted from a single child (which skips the fallback).
+      await insertSummary(mind, "day", "2026-04-05", "A day.");
+      await insertSummary(mind, "day", "2026-04-06", "Another day.");
+
+      // First failure creates the provisional (attempts=1).
+      await summarizePeriod(mind, "month", "2026-04", failAi);
+      assert.equal(JSON.parse((await getSummary(mind, "month", "2026-04"))!.metadata!).attempts, 1);
+
+      // Each subsequent attempt only lands once the backoff has elapsed, so the budget genuinely
+      // spans the window rather than exhausting at tick cadence.
+      for (let expected = 2; expected <= 5; expected++) {
+        await agePastBackoff(mind, "month", "2026-04");
+        const retried = await summarizePeriod(mind, "month", "2026-04", failAi);
+        assert.equal(retried, true, `attempt ${expected} should run`);
+        assert.equal(
+          JSON.parse((await getSummary(mind, "month", "2026-04"))!.metadata!).attempts,
+          expected,
+        );
+      }
+
+      // Budget exhausted: even with the AI back and the backoff elapsed, no further retries.
+      await agePastBackoff(mind, "month", "2026-04");
+      const done = await summarizePeriod(mind, "month", "2026-04", async () => "healed");
+      assert.equal(done, false, "should stop after the attempt budget is exhausted");
+      assert.equal(
+        JSON.parse((await getSummary(mind, "month", "2026-04"))!.metadata!).deterministic,
+        true,
+      );
+    });
+
+    it("bounds the week deterministic fallback and labels it as a week", async () => {
+      const mind = "bounded-week-mind";
+      const child = `${"lorem ipsum ".repeat(500)}Done.`; // ~6k chars each
+      // Days 2026-03-09..13 fall inside ISO week 2026-W11.
+      for (let d = 9; d <= 13; d++) {
+        await insertSummary(
+          mind,
+          "day",
+          `2026-03-${String(d).padStart(2, "0")}`,
+          `Day ${d}: ${child}`,
+        );
+      }
+
+      const generated = await summarizePeriod(mind, "week", "2026-W11", failAi);
+      assert.equal(generated, true);
+
+      const row = await getSummary(mind, "week", "2026-W11");
+      assert.ok(row, "week summary should exist");
+      assert.ok(row!.content.length < 5000, `digest too large: ${row!.content.length}`);
+      assert.match(row!.content, /Week 2026-W11/, "should carry the week label");
+      assert.match(row!.content, /2026-03-09:/);
+      assert.match(row!.content, /AI summary pending/);
+      assert.equal(JSON.parse(row!.metadata!).attempts, 1);
     });
 
     it("truncates an oversized child before building the _system rollup", async () => {


### PR DESCRIPTION
Higher-level meta-summaries were frequently unreadable, and the worst ones were permanent — a single AI outage at a month boundary produced a 100k+ char concatenation blob that then poisoned the `_system` rollup.

## Backend (#404)
- Week/month/`_system` deterministic fallbacks are now a bounded *index* of their children (first sentence per child, capped at ~4KB) instead of a verbatim concatenation, clearly marked "(auto-generated digest — AI summary pending)".
- Deterministic week/month summaries are treated as **provisional**: the tick's new `repairProvisionalSummaries` pass retries them and UPDATEs the row on AI success, healing existing blobs on upgrade.
- **Retries are spaced across the 7-day window.** The budget of 5 attempts is enforced with a `last_attempt_at` backoff (~1.4 days) so the 5-minute tick can't burn the whole budget in ~25 minutes — the failure mode where a sustained outage would still scar a month permanently. Rows with no `last_attempt_at` (pre-feature blobs) stay eligible immediately, so upgrade-healing fires on the next tick.
- The `_system` rollup truncates any oversized per-mind child before feeding the AI (and its fallback), so one pathological child can't cascade.
- Tightened the weekly/monthly prompts: structure over length, markdown headers, hard caps (600/800 words), "prefer omission over completeness".

## Frontend (#405)
- Expanded summaries render through the DOMPurify-backed `renderMarkdown`, so headers/paragraphs/emphasis are honored instead of shown literally, with a `max-height` + internal scroll so a long month can't push the timeline off-screen. Clamped previews strip leading markdown sigils.

## Review triage
- **[important] Retry budget burned at tick cadence (flagged by all three reviewers) — fixed.** Added `last_attempt_at` spacing (`PROVISIONAL_RETRY_BACKOFF_MS = window / max_attempts`) in `shouldRetry`/`trackProvisionalAttempt`, so the 5 attempts genuinely span the 7-day window and the row heals whenever the AI recovers within a week. Also fixes the double-count where creation + same-tick repair burned two attempts at once. Added tests driving the real accumulation loop (1→5 then stop), asserting no retry lands within the backoff, and covering upgrade-healing across a spaced tick.
- **[minor] Week period untested — addressed.** Added a week case asserting the `Week <key>` digest label and bounded size.
- **[minor] `SummaryNode.plainPreview` untested / strips intra-word markers — skipped.** Clamped previews are cosmetic (plain-text extraction of a 3-line clamp); extracting a helper and wiring a new frontend test harness is out of scope for a release fix, and XSS safety of the expanded path rides on the existing `renderMarkdown`/DOMPurify util tests as #405 permits.
- **[minor] `_system` hour/day deterministic fallback drops the `[mind]` label — skipped.** A deliberate tradeoff noted by the implementer; attribution is retained in `metadata.minds`, week/month digests still carry it via the child key, and this fallback only appears during an AI outage. Restoring it cleanly would introduce redundant `mind: [mind]` prefixes in the week/month digest.

## Test evidence
Full `npm test`: **1932 pass / 0 fail** (3 new tests). Pre-push hook ran `svelte-check` + full suite — both clean.

Fixes #404
Fixes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)