### PR TITLE
fix(delivery): bound gated-channel release, re-route on release, repeat invites, allow decline

### DIFF
--- a/drizzle/0012_channel_gates.sql
+++ b/drizzle/0012_channel_gates.sql
@@ -1,0 +1,17 @@
+-- Per-(mind, channel) gate state so a mind can explicitly decline an unrouted
+-- channel. Absence of a row means "pending" (undecided); the only stored state
+-- is "declined". Declined channels are never released and never re-notify.
+CREATE TABLE `channel_gates` (
+	`mind` text NOT NULL,
+	`channel` text NOT NULL,
+	`state` text NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	PRIMARY KEY(`mind`, `channel`)
+);
+--> statement-breakpoint
+-- Backfill: archive stale gated rows so the first routes.json edit on an existing
+-- mind with a months-old backlog can't release hundreds of messages at once. The
+-- bounded release only ever promotes the newest N per channel anyway; anything
+-- older than a week is treated as history and made inert here.
+UPDATE `delivery_queue` SET `status` = 'archived'
+	WHERE `status` = 'gated' AND `created_at` < datetime('now', '-7 days');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1775600000000,
       "tag": "0011_drop_turn_summary_event_id",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1775700000000,
+      "tag": "0012_channel_gates",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -24,6 +24,10 @@ const cmd = subcommands({
       description: "Manage platform bridges",
       run: (args) => import("./chat/bridge.js").then((m) => m.run(args)),
     },
+    channels: {
+      description: "Manage unrouted (gated) channels",
+      run: (args) => import("./chat/channels.js").then((m) => m.run(args)),
+    },
     files: {
       description: "List pending incoming files",
       run: (args) => import("./chat/files.js").then((m) => m.run(args)),

--- a/packages/cli/src/commands/chat/channels.ts
+++ b/packages/cli/src/commands/chat/channels.ts
@@ -1,0 +1,89 @@
+import { command, subcommands } from "../../lib/command.js";
+import { daemonFetch } from "../../lib/daemon-client.js";
+import { resolveMindName } from "../../lib/resolve-mind-name.js";
+
+const channelsListCmd = command({
+  name: "volute chat channels",
+  description: "List unrouted (gated) channels holding messages",
+  args: [],
+  flags: {
+    mind: { type: "string", description: "Mind name" },
+  },
+  run: async ({ flags }) => {
+    const mind = resolveMindName(flags);
+
+    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/delivery/pending`);
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      console.error(data.error ?? `Failed to list gated channels: ${res.status}`);
+      process.exit(1);
+    }
+
+    const pending = (await res.json()) as Array<{
+      channel: string | null;
+      sender: string | null;
+      count: number;
+      firstSeen: string;
+    }>;
+
+    if (pending.length === 0) {
+      console.log("No unrouted channels holding messages.");
+      return;
+    }
+
+    const chW = Math.max(7, ...pending.map((p) => (p.channel ?? "unknown").length));
+    console.log(`${"CHANNEL".padEnd(chW)}  HELD  SINCE`);
+    for (const p of pending) {
+      console.log(
+        `${(p.channel ?? "unknown").padEnd(chW)}  ${String(p.count).padStart(4)}  ${p.firstSeen}`,
+      );
+    }
+    console.log(`\nRoute one to hear it, or 'volute chat channels decline <channel>' to opt out.`);
+  },
+});
+
+const channelsDeclineCmd = command({
+  name: "volute chat channels decline",
+  description: "Decline an unrouted channel: stop invites and archive its held backlog",
+  args: [{ name: "channel", required: true, description: "Channel to decline (e.g. #bardo)" }],
+  flags: {
+    mind: { type: "string", description: "Mind name" },
+  },
+  run: async ({ args, flags }) => {
+    const mind = resolveMindName(flags);
+    const channel = args.channel!;
+
+    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/gates/decline`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel }),
+    });
+
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      console.error(data.error ?? `Failed to decline channel: ${res.status}`);
+      process.exit(1);
+    }
+
+    const data = (await res.json()) as { archived: number };
+    console.log(`Declined ${channel}; archived ${data.archived} held message(s).`);
+  },
+});
+
+const cmd = subcommands({
+  name: "volute chat channels",
+  description: "Manage unrouted (gated) channels",
+  commands: {
+    list: {
+      description: "List unrouted channels holding messages",
+      run: channelsListCmd.execute,
+    },
+    decline: {
+      description: "Decline an unrouted channel",
+      run: channelsDeclineCmd.execute,
+    },
+  },
+  footer: "Use --mind <name> or VOLUTE_MIND to identify the mind.",
+});
+
+export const run = cmd.execute;

