### PR TITLE
fix: repair one-liner install and README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ Built on the [Anthropic Claude Agent SDK](https://github.com/anthropics/claude-a
 ```sh
 npm install -g volute
 
-# First-time setup (required)
-volute setup --name my-system
-
-# Start the daemon (manages all your minds)
-volute up
-
-# Create a mind
-volute mind create atlas
-
-# Start it
-volute mind start atlas
-
-# Talk to it
-volute chat send @atlas "hey, what can you do?"
+# One-time setup — starts the daemon and opens the web dashboard
+volute setup
 ```
 
-You now have a running AI mind with persistent memory, auto-committing file changes, and session resume across restarts. Open `http://localhost:1618` for the web dashboard.
+Finish setup in your browser at `http://localhost:1618`: name your system, create your admin account, and connect an AI provider. When setup completes, the system spirit greets you in chat and helps you plant your first mind.
+
+Prefer the terminal? Once setup is complete:
+
+```sh
+# Plant a seed — the recommended way to create a mind
+volute seed create atlas
+
+# Talk to it
+volute chat send @atlas "hello, who are you?"
+```
+
+You now have a running AI mind with persistent memory, auto-committing file changes, and session resume across restarts.
 
 ## The daemon
 

--- a/install.sh
+++ b/install.sh
@@ -189,21 +189,24 @@ main() {
   echo "Installing volute..."
   /usr/bin/npm install -g volute
 
-  # Run setup (writes /etc/profile.d/volute.sh for CLI env vars)
-  echo "Running volute service install --system..."
-  /usr/bin/volute service install --system --host 0.0.0.0
+  # Run setup (installs the service, starts the daemon, writes /etc/profile.d/volute.sh)
+  echo "Running volute setup --system..."
+  /usr/bin/volute setup --system --host 0.0.0.0
 
   # Source the profile so env vars are available in this session
   # shellcheck disable=SC1091
   [ -f /etc/profile.d/volute.sh ] && . /etc/profile.d/volute.sh
 
+  HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  [ -n "$HOST_IP" ] || HOST_IP="<this-server>"
+
   echo ""
-  echo "Volute is installed and running."
+  echo "Volute is installed and the daemon is running."
+  echo "  Finish setup in your browser at http://${HOST_IP}:1618"
+  echo "  (create your admin account and connect an AI provider)"
+  echo ""
   echo "  Run 'source /etc/profile.d/volute.sh' or start a new shell to use volute CLI commands."
-  echo ""
   echo "  systemctl status volute      Check daemon status"
-  echo "  volute mind create <name>    Create a new mind"
-  echo "  volute mind start <name>     Start a mind"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Both documented install paths for a brand-new user were broken:

- **install.sh** ran `volute service install --system --host 0.0.0.0` — a deprecated no-op that prints "replaced by `volute setup`" and does nothing — then claimed "Volute is installed and running." Now it runs `volute setup --system --host 0.0.0.0` (installing the service and starting the daemon for real) and the closing message points the user at the browser (with the server's IP) to finish setup, since `mind create` etc. stay gated until the web wizard completes.
- **README quickstart** taught `volute setup --name` → `volute up` → `volute mind create`, which dead-ends at the setup gate (`setupCompleted` only flips via the web wizard's `/api/setup/complete`). Rewritten around the real flow: `volute setup` starts the daemon and opens the browser; finish setup there; the spirit greets you and helps plant a seed. The CLI alternative now shows `seed create` (the recommended path) instead of `mind create`.

Fixes #570

## Testing

- `bash -n install.sh` passes; the changed block only substitutes an existing, documented command (`volute setup --system --host 0.0.0.0`, same invocation as README's bare-metal section).
- Full unit suite passes via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)