### PR TITLE
fix(pi): survive burst delivery races instead of crashing the mind server

### DIFF
--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -22,6 +22,7 @@ import {
   readSkillDescriptions,
 } from "./lib/context-breakdown.js";
 import { daemonEmit } from "./lib/daemon-client.js";
+import { dispatchPrompt } from "./lib/dispatch.js";
 import { createEventHandler, emit } from "./lib/event-handler.js";
 import { runHooks } from "./lib/hook-loader.js";
 import { log } from "./lib/logger.js";
@@ -489,16 +490,12 @@ export function createMind(options: {
             broadcast(session, { type: "done" });
             return;
           }
-          if (session.agentSession.isStreaming) {
-            if (meta.interrupt) {
-              interruptSession(sessionName);
-              session.agentSession.prompt(text, { streamingBehavior: "steer", ...opts });
-            } else {
-              session.agentSession.prompt(text, { streamingBehavior: "followUp", ...opts });
-            }
-          } else {
-            session.agentSession.prompt(text, opts);
-          }
+          // This await is load-bearing: without it a prompt rejection (burst race,
+          // auth failure, ...) floats as an unhandled rejection and crashes the
+          // mind server instead of landing in the .catch below (issue #565).
+          await dispatchPrompt(session.agentSession, text, opts, meta.interrupt === true, () =>
+            interruptSession(sessionName),
+          );
         })().catch(async (err) => {
           log("mind", `session "${sessionName}": prompt failed:`, err);
           // Tell the daemon the turn failed (so it records a notice for the mind's next

--- a/templates/pi/src/lib/dispatch.ts
+++ b/templates/pi/src/lib/dispatch.ts
@@ -1,0 +1,65 @@
+import type { ImageContent } from "@earendil-works/pi-ai";
+
+/** Options accepted by {@link PromptTarget.prompt}. Subset of pi's PromptOptions. */
+export interface DispatchOptions {
+  streamingBehavior?: "steer" | "followUp";
+  images?: ImageContent[];
+}
+
+/** The slice of a pi AgentSession that {@link dispatchPrompt} needs. */
+export interface PromptTarget {
+  readonly isStreaming: boolean;
+  prompt(text: string, options?: DispatchOptions): Promise<void>;
+}
+
+/**
+ * True when `err` is pi's "agent is already processing" rejection — thrown when a
+ * fresh (non-streaming) prompt is sent while a turn is actually in flight.
+ */
+export function isAlreadyProcessingError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("already processing");
+}
+
+/**
+ * Send `text` to the agent, choosing the right queueing behavior for burst delivery.
+ *
+ * `AgentSession.isStreaming` only flips to `true` partway through an in-flight
+ * `prompt()` call, so a second message that arrives in the same tick can observe
+ * `isStreaming === false`, take the fresh-prompt path, and race the first message.
+ * pi rejects the loser with "agent is already processing". Awaiting the dispatch
+ * (so the rejection is caught, not left floating as an unhandled rejection that
+ * crashes the mind server) and re-routing the loser as a follow-up keeps both
+ * messages: nothing is dropped, and the server survives.
+ *
+ * - Idle: fresh prompt. On the race rejection, re-route as a follow-up.
+ * - Streaming + interrupt: steer the current turn (after `onInterrupt`).
+ * - Streaming: queue as a follow-up to run after the current turn.
+ */
+export async function dispatchPrompt(
+  agent: PromptTarget,
+  text: string,
+  opts: { images?: ImageContent[] },
+  interrupt: boolean,
+  onInterrupt: () => void,
+): Promise<void> {
+  if (agent.isStreaming) {
+    if (interrupt) {
+      onInterrupt();
+      await agent.prompt(text, { streamingBehavior: "steer", ...opts });
+    } else {
+      await agent.prompt(text, { streamingBehavior: "followUp", ...opts });
+    }
+    return;
+  }
+
+  try {
+    await agent.prompt(text, opts);
+  } catch (err) {
+    if (!isAlreadyProcessingError(err)) throw err;
+    // Lost the race: another burst message started a turn between our isStreaming
+    // check and this dispatch. Queue as a follow-up instead of crashing. If the
+    // winning turn has already finished by now, pi only consults streamingBehavior
+    // while streaming, so this is sent as a fresh prompt — delivered either way.
+    await agent.prompt(text, { streamingBehavior: "followUp", ...opts });
+  }
+}

--- a/test/pi-dispatch.test.ts
+++ b/test/pi-dispatch.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  type DispatchOptions,
+  dispatchPrompt,
+  isAlreadyProcessingError,
+  type PromptTarget,
+} from "../templates/pi/src/lib/dispatch.js";
+
+const ALREADY_PROCESSING =
+  "Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.";
+
+const IMAGE = { type: "image", data: "abc", mimeType: "image/png" } as const;
+
+/**
+ * Models pi's AgentSession closely enough to reproduce the burst-delivery race:
+ * a fresh (non-streaming) prompt only flips `isStreaming` after an async tick, so
+ * two prompts sent in the same tick both observe `isStreaming === false` and race.
+ * The loser is rejected with "agent is already processing", exactly like pi.
+ */
+class FakeAgentSession implements PromptTarget {
+  streaming = false;
+  turns: string[] = []; // fresh prompts that started a turn
+  queued: string[] = []; // messages queued via steer/followUp
+  calls: { text: string; options?: DispatchOptions }[] = [];
+
+  get isStreaming(): boolean {
+    return this.streaming;
+  }
+
+  async prompt(text: string, options?: DispatchOptions): Promise<void> {
+    this.calls.push({ text, options });
+    if (options?.streamingBehavior) {
+      this.queued.push(text);
+      return;
+    }
+    // Async gap before streaming flips on — this is the race window.
+    await Promise.resolve();
+    if (this.streaming) {
+      throw new Error(ALREADY_PROCESSING);
+    }
+    this.streaming = true;
+    this.turns.push(text);
+  }
+}
+
+describe("pi template dispatchPrompt", () => {
+  it("sends a fresh prompt when the agent is idle", async () => {
+    const agent = new FakeAgentSession();
+    let interrupts = 0;
+    await dispatchPrompt(agent, "hello", {}, false, () => {
+      interrupts++;
+    });
+    assert.deepEqual(agent.turns, ["hello"]);
+    assert.deepEqual(agent.queued, []);
+    assert.equal(interrupts, 0);
+  });
+
+  it("survives a two-message burst and delivers both", async () => {
+    const agent = new FakeAgentSession();
+    const noop = () => {};
+
+    // Two messages dispatched in the same tick: both observe isStreaming === false.
+    const p1 = dispatchPrompt(agent, "first", {}, false, noop);
+    const p2 = dispatchPrompt(agent, "second", {}, false, noop);
+
+    // The core regression: neither promise rejects (no unhandled rejection to crash
+    // the mind server), and both messages land — one as a turn, one queued.
+    await assert.doesNotReject(Promise.all([p1, p2]));
+    assert.equal(agent.turns.length, 1, "exactly one message won the race");
+    assert.equal(agent.queued.length, 1, "the loser was re-routed as a follow-up");
+    assert.deepEqual([...agent.turns, ...agent.queued].sort(), ["first", "second"]);
+  });
+
+  it("carries images through the race-loser follow-up re-route", async () => {
+    const agent = new FakeAgentSession();
+    const noop = () => {};
+    const p1 = dispatchPrompt(agent, "first", {}, false, noop);
+    const p2 = dispatchPrompt(agent, "second", { images: [IMAGE] }, false, noop);
+    await Promise.all([p1, p2]);
+    const second = agent.calls.filter((c) => c.text === "second").at(-1);
+    assert.deepEqual(second?.options?.images, [IMAGE], "images survive the re-route");
+  });
+
+  it("queues a follow-up when the agent is already streaming", async () => {
+    const agent = new FakeAgentSession();
+    agent.streaming = true;
+    let interrupts = 0;
+    await dispatchPrompt(agent, "later", { images: [IMAGE] }, false, () => {
+      interrupts++;
+    });
+    assert.deepEqual(agent.turns, []);
+    assert.deepEqual(agent.queued, ["later"]);
+    assert.equal(interrupts, 0, "no interrupt without the interrupt flag");
+    assert.deepEqual(agent.calls[0]?.options?.images, [IMAGE], "images pass through");
+  });
+
+  it("steers and interrupts (in that order) when interrupt is set mid-turn", async () => {
+    const agent = new FakeAgentSession();
+    agent.streaming = true;
+    const order: string[] = [];
+    const origPrompt = agent.prompt.bind(agent);
+    agent.prompt = async (text, options) => {
+      order.push(`prompt:${options?.streamingBehavior}`);
+      return origPrompt(text, options);
+    };
+    await dispatchPrompt(agent, "urgent", { images: [IMAGE] }, true, () => {
+      order.push("interrupt");
+    });
+    assert.deepEqual(agent.queued, ["urgent"]);
+    assert.deepEqual(order, ["interrupt", "prompt:steer"], "interrupt fires before the steer");
+    assert.deepEqual(agent.calls[0]?.options?.images, [IMAGE], "images pass through steer");
+  });
+
+  it("sends a fresh prompt (no interrupt) when interrupt is set but the agent is idle", async () => {
+    const agent = new FakeAgentSession();
+    let interrupts = 0;
+    await dispatchPrompt(agent, "hello", {}, true, () => {
+      interrupts++;
+    });
+    assert.deepEqual(agent.turns, ["hello"]);
+    assert.equal(interrupts, 0, "interrupt only applies mid-stream");
+  });
+
+  it("rethrows errors that are not the already-processing race", async () => {
+    const agent: PromptTarget = {
+      isStreaming: false,
+      async prompt() {
+        throw new Error("model authentication failed");
+      },
+    };
+    await assert.rejects(
+      dispatchPrompt(agent, "x", {}, false, () => {}),
+      /model authentication failed/,
+    );
+  });
+
+  it("recognizes the pi already-processing error message", () => {
+    assert.equal(isAlreadyProcessingError(new Error(ALREADY_PROCESSING)), true);
+    assert.equal(isAlreadyProcessingError(new Error("something else")), false);
+    assert.equal(isAlreadyProcessingError("not an error"), false);
+  });
+
+  it("matches the error message actually thrown by the installed pi-coding-agent", () => {
+    // isAlreadyProcessingError matches on message text — pi exports no error class
+    // for this case. Guard against silent drift: find the message pi really throws
+    // in the installed package and assert our matcher still recognizes it. If a pi
+    // upgrade rewords the error, this fails instead of the crash quietly returning.
+    // The package only exports its root, so resolve the entry and walk to the file.
+    const entry = fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"));
+    const source = readFileSync(resolvePath(entry, "../core/agent-session.js"), "utf-8");
+    const match = source.match(/throw new Error\("(Agent is already processing[^"]*)"\)/);
+    assert.ok(match, "pi's already-processing throw not found — did the error move or reword?");
+    assert.equal(isAlreadyProcessingError(new Error(match[1])), true);
+    assert.equal(match[1], ALREADY_PROCESSING, "FakeAgentSession message drifted from real pi");
+  });
+});