--- a/packages/cli/src/commands/mind-status.ts
+++ b/packages/cli/src/commands/mind-status.ts
@@ -67,6 +67,25 @@ const cmd = command({
     }
 
     if (mind.hasPages) console.log(`\nPages:   published`);
+
+    // Surface unrouted (gated) channels holding messages, so a months-long silence
+    // is visible without reading the DB. #537
+    const pendingRes = await daemonFetch(
+      `/api/minds/${encodeURIComponent(name)}/delivery/pending`,
+    ).catch(() => null);
+    if (pendingRes?.ok) {
+      const pending = (await pendingRes.json().catch(() => [])) as Array<{
+        channel: string | null;
+        count: number;
+      }>;
+      if (pending.length > 0) {
+        const total = pending.reduce((sum, p) => sum + p.count, 0);
+        console.log(`\nGated channels (held, unrouted): ${total} message(s)`);
+        for (const p of pending) {
+          console.log(`  ${p.channel ?? "unknown"}: ${p.count}`);
+        }
+      }
+    }
   },
 });
 

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -9,7 +9,7 @@ import { getParticipants } from "../events/conversations.js";
 import { onMindEvent } from "../events/mind-activity-tracker.js";
 import { findMind, getBaseName, mindDir, voluteHome } from "../mind/registry.js";
 import { readVoluteConfig } from "../mind/volute-config.js";
