### PR TITLE
fix: make timeline summaries reachable (week filtering, backward paging, tz anchoring)

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -6,11 +6,18 @@ import { getPrompt } from "../prompts.js";
 import { messages, mindHistory, summaries, turns } from "../schema.js";
 import { summarizeTool } from "../util/format-tool.js";
 import log from "../util/logger.js";
+import {
+  getPeriodKey,
+  getPreviousPeriodKey,
+  getTimeRange,
+  parseUtcDateTime,
+  type TimerPeriod,
+  utcDateTimeStr,
+} from "../util/period-keys.js";
 
 const sLog = log.child("summarizer");
 
-/** Periods that participate in timer-driven periodic summarization */
-export type TimerPeriod = "hour" | "day" | "week" | "month";
+export { getPeriodKey, getPreviousPeriodKey, getTimeRange, type TimerPeriod };
 
 /** All summary periods including event-driven turn summaries */
 export type Period = "turn" | TimerPeriod;
@@ -25,131 +32,6 @@ export const SYSTEM_MIND = "_system";
  * turn must look before we step in.
  */
 const WEDGED_TURN_IDLE_MS = 15 * 60_000;
-
-// ── Period key helpers (local time) ──
-// Period keys use local time so summaries align with the user's day/hour boundaries.
-
-export function getPeriodKey(date: Date, period: TimerPeriod): string {
-  switch (period) {
-    case "hour": {
-      const y = date.getFullYear();
-      const m = String(date.getMonth() + 1).padStart(2, "0");
-      const d = String(date.getDate()).padStart(2, "0");
-      const h = String(date.getHours()).padStart(2, "0");
-      return `${y}-${m}-${d}T${h}`;
-    }
-    case "day": {
-      const y = date.getFullYear();
-      const m = String(date.getMonth() + 1).padStart(2, "0");
-      const d = String(date.getDate()).padStart(2, "0");
-      return `${y}-${m}-${d}`;
-    }
-    case "week":
-      return getISOWeekKey(date);
-    case "month": {
-      const y = date.getFullYear();
-      const m = String(date.getMonth() + 1).padStart(2, "0");
-      return `${y}-${m}`;
-    }
-  }
-}
-
-function getISOWeekKey(date: Date): string {
-  // Use local date for week calculation
-  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  d.setDate(d.getDate() + 4 - (d.getDay() || 7));
-  const yearStart = new Date(d.getFullYear(), 0, 1);
-  const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-  return `${d.getFullYear()}-W${String(weekNum).padStart(2, "0")}`;
-}
-
-export function getPreviousPeriodKey(key: string, period: TimerPeriod): string {
-  switch (period) {
-    case "hour": {
-      const d = new Date(`${key.slice(0, 10)}T${key.slice(11)}:00:00`);
-      d.setHours(d.getHours() - 1);
-      return getPeriodKey(d, "hour");
-    }
-    case "day": {
-      const d = new Date(`${key}T00:00:00`);
-      d.setDate(d.getDate() - 1);
-      return getPeriodKey(d, "day");
-    }
-    case "week": {
-      const d = isoWeekToDate(key);
-      d.setDate(d.getDate() - 7);
-      return getPeriodKey(d, "week");
-    }
-    case "month": {
-      const [y, m] = key.split("-").map(Number);
-      const d = new Date(y, m - 2, 1);
-      return getPeriodKey(d, "month");
-    }
-  }
-}
-
-function isoWeekToDate(weekKey: string): Date {
-  const [yearStr, weekStr] = weekKey.split("-W");
-  const year = parseInt(yearStr, 10);
-  const week = parseInt(weekStr, 10);
-  const jan4 = new Date(year, 0, 4);
-  const dayOfWeek = jan4.getDay() || 7;
-  const monday = new Date(jan4);
-  monday.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
-  return monday;
-}
-
-function localDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-/** Format a Date as "YYYY-MM-DD HH:MM:SS" in UTC (matching SQLite datetime('now') format) */
-function utcDateTimeStr(d: Date): string {
-  return d.toISOString().replace("T", " ").slice(0, 19);
-}
-
-/** Parse a "YYYY-MM-DD HH:MM:SS" UTC datetime string (as stored via datetime('now')). */
-function parseUtcDateTime(s: string): Date {
-  return new Date(`${s.replace(" ", "T")}Z`);
-}
-
-export function getTimeRange(
-  periodKey: string,
-  period: TimerPeriod,
-): { start: string; end: string } {
-  // Hour: convert local period key to UTC for comparison against created_at
-  // (stored as UTC via datetime('now')). Other periods return local-time
-  // strings for comparison against period_key columns (which are local).
-  switch (period) {
-    case "hour": {
-      const d = new Date(`${periodKey.slice(0, 10)}T${periodKey.slice(11)}:00:00`);
-      const dEnd = new Date(d.getTime() + 3600000);
-      return { start: utcDateTimeStr(d), end: utcDateTimeStr(dEnd) };
-    }
-    case "day":
-      return { start: `${periodKey} 00:00:00`, end: `${periodKey} 23:59:59` };
-    case "week": {
-      const monday = isoWeekToDate(periodKey);
-      const sunday = new Date(monday);
-      sunday.setDate(monday.getDate() + 6);
-      return {
-        start: `${localDateStr(monday)} 00:00:00`,
-        end: `${localDateStr(sunday)} 23:59:59`,
-      };
-    }
-    case "month": {
-      const [y, m] = periodKey.split("-").map(Number);
-      const lastDay = new Date(y, m, 0).getDate();
-      return {
-        start: `${periodKey}-01 00:00:00`,
-        end: `${periodKey}-${String(lastDay).padStart(2, "0")} 23:59:59`,
-      };
-    }
-  }
-}
 
 // ── Turn summarization (event-driven) ──
 

