### PR TITLE
fix: make the setup gate distinguish unfinished wizard from no setup

### DIFF
--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -271,10 +271,44 @@ export function migrateConfigSecrets(): void {
   writeGlobalConfig(readGlobalConfig()); // re-split with correct perms
 }
 
+/**
+ * Setup lifecycle state:
+ * - `complete` — the full flow finished (or a legacy install predating the flag).
+ * - `in-progress` — a setup entry point ran (`volute setup` CLI or a wizard step)
+ *   but the browser wizard hasn't been completed. Re-running `volute setup` won't
+ *   advance this; the user must finish in the browser.
+ * - `none` — setup has never been started.
+ */
+export type SetupStatus = "complete" | "in-progress" | "none";
+
+export function setupStatus(): SetupStatus {
+  const config = readGlobalConfig();
+  if (config.setupCompleted === true) return "complete";
+  // Legacy install: has a setup block but predates the `setupCompleted` flag.
+  // migrateSetupCompleted() persists these as complete on daemon start; the CLI
+  // gate must agree even before the daemon has run that migration.
+  if (config.setup != null && config.setupCompleted == null) return "complete";
+  // A setup entry point ran but the browser wizard hasn't finished.
+  if (config.setup != null) return "in-progress";
+  return "none";
+}
+
 /** Check if setup has been completed. Returns true once the full setup flow has finished. */
 export function isSetupComplete(): boolean {
+  return setupStatus() === "complete";
+}
+
+/**
+ * Best-effort URL for finishing setup in the browser wizard, derived from the
+ * saved config (no dependency on the daemon running). Falls back to localhost:1618.
+ */
+export function setupUrl(): string {
   const config = readGlobalConfig();
-  return config.setupCompleted === true;
+  const port = config.port || 1618;
+  let host = config.hostname || "127.0.0.1";
+  if (host === "0.0.0.0" || host === "::") host = "localhost";
+  if (host.includes(":") && !host.startsWith("[")) host = `[${host}]`; // bracket bare IPv6
+  return `http://${host}:${port}`;
 }
 
 export function isImagegenEnabled(): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,9 +39,19 @@ const ungatedCommands = new Set([
   undefined,
 ]);
 if (!ungatedCommands.has(command)) {
-  const { isSetupComplete } = await import("@volute/daemon/lib/config/setup.js");
-  if (!isSetupComplete()) {
-    console.error("Volute is not set up. Run `volute setup` first.");
+  const { setupStatus, setupUrl } = await import("@volute/daemon/lib/config/setup.js");
+  const status = setupStatus();
+  if (status !== "complete") {
+    if (status === "in-progress") {
+      // Setup was started but the browser wizard hasn't been finished. Re-running
+      // `volute setup` won't advance it — point the user at the wizard instead.
+      console.error("Volute setup isn't finished yet.");
+      console.error(`Open ${setupUrl()} in your browser to complete it.`);
+      console.error("(If the daemon isn't running, start it with `volute up` first.)");
+    } else {
+      console.error("Volute is not set up. Run `volute setup` to get started.");
+      console.error("It starts the daemon and opens a browser wizard to finish configuration.");
+    }
     process.exit(1);
   }
 }

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -7,6 +7,8 @@ import {
   type GlobalConfig,
   isSetupComplete,
   readGlobalConfig,
+  setupStatus,
+  setupUrl,
   writeGlobalConfig,
 } from "../packages/daemon/src/lib/config/setup.js";
 import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
@@ -76,12 +78,14 @@ describe("setup config", () => {
     assert.equal(isSetupComplete(), false);
   });
 
-  it("isSetupComplete returns false when setup field exists but setupCompleted is not set", () => {
+  it("isSetupComplete treats a legacy config (setup block, no setupCompleted flag) as complete", () => {
+    // Predates the setupCompleted flag; migrateSetupCompleted() persists these as
+    // complete on daemon start, so the CLI gate must agree even before that runs.
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp", isolation: "sandbox", service: false },
     });
-    assert.equal(isSetupComplete(), false);
+    assert.equal(isSetupComplete(), true);
   });
 
   it("isSetupComplete returns true when setupCompleted is true", () => {
@@ -91,5 +95,83 @@ describe("setup config", () => {
       setupCompleted: true,
     });
     assert.equal(isSetupComplete(), true);
+  });
+
+  it("isSetupComplete returns false while setup is in progress (setupCompleted === false)", () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp", isolation: "sandbox", service: false },
+      setupCompleted: false,
+    });
+    assert.equal(isSetupComplete(), false);
+  });
+});
+
+describe("setupStatus", () => {
+  afterEach(cleanup);
+
+  it("returns 'none' when no config exists", () => {
+    assert.equal(setupStatus(), "none");
+  });
+
+  it("returns 'none' when config has no setup field", () => {
+    writeGlobalConfig({ name: "test" });
+    assert.equal(setupStatus(), "none");
+  });
+
+  it("returns 'in-progress' after `volute setup` ran but the wizard is unfinished", () => {
+    // This is the state `volute setup` leaves behind: config written, browser
+    // wizard not yet completed. The old strict gate misreported it as "not set up".
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp", isolation: "sandbox", service: false },
+      setupCompleted: false,
+    });
+    assert.equal(setupStatus(), "in-progress");
+  });
+
+  it("returns 'complete' for a legacy config missing the setupCompleted flag", () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp", isolation: "sandbox", service: false },
+    });
+    assert.equal(setupStatus(), "complete");
+  });
+
+  it("returns 'complete' when setupCompleted is true", () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp", isolation: "sandbox", service: false },
+      setupCompleted: true,
+    });
+    assert.equal(setupStatus(), "complete");
+  });
+});
+
+describe("setupUrl", () => {
+  afterEach(cleanup);
+
+  it("defaults to 127.0.0.1:1618 when config is empty", () => {
+    assert.equal(setupUrl(), "http://127.0.0.1:1618");
+  });
+
+  it("uses the configured port and rewrites a wildcard host to localhost", () => {
+    writeGlobalConfig({ hostname: "0.0.0.0", port: 9000 });
+    assert.equal(setupUrl(), "http://localhost:9000");
+  });
+
+  it("preserves a concrete hostname", () => {
+    writeGlobalConfig({ hostname: "myhost.local", port: 1618 });
+    assert.equal(setupUrl(), "http://myhost.local:1618");
+  });
+
+  it("rewrites the IPv6 wildcard host to localhost", () => {
+    writeGlobalConfig({ hostname: "::", port: 1618 });
+    assert.equal(setupUrl(), "http://localhost:1618");
+  });
+
+  it("brackets a bare IPv6 hostname", () => {
+    writeGlobalConfig({ hostname: "::1", port: 1618 });
+    assert.equal(setupUrl(), "http://[::1]:1618");
   });
 });