-import { deliveryQueue } from "../schema.js";
+import { channelGates, deliveryQueue } from "../schema.js";
 import { type AvatarBlock, renderAvatarBlock } from "../util/avatar-image.js";
 import log from "../util/logger.js";
 import {
@@ -35,6 +35,16 @@ const REDRIVE_INTERVAL_MS = 15_000;
 const RETRY_BASE_MS = 5_000;
 const RETRY_MAX_MS = 5 * 60_000;
 const REDRIVE_BATCH_LIMIT = 200;
+
+// --- Gated-channel release tuning ---
+// When a routing change matches a previously-gated channel, deliver at most this many
+// of the newest held messages per channel. The rest are archived (inert) so a
+// months-old backlog can't flood the mind's context in a single sweep. #537
+const GATED_RELEASE_LIMIT_PER_CHANNEL = 10;
+// Re-send the "new channel" invite every N held messages, not just on the first. A
+// mind should be able to tell "nobody is talking to me" from "I've been deaf for
+// months". #537
+const GATED_NOTIFY_EVERY = 10;
 
 const mentionRegexCache = new Map<string, RegExp>();
 
@@ -95,6 +105,12 @@ export class DeliveryManager {
   private isMindRunning: (baseName: string) => boolean = (name) =>
     tryGetMindManager()?.isRunning(name) ?? false;
 
+  /** Sends a system message to a mind (invites, release summaries); overridable in tests. */
+  private notify: (mindName: string, text: string) => Promise<void> = async (mindName, text) => {
+    const { sendSystemMessage } = await import("../chat/system-chat.js");
+    await sendSystemMessage(mindName, text);
+  };
+
   constructor() {
     // Release gated messages when a mind's routes.json changes.
     setRoutesChangeListener((mind) => {
@@ -107,6 +123,11 @@ export class DeliveryManager {
   /** Test seam: override the mind-running predicate. */
   setRunningCheck(fn: (baseName: string) => boolean): void {
     this.isMindRunning = fn;
+  }
+
+  /** Test seam: capture/override system notifications sent to minds. */
+  setNotifier(fn: (mindName: string, text: string) => Promise<void>): void {
+    this.notify = fn;
   }
 
   // --- Public API ---
@@ -330,9 +351,15 @@ export class DeliveryManager {
   }
 
   /**
-   * Re-evaluate a mind's `gated` rows against its current routes.json and promote any
-   * that now match to `pending` (delivered by the next redrive sweep). Called when the
-   * routing config changes.
+   * Re-evaluate a mind's `gated` rows against its current routes.json when the routing
+   * config changes. For each channel that now matches a `mind` route:
+   *  - the newest {@link GATED_RELEASE_LIMIT_PER_CHANNEL} rows are promoted to `pending`
+   *    and re-stamped with the freshly-resolved session (NOT the gate-time fallback), so
+   *    they land in the correct session instead of `main` (#537 bug 1);
+   *  - any older rows are `archived` (inert) so a long backlog can't flood the mind
+   *    in one sweep (#537 bug 2), and the mind gets one summary rather than a flood.
+   * Rows resolving to a `file` destination are archived (the delivery manager doesn't
+   * deliver file routes). Declined channels are skipped entirely — they stay gated.
    */
   async releaseGated(mindName: string): Promise<void> {
     const baseName = await getBaseName(mindName);
@@ -349,7 +376,12 @@ export class DeliveryManager {
       return;
     }
 
-    const promote: number[] = [];
+    // Group newly-matching mind-route rows by channel, recomputing the session so the
+    // release delivers to the CURRENT route. File-route matches are archived.
+    type Promotable = { id: number; session: string };
+    const byChannel = new Map<string, Promotable[]>();
+    const archiveIds: number[] = [];
+
     for (const row of rows) {
       let payload: DeliveryPayload;
       try {
@@ -364,25 +396,150 @@ export class DeliveryManager {
         participantCount: payload.participantCount,
       };
       const route = resolveRoute(config, meta);
-      if (route.matched && route.destination === "mind") {
-        promote.push(row.id);
+      if (!route.matched) continue; // still unrouted → leave gated
+      if (route.destination === "file") {
+        archiveIds.push(row.id); // not deliverable via the delivery manager
+        continue;
+      }
+      let session = route.session;
+      if (session === "$new") {
+        session = `new-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      }
+      const channel = row.channel ?? payload.channel ?? "unknown";
+      const list = byChannel.get(channel) ?? [];
+      list.push({ id: row.id, session });
+      byChannel.set(channel, list);
+    }
+
+    const promote: Promotable[] = [];
+    const truncationNotes: string[] = [];
+    for (const [channel, items] of byChannel) {
+      // A declined channel stays gated even if a rule now matches — the mind opted out.
+      if (await this.isChannelDeclined(baseName, channel)) continue;
+      // Newest-first so the release keeps the most recent context.
+      items.sort((a, b) => b.id - a.id);
+      const keep = items.slice(0, GATED_RELEASE_LIMIT_PER_CHANNEL);
+      const drop = items.slice(GATED_RELEASE_LIMIT_PER_CHANNEL);
+      promote.push(...keep);
+      for (const d of drop) archiveIds.push(d.id);
+      if (drop.length > 0) {
+        truncationNotes.push(
+          `${channel}: released the ${keep.length} most recent message(s); ${drop.length} earlier ` +
+            `message(s) were held while unrouted and remain in the channel history ` +
+            `(volute chat read ${channel}).`,
+        );
+        dlog.info(
+          `truncated gated release for ${baseName} on ${channel}: kept ${keep.length}, archived ${drop.length}`,
+        );
       }
     }
 
-    if (promote.length === 0) return;
+    if (archiveIds.length > 0) {
+      try {
+        const db = await getDb();
+        await db
+          .update(deliveryQueue)
+          .set({ status: "archived" })
+          .where(inArray(deliveryQueue.id, archiveIds));
+      } catch (err) {
+        dlog.warn(`failed to archive gated rows for ${baseName}`, log.errorData(err));
+      }
+    }
+
+    if (promote.length === 0) {
+      if (truncationNotes.length > 0) await this.sendReleaseSummary(mindName, truncationNotes);
+      return;
+    }
+
+    // Promote per-row so each carries its freshly-resolved session (bug 1 fix). Bounded
+    // to GATED_RELEASE_LIMIT_PER_CHANNEL per channel, so this loop is small.
     try {
       const db = await getDb();
-      await db
-        .update(deliveryQueue)
-        .set({ status: "pending", attempts: 0, next_attempt_at: null })
-        .where(inArray(deliveryQueue.id, promote));
+      for (const p of promote) {
+        await db
+          .update(deliveryQueue)
+          .set({ status: "pending", session: p.session, attempts: 0, next_attempt_at: null })
+          .where(eq(deliveryQueue.id, p.id));
+      }
       dlog.info(`released ${promote.length} gated message(s) for ${baseName} after route change`);
     } catch (err) {
       dlog.warn(`failed to promote gated rows for ${baseName}`, log.errorData(err));
       return;
     }
+
+    if (truncationNotes.length > 0) await this.sendReleaseSummary(mindName, truncationNotes);
     // Deliver immediately rather than waiting for the next sweep.
     await this.redrive();
+  }
+
+  /**
+   * Whether the mind has explicitly declined a channel. A declined channel keeps
+   * persisting history but never notifies and is never released. #537
+   */
+  private async isChannelDeclined(baseName: string, channel: string | null): Promise<boolean> {
+    if (!channel) return false;
+    try {
+      const db = await getDb();
+      const rows = await db
+        .select({ state: channelGates.state })
+        .from(channelGates)
+        .where(and(eq(channelGates.mind, baseName), eq(channelGates.channel, channel)));
+      return rows[0]?.state === "declined";
+    } catch (err) {
+      dlog.warn(`failed to read gate state for ${baseName}/${channel}`, log.errorData(err));
+      return false;
+    }
+  }
+
+  /**
+   * Record that a mind has declined an unrouted channel: future messages are still
+   * persisted (history is preserved) but never notify, and any currently-gated rows are
+   * archived so they're inert. Returns the number of held messages archived. #537
+   */
+  async declineChannel(mindName: string, channel: string): Promise<number> {
+    const baseName = await getBaseName(mindName);
+    const db = await getDb();
+    await db
+      .insert(channelGates)
+      .values({ mind: baseName, channel, state: "declined" })
+      .onConflictDoUpdate({
+        target: [channelGates.mind, channelGates.channel],
+        set: { state: "declined", updated_at: sql`(datetime('now'))` },
+      });
+    const archived = await db
+      .update(deliveryQueue)
+      .set({ status: "archived" })
+      .where(
+        and(
+          eq(deliveryQueue.mind, baseName),
+          eq(deliveryQueue.channel, channel),
+          eq(deliveryQueue.status, "gated"),
+        ),
+      )
+      .returning({ id: deliveryQueue.id });
+    dlog.info(
+      `declined channel ${channel} for ${baseName}; archived ${archived.length} held row(s)`,
+    );
+    return archived.length;
+  }
+
+  /**
+   * Send the mind a single summary when a routing change released a truncated backlog,
+   * rather than a flood of individual messages. #537
+   */
+  private async sendReleaseSummary(mindName: string, notes: string[]): Promise<void> {
+    const body = [
+      `[Channel backlog released]`,
+      `A routing change matched channel(s) that had held messages while unrouted. To avoid ` +
+        `flooding you, only the ${GATED_RELEASE_LIMIT_PER_CHANNEL} most recent per channel were delivered:`,
+      "",
+      ...notes.map((n) => `- ${n}`),
+    ].join("\n");
+    try {
+      await this.notify(mindName, body);
+    } catch (err) {
+      dlog.warn(`failed to send release summary for ${mindName}`, log.errorData(err));
+    }
   }
 
   /**
@@ -926,53 +1083,67 @@ export class DeliveryManager {
     payload: DeliveryPayload,
   ): Promise<void> {
     const baseName = await getBaseName(mindName);
+    // A declined channel still persists history, but never notifies. #537
+    const declined = await this.isChannelDeclined(baseName, payload.channel);
     await this.persistToQueue(mindName, session, payload, "gated");
+    if (declined) return;
 
-    // Check if this is the first gated message for this channel — send invite
+    // Re-notify on a cadence, not just once, so a long silence stays visible. Count over
+    // both gated AND archived rows so clearing/truncating the backlog doesn't silently
+    // re-arm the invite, and the cadence reflects total messages seen on the channel. #537
     try {
       const db = await getDb();
-      const count = await db
+      const rows = await db
         .select({ count: sql<number>`count(*)` })
         .from(deliveryQueue)
         .where(
           and(
             eq(deliveryQueue.mind, baseName),
             eq(deliveryQueue.channel, payload.channel),
-            eq(deliveryQueue.status, "gated"),
+            inArray(deliveryQueue.status, ["gated", "archived"]),
           ),
         );
-
-      // If this is the first (count === 1 after our insert), send invite
-      if ((count[0]?.count ?? 0) <= 1) {
-        await this.sendInviteNotification(mindName, payload);
+      const count = rows[0]?.count ?? 0;
+      if (count === 1 || count % GATED_NOTIFY_EVERY === 0) {
+        await this.sendInviteNotification(mindName, payload, count);
       }
     } catch (err) {
       dlog.warn(`failed to check gated count for ${baseName}`, log.errorData(err));
     }
   }
 
-  private async sendInviteNotification(mindName: string, payload: DeliveryPayload): Promise<void> {
+  private async sendInviteNotification(
+    mindName: string,
+    payload: DeliveryPayload,
+    gatedCount = 1,
+  ): Promise<void> {
     const text = extractTextContent(payload.content);
     const preview = text.length > 200 ? `${text.slice(0, 200)}...` : text;
     const channel = payload.channel ?? "unknown";
 
+    const heldLine =
+      gatedCount > 1
+        ? `${gatedCount} messages from this channel are being held, unrouted — you've not routed it yet.`
+        : `Someone new is reaching out — you don't have a route for this channel yet.`;
+
     const notification = [
       `[New channel: ${channel}]`,
-      `Someone new is reaching out — you don't have a route for this channel yet.`,
+      heldLine,
       `Sender: ${payload.sender ?? "unknown"}`,
       payload.platform ? `Platform: ${payload.platform}` : null,
       payload.participantCount ? `Participants: ${payload.participantCount}` : null,
       "",
       `Preview: ${preview}`,
       "",
-      `To start hearing this channel, add a routing rule for "${channel}" to .config/routes.json.`,
-      `Messages are held safely until you do — nothing is lost. If you'd rather not engage, just leave it unrouted.`,
+      `To start hearing this channel, add a routing rule for "${channel}" to .config/routes.json ` +
+        `— only the ${GATED_RELEASE_LIMIT_PER_CHANNEL} most recent held messages are replayed; older ` +
+        `ones stay in the channel history (volute chat read ${channel}).`,
+      `To stop hearing about it, decline the channel: volute chat channels decline ${channel}`,
     ]
       .filter((line) => line !== null)
       .join("\n");
 
-    const { sendSystemMessage } = await import("../chat/system-chat.js");
-    await sendSystemMessage(mindName, notification);
+    await this.notify(mindName, notification);
   }
 
   /**

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -437,10 +437,14 @@ export class DeliveryManager {
     if (archiveIds.length > 0) {
       try {
         const db = await getDb();
-        await db
-          .update(deliveryQueue)
-          .set({ status: "archived" })
-          .where(inArray(deliveryQueue.id, archiveIds));
+        // Chunk the id list so a large sub-7-day backlog can't exceed SQLite's ~999
+        // bound-variable limit — this IS the flood-prevention path, so it must not throw.
+        for (let i = 0; i < archiveIds.length; i += 500) {
+          await db
+            .update(deliveryQueue)
+            .set({ status: "archived" })
+            .where(inArray(deliveryQueue.id, archiveIds.slice(i, i + 500)));
+        }
       } catch (err) {
         dlog.warn(`failed to archive gated rows for ${baseName}`, log.errorData(err));
       }
@@ -1083,9 +1087,11 @@ export class DeliveryManager {
     payload: DeliveryPayload,
   ): Promise<void> {
     const baseName = await getBaseName(mindName);
-    // A declined channel still persists history, but never notifies. #537
+    // A declined channel's messages are archived immediately (inert): history is still
+    // preserved, but they never notify, never surface in getPending/status, and never
+    // accumulate as live gated rows — matching declineChannel's own archiving. #537
     const declined = await this.isChannelDeclined(baseName, payload.channel);
-    await this.persistToQueue(mindName, session, payload, "gated");
+    await this.persistToQueue(mindName, session, payload, declined ? "archived" : "gated");
     if (declined) return;
 
     // Re-notify on a cadence, not just once, so a long silence stays visible. Count over
@@ -1158,7 +1164,7 @@ export class DeliveryManager {
     mindName: string,
     session: string,
     payload: DeliveryPayload,
-    status: "pending" | "gated" = "pending",
+    status: "pending" | "gated" | "archived" = "pending",
   ): Promise<number | undefined> {
     try {
       const baseName = await getBaseName(mindName);

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -1,5 +1,12 @@
 import { sql } from "drizzle-orm";
-import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 export const minds = sqliteTable(
   "minds",
@@ -290,4 +297,20 @@ export const mindNotices = sqliteTable(
     created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
   },
   (table) => [index("idx_mind_notices_mind_session").on(table.mind, table.session)],
+);
+
+// Per-(mind, channel) gate state for unrouted channels. A row exists once a mind
+// has taken an explicit position on a gated channel; the only non-default state is
+// "declined" (the mind has said it does not want this channel). Absence of a row
+// means "pending" — the mind hasn't decided, so invites keep arriving on the
+// notify cadence. Declined channels are never released and never re-notify.
+export const channelGates = sqliteTable(
+  "channel_gates",
+  {
+    mind: text("mind").notNull(),
+    channel: text("channel").notNull(),
+    state: text("state").$type<"pending" | "declined">().notNull(),
+    updated_at: text("updated_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [primaryKey({ columns: [table.mind, table.channel] })],
 );

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -2502,6 +2502,25 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Failed to retrieve pending messages" }, 500);
     }
   })
+  // Decline an unrouted (gated) channel: stops invites and archives the held backlog.
+  // The channel is passed in the body (not the path) since channel slugs can contain
+  // slashes (e.g. "discord:server/general") that a path param can't carry.
+  .post("/:name/gates/decline", requireSelf(), async (c) => {
+    const name = c.req.param("name");
+    const body = (await c.req.json().catch(() => ({}))) as { channel?: string };
+    const channel = body.channel?.trim();
+    if (!channel) return c.json({ error: "channel required" }, 400);
+    try {
+      const archived = await getDeliveryManager().declineChannel(name, channel);
+      return c.json({ ok: true, channel, archived });
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("not initialized")) {
+        return c.json({ error: "Delivery manager not available" }, 503);
+      }
+      log.error(`failed to decline channel ${channel} for ${name}`, log.errorData(err));
+      return c.json({ error: "Failed to decline channel" }, 500);
+    }
+  })
   // AI completion proxy for minds
   .post("/:name/ai/complete", requireSelf(), async (c) => {
     const body = (await c.req.json()) as { systemPrompt: string; message: string; model?: string };

--- a/test/gated-release.test.ts
+++ b/test/gated-release.test.ts
@@ -77,14 +77,30 @@ describe("gated-channel release (#537)", () => {
       const m = makeManager();
       manager = m.manager;
 
-      const fireCounts: number[] = [];
+      const fires: string[] = [];
       manager.setNotifier(async (_mind, text) => {
-        if (text.includes("[New channel:")) fireCounts.push(1);
+        if (text.includes("[New channel:")) fires.push(text);
       });
 
       for (let i = 0; i < 21; i++) await gate(manager, name, "discord:general");
       // counts 1..21 → notify at 1, 10, 20 → 3 fires
-      assert.equal(fireCounts.length, 3);
+      assert.equal(fires.length, 3);
+
+      // The first invite reads as "nobody has reached out here before"; later invites
+      // carry the held-count context so the mind can tell a fresh ping from months of
+      // silence (bug 3). Regressing heldLine back to one string must fail this.
+      assert.ok(
+        fires[0].includes("Someone new is reaching out"),
+        "first invite uses the fresh-contact wording",
+      );
+      assert.ok(
+        /\d+ messages from this channel are being held, unrouted/.test(fires[2]),
+        "a repeat invite reports how many messages are held, unrouted",
+      );
+      assert.ok(
+        !fires[2].includes("Someone new is reaching out"),
+        "a repeat invite drops the fresh-contact wording",
+      );
     });
 
     it("never notifies for a declined channel, but still records history", async () => {
@@ -103,11 +119,18 @@ describe("gated-channel release (#537)", () => {
         0,
         "declined channel never invites",
       );
-      // History still persisted as gated rows.
-      const gated = (await rows(name)).filter(
-        (r) => r.channel === "discord:spam" && r.status === "gated",
+      // History still persisted, but as inert archived rows (never re-surfaced as gated).
+      const all = (await rows(name)).filter((r) => r.channel === "discord:spam");
+      assert.equal(
+        all.filter((r) => r.status === "gated").length,
+        0,
+        "declined channel accumulates no live gated rows",
       );
-      assert.equal(gated.length, 15, "messages are still held (history preserved)");
+      assert.equal(
+        all.filter((r) => r.status === "archived").length,
+        15,
+        "messages are archived (history preserved)",
+      );
     });
   });
 
@@ -163,6 +186,28 @@ describe("gated-channel release (#537)", () => {
       assert.ok(row);
       assert.equal(row.status, "pending", "promoted to pending");
       assert.equal(row.session, "discord-inbox", "session rewritten to the current route");
+    });
+
+    it("expands a $new route to a generated session on release, not the literal '$new'", async () => {
+      const name = createMind({ rules: [], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      await gate(manager, name, "discord:general");
+
+      writeRoutes(name, {
+        rules: [{ channel: "discord:*", session: "$new" }],
+        default: "main",
+      });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      const row = after.find((r) => r.channel === "discord:general");
+      assert.ok(row);
+      assert.equal(row.status, "pending", "promoted to pending");
+      assert.notEqual(row.session, "$new", "the literal '$new' is never persisted");
+      assert.match(row.session, /^new-/, "session expanded to a generated ephemeral name");
     });
 
     it("promotes at most N per channel (newest) and archives the remainder with one summary", async () => {
@@ -231,7 +276,8 @@ describe("gated-channel release (#537)", () => {
       manager = m.manager;
 
       for (let i = 0; i < 3; i++) await gate(manager, name, "discord:general");
-      // Decline archives the current 3; add 2 fresh gated rows after declining.
+      // Decline archives the current 3; the 2 fresh messages after declining are
+      // archived on arrival (never gated), so they never re-surface as actionable.
       await manager.declineChannel(name, "discord:general");
       for (let i = 0; i < 2; i++) await gate(manager, name, "discord:general");
 
@@ -246,8 +292,13 @@ describe("gated-channel release (#537)", () => {
       );
       assert.equal(
         after.filter((r) => r.status === "gated").length,
-        2,
-        "post-decline gated rows stay gated",
+        0,
+        "a declined channel accumulates no live gated rows",
+      );
+      assert.equal(
+        after.filter((r) => r.status === "archived").length,
+        5,
+        "all declined-channel messages are archived (inert)",
       );
     });
 

--- a/test/gated-release.test.ts
+++ b/test/gated-release.test.ts
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { DeliveryManager } from "../packages/daemon/src/lib/delivery/delivery-manager.js";
+import {
+  clearConfigCache,
+  type RoutingConfig,
+  setRoutesChangeListener,
+} from "../packages/daemon/src/lib/delivery/delivery-router.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import { channelGates, deliveryQueue } from "../packages/daemon/src/lib/schema.js";
+
+// --- Helpers ---
+
+function mindName(): string {
+  return `gated-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function writeRoutes(name: string, config: RoutingConfig | object): void {
+  const dir = resolve(process.env.VOLUTE_HOME!, "minds", name);
+  const configDir = resolve(dir, "home/.config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(resolve(configDir, "routes.json"), JSON.stringify(config));
+  clearConfigCache(name);
+}
+
+function createMind(config: RoutingConfig | object): string {
+  const name = mindName();
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  addMind(name, port);
+  writeRoutes(name, config);
+  return name;
+}
+
+async function rows(name: string): Promise<(typeof deliveryQueue.$inferSelect)[]> {
+  const db = await getDb();
+  return db.select().from(deliveryQueue).where(eq(deliveryQueue.mind, name));
+}
+
+/** Build a manager whose notifications are captured and whose routes listener is inert. */
+function makeManager(): { manager: DeliveryManager; notes: { mind: string; text: string }[] } {
+  const manager = new DeliveryManager();
+  // Neutralize the global routes-change listener so tests drive releaseGated directly.
+  setRoutesChangeListener(() => {});
+  const notes: { mind: string; text: string }[] = [];
+  manager.setNotifier(async (mind, text) => {
+    notes.push({ mind, text });
+  });
+  // Pretend the mind is up so redrive attempts delivery (which fails harmlessly).
+  manager.setRunningCheck(() => false);
+  return { manager, notes };
+}
+
+describe("gated-channel release (#537)", () => {
+  let manager: DeliveryManager | undefined;
+  let cleanup: string[] = [];
+
+  afterEach(() => {
+    manager?.dispose();
+    manager = undefined;
+    for (const n of cleanup) removeMind(n);
+    cleanup = [];
+    clearConfigCache();
+  });
+
+  async function gate(mgr: DeliveryManager, name: string, channel: string, text = "hi") {
+    return mgr.routeAndDeliver(name, { channel, sender: "alice", content: text });
+  }
+
+  describe("invite cadence", () => {
+    it("fires exactly on the first message and every 10th thereafter", async () => {
+      const name = createMind({ rules: [] });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      const fireCounts: number[] = [];
+      manager.setNotifier(async (_mind, text) => {
+        if (text.includes("[New channel:")) fireCounts.push(1);
+      });
+
+      for (let i = 0; i < 21; i++) await gate(manager, name, "discord:general");
+      // counts 1..21 → notify at 1, 10, 20 → 3 fires
+      assert.equal(fireCounts.length, 3);
+    });
+
+    it("never notifies for a declined channel, but still records history", async () => {
+      const name = createMind({ rules: [] });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      await manager.declineChannel(name, "discord:spam");
+      m.notes.length = 0;
+
+      for (let i = 0; i < 15; i++) await gate(manager, name, "discord:spam");
+
+      assert.equal(
+        m.notes.filter((n) => n.text.includes("[New channel:")).length,
+        0,
+        "declined channel never invites",
+      );
+      // History still persisted as gated rows.
+      const gated = (await rows(name)).filter(
+        (r) => r.channel === "discord:spam" && r.status === "gated",
+      );
+      assert.equal(gated.length, 15, "messages are still held (history preserved)");
+    });
+  });
+
+  describe("declineChannel", () => {
+    it("archives currently-held rows and records declined state", async () => {
+      const name = createMind({ rules: [] });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      for (let i = 0; i < 3; i++) await gate(manager, name, "discord:noise");
+      const archived = await manager.declineChannel(name, "discord:noise");
+      assert.equal(archived, 3, "returns count of archived rows");
+
+      const all = await rows(name);
+      assert.equal(all.filter((r) => r.status === "gated").length, 0, "no gated rows remain");
+      assert.equal(all.filter((r) => r.status === "archived").length, 3, "held rows archived");
+
+      const db = await getDb();
+      const gateRow = await db
+        .select()
+        .from(channelGates)
+        .where(and(eq(channelGates.mind, name), eq(channelGates.channel, "discord:noise")));
+      assert.equal(gateRow[0]?.state, "declined");
+    });
+  });
+
+  describe("releaseGated", () => {
+    it("rewrites session to the newly-resolved route, not the gate-time fallback", async () => {
+      // Gate with default 'main' (no rule matches discord:general).
+      const name = createMind({ rules: [{ channel: "web", session: "web" }], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      await gate(manager, name, "discord:general");
+      const before = await rows(name);
+      assert.equal(before[0].session, "main", "gated at the fallback session");
+      assert.equal(before[0].status, "gated");
+
+      // Add a rule mapping the channel to a distinct session, then release.
+      writeRoutes(name, {
+        rules: [
+          { channel: "web", session: "web" },
+          { channel: "discord:*", session: "discord-inbox" },
+        ],
+        default: "main",
+      });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      const row = after.find((r) => r.channel === "discord:general");
+      assert.ok(row);
+      assert.equal(row.status, "pending", "promoted to pending");
+      assert.equal(row.session, "discord-inbox", "session rewritten to the current route");
+    });
+
+    it("promotes at most N per channel (newest) and archives the remainder with one summary", async () => {
+      const name = createMind({ rules: [{ channel: "web", session: "web" }], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      // 25 gated messages on one channel.
+      for (let i = 0; i < 25; i++) await gate(manager, name, "discord:general", `msg ${i}`);
+      m.notes.length = 0;
+
+      writeRoutes(name, {
+        rules: [
+          { channel: "web", session: "web" },
+          { channel: "discord:*", session: "discord" },
+        ],
+        default: "main",
+      });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      const pending = after.filter((r) => r.status === "pending");
+      const archived = after.filter((r) => r.status === "archived");
+      assert.equal(pending.length, 10, "at most 10 promoted");
+      assert.equal(archived.length, 15, "the older 15 are archived");
+
+      // The promoted rows are the newest (highest ids).
+      const maxArchivedId = Math.max(...archived.map((r) => r.id));
+      const minPendingId = Math.min(...pending.map((r) => r.id));
+      assert.ok(minPendingId > maxArchivedId, "kept the newest rows");
+
+      // One summary message, mentioning the truncation.
+      const summaries = m.notes.filter((n) => n.text.includes("[Channel backlog released]"));
+      assert.equal(summaries.length, 1, "exactly one summary, not a flood");
+      assert.ok(summaries[0].text.includes("discord:general"));
+      assert.ok(summaries[0].text.includes("15 earlier"));
+    });
+
+    it("does not truncate or summarize when the backlog is within the limit", async () => {
+      const name = createMind({ rules: [], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      for (let i = 0; i < 3; i++) await gate(manager, name, "discord:general");
+      m.notes.length = 0;
+
+      writeRoutes(name, { rules: [{ channel: "discord:*", session: "discord" }], default: "main" });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      assert.equal(after.filter((r) => r.status === "pending").length, 3);
+      assert.equal(after.filter((r) => r.status === "archived").length, 0);
+      assert.equal(
+        m.notes.filter((n) => n.text.includes("[Channel backlog released]")).length,
+        0,
+        "no summary when nothing was truncated",
+      );
+    });
+
+    it("skips declined channels — they stay gated even if a rule now matches", async () => {
+      const name = createMind({ rules: [], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      for (let i = 0; i < 3; i++) await gate(manager, name, "discord:general");
+      // Decline archives the current 3; add 2 fresh gated rows after declining.
+      await manager.declineChannel(name, "discord:general");
+      for (let i = 0; i < 2; i++) await gate(manager, name, "discord:general");
+
+      writeRoutes(name, { rules: [{ channel: "discord:*", session: "discord" }], default: "main" });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      assert.equal(
+        after.filter((r) => r.status === "pending").length,
+        0,
+        "declined channel is never promoted",
+      );
+      assert.equal(
+        after.filter((r) => r.status === "gated").length,
+        2,
+        "post-decline gated rows stay gated",
+      );
+    });
+
+    it("archives file-destination matches instead of promoting them", async () => {
+      const name = createMind({ rules: [], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      await gate(manager, name, "logs:system");
+
+      writeRoutes(name, {
+        rules: [{ channel: "logs:*", destination: "file", path: "inbox/logs.md" }],
+        default: "main",
+      });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      assert.equal(after.filter((r) => r.status === "pending").length, 0);
+      assert.equal(after.filter((r) => r.status === "archived").length, 1, "file match archived");
+    });
+
+    it("leaves genuinely-unmatched channels gated", async () => {
+      const name = createMind({ rules: [], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      await gate(manager, name, "discord:general");
+
+      // A rule that matches a different channel only.
+      writeRoutes(name, { rules: [{ channel: "slack:*", session: "slack" }], default: "main" });
+      await manager.releaseGated(name);
+
+      const after = await rows(name);
+      assert.equal(after.filter((r) => r.status === "gated").length, 1, "still held");
+      assert.equal(after.filter((r) => r.status === "pending").length, 0);
+    });
+  });
+
+  describe("archived rows are inert", () => {
+    it("are invisible to getPending", async () => {
+      const name = createMind({ rules: [], default: "main" });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      for (let i = 0; i < 4; i++) await gate(manager, name, "discord:general");
+      await manager.declineChannel(name, "discord:general"); // archives all 4
+
+      const pending = await manager.getPending(name);
+      assert.deepEqual(pending, [], "archived rows do not show as pending/gated");
+    });
+  });
+});


### PR DESCRIPTION
Fixes the four gated-channel release defects in #537.

## Problem
When an unrouted channel was later routed, every held message was replayed into the gate-time fallback session (`main`), a months-old backlog flooded the mind in one sweep, the "new channel" invite fired only once (so a mind couldn't tell "nobody is talking to me" from "I've been deaf for months"), and there was no way for a mind to opt out of an unrouted channel it didn't want.

## Changes
- **Re-route on release (bug 1)** — `releaseGated` recomputes each held row's route against the current `routes.json` and re-stamps its session, so releases land in the correct session, not the gate-time `main`.
- **Bound the release (bug 2)** — release is capped at the newest 10 messages per channel; the remainder move to a new inert `archived` status and the mind gets a single summary instead of a flood. Migration `0011` adds the `channel_gates` table and backfills gated rows older than 7 days to `archived`.
- **Repeat the invite (bug 3)** — the invite now fires on a 1-then-every-10 cadence counted over gated+archived rows, and repeat invites carry held-count context ("N messages from this channel are being held, unrouted") distinct from the first-contact wording.
- **Decline (bug 4)** — a mind can opt out of a channel via `volute chat channels decline <channel>` (POST `/api/minds/:name/gates/decline`, guarded by `requireSelf`). Declining archives the current backlog; `releaseGated` skips declined channels.
- **Visibility** — `volute mind status` and `volute chat channels list` surface held/unrouted channels.

## Review triage
Addressed from the code review:
- **Declined channels no longer re-accumulate visible gated rows (important, two reviewers).** Post-decline messages are now archived on arrival instead of re-persisted as `gated`. Previously they resurfaced in `getPending()` (`volute chat channels list`, `volute mind status`) and grew unbounded — quietly reintroducing the ambiguity and flood #537 set out to fix. Now consistent with `declineChannel`'s own archiving; history is still preserved.
- **Chunked `releaseGated`'s archive update (minor).** The single `inArray` over the dropped-row ids could exceed SQLite's ~999 bound-variable limit on a large sub-7-day backlog — exactly the flood-prevention path. Now batched in 500-id chunks.
- **Test coverage (minor).** Added assertions that repeat invites carry the held-count phrasing (pins bug 3 against a silent regression) and that the `$new` session route expands to a generated ephemeral session on release rather than persisting the literal `$new`.

Skipped, with reasons:
- **Fail-open on the decline check (minor, marked optional).** `isChannelDeclined` returns `false` on a DB read error. Failing closed has the opposite failure mode (a transient blip suppresses invites / skips release for a genuinely-undecided channel). The anomaly is already logged and traceable, and the blast radius is bounded (release capped at 10). Left as-is.

## Testing
Full `npm test`: 1934 pass / 0 fail. Targeted `test/gated-release.test.ts`: 11 pass. Pre-commit typecheck + lint clean.

Fixes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
