### PR TITLE
feat: surface stale mind templates in status, list, and web UI

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -19,6 +19,7 @@ export type Mind = {
   template?: string;
   channels: PlatformConnection[];
   hasPages?: boolean;
+  templateStale?: boolean;
   lastActiveAt?: string | null;
   displayName?: string;
   description?: string;

--- a/packages/cli/src/commands/mind-list.ts
+++ b/packages/cli/src/commands/mind-list.ts
@@ -20,6 +20,7 @@ const cmd = command({
       running: boolean;
       status?: string;
       stage?: string;
+      templateStale?: boolean;
     }>;
 
     if (minds.length === 0) {
@@ -30,7 +31,8 @@ const cmd = command({
     for (const mind of minds) {
       const status = mind.status ?? (mind.running ? "running" : "stopped");
       const label = mind.stage === "seed" ? " (seed)" : "";
-      console.log(`  ${mind.name}: ${status}${label}`);
+      const template = mind.templateStale ? "  [template: outdated]" : "";
+      console.log(`  ${mind.name}: ${status}${label}${template}`);
     }
   },
 });

--- a/packages/cli/src/commands/mind-status.ts
+++ b/packages/cli/src/commands/mind-status.ts
@@ -35,6 +35,7 @@ const cmd = command({
       stage?: string;
       parent?: string;
       model?: string;
+      templateStale?: boolean;
       channels?: Array<{ type: string; status: string }>;
       variants?: Array<{ name: string; status: string }>;
       hasPages?: boolean;
@@ -47,6 +48,9 @@ const cmd = command({
     if (mind.stage) console.log(`Stage:   ${mind.stage}`);
     if (mind.parent) console.log(`Parent:  ${mind.parent}`);
     if (mind.model) console.log(`Model:   ${mind.model}`);
+    if (mind.templateStale) {
+      console.log(`Template: outdated — run 'volute mind upgrade ${mind.name}'`);
+    }
 
     if (mind.channels && mind.channels.length > 0) {
       console.log(`\nChannels:`);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -350,8 +350,15 @@ export async function startDaemon(opts: {
 
   // Backfill template hashes + notify minds about version updates
   try {
-    const { backfillTemplateHashes, notifyVersionUpdate } = await import("./lib/version-notify.js");
-    backfillTemplateHashes();
+    const { backfillTemplateHashes, notifyVersionUpdate, warnStaleTemplates } = await import(
+      "./lib/version-notify.js"
+    );
+    // Backfill first (measures on-disk hashes), then warn about stale minds.
+    backfillTemplateHashes()
+      .then(() => warnStaleTemplates())
+      .catch((err) => {
+        log.warn("failed to check template staleness", log.errorData(err));
+      });
     // Fire-and-forget notification (non-blocking)
     notifyVersionUpdate().catch((err) => {
       log.warn("failed to send version update notifications", log.errorData(err));

--- a/packages/daemon/src/lib/mind/template-staleness.ts
+++ b/packages/daemon/src/lib/mind/template-staleness.ts
@@ -8,15 +8,20 @@ import {
   type TemplateManifest,
 } from "../template/template.js";
 import { computeTemplateHash } from "../template/template-hash.js";
+import log from "../util/logger.js";
 import { type MindEntry, mindDir } from "./registry.js";
 
-type TemplateFileList = { files: string[]; manifest: TemplateManifest };
+type TemplateFileList = {
+  files: string[];
+  manifest: TemplateManifest;
+  contents: Map<string, Buffer>;
+};
 
 const fileListCache = new Map<string, TemplateFileList>();
 
 /**
- * The list of composed template files (excluding .init/) plus the manifest,
- * memoized per template name. This mirrors the file selection in
+ * The list of composed template files (excluding .init/), their contents, and
+ * the manifest, memoized per template name. This mirrors the file selection in
  * computeTemplateHash() so the two hashes are directly comparable.
  */
 function getTemplateFileList(templateName: string): TemplateFileList {
@@ -34,7 +39,11 @@ function getTemplateFileList(templateName: string): TemplateFileList {
     const files = listFiles(composedDir)
       .filter((f) => !f.startsWith(".init/") && !f.startsWith(".init\\"))
       .sort();
-    const result: TemplateFileList = { files, manifest };
+    const contents = new Map<string, Buffer>();
+    for (const file of files) {
+      contents.set(file, readFileSync(resolve(composedDir, file)));
+    }
+    const result: TemplateFileList = { files, manifest, contents };
     fileListCache.set(templateName, result);
     return result;
   } finally {
@@ -44,18 +53,27 @@ function getTemplateFileList(templateName: string): TemplateFileList {
 
 /**
  * Hash a mind's actual on-disk template files, using the same file list and
- * algorithm as computeTemplateHash(). Renames from the manifest are reversed
- * (on-disk `package.json` maps back to composed `package.json.tmpl`) and the
- * `{{name}}` substitution applied at creation is undone, so a pristine mind
- * hashes identically to computeTemplateHash(templateName). Missing files hash
- * as absent, producing a mismatch rather than a false match.
+ * algorithm as computeTemplateHash(), so a pristine mind hashes identically to
+ * computeTemplateHash(templateName). Renames from the manifest are applied
+ * (composed `package.json.tmpl` maps to on-disk `package.json`).
+ *
+ * For files that carry a `{{name}}` substitution, the expected on-disk bytes are
+ * derived by forward-substituting the mind name into the composed template — the
+ * same transform copyTemplateToDir() applies at creation — and compared to the
+ * actual file. A pristine file contributes the canonical `{{name}}` form (so the
+ * total lines up with computeTemplateHash), a drifted file contributes its own
+ * on-disk bytes (guaranteeing a mismatch). This avoids reverse-substituting the
+ * mind name, which over-replaces when the name is a substring of file content
+ * (e.g. a mind named "dev" colliding with package.json's "devDependencies").
+ *
+ * Missing files hash as absent, producing a mismatch rather than a false match.
  */
 export function computeMindTemplateHash(
   mindProjectDir: string,
   templateName: string,
   mindName: string,
 ): string {
-  const { files, manifest } = getTemplateFileList(templateName);
+  const { files, manifest, contents } = getTemplateFileList(templateName);
   const substituteSet = new Set(manifest.substitute);
 
   const hash = createHash("sha256");
@@ -70,22 +88,49 @@ export function computeMindTemplateHash(
       continue;
     }
 
-    let content: Buffer;
+    const composed = contents.get(file) as Buffer;
+    const onDisk = readFileSync(onDiskPath);
+
     if (substituteSet.has(onDiskRel) && mindName.length > 0) {
-      // Reverse the {{name}} substitution so a pristine mind matches the
-      // composed template (whose content still has the {{name}} placeholder).
-      const text = readFileSync(onDiskPath, "utf-8").replaceAll(mindName, "{{name}}");
-      content = Buffer.from(text, "utf-8");
+      const expected = Buffer.from(
+        composed.toString("utf-8").replaceAll("{{name}}", mindName),
+        "utf-8",
+      );
+      hash.update(onDisk.equals(expected) ? composed : onDisk);
     } else {
-      content = readFileSync(onDiskPath);
+      hash.update(onDisk);
     }
-    hash.update(content);
   }
   return hash.digest("hex");
 }
 
-type StaleCacheEntry = { mtime: number; stale: boolean };
+/**
+ * A cheap directory-wide change signal over the mind's tracked template files:
+ * the max mtime of the files that exist, plus how many exist. Any edit (mtime
+ * rises), removal (count drops), or re-addition (count rises) of a tracked file
+ * changes the signal, so the staleness memo below is invalidated when *any*
+ * template-owned file drifts — not just the sentinel.
+ */
+function trackedSignal(mindProjectDir: string, templateName: string): string {
+  const { files, manifest } = getTemplateFileList(templateName);
+  let maxMtime = 0;
+  let present = 0;
+  for (const file of files) {
+    const onDiskRel = manifest.rename[file] ?? file;
+    try {
+      const m = statSync(resolve(mindProjectDir, onDiskRel)).mtimeMs;
+      present++;
+      if (m > maxMtime) maxMtime = m;
+    } catch {
+      // Missing file — reflected by the lower `present` count.
+    }
+  }
+  return `${maxMtime}:${present}`;
+}
+
+type StaleCacheEntry = { signal: string; stale: boolean };
 const staleCache = new Map<string, StaleCacheEntry>();
+const warnedTemplates = new Set<string>();
 
 /**
  * Whether a mind is running an out-of-date copy of its template's framework
@@ -98,8 +143,9 @@ const staleCache = new Map<string, StaleCacheEntry>();
  * fast path — when it already matches the current template we skip the disk
  * read. A mismatch, a null hash, or an unreadable mind dir all read as stale.
  *
- * Results are memoized per mind dir keyed on the mtime of src/agent.ts, so
- * `volute mind list` doesn't re-hash every mind on each call.
+ * Results are memoized per mind dir keyed on a directory-wide change signal over
+ * the tracked files, so `volute mind list` doesn't re-hash every mind on each
+ * call yet still notices drift in any template-owned file.
  */
 export function isTemplateStale(entry: MindEntry): boolean {
   if (entry.mindType !== "mind") return false;
@@ -110,8 +156,16 @@ export function isTemplateStale(entry: MindEntry): boolean {
   let current: string;
   try {
     current = computeTemplateHash(templateName);
-  } catch {
-    // Unknown/unbuildable template — can't assess, don't nag.
+  } catch (err) {
+    // Can't resolve/build the template — surface it once so a broken template
+    // doesn't silently disable the staleness check for every mind.
+    if (!warnedTemplates.has(templateName)) {
+      warnedTemplates.add(templateName);
+      log.warn(
+        `cannot compute template hash for '${templateName}'; skipping staleness check`,
+        log.errorData(err),
+      );
+    }
     return false;
   }
 
@@ -119,11 +173,10 @@ export function isTemplateStale(entry: MindEntry): boolean {
   if (entry.templateHash != null && entry.templateHash === current) return false;
 
   const dir = mindDir(entry.name);
-  const sentinel = resolve(dir, "src", "agent.ts");
-  const mtime = existsSync(sentinel) ? statSync(sentinel).mtimeMs : 0;
+  const signal = trackedSignal(dir, templateName);
 
   const cached = staleCache.get(dir);
-  if (cached && cached.mtime === mtime) return cached.stale;
+  if (cached && cached.signal === signal) return cached.stale;
 
   let stale: boolean;
   try {
@@ -132,6 +185,6 @@ export function isTemplateStale(entry: MindEntry): boolean {
     // Can't read the mind's on-disk template — treat unknown as stale.
     stale = true;
   }
-  staleCache.set(dir, { mtime, stale });
+  staleCache.set(dir, { signal, stale });
   return stale;
 }

--- a/packages/daemon/src/lib/mind/template-staleness.ts
+++ b/packages/daemon/src/lib/mind/template-staleness.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  composeTemplate,
+  findTemplatesRoot,
+  listFiles,
+  type TemplateManifest,
+} from "../template/template.js";
+import { computeTemplateHash } from "../template/template-hash.js";
+import { type MindEntry, mindDir } from "./registry.js";
+
+type TemplateFileList = { files: string[]; manifest: TemplateManifest };
+
+const fileListCache = new Map<string, TemplateFileList>();
+
+/**
+ * The list of composed template files (excluding .init/) plus the manifest,
+ * memoized per template name. This mirrors the file selection in
+ * computeTemplateHash() so the two hashes are directly comparable.
+ */
+function getTemplateFileList(templateName: string): TemplateFileList {
+  const cached = fileListCache.get(templateName);
+  if (cached) return cached;
+
+  const templatesRoot = findTemplatesRoot();
+  const baseDir = resolve(templatesRoot, "_base");
+  const templateDir = resolve(templatesRoot, templateName);
+  if (!existsSync(baseDir)) throw new Error(`Base template not found: ${baseDir}`);
+  if (!existsSync(templateDir)) throw new Error(`Template not found: ${templateName}`);
+
+  const { composedDir, manifest } = composeTemplate(templatesRoot, templateName);
+  try {
+    const files = listFiles(composedDir)
+      .filter((f) => !f.startsWith(".init/") && !f.startsWith(".init\\"))
+      .sort();
+    const result: TemplateFileList = { files, manifest };
+    fileListCache.set(templateName, result);
+    return result;
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Hash a mind's actual on-disk template files, using the same file list and
+ * algorithm as computeTemplateHash(). Renames from the manifest are reversed
+ * (on-disk `package.json` maps back to composed `package.json.tmpl`) and the
+ * `{{name}}` substitution applied at creation is undone, so a pristine mind
+ * hashes identically to computeTemplateHash(templateName). Missing files hash
+ * as absent, producing a mismatch rather than a false match.
+ */
+export function computeMindTemplateHash(
+  mindProjectDir: string,
+  templateName: string,
+  mindName: string,
+): string {
+  const { files, manifest } = getTemplateFileList(templateName);
+  const substituteSet = new Set(manifest.substitute);
+
+  const hash = createHash("sha256");
+  for (const file of files) {
+    const onDiskRel = manifest.rename[file] ?? file;
+    const onDiskPath = resolve(mindProjectDir, onDiskRel);
+    hash.update(file);
+    hash.update("\0");
+
+    if (!existsSync(onDiskPath)) {
+      hash.update("\0__ABSENT__\0");
+      continue;
+    }
+
+    let content: Buffer;
+    if (substituteSet.has(onDiskRel) && mindName.length > 0) {
+      // Reverse the {{name}} substitution so a pristine mind matches the
+      // composed template (whose content still has the {{name}} placeholder).
+      const text = readFileSync(onDiskPath, "utf-8").replaceAll(mindName, "{{name}}");
+      content = Buffer.from(text, "utf-8");
+    } else {
+      content = readFileSync(onDiskPath);
+    }
+    hash.update(content);
+  }
+  return hash.digest("hex");
+}
+
+type StaleCacheEntry = { mtime: number; stale: boolean };
+const staleCache = new Map<string, StaleCacheEntry>();
+
+/**
+ * Whether a mind is running an out-of-date copy of its template's framework
+ * code. Only regular minds carry a per-mind template copy that can drift;
+ * spirits (they sync via syncSpiritTemplate on restart), seeds, and variants
+ * (which share the parent's worktree) are never reported stale.
+ *
+ * The measurement is truthful: it hashes the mind's actual on-disk files rather
+ * than trusting the stored `template_hash`. The stored hash is used only as a
+ * fast path — when it already matches the current template we skip the disk
+ * read. A mismatch, a null hash, or an unreadable mind dir all read as stale.
+ *
+ * Results are memoized per mind dir keyed on the mtime of src/agent.ts, so
+ * `volute mind list` doesn't re-hash every mind on each call.
+ */
+export function isTemplateStale(entry: MindEntry): boolean {
+  if (entry.mindType !== "mind") return false;
+  if (entry.stage === "seed") return false;
+  if (entry.parent) return false;
+
+  const templateName = entry.template ?? "claude";
+  let current: string;
+  try {
+    current = computeTemplateHash(templateName);
+  } catch {
+    // Unknown/unbuildable template — can't assess, don't nag.
+    return false;
+  }
+
+  // Fast path: the last hash we wrote already matches the current template.
+  if (entry.templateHash != null && entry.templateHash === current) return false;
+
+  const dir = mindDir(entry.name);
+  const sentinel = resolve(dir, "src", "agent.ts");
+  const mtime = existsSync(sentinel) ? statSync(sentinel).mtimeMs : 0;
+
+  const cached = staleCache.get(dir);
+  if (cached && cached.mtime === mtime) return cached.stale;
+
+  let stale: boolean;
+  try {
+    stale = computeMindTemplateHash(dir, templateName, entry.name) !== current;
+  } catch {
+    // Can't read the mind's on-disk template — treat unknown as stale.
+    stale = true;
+  }
+  staleCache.set(dir, { mtime, stale });
+  return stale;
+}

--- a/packages/daemon/src/lib/version-notify.ts
+++ b/packages/daemon/src/lib/version-notify.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { sendSystemMessage } from "./chat/system-chat.js";
-import { readRegistry, setMindTemplateHash, voluteSystemDir } from "./mind/registry.js";
+import { mindDir, readRegistry, setMindTemplateHash, voluteSystemDir } from "./mind/registry.js";
+import { computeMindTemplateHash } from "./mind/template-staleness.js";
 import { parseReleaseNotes } from "./release-notes.js";
 import { computeTemplateHash } from "./template/template-hash.js";
 import { getCurrentVersion } from "./update-check.js";
@@ -29,8 +30,10 @@ function writeState(state: VersionNotifyState): void {
 }
 
 /**
- * Backfill templateHash for minds that don't have one.
- * Uses the current template hash so existing minds won't get a false upgrade notification.
+ * Backfill templateHash for minds that don't have one, measuring the mind's
+ * actual on-disk template rather than stamping the current hash. A mind that is
+ * genuinely stale is recorded as stale (not falsely current); if its files
+ * can't be read, the column is left null and null reads as unknown → stale.
  */
 export async function backfillTemplateHashes(): Promise<void> {
   const entries = await readRegistry();
@@ -41,11 +44,25 @@ export async function backfillTemplateHashes(): Promise<void> {
 
     const tmpl = entry.template ?? "claude";
     try {
-      const hash = computeTemplateHash(tmpl);
+      const hash = computeMindTemplateHash(mindDir(entry.name), tmpl, entry.name);
       await setMindTemplateHash(entry.name, hash);
     } catch (err) {
-      log.warn(`failed to compute template hash for ${entry.name}`, log.errorData(err));
+      // Leave the column null: null reads as unknown → stale, not fresh.
+      log.warn(`failed to compute on-disk template hash for ${entry.name}`, log.errorData(err));
     }
+  }
+}
+
+/**
+ * Log a warning at daemon start for each mind running an outdated template copy,
+ * so staleness is visible in the daemon log even when nobody runs `volute status`.
+ */
+export async function warnStaleTemplates(): Promise<void> {
+  const { isTemplateStale } = await import("./mind/template-staleness.js");
+  const entries = await readRegistry();
+  const stale = entries.filter((e) => isTemplateStale(e)).map((e) => e.name);
+  for (const name of stale) {
+    log.warn(`${name} is running an outdated template — run 'volute mind upgrade ${name}'`);
   }
 }
 

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -69,6 +69,7 @@ import {
   stateDir,
   validateMindName,
 } from "../../lib/mind/registry.js";
+import { isTemplateStale } from "../../lib/mind/template-staleness.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
 import { validateBranchName } from "../../lib/mind/variants.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
@@ -1274,7 +1275,13 @@ const app = new Hono<AuthEnv>()
         const hasPages = existsSync(resolve(mindDir(entry.name), "home", "pages"));
         const lastActiveAt = lastActiveMap.get(entry.name) ?? null;
         if (!privileged) return toPublicMind(entry, mindStatus, { hasPages, lastActiveAt });
-        return { ...entry, ...mindStatus, hasPages, lastActiveAt };
+        return {
+          ...entry,
+          ...mindStatus,
+          hasPages,
+          templateStale: isTemplateStale(entry),
+          lastActiveAt,
+        };
       }),
     );
     return c.json(minds);
@@ -1311,7 +1318,13 @@ const app = new Hono<AuthEnv>()
       }),
     );
 
-    return c.json({ ...entry, ...mindStatus, variants: variantStatuses, hasPages });
+    return c.json({
+      ...entry,
+      ...mindStatus,
+      variants: variantStatuses,
+      hasPages,
+      templateStale: isTemplateStale(entry),
+    });
   })
   // Context info — proxy to mind's /context endpoint
   .get("/:name/context", requireSelf(), async (c) => proxyToMind(c, "context"))

--- a/packages/web/src/ui/components/mind/MindCard.svelte
+++ b/packages/web/src/ui/components/mind/MindCard.svelte
@@ -25,6 +25,9 @@ let { mind }: { mind: Mind } = $props();
     {#if mind.stage === "seed"}
       <span class="seed-badge">seed</span>
     {/if}
+    {#if mind.templateStale}
+      <span class="stale-badge" title="Running an outdated template — run 'volute mind upgrade {mind.name}'">outdated</span>
+    {/if}
     <StatusBadge status={mind.status} />
   </div>
   {#if mind.description}
@@ -109,6 +112,20 @@ let { mind }: { mind: Mind } = $props();
     font-weight: 500;
     letter-spacing: 0.02em;
     text-transform: uppercase;
+  }
+
+  .stale-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: var(--radius);
+    background: var(--yellow-bg);
+    color: var(--yellow);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    cursor: help;
   }
 
   .meta {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -95,9 +95,10 @@ const cmd = command({
           }
           const stale = minds.filter((m) => m.templateStale).map((m) => m.name);
           if (stale.length > 0) {
-            const noun = stale.length === 1 ? "mind is" : "minds are";
+            const subject = stale.length === 1 ? "mind is" : "minds are";
+            const object = stale.length === 1 ? "an outdated template" : "outdated templates";
             console.log(
-              `\n⚠ ${stale.length} ${noun} running outdated templates: ${stale.join(", ")} — run 'volute mind upgrade <name>'`,
+              `\n⚠ ${stale.length} ${subject} running ${object}: ${stale.join(", ")} — run 'volute mind upgrade <name>'`,
             );
           }
         } else {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -83,13 +83,22 @@ const cmd = command({
           running: boolean;
           status?: string;
           stage?: string;
+          templateStale?: boolean;
         }>;
         if (minds.length > 0) {
           console.log(`\nMinds (${minds.length}):`);
           for (const mind of minds) {
             const status = mind.status ?? (mind.running ? "running" : "stopped");
             const label = mind.stage === "seed" ? " (seed)" : "";
-            console.log(`  ${mind.name}: ${status}${label}`);
+            const template = mind.templateStale ? "  [template: outdated]" : "";
+            console.log(`  ${mind.name}: ${status}${label}${template}`);
+          }
+          const stale = minds.filter((m) => m.templateStale).map((m) => m.name);
+          if (stale.length > 0) {
+            const noun = stale.length === 1 ? "mind is" : "minds are";
+            console.log(
+              `\n⚠ ${stale.length} ${noun} running outdated templates: ${stale.join(", ")} — run 'volute mind upgrade <name>'`,
+            );
           }
         } else {
           console.log("\nNo minds configured.");

--- a/test/template-staleness.test.ts
+++ b/test/template-staleness.test.ts
@@ -44,6 +44,35 @@ describe("computeMindTemplateHash", () => {
     }
   });
 
+  it("does not false-positive when the mind name is a substring of file content", () => {
+    // "dev" appears in package.json ("dev" script, "devDependencies"). A naive
+    // reverse-substitution of the mind name would mangle those and report a
+    // pristine mind as stale. Forward-rendering must keep it current.
+    const name = "dev";
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    try {
+      assert.equal(computeMindTemplateHash(dir, "claude", name), computeTemplateHash("claude"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("differs when a non-sentinel template file drifts", () => {
+    // Drift a tracked file other than the src/agent.ts sentinel to confirm the
+    // measurement (and the isTemplateStale memo signal) covers the whole set.
+    const name = `stale-router-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    try {
+      const router = resolve(dir, "src", "lib", "router.ts");
+      writeFileSync(router, `${readFileSync(router, "utf-8")}\n// drift\n`);
+      assert.notEqual(computeMindTemplateHash(dir, "claude", name), computeTemplateHash("claude"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("differs when a source file is mutated", () => {
     const name = `stale-mutated-${Date.now()}`;
     const dir = resolve(mindDir(name));

--- a/test/template-staleness.test.ts
+++ b/test/template-staleness.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  addMind,
+  findMind,
+  mindDir,
+  removeMind,
+  setMindTemplateHash,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  computeMindTemplateHash,
+  isTemplateStale,
+} from "../packages/daemon/src/lib/mind/template-staleness.js";
+import {
+  composeTemplate,
+  copyTemplateToDir,
+  findTemplatesRoot,
+} from "../packages/daemon/src/lib/template/template.js";
+import { computeTemplateHash } from "../packages/daemon/src/lib/template/template-hash.js";
+
+/** Build a pristine mind project at `destDir` from the given template. */
+function buildPristineMind(destDir: string, templateName: string, mindName: string) {
+  rmSync(destDir, { recursive: true, force: true });
+  mkdirSync(destDir, { recursive: true });
+  const { composedDir, manifest } = composeTemplate(findTemplatesRoot(), templateName);
+  try {
+    copyTemplateToDir(composedDir, destDir, mindName, manifest);
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+}
+
+describe("computeMindTemplateHash", () => {
+  it("matches computeTemplateHash for a pristine mind dir", () => {
+    const name = `stale-pristine-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    try {
+      assert.equal(computeMindTemplateHash(dir, "claude", name), computeTemplateHash("claude"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("differs when a source file is mutated", () => {
+    const name = `stale-mutated-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    try {
+      const agent = resolve(dir, "src", "agent.ts");
+      writeFileSync(agent, `${readFileSync(agent, "utf-8")}\n// drift\n`);
+      assert.notEqual(computeMindTemplateHash(dir, "claude", name), computeTemplateHash("claude"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("differs when a template file is missing", () => {
+    const name = `stale-missing-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    try {
+      rmSync(resolve(dir, "src", "agent.ts"));
+      assert.notEqual(computeMindTemplateHash(dir, "claude", name), computeTemplateHash("claude"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("isTemplateStale", () => {
+  const created: string[] = [];
+
+  afterEach(async () => {
+    for (const name of created.splice(0)) {
+      try {
+        await removeMind(name);
+      } catch {}
+      rmSync(resolve(mindDir(name)), { recursive: true, force: true });
+    }
+  });
+
+  async function makeMind(name: string, mutate: boolean) {
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    if (mutate) {
+      const agent = resolve(dir, "src", "agent.ts");
+      writeFileSync(agent, `${readFileSync(agent, "utf-8")}\n// drift\n`);
+    }
+    await addMind(name, 4100, undefined, "claude");
+    created.push(name);
+    return (await findMind(name))!;
+  }
+
+  it("reports a pristine mind as current", async () => {
+    const entry = await makeMind(`stale-cur-${Date.now()}`, false);
+    assert.equal(isTemplateStale(entry), false);
+  });
+
+  it("reports a drifted mind as stale even with no stored hash", async () => {
+    const entry = await makeMind(`stale-old-${Date.now()}`, true);
+    assert.equal(entry.templateHash, undefined);
+    assert.equal(isTemplateStale(entry), true);
+  });
+
+  it("uses the stored hash as a fast path when it matches the current template", async () => {
+    const name = `stale-fast-${Date.now()}`;
+    await makeMind(name, true);
+    // Even though the dir is drifted, a stored hash equal to the current
+    // template short-circuits to "current" without re-reading the disk.
+    await setMindTemplateHash(name, computeTemplateHash("claude"));
+    assert.equal(isTemplateStale((await findMind(name))!), false);
+  });
+
+  it("never reports seeds, variants, or spirits", () => {
+    assert.equal(
+      isTemplateStale({
+        name: "x",
+        port: 1,
+        created: "",
+        running: false,
+        mindType: "mind",
+        stage: "seed",
+      }),
+      false,
+    );
+    assert.equal(
+      isTemplateStale({
+        name: "x",
+        port: 1,
+        created: "",
+        running: false,
+        mindType: "mind",
+        parent: "p",
+      }),
+      false,
+    );
+    assert.equal(
+      isTemplateStale({ name: "x", port: 1, created: "", running: false, mindType: "spirit" }),
+      false,
+    );
+  });
+});
+
+describe("backfillTemplateHashes (on-disk measurement)", () => {
+  const created: string[] = [];
+
+  afterEach(async () => {
+    for (const name of created.splice(0)) {
+      try {
+        await removeMind(name);
+      } catch {}
+      rmSync(resolve(mindDir(name)), { recursive: true, force: true });
+    }
+  });
+
+  it("stamps a drifted mind with its real (non-current) hash, not a false-current one", async () => {
+    const { backfillTemplateHashes } = await import("../packages/daemon/src/lib/version-notify.js");
+    const name = `backfill-drift-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    const agent = resolve(dir, "src", "agent.ts");
+    writeFileSync(agent, `${readFileSync(agent, "utf-8")}\n// drift\n`);
+    await addMind(name, 4100, undefined, "claude");
+    created.push(name);
+
+    await backfillTemplateHashes();
+
+    const entry = await findMind(name);
+    assert.ok(entry?.templateHash, "should stamp a hash");
+    assert.notEqual(
+      entry!.templateHash,
+      computeTemplateHash("claude"),
+      "a drifted mind must not be stamped as current",
+    );
+    assert.equal(isTemplateStale(entry!), true);
+  });
+
+  it("stamps a pristine mind with the current hash", async () => {
+    const { backfillTemplateHashes } = await import("../packages/daemon/src/lib/version-notify.js");
+    const name = `backfill-clean-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    buildPristineMind(dir, "claude", name);
+    await addMind(name, 4100, undefined, "claude");
+    created.push(name);
+
+    await backfillTemplateHashes();
+
+    const entry = await findMind(name);
+    assert.equal(entry?.templateHash, computeTemplateHash("claude"));
+    assert.equal(isTemplateStale(entry!), false);
+  });
+});

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -188,4 +188,56 @@ describe("web minds routes", () => {
 
     await deleteSession(cookie2);
   });
+
+  it("GET / — exposes templateStale for each mind", async () => {
+    const { mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const { addMind, mindDir, removeMind } = await import(
+      "../packages/daemon/src/lib/mind/registry.js"
+    );
+    const { composeTemplate, copyTemplateToDir, findTemplatesRoot } = await import(
+      "../packages/daemon/src/lib/template/template.js"
+    );
+    const { initMindManager, tryGetMindManager } = await import(
+      "../packages/daemon/src/lib/daemon/mind-manager.js"
+    );
+    if (!tryGetMindManager()) initMindManager();
+
+    const name = `web-stale-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    const { composedDir, manifest } = composeTemplate(findTemplatesRoot(), "claude");
+    try {
+      copyTemplateToDir(composedDir, dir, name, manifest);
+    } finally {
+      rmSync(composedDir, { recursive: true, force: true });
+    }
+    await addMind(name, 4199, undefined, "claude");
+
+    try {
+      const cookie = await setupAuth();
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("/api/minds", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Array<{ name: string; templateStale?: boolean }>;
+      const pristine = body.find((m) => m.name === name);
+      assert.ok(pristine, "created mind should be listed");
+      assert.equal(pristine.templateStale, false, "a pristine mind is current");
+
+      // Drift the mind's framework code and confirm the API flips to stale.
+      const agent = resolve(dir, "src", "agent.ts");
+      writeFileSync(agent, `${readFileSync(agent, "utf-8")}\n// drift\n`);
+      const res2 = await app.request("/api/minds", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      const body2 = (await res2.json()) as Array<{ name: string; templateStale?: boolean }>;
+      assert.equal(body2.find((m) => m.name === name)?.templateStale, true);
+    } finally {
+      await removeMind(name);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Minds keep their own on-disk copy of the framework template (`src/`, `package.json`, etc.), so after a Volute upgrade a mind can silently run outdated framework code until someone runs `volute mind upgrade`. This adds measured staleness detection and surfaces it to operators.

- **New `packages/daemon/src/lib/mind/template-staleness.ts`** — hashes a mind's *actual on-disk* template files and compares against the current composed template hash. The stored `template_hash` is used only as a fast path; a null/mismatched/unreadable state all read as stale (errs toward visibility, not silence).
- **Fixed `backfillTemplateHashes`** to stamp the on-disk hash rather than blindly the current one, so genuinely-stale minds aren't falsely marked current.
- **Surfaced staleness** across the daemon startup log, the minds API (`templateStale`), `volute mind list`, `volute mind status`, `volute status`, and the web mind card.

Scope is deliberately visibility-only — no auto-upgrade. Decoupling notification from version bumps (§4) and opt-in auto-upgrade (§5) are deferred as separate follow-ups.

## Review triage

Addressed the code-review findings:

- **False positive on name/content collision (important):** the on-disk hash previously reverse-substituted the mind name back to `{{name}}` via a global `replaceAll`, which over-replaced when the name was a substring of file content (e.g. a mind named `dev` colliding with `devDependencies` in `package.json`), falsely reporting a pristine mind as outdated. Replaced with forward-rendering: the expected on-disk bytes are derived by substituting the name into the composed template — the same transform `copyTemplateToDir` applies — and compared. Added a regression test (mind named `dev`).
- **Silent catch (important):** `isTemplateStale` swallowed a `computeTemplateHash` failure and returned "current" with no signal — the exact silent-failure class this feature exists to remove. Now logs a deduped warning.
- **Cache keyed on a single sentinel (minor, x2):** the staleness memo was keyed only on `src/agent.ts`'s mtime, so drift in another template-owned file within a running daemon could be missed (plausible given minds self-modify). Re-keyed on a directory-wide signal (max mtime + file count over tracked files). Added a non-sentinel-drift test.
- **CLI wording (minor):** reconciled the singular/plural `volute status` summary ("1 mind is running an outdated template").

Deferred/skipped: a dedicated CLI-render harness test was not added — the marker rendering is trivial string interpolation and the wording quirk it flagged is fixed directly; the higher-value invariant tests (name collision, non-sentinel drift) are covered instead.

## Test evidence

- Full `npm test`: 1935 pass, 0 fail.
- Targeted `test/template-staleness.test.ts` + `test/web-minds.test.ts`: all pass, including the new collision and non-sentinel-drift cases.
- Biome + tsc clean on changed files (pre-commit hooks pass).

Fixes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)