### PR TITLE
fix: give composeTemplate a collision-proof temp dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,7 +1797,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/packages/daemon/src/lib/template/template.ts
+++ b/packages/daemon/src/lib/template/template.ts
@@ -2,6 +2,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readdirSync,
   readFileSync,
   renameSync,
@@ -70,10 +71,10 @@ export function composeTemplate(
     process.exit(1);
   }
 
-  // Create temp staging directory (include template name to avoid collisions when
-  // composing multiple templates in quick succession, e.g. in tests)
-  const composedDir = resolve(tmpdir(), `volute-template-${templateName}-${Date.now()}`);
-  mkdirSync(composedDir, { recursive: true });
+  // Create a unique temp staging directory. A timestamp suffix is not enough: two
+  // concurrent compositions of the same template in the same millisecond would share
+  // the dir, and one's cleanup rmSync yanks it out from under the other (test flake).
+  const composedDir = mkdtempSync(resolve(tmpdir(), `volute-template-${templateName}-`));
 
   // Copy _base first
   cpSync(baseDir, composedDir, { recursive: true });


### PR DESCRIPTION
## Summary
- `composeTemplate()` staged into `volute-template-<name>-${Date.now()}`, so two concurrent compositions of the same template in the same millisecond shared the directory — one caller's cleanup `rmSync` then deleted it out from under the other.
- This surfaced as an ENOENT flake in `template-hash.test.ts` (`scandir .../.init/.config`) once #558's template-staleness tests began composing templates concurrently in the full suite; it failed a pre-push run while landing #559.
- `mkdtempSync` guarantees a unique staging dir per caller (also closes the same theoretical race for two simultaneous `mind create` calls).

## Test plan
- [x] `template-hash`, `template-staleness`, and `template` suites pass
- [x] Full suite green via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)