### PR DESCRIPTION
## Summary

The CLI setup gate said "Volute is not set up. Run `volute setup` first." in two situations where that advice loops (#571):

- **After running `volute setup`**: every setup entry point writes `setupCompleted: false` and hands off to the browser wizard — only the wizard's completion flips it to `true`. Until then, every gated command told the user to run setup *again*, which just re-wrote the same config and re-opened the browser. The message never mentioned the wizard.
- **Legacy installs**: configs predating the `setupCompleted` flag (a `setup` block with no flag) were treated as "not set up" by the CLI gate until the daemon happened to run `migrateSetupCompleted()` — so a CLI command run before the daemon started (or after an update, before restart) hit a false gate.

## Changes

- New `setupStatus(): "complete" | "in-progress" | "none"` in `packages/daemon/src/lib/config/setup.ts`. The legacy predicate (`setup != null && setupCompleted == null`) matches `migrateSetupCompleted()` exactly, so the gate agrees with the daemon migration before it runs.
- `isSetupComplete()` now delegates to `setupStatus()` (legacy configs count as complete everywhere, including the web wizard's own guards — consistent, since the daemon migrates them on start anyway).
- New `setupUrl()` derives the wizard URL from saved config (port/hostname; `0.0.0.0`/`::` rewritten to `localhost`, bare IPv6 bracketed) with no dependency on the daemon running.
- The CLI gate in `src/cli.ts` now prints per-state messages: in-progress → "Volute setup isn't finished yet. Open <url> in your browser to complete it." (plus a `volute up` hint); none → "Run `volute setup` to get started" with a note that it opens the browser wizard.

Messaging is consistent with #584 (install.sh/README fixes), which documents the same setup → browser → CLI-unlocks flow. No wizard code touched (#572's scope).

## Test plan

- New unit tests in `test/setup.test.ts`: all three `setupStatus()` states (including both paths to `none` and both to `complete`), `isSetupComplete()` legacy-as-complete and in-progress-as-false, and `setupUrl()` defaults, wildcard rewrites (IPv4 + IPv6), concrete hostnames, and IPv6 bracketing.
- Full `npm test`: 2058/2059 pass; the single failure (`test/shutdown-signal.test.ts`, untouched by this PR) is a subprocess-timing phantom from concurrent fleet testing — it passes on a solo rerun (0 failures).

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)