### PR TITLE
fix: bake tini into the Docker image so zombie reaping doesn't depend on runner flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,10 +452,10 @@ The daemon is a single privileged process (root on `--system`/Docker) that expos
 
 ```sh
 docker build -t volute .
-docker run -d --init -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
+docker run -d -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
 ```
 
-`--init` runs tini as PID 1 so orphaned mind grandchildren get reaped instead of accumulating as `<defunct>` zombies (the daemon is PID 1 otherwise and does not reap reparented orphans). The compose file sets `init: true` for the same reason.
+The image bakes tini in as its `ENTRYPOINT` (PID 1) so orphaned mind grandchildren get reaped instead of accumulating as `<defunct>` zombies (the daemon does not reap reparented orphans). This works for every launch path — plain `docker run`, compose, or the e2e scripts — with no `--init` flag or `init: true` needed.
 
 Or with docker-compose: `docker compose up -d`. The container runs with `VOLUTE_ISOLATION=user` enabled, so each mind gets its own Linux user inside the container.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:24-slim
 
-# git needed for mind git init + variants; procps/lsof for process management; curl for hooks/scripts; restic for backups
-RUN apt-get update && apt-get install -y --no-install-recommends git procps lsof ca-certificates curl restic \
+# git needed for mind git init + variants; procps/lsof for process management; curl for hooks/scripts; restic for backups;
+# tini as PID 1 so orphaned mind grandchildren get reaped instead of piling up as <defunct> zombies
+RUN apt-get update && apt-get install -y --no-install-recommends git procps lsof ca-certificates curl restic tini \
     && rm -rf /var/lib/apt/lists/* \
     && git config --system user.name "Volute" \
     && git config --system user.email "volute@localhost"
@@ -31,5 +32,7 @@ VOLUME /data
 VOLUME /minds
 
 COPY docker/entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# tini reaps reparented orphans (the daemon runs as PID 1's child and never wait()s
+# adopted mind grandchildren), so zombie reaping doesn't depend on `docker run --init`.
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
 CMD ["node", "dist/daemon.js", "--host", "0.0.0.0", "--foreground"]

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Set the model via `home/.config/config.json` (SDK config) or `home/.config/volut
 
 ```sh
 docker build -t volute .
-docker run -d --init -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
+docker run -d -p 1618:1618 -v volute-data:/data -v volute-minds:/minds volute
 ```
 
 Or with docker-compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 services:
   volute:
     build: .
-    # Run an init (tini) as PID 1 so orphaned mind grandchildren (e.g. a claude
-    # SDK subprocess whose mind server was killed) get reaped instead of piling
-    # up as <defunct> zombies under the daemon. Defense-in-depth for minds still
-    # running an older template whose server doesn't reap on shutdown.
-    init: true
+    # The image bakes in tini as PID 1 (see Dockerfile ENTRYPOINT) so orphaned
+    # mind grandchildren get reaped instead of piling up as <defunct> zombies —
+    # no `init: true` needed here.
     ports:
       - "1618:1618"
     environment:

--- a/test/docker-e2e.sh
+++ b/test/docker-e2e.sh
@@ -403,6 +403,39 @@ else
   fail "bob mind log missing"
 fi
 
+# ─── Phase: Zombie reaping (tini as PID 1) ───────────────────────────────────
+#
+# The image bakes tini in as ENTRYPOINT so reparented orphans get reaped
+# instead of piling up as <defunct> zombies under the daemon (issue #563).
+
+# Direct guard against an ENTRYPOINT regression: PID 1 must be tini.
+pid1=$(docker exec "$CONTAINER" cat /proc/1/comm | tr -d '[:space:]')
+assert_eq "$pid1" "tini" "PID 1 is tini"
+
+# Deliberately orphan a short-lived process: the sh parent exits immediately,
+# the sleep reparents to PID 1 and must be reaped when it exits — without tini
+# it would stay <defunct> forever. This guarantees the zombie check below
+# exercises reaping even if the mind-stop path happened to leave no orphans.
+docker exec "$CONTAINER" sh -c 'sleep 1 >/dev/null 2>&1 & exit 0'
+sleep 3
+
+# After stopping both minds (and the orphan above exiting), no <defunct>
+# entries may remain. Capture the process list first so a ps failure is a
+# loud test failure rather than being laundered into a passing "0".
+if ! ps_out=$(docker exec "$CONTAINER" ps -eo pid,ppid,stat,comm); then
+  fail "ps failed in container — zombie check did not run"
+elif [[ -z "$ps_out" ]]; then
+  fail "ps produced no output — zombie check did not run"
+else
+  zombie_count=$(printf '%s\n' "$ps_out" | grep -cE '^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+Z' || true)
+  if [[ "$zombie_count" == "0" ]]; then
+    pass "no <defunct> zombie processes"
+  else
+    fail "found $zombie_count zombie process(es)"
+    printf '%s\n' "$ps_out" | grep -E '^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+Z'
+  fi
+fi
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## What / why

Found in the 0.47 release integration pass (#563): plain `docker run` (without `--init`) runs the daemon as PID 1, which never `wait()`s reparented orphans — after `volute mind stop`, the stopped mind's server process and `esbuild` service children pile up as `<defunct>` zombies. The interim mitigation (`init: true` in compose, `--init` in docs) only covered launch paths that remembered the flag.

This bakes tini into the image so every launch path gets a real init with no flags needed:

- **Dockerfile** — install `tini` (~1 MB, Debian package on `node:24-slim`), `ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]`. `entrypoint.sh` still `exec`s the CMD, so the daemon runs as tini's direct child and reparented orphans get reaped by tini.
- **docker-compose.yml** — drop the now-redundant `init: true` (one mechanism is cleaner than tini-under-tini).
- **README / CLAUDE.md** — drop `--init` from the `docker run` example; document the baked-in ENTRYPOINT.
- **test/docker-e2e.sh** — new zombie-reaping phase after mind stop:
  - asserts PID 1 is `tini` (direct, deterministic guard against an ENTRYPOINT regression)
  - deliberately orphans a short-lived process and asserts it gets reaped, so the check exercises reaping even if the mind-stop path happens to leave no orphans of its own
  - asserts zero `<defunct>` entries, with the process list captured up-front so a `ps` failure fails loudly instead of laundering into a passing "0"

## Test plan

- `bash test/docker-e2e.sh` — 31/31 pass, including the new `PID 1 is tini`, orphan-reap, and zero-zombie assertions (Phases 6/7 skipped: no `ANTHROPIC_API_KEY`)
- `npm test` — 2048/2048 pass
- Minimal-image check: `docker run --rm <img> cat /proc/1/comm` → `tini`

Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)