### PR TITLE
fix(cli): onboarding papercuts — seed steering, aligned next steps, login-before-wizard

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -2,7 +2,7 @@ import { command } from "../lib/command.js";
 
 const cmd = command({
   name: "volute mind create",
-  description: "Create a new mind",
+  description: "Create a new mind (see 'volute seed create' for the recommended path)",
   args: [{ name: "name", required: true, description: "Name for the new mind" }],
   flags: {
     template: { type: "string", description: "Template to use (claude, pi, codex)" },
@@ -45,8 +45,14 @@ const cmd = command({
       process.exit(1);
     }
 
-    console.log(`\n${data.message ?? `Created mind: ${data.name} (port ${data.port})`}`);
-    console.log(`\n  volute mind start ${data.name ?? name}`);
+    const created = data.name ?? name;
+    console.log(`\n${data.message ?? `Created mind: ${created} (port ${data.port})`}`);
+    console.log(`\nStart it, then say hello:`);
+    console.log(`  volute mind start ${created}`);
+    console.log(`  volute chat send @${created} "hello"`);
+    console.log(
+      `\nTip: 'volute seed create' grows a mind that shapes its own identity — the recommended way to start.`,
+    );
   },
 });
 

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { voluteUserHome } from "@volute/daemon/lib/mind/registry.js";
 import { command } from "../lib/command.js";
-import { daemonFetch } from "../lib/daemon-client.js";
+import { daemonFetch, resolveWebUrl } from "../lib/daemon-client.js";
 import { promptLine, promptPassword } from "../lib/prompt.js";
 
 const cmd = command({
@@ -10,6 +10,21 @@ const cmd = command({
   description: "Log in to the daemon",
   flags: {},
   run: async () => {
+    // The first account is created in the browser setup wizard. If no account
+    // exists yet, there is nothing to log in as — steer the user there instead
+    // of prompting for credentials that can't work.
+    const statusRes = await daemonFetch("/api/setup/status");
+    if (statusRes.ok) {
+      const status = (await statusRes.json().catch(() => ({}))) as {
+        complete?: boolean;
+        hasAccount?: boolean;
+      };
+      if (status.complete === false && status.hasAccount === false) {
+        console.error(`No account exists yet — finish setup at ${resolveWebUrl()} first.`);
+        process.exit(1);
+      }
+    }
+
     const username = await promptLine("Username: ");
     const password = await promptPassword("Password: ");
 

--- a/packages/cli/src/commands/mind.ts
+++ b/packages/cli/src/commands/mind.ts
@@ -13,7 +13,7 @@ const cmd = subcommands({
   description: "Manage minds",
   commands: {
     create: {
-      description: "Create a new mind",
+      description: "Create a new mind (see 'volute seed create' for the recommended path)",
       run: (args) => import("./create.js").then((m) => m.run(args)),
     },
     start: {

--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -52,7 +52,13 @@ function readCliSession(): CliSession | null {
   }
 }
 
-type DaemonConfig = { port: number; internalPort?: number; hostname?: string; token?: string };
+type DaemonConfig = {
+  port: number;
+  internalPort?: number;
+  hostname?: string;
+  token?: string;
+  tls?: boolean;
+};
 
 // This module is CLI-only (imported by src/commands/). process.exit() is intentional —
 // CLI commands should terminate immediately with a clear error when the daemon is unreachable.
@@ -105,6 +111,21 @@ export function resolveDaemonUrl(): string {
   return buildUrl(readDaemonConfig());
 }
 
+/** Browser-facing dashboard URL (public port, https when TLS is enabled). */
+export function resolveWebUrl(): string {
+  if (process.env.VOLUTE_DAEMON_URL) return process.env.VOLUTE_DAEMON_URL;
+  const session = readCliSession();
+  if (session?.daemonUrl) return session.daemonUrl;
+  const config = readDaemonConfig();
+  const url = new URL(config.tls ? "https://localhost" : "http://localhost");
+  url.port = String(config.port);
+  let hostname = config.hostname || "localhost";
+  if (hostname === "0.0.0.0") hostname = "localhost";
+  if (hostname === "::") hostname = "localhost";
+  url.hostname = hostname;
+  return url.origin;
+}
+
 /** The bearer token daemonFetch would use: mind token (in a mind) or CLI session (operator). */
 export function getAuthToken(): string | undefined {
   return process.env.VOLUTE_MIND_TOKEN ?? readCliSession()?.sessionId;
@@ -139,7 +160,9 @@ export async function daemonFetch(path: string, options?: RequestInit): Promise<
       headers,
       dispatcher: daemonDispatcher,
     } as RequestInit & { dispatcher: Agent });
-    if (res.status === 401 && !path.startsWith("/api/auth/")) {
+    // /api/auth/ and /api/setup/ are public endpoints — a 401 from them is not
+    // a session problem, and "run `volute login`" would be nonsense mid-login.
+    if (res.status === 401 && !path.startsWith("/api/auth/") && !path.startsWith("/api/setup/")) {
       if (cliSession) {
         console.error("Session expired. Run `volute login` again.");
       } else {

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -117,6 +117,7 @@ describe("CLI --help", () => {
     const out = combined(r);
     assert.ok(out.includes("--template"), "should show --template flag");
     assert.ok(out.includes("Create a new mind"), "should show description");
+    assert.ok(out.includes("seed create"), "should steer toward 'seed create'");
     assert.ok(!out.includes("Missing required"), "should NOT show missing arg error");
   });
 

--- a/test/daemon-client.test.ts
+++ b/test/daemon-client.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
-import { after, before, describe, it } from "node:test";
+import { resolve } from "node:path";
+import { after, afterEach, before, describe, it } from "node:test";
 import { Agent } from "undici";
-import { daemonDispatcher } from "../packages/cli/src/lib/daemon-client.js";
+import { daemonDispatcher, resolveWebUrl } from "../packages/cli/src/lib/daemon-client.js";
 
 // A server that waits before sending any response headers, simulating a
 // long-running daemon operation (e.g. upgrade running `npm install`).
@@ -51,5 +53,37 @@ describe("daemonDispatcher", () => {
     const res = await fetch(url, { dispatcher: daemonDispatcher });
     assert.equal(res.status, 200);
     assert.deepEqual(await res.json(), { ok: true });
+  });
+});
+
+describe("resolveWebUrl", () => {
+  const systemDir = resolve(process.env.VOLUTE_HOME!, "system");
+  const configPath = resolve(systemDir, "daemon.json");
+
+  function writeDaemonConfig(config: Record<string, unknown>) {
+    mkdirSync(systemDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify(config));
+  }
+
+  afterEach(() => {
+    rmSync(configPath, { force: true });
+    delete process.env.VOLUTE_DAEMON_URL;
+  });
+
+  it("builds an http URL from the public port and hostname", () => {
+    writeDaemonConfig({ port: 1618, hostname: "0.0.0.0" });
+    assert.equal(resolveWebUrl(), "http://localhost:1618");
+  });
+
+  it("uses https and the public port when TLS is enabled", () => {
+    // With TLS, CLI traffic goes to internalPort, but the browser-facing URL
+    // must stay on the public https port.
+    writeDaemonConfig({ port: 1618, internalPort: 1619, hostname: "myhost.ts.net", tls: true });
+    assert.equal(resolveWebUrl(), "https://myhost.ts.net:1618");
+  });
+
+  it("prefers VOLUTE_DAEMON_URL when set", () => {
+    process.env.VOLUTE_DAEMON_URL = "https://remote.example:8443";
+    assert.equal(resolveWebUrl(), "https://remote.example:8443");
   });
 });

--- a/test/setup-status.test.ts
+++ b/test/setup-status.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
+import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { users } from "../packages/daemon/src/lib/schema.js";
+import setup from "../packages/daemon/src/web/api/setup.js";
+
+// Guards the fields `volute login` relies on to detect the login-before-wizard
+// case (packages/cli/src/commands/login.ts): when setup is incomplete and no
+// brain account exists, /api/setup/status must report complete:false + hasAccount:false.
+
+const TEST_USERNAME = "setupstatususer";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/setup", setup);
+  return app;
+}
+
+async function cleanup() {
+  const db = await getDb();
+  await db.delete(users).where(eq(users.username, TEST_USERNAME));
+  const config = readGlobalConfig();
+  delete config.name;
+  delete config.setup;
+  delete config.setupCompleted;
+  writeGlobalConfig(config);
+}
+
+describe("GET /api/setup/status", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("reports no account when setup is incomplete and no brain exists", async () => {
+    const config = readGlobalConfig();
+    config.name = "test-system";
+    config.setup = { type: "local", mindsDir: "/tmp/minds", isolation: "none", service: false };
+    config.setupCompleted = false;
+    writeGlobalConfig(config);
+
+    const res = await createApp().request("/api/setup/status");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { complete: boolean; hasAccount: boolean };
+    assert.equal(body.complete, false);
+    assert.equal(body.hasAccount, false);
+  });
+
+  it("reports an account once a brain user exists", async () => {
+    const config = readGlobalConfig();
+    config.name = "test-system";
+    config.setup = { type: "local", mindsDir: "/tmp/minds", isolation: "none", service: false };
+    config.setupCompleted = false;
+    writeGlobalConfig(config);
+
+    await createUser(TEST_USERNAME, "pass123");
+
+    const res = await createApp().request("/api/setup/status");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { complete: boolean; hasAccount: boolean };
+    assert.equal(body.complete, false);
+    assert.equal(body.hasAccount, true);
+  });
+});


### PR DESCRIPTION
## What / why

Fixes the three CLI onboarding papercuts from #579:

1. **Creation-path steering** — `volute mind create`'s help/description (both the leaf command and the `volute mind` dispatcher listing) now note that `volute seed create` is the recommended path, and the success output ends with a tip pointing at it. Wording matches the README quickstart being updated in #584.
2. **Aligned next steps** — `mind create` success output now prints the same shape as `seed create`: start the mind, then `volute chat send @<name> "hello"`. (Left `mind create` as not auto-starting — auto-start remains `seed create`'s behavior; #576's agent owns deeper seed-flow changes.)
3. **Login before the wizard** — `volute login` now checks the public `/api/setup/status` endpoint first; when setup is incomplete and no account exists, it prints `No account exists yet — finish setup at <url> first.` and exits instead of prompting for credentials that can't work. The guard is fail-open: any missing field, non-OK response, or older daemon falls through to the normal prompt.

Supporting changes from review:
- New `resolveWebUrl()` in `packages/cli/src/lib/daemon-client.ts` — the browser-facing dashboard URL (public port, `https` when TLS is enabled). `resolveDaemonUrl()` points at the internal loopback HTTP port under TLS, which would have been a wrong suggestion to open in a browser.
- `daemonFetch` no longer treats a 401 from public `/api/setup/` endpoints as "run `volute login`" (which would be a nonsensical instruction mid-login).

Considered and intentionally not changed: if the daemon's DB errors while computing `hasAccount`, the endpoint reports `false` and login is blocked with the finish-setup message — but that branch only runs when setup is genuinely incomplete, where "finish setup first" is correct guidance anyway (and login couldn't succeed against a broken DB either).

## Test plan

- New `test/setup-status.test.ts` — in-process contract test pinning the `/api/setup/status` fields `login.ts` depends on (`complete:false` + `hasAccount:false` with no brain account; `hasAccount:true` once one exists).
- New `resolveWebUrl` cases in `test/daemon-client.test.ts` (public port + hostname mapping, https under TLS, `VOLUTE_DAEMON_URL` override).
- `test/cli-help.test.ts` now asserts `mind create --help` steers toward `seed create`.
- Full `npm test`: 2052/2053 pass; the one failure (`shutdown-signal.test.ts`) is unrelated signal-timing contention from concurrent test runs and passes when rerun alone.

Fixes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)