### PR DESCRIPTION
## What / why

The pi template crashed when a second message arrived while the agent was mid-turn. pi's `AgentSession.isStreaming` only flips true partway through an in-flight `prompt()` call, so two burst messages dispatched in the same tick both observe `isStreaming === false`, both take the fresh-prompt path, and pi rejects the loser with `"Agent is already processing..."`. The dispatch was fire-and-forget, so that rejection floated as an unhandled rejection and took down the whole mind server.

This extracts the dispatch into a small, testable `dispatchPrompt` helper (`templates/pi/src/lib/dispatch.ts`) that:

- **awaits** the prompt, so any rejection lands in the existing per-message error handler (daemon error notice + `done`) instead of crashing the process
- **catches the already-processing race** on the idle path and re-routes the losing message through pi's `followUp` queue — matching the claude template's burst semantics: no message dropped, no crash
- keeps the existing mid-turn semantics: `followUp` when streaming, `steer` + interrupt when `meta.interrupt` is set

If the winning turn has already finished by retry time, pi only consults `streamingBehavior` while streaming, so the re-route is delivered as a fresh prompt — the loser lands either way.

## Test plan

- New `test/pi-dispatch.test.ts` (9 tests): a `FakeAgentSession` reproduces pi's race window (isStreaming flips after an async gap). Covers the two-message burst regression (no rejection, both delivered), streaming/steer/interrupt paths, interrupt-on-idle, images propagation, non-race error rethrow, and a drift guard that greps the installed pi package for the real error message so a pi upgrade that rewords it fails CI instead of silently reintroducing the crash.
- Full `npm test`: 2039 pass, 0 fail. Per-template typecheck (pre-commit) passes for claude/pi/codex.

Fixes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)