--- a/packages/daemon/src/lib/util/period-keys.ts
+++ b/packages/daemon/src/lib/util/period-keys.ts
@@ -1,0 +1,153 @@
+// ── Period key helpers (server-local time) ──
+//
+// Period keys use the daemon host's local time so summaries align with the
+// operator's day/hour boundaries. This is the single source of truth shared by
+// the summarizer, the history API range filters, and the backfill script.
+//
+// Formats:
+//   hour  → "YYYY-MM-DDTHH"   (e.g. "2026-03-22T14")
+//   day   → "YYYY-MM-DD"      (e.g. "2026-03-22")
+//   week  → "YYYY-Www"        ISO week (e.g. "2026-W14")
+//   month → "YYYY-MM"         (e.g. "2026-03")
+
+/** Periods that participate in timer-driven periodic summarization */
+export type TimerPeriod = "hour" | "day" | "week" | "month";
+
+const DATE_STR_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function getPeriodKey(date: Date, period: TimerPeriod): string {
+  switch (period) {
+    case "hour": {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, "0");
+      const d = String(date.getDate()).padStart(2, "0");
+      const h = String(date.getHours()).padStart(2, "0");
+      return `${y}-${m}-${d}T${h}`;
+    }
+    case "day": {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, "0");
+      const d = String(date.getDate()).padStart(2, "0");
+      return `${y}-${m}-${d}`;
+    }
+    case "week":
+      return getISOWeekKey(date);
+    case "month": {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, "0");
+      return `${y}-${m}`;
+    }
+  }
+}
+
+export function getISOWeekKey(date: Date): string {
+  // Use local date for week calculation
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  d.setDate(d.getDate() + 4 - (d.getDay() || 7));
+  const yearStart = new Date(d.getFullYear(), 0, 1);
+  const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getFullYear()}-W${String(weekNum).padStart(2, "0")}`;
+}
+
+export function isoWeekToDate(weekKey: string): Date {
+  const [yearStr, weekStr] = weekKey.split("-W");
+  const year = parseInt(yearStr, 10);
+  const week = parseInt(weekStr, 10);
+  const jan4 = new Date(year, 0, 4);
+  const dayOfWeek = jan4.getDay() || 7;
+  const monday = new Date(jan4);
+  monday.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
+  return monday;
+}
+
+/**
+ * Convert a `YYYY-MM-DD` date string to the ISO week key of the week that
+ * contains it. Used by the history API to translate date-format range bounds
+ * into week keys for correct comparison against week `period_key`s.
+ * Returns the input unchanged if it isn't a plain date string.
+ */
+export function isoWeekKeyForDateStr(dateStr: string): string {
+  if (!DATE_STR_RE.test(dateStr)) return dateStr;
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return getISOWeekKey(new Date(y, m - 1, d));
+}
+
+export function getPreviousPeriodKey(key: string, period: TimerPeriod): string {
+  switch (period) {
+    case "hour": {
+      // Derive the previous hour by subtracting one hour from the UTC instant
+      // rather than mutating local fields, so DST transitions (where a local
+      // hour is skipped or repeated) don't skip or duplicate a bucket.
+      const d = new Date(`${key.slice(0, 10)}T${key.slice(11)}:00:00`);
+      const prev = new Date(d.getTime() - 3600000);
+      return getPeriodKey(prev, "hour");
+    }
+    case "day": {
+      const d = new Date(`${key}T00:00:00`);
+      d.setDate(d.getDate() - 1);
+      return getPeriodKey(d, "day");
+    }
+    case "week": {
+      const d = isoWeekToDate(key);
+      d.setDate(d.getDate() - 7);
+      return getPeriodKey(d, "week");
+    }
+    case "month": {
+      const [y, m] = key.split("-").map(Number);
+      const d = new Date(y, m - 2, 1);
+      return getPeriodKey(d, "month");
+    }
+  }
+}
+
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Format a Date as "YYYY-MM-DD HH:MM:SS" in UTC (matching SQLite datetime('now') format) */
+export function utcDateTimeStr(d: Date): string {
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+/** Parse a "YYYY-MM-DD HH:MM:SS" UTC datetime string (as stored via datetime('now')). */
+export function parseUtcDateTime(s: string): Date {
+  return new Date(`${s.replace(" ", "T")}Z`);
+}
+
+export function getTimeRange(
+  periodKey: string,
+  period: TimerPeriod,
+): { start: string; end: string } {
+  // Hour: convert local period key to UTC for comparison against created_at
+  // (stored as UTC via datetime('now')). Other periods return local-time
+  // strings for comparison against period_key columns (which are local).
+  switch (period) {
+    case "hour": {
+      const d = new Date(`${periodKey.slice(0, 10)}T${periodKey.slice(11)}:00:00`);
+      const dEnd = new Date(d.getTime() + 3600000);
+      return { start: utcDateTimeStr(d), end: utcDateTimeStr(dEnd) };
+    }
+    case "day":
+      return { start: `${periodKey} 00:00:00`, end: `${periodKey} 23:59:59` };
+    case "week": {
+      const monday = isoWeekToDate(periodKey);
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+      return {
+        start: `${localDateStr(monday)} 00:00:00`,
+        end: `${localDateStr(sunday)} 23:59:59`,
+      };
+    }
+    case "month": {
+      const [y, m] = periodKey.split("-").map(Number);
+      const lastDay = new Date(y, m, 0).getDate();
+      return {
+        start: `${periodKey}-01 00:00:00`,
+        end: `${periodKey}-${String(lastDay).padStart(2, "0")} 23:59:59`,
+      };
+    }
+  }
+}

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -15,6 +15,7 @@ import {
   users,
 } from "../../lib/schema.js";
 import log from "../../lib/util/logger.js";
+import { isoWeekKeyForDateStr } from "../../lib/util/period-keys.js";
 import type { AuthEnv } from "../middleware/auth.js";
 
 /**
@@ -498,8 +499,17 @@ const history = new Hono<HistoryEnv>()
     const db = await getDb();
     const conditions = [eq(summaries.mind, mind), eq(summaries.period, period)];
 
-    if (from) conditions.push(gte(summaries.period_key, from));
-    if (to) conditions.push(sql`${summaries.period_key} <= ${to}`);
+    // Week period keys are ISO-week format ("YYYY-Www"), which does not sort
+    // against date-format ("YYYY-MM-DD") bounds under binary collation. When a
+    // caller passes date bounds for the week tier, translate them to the ISO
+    // week key of the week *containing* that date so the string comparison is
+    // correct (a week straddling the bound is included when any day falls in
+    // range). Other tiers already use prefix-compatible date keys.
+    const normalizeBound = (bound: string) =>
+      period === "week" ? isoWeekKeyForDateStr(bound) : bound;
+
+    if (from) conditions.push(gte(summaries.period_key, normalizeBound(from)));
+    if (to) conditions.push(sql`${summaries.period_key} <= ${normalizeBound(to)}`);
 
     const rows = await db
       .select({

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -93,7 +93,15 @@ const app = new Hono<AuthEnv>()
   .get("/info", (c) => {
     const config = readSystemsConfig();
     const globalConfig = readGlobalConfig();
-    return c.json({ system: config?.system ?? null, name: globalConfig.name ?? null });
+    // The daemon host's timezone is the canonical timeline timezone: period
+    // keys are computed in server-local time, so remote viewers anchor their
+    // boundary math and labels to it rather than the browser's zone.
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? null;
+    return c.json({
+      system: config?.system ?? null,
+      name: globalConfig.name ?? null,
+      timezone,
+    });
   })
   .put("/info", requireAdmin, zValidator("json", z.object({ name: z.string() })), (c) => {
     const { name } = c.req.valid("json");

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -14,13 +14,16 @@ import {
   fetchHistory,
   fetchSummaries,
   fetchSummaryByIds,
+  fetchSystemInfo,
   fetchTurnEvents,
   fetchTurns,
 } from "../lib/client";
 import { extractTextContent } from "../lib/feed-utils";
 import { formatRelativeTime } from "../lib/format";
 import { navigate } from "../lib/navigate";
+import { parseISOWeek, summaryBounds, wallNow } from "../lib/period-keys";
 import { activeMinds } from "../lib/stores.svelte";
+import { mergeOlderSummaries, nextSummaryPage } from "../lib/summary-paging";
 import {
   isRecentInbound,
   isTurnStale,
@@ -49,19 +52,7 @@ const CHILD_PERIOD: Record<string, "turn" | "hour" | "day" | "week" | "month"> =
   month: "week",
 };
 
-function parseISOWeek(weekKey: string): Date {
-  // weekKey format: "2026-W12" — returns the Monday of that week (local time)
-  const [yearStr, weekStr] = weekKey.split("-W");
-  const year = parseInt(yearStr, 10);
-  const week = parseInt(weekStr, 10);
-  const jan4 = new Date(year, 0, 4);
-  const dayOfWeek = jan4.getDay() || 7;
-  const monday = new Date(jan4);
-  monday.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
-  return monday;
-}
-
-// Period keys are local time. Parse without Z suffix.
+// Period keys are server-local wall-clock time. Parse without Z suffix.
 function periodKeyToDate(period: string, periodKey: string): Date {
   if (period === "hour")
     return new Date(`${periodKey.slice(0, 10)}T${periodKey.slice(11, 13)}:00:00`);
@@ -71,14 +62,17 @@ function periodKeyToDate(period: string, periodKey: string): Date {
   return new Date(periodKey);
 }
 
-function formatPeriodTime(period: string, periodKey: string): string {
-  const now = new Date();
-  const todayLocal = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+// `serverTz` anchors Today/Yesterday and the current-year comparison to the
+// daemon's timezone (period keys are server-local). Wall-clock labels
+// themselves format the key's own numbers, so they're already zone-agnostic.
+function formatPeriodTime(period: string, periodKey: string, serverTz?: string): string {
+  const w = wallNow(serverTz);
+  const todayLocal = new Date(w.year, w.month - 1, w.day);
   const yesterdayLocal = new Date(todayLocal);
   yesterdayLocal.setDate(todayLocal.getDate() - 1);
 
   if (period === "hour") {
-    // Period keys are local time — parse directly
+    // Period keys are server-local wall time — parse and render directly
     const start = periodKeyToDate("hour", periodKey);
     const end = new Date(start.getTime() + 3600000);
 
@@ -108,7 +102,7 @@ function formatPeriodTime(period: string, periodKey: string): string {
     end.setDate(start.getDate() + 6);
     const fmtDate = (d: Date) =>
       d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-    if (start.getFullYear() !== now.getFullYear()) {
+    if (start.getFullYear() !== w.year) {
       return `${fmtDate(start)} \u2013 ${fmtDate(end)}, ${start.getFullYear()}`;
     }
     return `${fmtDate(start)} \u2013 ${fmtDate(end)}`;
@@ -153,9 +147,12 @@ let { name, mindStatus }: { name?: string; mindStatus?: string } = $props();
 // --- Turns data ---
 const PAGE_SIZE = 100;
 let turnsData = $state<TurnRow[]>([]);
-let hasMore = $state(true);
 let loading = $state(false);
 let historyError = $state("");
+
+// Canonical timezone of the daemon host (period keys are computed in it).
+// Fetched once at load; undefined falls back to browser-local time.
+let serverTz = $state<string | undefined>(undefined);
 
 let readOnlyConv = $state<ConversationWithParticipants | null>(null);
 
@@ -165,6 +162,12 @@ let daySummaries = $state<SummaryRow[]>([]);
 let weekSummaries = $state<SummaryRow[]>([]);
 let monthSummaries = $state<SummaryRow[]>([]);
 let summariesLoaded = $state(false);
+// Backward summary paging (older history coarsens to week/month tiers).
+let hasMoreSummaries = $state(true);
+let loadingOlder = $state(false);
+let canLoadOlder = $derived(
+  hasMoreSummaries && (weekSummaries.length > 0 || monthSummaries.length > 0),
+);
 let expandedSummaries = $state(new SvelteMap<number, SummaryRow[] | TurnRow[]>());
 let loadingChildren = new SvelteSet<number>();
 // For single-turn hours: expand directly to raw events instead of showing the turn summary
@@ -454,21 +457,21 @@ function disconnectSSE() {
 }
 
 // --- Data loading ---
-async function loadTurns(offset: number) {
+// Turns are only ever displayed for the current hour (older turns are reached
+// through summaries), so a single page more than covers what's shown. There is
+// no offset paging — walking back in time happens via loadOlderSummaries. All
+// ingestion routes through upsertTurnRows, which dedups by id, so a re-fetch
+// never produces duplicate keys in the keyed {#each} (which would crash it).
+async function loadTurns() {
   loading = true;
   historyError = "";
   try {
-    const rows = await fetchTurns({ mind: name, limit: PAGE_SIZE, offset });
+    const rows = await fetchTurns({ mind: name, limit: PAGE_SIZE });
     const chronological = [...rows].reverse();
-    if (offset === 0) {
-      turnsData = chronological;
-    } else {
-      turnsData = [...chronological, ...turnsData];
-    }
-    hasMore = rows.length === PAGE_SIZE;
+    upsertTurnRows(chronological);
 
     // Check for recent untagged inbound events (message sent but turn not yet started)
-    if (offset === 0 && pendingInbounds.length === 0 && name) {
+    if (pendingInbounds.length === 0 && name) {
       fetchHistory(name, { preset: "all", limit: 10 })
         .then((recent) => {
           // Only promote recent untagged inbounds — an old inbound a stopped/sleeping
@@ -505,49 +508,84 @@ async function loadTurns(offset: number) {
 
 async function loadSummaries() {
   try {
-    const now = new Date();
-
-    // Period keys are local time. Build boundaries directly.
-    const pad2 = (n: number) => String(n).padStart(2, "0");
-    const todayKey = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
-    const hourCutoff = `${todayKey}T${pad2(now.getHours())}`;
-    const todayHourFrom = `${todayKey}T00`;
-    const todayDayKey = todayKey;
-
-    // Week boundary (7 days ago)
-    const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
-    const weekCutoff = `${weekAgo.getFullYear()}-${pad2(weekAgo.getMonth() + 1)}-${pad2(weekAgo.getDate())}`;
-
-    const currentMonth = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`;
+    // Boundaries are anchored to the server's timezone, since period keys are
+    // computed there (see period-keys.ts). weekCutoff/currentMonthKey are the
+    // date bounds for the tiers below "today"; the server translates the week
+    // date bound to the matching ISO-week key.
+    const bounds = summaryBounds(serverTz);
 
     // Fetch all summary periods in parallel
     const [hours, days, weeks, months] = await Promise.all([
       fetchSummaries({
         mind: name,
         period: "hour",
-        from: todayHourFrom,
-        to: hourCutoff,
+        from: bounds.todayHourFrom,
+        to: bounds.hourCutoff,
         limit: 24,
       }),
-      fetchSummaries({ mind: name, period: "day", from: weekCutoff, to: todayDayKey, limit: 7 }),
-      fetchSummaries({ mind: name, period: "week", to: weekCutoff, limit: 12 }),
-      fetchSummaries({ mind: name, period: "month", to: currentMonth, limit: 12 }),
+      fetchSummaries({
+        mind: name,
+        period: "day",
+        from: bounds.weekCutoff,
+        to: bounds.todayKey,
+        limit: 7,
+      }),
+      fetchSummaries({ mind: name, period: "week", to: bounds.weekCutoff, limit: 12 }),
+      fetchSummaries({ mind: name, period: "month", to: bounds.currentMonthKey, limit: 12 }),
     ]);
 
     hourSummaries = hours.sort((a, b) => a.period_key.localeCompare(b.period_key));
     daySummaries = days
