### PR TITLE
fix(web): show the stale-template badge in the live sidebar

### DIFF
--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -293,6 +293,12 @@ let isSystemActive = $derived(
                       style:background={activeMinds.has(mind.name) ? undefined : mindDotColor(mind)}
                     ></span>
                     <span class="nav-label">{mind.displayName ?? mind.name}</span>
+                    {#if mind.templateStale}
+                      <span
+                        class="stale-badge"
+                        use:tooltipAction={{ text: `Running an outdated template — run 'volute mind upgrade ${mind.name}'`, position: "right" }}
+                      >outdated</span>
+                    {/if}
                     {#if mindUnread > 0}
                       <span class="unread-dot"></span>
                     {/if}
@@ -594,6 +600,16 @@ let isSystemActive = $derived(
     height: 6px;
     border-radius: 50%;
     background: var(--accent);
+    flex-shrink: 0;
+  }
+
+  .stale-badge {
+    padding: 1px 6px;
+    border-radius: var(--radius);
+    background: var(--yellow-bg);
+    color: var(--yellow);
+    font-size: 10px;
+    font-weight: 500;
     flex-shrink: 0;
   }
 


### PR DESCRIPTION
## Problem
Found during the 0.47 release integration-test pass: #558's web-UI part never renders. The `outdated` badge was added to `MindCard.svelte`, but nothing imports that component (it appears to be a leftover from an older dashboard layout, along with `MindInfo.svelte` / `MindSettingsAdvanced.svelte`), so Vite tree-shakes it and `templateStale` doesn't exist anywhere in the shipped bundle.

## Change
Render the badge in `UnifiedSidebar`'s mind rows — the component that actually lists minds — with the same yellow styling and an upgrade-hint tooltip. `/api/minds` already returns `templateStale` to privileged callers, so no backend change is needed (non-admin users simply never get the field and see no badge).

Left `MindCard.svelte` untouched; if it's truly dead, removing it (and the other orphaned mind/* components) could be a separate cleanup.

## Testing
- svelte-check: 0 errors
- Full `npm test` via pre-push hook: green
- Verified against a live Docker integration environment that `/api/minds` reports `templateStale: true` for imported fixture minds and `false` for freshly created ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)