-      .filter((d) => d.period_key < todayDayKey)
+      .filter((d) => d.period_key < bounds.todayKey)
       .sort((a, b) => a.period_key.localeCompare(b.period_key));
-    weekSummaries = weeks.sort((a, b) => a.period_key.localeCompare(b.period_key));
+    // Drop the current (partial) week so it doesn't show at both the week tier
+    // and the day tier — days already cover the last 7 days. The server maps
+    // weekCutoff (a date) to the week containing it, which may be the current
+    // week, so this client-side guard is what keeps the seam clean.
+    weekSummaries = weeks
+      .filter((w) => w.period_key < bounds.currentWeekKey)
+      .sort((a, b) => a.period_key.localeCompare(b.period_key));
     monthSummaries = months
-      .filter((m) => m.period_key < currentMonth)
+      .filter((m) => m.period_key < bounds.currentMonthKey)
       .sort((a, b) => a.period_key.localeCompare(b.period_key));
 
+    hasMoreSummaries = true;
     summariesLoaded = true;
   } catch (e) {
     console.warn("[TurnTimeline] Failed to load summaries:", e);
     summariesLoaded = true; // still mark loaded so we don't block the UI
   }
+}
+
+// Page backward through older summaries at the coarsest loaded tier.
+async function loadOlderSummaries() {
+  if (loadingOlder) return;
+  const next = nextSummaryPage(weekSummaries, monthSummaries);
+  if (!next) {
+    hasMoreSummaries = false;
+    return;
+  }
+  loadingOlder = true;
+  try {
+    const fetched = await fetchSummaries({
+      mind: name,
+      period: next.tier,
+      to: next.to,
+      limit: 12,
+    });
+    if (next.tier === "month") {
+      const { merged, exhausted } = mergeOlderSummaries(monthSummaries, fetched);
+      monthSummaries = merged;
+      if (exhausted) hasMoreSummaries = false;
+    } else {
+      const { merged, exhausted } = mergeOlderSummaries(weekSummaries, fetched);
+      weekSummaries = merged;
+      if (exhausted) hasMoreSummaries = false;
+    }
+  } catch (e) {
+    console.warn("[TurnTimeline] Failed to load older summaries:", e);
+  }
+  loadingOlder = false;
 }
 
 async function toggleSummaryExpand(summary: SummaryRow) {
@@ -629,9 +667,13 @@ async function toggleSummaryExpand(summary: SummaryRow) {
         from = `${monday.getFullYear()}-${pad2(monday.getMonth() + 1)}-${pad2(monday.getDate())}`;
         to = `${sunday.getFullYear()}-${pad2(sunday.getMonth() + 1)}-${pad2(sunday.getDate())}`;
       } else if (summary.period === "month") {
-        // Month "2026-03" → weeks/days within
+        // Month "2026-03" → weeks/days within. Use the real last day so the
+        // server's date→week-key mapping (for the week child tier) doesn't
+        // overflow into the next month and pull in a non-overlapping week.
+        const [my, mm] = summary.period_key.split("-").map(Number);
+        const lastDay = new Date(my, mm, 0).getDate();
         from = `${summary.period_key}-01`;
-        to = `${summary.period_key}-31`;
+        to = `${summary.period_key}-${String(lastDay).padStart(2, "0")}`;
       } else {
         from = summary.period_key;
         to = summary.period_key;
@@ -731,7 +773,6 @@ $effect(() => {
   if (n !== prevName) {
     prevName = n;
     turnsData = [];
-    hasMore = true;
     streamingEvents = new SvelteMap();
     nextSyntheticId = -1;
     pendingInbounds = [];
@@ -740,13 +781,14 @@ $effect(() => {
     weekSummaries = [];
     monthSummaries = [];
     summariesLoaded = false;
+    hasMoreSummaries = true;
     expandedSummaries = new SvelteMap();
     directEventsSummaries = new SvelteMap();
     reconnecting = false;
     reconnectAttempts = 0;
     lastEventAt.clear();
     startScrollToBottom();
-    loadTurns(0);
+    loadTurns();
   }
 });
 
@@ -777,6 +819,16 @@ $effect(() => {
     }
   }, 30_000);
   return () => clearInterval(interval);
+});
+
+// Fetch the daemon's canonical timezone once, so boundary math and labels
+// anchor to server-local time even when the browser is in another zone.
+$effect(() => {
+  fetchSystemInfo()
+    .then((info) => {
+      serverTz = info.timezone ?? undefined;
+    })
+    .catch(() => {});
 });
 
 // Load summaries once turns are available
@@ -813,15 +865,15 @@ function jumpToLatest() {
 
 <div class="turn-timeline">
   <div class="turn-scroll" bind:this={scrollContainer} onscroll={handleScroll} onwheel={() => stopScrollTimer()}>
-    {#if hasMore}
+    {#if canLoadOlder}
       <div class="load-older">
         <button
-          onclick={() => loadTurns(turnsData.length)}
-          disabled={loading}
+          onclick={loadOlderSummaries}
+          disabled={loadingOlder}
           class="load-older-btn"
-          style:opacity={loading ? 0.5 : 1}
+          style:opacity={loadingOlder ? 0.5 : 1}
         >
-          {loading ? "loading..." : "load older"}
+          {loadingOlder ? "loading..." : "load older"}
         </button>
       </div>
     {/if}
@@ -877,7 +929,7 @@ function jumpToLatest() {
                     {directEventsSummaries}
                     {loadingChildren}
                     {toggleSummaryExpand}
-                    {formatPeriodTime}
+                    formatPeriodTime={(p, k) => formatPeriodTime(p, k, serverTz)}
                   />
                 </div>
               </div>

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -153,6 +153,10 @@ let historyError = $state("");
 // Canonical timezone of the daemon host (period keys are computed in it).
 // Fetched once at load; undefined falls back to browser-local time.
 let serverTz = $state<string | undefined>(undefined);
+// True once the timezone fetch has settled (resolved or failed). The initial
+// summary load waits on this so cross-timezone viewers fetch server-anchored
+// buckets on first paint instead of racing the fetch and using browser-local.
+let serverTzResolved = $state(false);
 
 let readOnlyConv = $state<ConversationWithParticipants | null>(null);
 
@@ -828,12 +832,16 @@ $effect(() => {
     .then((info) => {
       serverTz = info.timezone ?? undefined;
     })
-    .catch(() => {});
+    .catch(() => {})
+    .finally(() => {
+      serverTzResolved = true;
+    });
 });
 
-// Load summaries once turns are available
+// Load summaries once turns are available AND the timezone fetch has settled,
+// so boundary math is anchored to the server zone on first paint.
 $effect(() => {
-  if (turnsData.length > 0 && !summariesLoaded && !loading) {
+  if (serverTzResolved && turnsData.length > 0 && !summariesLoaded && !loading) {
     loadSummaries();
   }
 });

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -461,11 +461,17 @@ export function restartDaemon(): Promise<void> {
   return post(`${V1}/system/restart`);
 }
 
-export async function fetchSystemInfo(): Promise<{ system: string | null; name: string | null }> {
+export async function fetchSystemInfo(): Promise<{
+  system: string | null;
+  name: string | null;
+  timezone: string | null;
+}> {
   try {
-    return await get<{ system: string | null; name: string | null }>(`${V1}/system/info`);
+    return await get<{ system: string | null; name: string | null; timezone: string | null }>(
+      `${V1}/system/info`,
+    );
   } catch {
-    return { system: null, name: null };
+    return { system: null, name: null, timezone: null };
   }
 }
 

--- a/packages/web/src/ui/lib/period-keys.ts
+++ b/packages/web/src/ui/lib/period-keys.ts
@@ -1,0 +1,93 @@
+// Client-side period-key helpers.
+//
+// Period keys are computed by the daemon in the *server's* local timezone
+// (see packages/daemon/src/lib/util/period-keys.ts). A browser viewing from a
+// different timezone must therefore anchor its "now" boundary math and its
+// Today/Yesterday comparisons to the server's timezone, not its own — otherwise
+// it asks for the wrong day's buckets and flips Today/Yesterday at the wrong
+// moment. The canonical server timezone is fetched once at load; when it is
+// unknown we fall back to the browser's local time (correct for same-TZ setups).
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/** Calendar fields of an instant, resolved in a given IANA timezone. */
+export type Wall = { year: number; month: number; day: number; hour: number };
+
+/** Resolve the wall-clock fields of `now` in `timeZone` (browser-local if unset). */
+export function wallNow(timeZone: string | undefined, now: Date = new Date()): Wall {
+  if (!timeZone) {
+    return {
+      year: now.getFullYear(),
+      month: now.getMonth() + 1,
+      day: now.getDate(),
+      hour: now.getHours(),
+    };
+  }
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(now);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "0";
+  let hour = parseInt(get("hour"), 10);
+  if (hour === 24) hour = 0; // some engines emit "24" for midnight
+  return {
+    year: parseInt(get("year"), 10),
+    month: parseInt(get("month"), 10),
+    day: parseInt(get("day"), 10),
+    hour,
+  };
+}
+
+/** ISO week key ("YYYY-Www") of a date, using its local calendar fields. */
+export function getISOWeekKey(date: Date): string {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  d.setDate(d.getDate() + 4 - (d.getDay() || 7));
+  const yearStart = new Date(d.getFullYear(), 0, 1);
+  const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getFullYear()}-W${pad2(weekNum)}`;
+}
+
+/** Monday (local midnight) of the given ISO week key. */
+export function parseISOWeek(weekKey: string): Date {
+  const [yearStr, weekStr] = weekKey.split("-W");
+  const year = parseInt(yearStr, 10);
+  const week = parseInt(weekStr, 10);
+  const jan4 = new Date(year, 0, 4);
+  const dayOfWeek = jan4.getDay() || 7;
+  const monday = new Date(jan4);
+  monday.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
+  return monday;
+}
+
+/** Day key ("YYYY-MM-DD") for a wall-clock calendar date. */
+export function dayKeyOf(w: Pick<Wall, "year" | "month" | "day">): string {
+  return `${w.year}-${pad2(w.month)}-${pad2(w.day)}`;
+}
+
+/**
+ * The set of boundary keys the timeline's initial summary load needs, anchored
+ * to the server timezone's "now".
+ */
+export function summaryBounds(timeZone: string | undefined, now: Date = new Date()) {
+  const w = wallNow(timeZone, now);
+  const todayKey = dayKeyOf(w);
+  // Seven days back in the server calendar. Reading only y/m/d off a
+  // browser-local Date built from server calendar fields is timezone-agnostic.
+  const weekAgo = new Date(w.year, w.month - 1, w.day - 7);
+  return {
+    todayKey,
+    hourCutoff: `${todayKey}T${pad2(w.hour)}`,
+    todayHourFrom: `${todayKey}T00`,
+    weekCutoff: dayKeyOf({
+      year: weekAgo.getFullYear(),
+      month: weekAgo.getMonth() + 1,
+      day: weekAgo.getDate(),
+    }),
+    currentMonthKey: `${w.year}-${pad2(w.month)}`,
+    currentWeekKey: getISOWeekKey(new Date(w.year, w.month - 1, w.day)),
+  };
+}

--- a/packages/web/src/ui/lib/summary-paging.ts
+++ b/packages/web/src/ui/lib/summary-paging.ts
@@ -1,0 +1,40 @@
+import type { SummaryRow } from "@volute/api";
+
+export type PagingTier = "week" | "month";
+
+/**
+ * Decide which tier to page and the `to` cursor for the next backward page.
+ * Going back in time, detail coarsens: page the coarsest loaded tier (month if
+ * any months are loaded, else week). Returns null when there is nothing coarser
+ * than the day tier loaded, i.e. no summary paging is possible.
+ *
+ * Callers keep each tier's rows sorted ascending by `period_key`, so index 0 is
+ * the oldest loaded key — the inclusive `to` cursor for the next older page.
+ */
+export function nextSummaryPage(
+  weeks: SummaryRow[],
+  months: SummaryRow[],
+): { tier: PagingTier; to: string } | null {
+  if (months.length > 0) return { tier: "month", to: months[0].period_key };
+  if (weeks.length > 0) return { tier: "week", to: weeks[0].period_key };
+  return null;
+}
+
+/**
+ * Merge a freshly-fetched older page into existing rows. The API `to` bound is
+ * inclusive, so the cursor row comes back again; dedup by id drops it (and any
+ * other overlap). Returns the merged, ascending-sorted list and whether the
+ * terminal page was reached (no new rows → hide the "load older" button).
+ */
+export function mergeOlderSummaries(
+  existing: SummaryRow[],
+  fetched: SummaryRow[],
+): { merged: SummaryRow[]; exhausted: boolean } {
+  const seen = new Set(existing.map((s) => s.id));
+  const additions = fetched.filter((s) => !seen.has(s.id));
+  if (additions.length === 0) return { merged: existing, exhausted: true };
+  const merged = [...existing, ...additions].sort((a, b) =>
+    a.period_key.localeCompare(b.period_key),
+  );
+  return { merged, exhausted: false };
+}

--- a/scripts/backfill-summaries.ts
+++ b/scripts/backfill-summaries.ts
@@ -14,9 +14,9 @@ import {
   summarizePeriod,
   summarizeSystem,
   type TimerPeriod,
-} from "../src/lib/daemon/summarizer.js";
-import { getDb } from "../src/lib/db.js";
-import { mindHistory, summaries, turns } from "../src/lib/schema.js";
+} from "../packages/daemon/src/lib/daemon/summarizer.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { mindHistory, summaries, turns } from "../packages/daemon/src/lib/schema.js";
 
 async function migrateTurnSummaries() {
   const db = await getDb();
@@ -98,26 +98,29 @@ async function discoverPeriodKeys(period: TimerPeriod): Promise<string[]> {
 
   if (!range?.min || !range?.max) return [];
 
+  // created_at is stored as UTC (datetime('now')), so parse the endpoints as
+  // UTC instants — but step the cursor in *local* calendar units so it matches
+  // getPeriodKey, which derives keys from local fields. Mixing UTC steps with
+  // local keys skips or duplicates the edge bucket around DST transitions.
   const start = new Date(range.min + "Z");
   const end = new Date(range.max + "Z");
   const keys = new Set<string>();
 
-  // Walk from start to end generating period keys
   const cursor = new Date(start);
   while (cursor <= end) {
     keys.add(getPeriodKey(cursor, period));
     switch (period) {
       case "hour":
-        cursor.setUTCHours(cursor.getUTCHours() + 1);
+        cursor.setHours(cursor.getHours() + 1);
         break;
       case "day":
-        cursor.setUTCDate(cursor.getUTCDate() + 1);
+        cursor.setDate(cursor.getDate() + 1);
         break;
       case "week":
-        cursor.setUTCDate(cursor.getUTCDate() + 7);
+        cursor.setDate(cursor.getDate() + 7);
         break;
       case "month":
-        cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+        cursor.setMonth(cursor.getMonth() + 1);
         break;
     }
   }

--- a/scripts/backfill-summaries.ts
+++ b/scripts/backfill-summaries.ts
@@ -120,6 +120,10 @@ async function discoverPeriodKeys(period: TimerPeriod): Promise<string[]> {
         cursor.setDate(cursor.getDate() + 7);
         break;
       case "month":
+        // Normalize to the 1st before stepping so a start day of 29-31 doesn't
+        // overflow and skip a shorter month (e.g. Jan 31 → Mar 3, losing Feb).
+        // Day-of-month is irrelevant to the "YYYY-MM" key.
+        cursor.setDate(1);
         cursor.setMonth(cursor.getMonth() + 1);
         break;
     }

--- a/test/period-keys.test.ts
+++ b/test/period-keys.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { describe, it } from "node:test";
 import {
   getISOWeekKey,
@@ -7,6 +8,17 @@ import {
   isoWeekKeyForDateStr,
   isoWeekToDate,
 } from "../packages/daemon/src/lib/util/period-keys.js";
+
+// Node resolves the process timezone once at startup, so DST-boundary behavior
+// can only be exercised by re-invoking a child process with a fixed TZ. This
+// runs the period-key module under a DST-observing zone and returns stdout.
+function runUnderTz(tz: string, script: string): string {
+  return execFileSync(process.execPath, ["--import", "tsx", "--input-type=module", "-"], {
+    input: script,
+    env: { ...process.env, TZ: tz },
+    encoding: "utf8",
+  }).trim();
+}
 
 describe("period-keys", () => {
   describe("getISOWeekKey", () => {
@@ -67,6 +79,18 @@ describe("period-keys", () => {
 
     it("crosses a day boundary", () => {
       assert.equal(getPreviousPeriodKey("2026-03-22T00", "hour"), "2026-03-21T23");
+    });
+
+    it("skips the nonexistent spring-forward hour under a DST zone", () => {
+      // 2026-03-08 02:00 America/New_York does not exist (clocks jump to 3 AM).
+      // The previous hour of 3 AM local must be 1 AM local — a naive
+      // setHours(h-1) would produce 2 AM (or loop back to 3 AM), which is wrong.
+      const out = runUnderTz(
+        "America/New_York",
+        `import { getPreviousPeriodKey } from "${new URL("../packages/daemon/src/lib/util/period-keys.ts", import.meta.url).pathname}";
+         process.stdout.write(getPreviousPeriodKey("2026-03-08T03", "hour"));`,
+      );
+      assert.equal(out, "2026-03-08T01");
     });
   });
 

--- a/test/period-keys.test.ts
+++ b/test/period-keys.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  getISOWeekKey,
+  getPeriodKey,
+  getPreviousPeriodKey,
+  isoWeekKeyForDateStr,
+  isoWeekToDate,
+} from "../packages/daemon/src/lib/util/period-keys.js";
+
+describe("period-keys", () => {
+  describe("getISOWeekKey", () => {
+    it("computes a mid-year week", () => {
+      // 2026-03-22 is a Sunday in ISO week 12
+      assert.equal(getISOWeekKey(new Date(2026, 2, 22)), "2026-W12");
+    });
+
+    it("Jan 1 belongs to the previous year's last week when early in the week", () => {
+      // 2027-01-01 is a Friday → ISO week 53 of 2026
+      assert.equal(getISOWeekKey(new Date(2027, 0, 1)), "2026-W53");
+    });
+
+    it("Dec 31 belongs to next year's W01 when late in the week", () => {
+      // 2025-12-31 is a Wednesday → ISO week 1 of 2026
+      assert.equal(getISOWeekKey(new Date(2025, 11, 31)), "2026-W01");
+    });
+  });
+
+  describe("isoWeekToDate", () => {
+    it("round-trips through getISOWeekKey (Monday of the week)", () => {
+      const monday = isoWeekToDate("2026-W12");
+      assert.equal(monday.getDay(), 1); // Monday
+      assert.equal(getISOWeekKey(monday), "2026-W12");
+    });
+  });
+
+  describe("isoWeekKeyForDateStr", () => {
+    it("maps a date to the week key of the week containing it", () => {
+      assert.equal(isoWeekKeyForDateStr("2026-03-22"), "2026-W12");
+      assert.equal(isoWeekKeyForDateStr("2026-03-16"), "2026-W12"); // Monday of W12
+      assert.equal(isoWeekKeyForDateStr("2026-03-23"), "2026-W13"); // next Monday
+    });
+
+    it("maps across a month boundary correctly", () => {
+      // 2026-03-01 is a Sunday → still ISO week 9 (the week that started Feb 23)
+      assert.equal(isoWeekKeyForDateStr("2026-03-01"), "2026-W09");
+    });
+
+    it("returns non-date strings unchanged", () => {
+      assert.equal(isoWeekKeyForDateStr("2026-W14"), "2026-W14");
+      assert.equal(isoWeekKeyForDateStr("2026-03"), "2026-03");
+    });
+
+    it("produces keys that sort correctly against stored week keys", () => {
+      // The whole point of the fix: a date bound must compare correctly with
+      // "W"-format week keys (binary collation sorts "W" above digits).
+      const bound = isoWeekKeyForDateStr("2026-06-29"); // 2026-W27
+      assert.ok("2026-W14" <= bound, "current-year week should pass the <= bound");
+      assert.ok(!("2026-W40" <= bound), "later week should fail the <= bound");
+    });
+  });
+
+  describe("getPreviousPeriodKey (hour) is DST-safe", () => {
+    it("steps back one hour normally", () => {
+      assert.equal(getPreviousPeriodKey("2026-03-22T14", "hour"), "2026-03-22T13");
+    });
+
+    it("crosses a day boundary", () => {
+      assert.equal(getPreviousPeriodKey("2026-03-22T00", "hour"), "2026-03-21T23");
+    });
+  });
+
+  describe("getPeriodKey", () => {
+    it("formats each tier", () => {
+      const d = new Date(2026, 2, 22, 14, 30, 0);
+      assert.equal(getPeriodKey(d, "hour"), "2026-03-22T14");
+      assert.equal(getPeriodKey(d, "day"), "2026-03-22");
+      assert.equal(getPeriodKey(d, "week"), "2026-W12");
+      assert.equal(getPeriodKey(d, "month"), "2026-03");
+    });
+  });
+});

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -309,6 +309,101 @@ describe("web history routes", () => {
     assert.equal(body[0].period_key, "2026-03-22T14");
   });
 
+  it("GET /api/v1/history/summaries — week tier: date bounds match ISO week keys", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    // Current-year week keys. Under binary collation "W" sorts above digits, so
+    // a raw date bound like "2026-06-29" would wrongly exclude "2026-W14".
+    await db.insert(summaries).values([
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W12", content: "W12" },
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W14", content: "W14" },
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W27", content: "W27" },
+    ]);
+
+    // Top-level week fetch used to pass `to=<date>` only. 2026-06-29 is in W27,
+    // so weeks up to and including W27 should return.
+    const res = await app.request(
+      "/api/v1/history/summaries?period=week&mind=test-history-weeks&to=2026-06-29",
+      { headers: { Cookie: `volute_session=${cookie}` } },
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{ period_key: string }>;
+    const keys = body.map((r) => r.period_key).sort();
+    assert.deepEqual(keys, ["2026-W12", "2026-W14", "2026-W27"]);
+  });
+
+  it("GET /api/v1/history/summaries — week tier: month-shaped range returns overlapping weeks", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    // March 2026: W09 (starts Feb 23, overlaps Mar 1) .. W14 (ends Apr 5).
+    await db.insert(summaries).values([
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W08", content: "W08" },
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W10", content: "W10" },
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W13", content: "W13" },
+      { mind: "test-history-weeks", period: "week", period_key: "2026-W20", content: "W20" },
+    ]);
+
+    // Month drill-down passes from=YYYY-MM-01, to=<last day of month>.
+    const res = await app.request(
+      "/api/v1/history/summaries?period=week&mind=test-history-weeks&from=2026-03-01&to=2026-03-31",
+      { headers: { Cookie: `volute_session=${cookie}` } },
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{ period_key: string }>;
+    const keys = body.map((r) => r.period_key).sort();
+    // W08 (all February) and W20 (May) excluded; the March-overlapping weeks returned.
+    assert.deepEqual(keys, ["2026-W10", "2026-W13"]);
+  });
+
+  it("GET /api/v1/history/summaries — month tier pages backward with an inclusive `to` cursor", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    await db.insert(summaries).values([
+      { mind: "test-history-page", period: "month", period_key: "2026-01", content: "Jan" },
+      { mind: "test-history-page", period: "month", period_key: "2026-02", content: "Feb" },
+      { mind: "test-history-page", period: "month", period_key: "2026-03", content: "Mar" },
+      { mind: "test-history-page", period: "month", period_key: "2026-04", content: "Apr" },
+    ]);
+
+    const fetchPage = async (to?: string) => {
+      const qs = new URLSearchParams({ period: "month", mind: "test-history-page", limit: "2" });
+      if (to) qs.set("to", to);
+      const res = await app.request(`/api/v1/history/summaries?${qs}`, {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      return (await res.json()) as Array<{ period_key: string }>;
+    };
+
+    // Page 1: newest two, returned descending.
+    const p1 = await fetchPage();
+    assert.deepEqual(
+      p1.map((r) => r.period_key),
+      ["2026-04", "2026-03"],
+    );
+
+    // Page 2: cursor = oldest loaded key (inclusive), so it re-returns "2026-03"
+    // (client dedups it) plus the next older month.
+    const p2 = await fetchPage("2026-03");
+    assert.deepEqual(
+      p2.map((r) => r.period_key),
+      ["2026-03", "2026-02"],
+    );
+
+    // Page 3: cursor = "2026-01" → only the terminal row, nothing older.
+    const p3 = await fetchPage("2026-01");
+    assert.deepEqual(
+      p3.map((r) => r.period_key),
+      ["2026-01"],
+    );
+  });
+
   it("GET /api/v1/history/summaries — caps limit at 200", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");

--- a/test/web-period-keys.test.ts
+++ b/test/web-period-keys.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { SummaryRow } from "../packages/api/src/types.js";
+import {
+  getISOWeekKey,
+  parseISOWeek,
+  summaryBounds,
+  wallNow,
+} from "../packages/web/src/ui/lib/period-keys.js";
+import { mergeOlderSummaries, nextSummaryPage } from "../packages/web/src/ui/lib/summary-paging.js";
+
+function sum(id: number, period: SummaryRow["period"], key: string): SummaryRow {
+  return { id, mind: "m", period, period_key: key, content: "", metadata: null, created_at: "" };
+}
+
+describe("web period-keys", () => {
+  describe("wallNow anchors to the given timezone", () => {
+    // 02:30 UTC on Mar 22 is still Mar 21 22:30 in New York (UTC-4 in DST).
+    const instant = new Date("2026-03-22T02:30:00Z");
+
+    it("resolves server-timezone calendar fields", () => {
+      assert.deepEqual(wallNow("America/New_York", instant), {
+        year: 2026,
+        month: 3,
+        day: 21,
+        hour: 22,
+      });
+      assert.deepEqual(wallNow("UTC", instant), { year: 2026, month: 3, day: 22, hour: 2 });
+    });
+  });
+
+  describe("getISOWeekKey / parseISOWeek", () => {
+    it("computes and round-trips a week key", () => {
+      assert.equal(getISOWeekKey(new Date(2026, 2, 21)), "2026-W12"); // Sat Mar 21
+      const monday = parseISOWeek("2026-W12");
+      assert.equal(monday.getDay(), 1);
+      assert.equal(getISOWeekKey(monday), "2026-W12");
+    });
+  });
+
+  describe("summaryBounds", () => {
+    it("derives boundary keys in the server timezone", () => {
+      const b = summaryBounds("America/New_York", new Date("2026-03-22T02:30:00Z"));
+      assert.equal(b.todayKey, "2026-03-21");
+      assert.equal(b.hourCutoff, "2026-03-21T22");
+      assert.equal(b.todayHourFrom, "2026-03-21T00");
+      assert.equal(b.weekCutoff, "2026-03-14");
+      assert.equal(b.currentMonthKey, "2026-03");
+      assert.equal(b.currentWeekKey, "2026-W12");
+    });
+  });
+
+  describe("nextSummaryPage", () => {
+    it("pages the month tier when months are loaded", () => {
+      const months = [sum(1, "month", "2026-01"), sum(2, "month", "2026-02")];
+      const weeks = [sum(3, "week", "2026-W05")];
+      assert.deepEqual(nextSummaryPage(weeks, months), { tier: "month", to: "2026-01" });
+    });
+
+    it("falls back to the week tier until months exist", () => {
+      const weeks = [sum(3, "week", "2026-W05"), sum(4, "week", "2026-W06")];
+      assert.deepEqual(nextSummaryPage(weeks, []), { tier: "week", to: "2026-W05" });
+    });
+
+    it("returns null when nothing coarser than days is loaded", () => {
+      assert.equal(nextSummaryPage([], []), null);
+    });
+  });
+
+  describe("mergeOlderSummaries", () => {
+    it("appends older rows, dedups the inclusive cursor row, and re-sorts", () => {
+      const existing = [sum(2, "month", "2026-02"), sum(3, "month", "2026-03")];
+      // to=2026-02 returned the cursor (id 2) again plus an older month.
+      const fetched = [sum(1, "month", "2026-01"), sum(2, "month", "2026-02")];
+      const { merged, exhausted } = mergeOlderSummaries(existing, fetched);
+      assert.equal(exhausted, false);
+      assert.deepEqual(
+        merged.map((m) => m.period_key),
+        ["2026-01", "2026-02", "2026-03"],
+      );
+      assert.equal(merged.length, 3, "no duplicate cursor row");
+    });
+
+    it("reports exhausted when the page adds nothing new", () => {
+      const existing = [sum(1, "month", "2026-01")];
+      const { merged, exhausted } = mergeOlderSummaries(existing, [sum(1, "month", "2026-01")]);
+      assert.equal(exhausted, true);
+      assert.equal(merged.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
Fixes three linked timeline-summary bugs that left summaries unreachable or bucketed into the wrong periods.

## What changed

**#392 — week/day seam & range filtering.** Extracted the server period-key helpers into `packages/daemon/src/lib/util/period-keys.ts` and made the `/api/v1/history/summaries` range filter week-aware (a date bound is translated to the containing ISO-week key so it compares correctly against `W`-format week keys). The client drops the current partial week (`period_key < currentWeekKey`) so a week never shows at both the week and day tiers, and sends the real month last-day for drill-down. The seam is kept clean client-side (chosen over shifting the server bound, per the issue's "pick one and comment").

**#397 — server-timezone anchoring.** Exposed the daemon's canonical timezone on `/api/system/info`; the client anchors boundary math and Today/Yesterday labels to it via `packages/web/src/ui/lib/period-keys.ts` (period keys are server-local wall clock). DST-hardened the summarizer's previous-hour derivation (subtract a UTC instant instead of mutating local hour fields, so a skipped/repeated local hour doesn't skip or duplicate a bucket). Fixed the backfill script's stale imports and local/UTC clock mixing.

**#401 — backward paging.** Repurposed "load older" to page summaries backward at the month/week tier with an inclusive to-cursor (`packages/web/src/ui/lib/summary-paging.ts`), removed offset turn paging, and routed all turn ingestion through `upsertTurnRows` to dedup.

## Review triage

Addressed:
- **Server-tz race (important, two reviewers).** `loadSummaries()` read `serverTz` synchronously before its first await while `serverTz` was populated by a *separate* racing fetch, so a cross-timezone viewer could compute bounds in browser-local time on first paint and fetch the wrong buckets — the exact defect #397 fixes, and it never self-corrected because `summariesLoaded` guarded the re-run. Now gated on a `serverTzResolved` flag set in the fetch's `.finally()`, preserving the browser-local fallback for same-TZ/offline cases.
- **DST hour-stepping unverified (important).** Added a subprocess test under `TZ=America/New_York` asserting `getPreviousPeriodKey("2026-03-08T03","hour") === "2026-03-08T01"` (spring-forward skips the nonexistent 2 AM) — a case where the old `setHours(h-1)` diverges from the fix.
- **Backfill month-cursor overflow (minor).** Normalized the month cursor to the 1st before stepping so a start day of 29-31 no longer overflows and silently skips a shorter month.

Skipped:
- **Dedicated `discoverPeriodKeys` test (minor).** The backfill script runs `main()` on import and doesn't export its helpers, so a unit test would require refactoring the maintenance script to be importable — out of scope for this pass, and the concrete overflow bug it would guard is fixed above.
- **Per-label "(server time, X)" suffix (#397 nicety).** The substantive fix is correct bucketing and day-flip; a suffix on every row was judged clutter. Labels self-correct reactively once `serverTz` arrives.

## Testing
- Full `npm test`: **1946 passed, 0 failed**.
- Targeted: `period-keys`, `web-period-keys`, `web-history`, `tool-groups` green in isolation; new DST subprocess test passes.
- `svelte-check`: 0 errors (2 pre-existing warnings unrelated to this change).

Fixes #392
Fixes #397
Fixes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)