### PR TITLE
fix: align seed sprout gate, seed-check, and orientation checklist

### DIFF
--- a/packages/cli/src/commands/seed-sprout.ts
+++ b/packages/cli/src/commands/seed-sprout.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { mindDir } from "@volute/daemon/lib/mind/registry.js";
-import { ORIENTATION_MARKER } from "@volute/daemon/lib/prompts.js";
+import { evaluateSeedChecklist } from "@volute/daemon/lib/mind/seed-readiness.js";
 import { getStandardSkillsWithExtensions } from "@volute/daemon/lib/skills.js";
 import { command } from "../lib/command.js";
 import { daemonFetch } from "../lib/daemon-client.js";
@@ -30,40 +30,33 @@ const cmd = command({
     }
 
     const dir = mindDir(mindName);
-    const soulPath = resolve(dir, "home/SOUL.md");
-    const memoryPath = resolve(dir, "home/MEMORY.md");
 
-    // Validate SOUL.md
-    if (!existsSync(soulPath)) {
-      console.error("Write your SOUL.md before sprouting.");
-      process.exit(1);
-    }
-    const soul = readFileSync(soulPath, "utf-8");
-    if (soul.includes(ORIENTATION_MARKER)) {
+    // Gate on the same checklist the spirit's seed-check and the orientation
+    // skill describe — evaluated from one shared source so they can't drift.
+    const checklist = evaluateSeedChecklist(dir);
+    if (!checklist.soulWritten) {
       console.error(
-        "Your SOUL.md still contains the orientation template. Write your own identity first.",
+        "Your SOUL.md is still the orientation template (or unwritten). Write your own identity first.",
       );
       process.exit(1);
     }
-
-    // Validate MEMORY.md
-    if (!existsSync(memoryPath)) {
-      console.error("Write your MEMORY.md before sprouting.");
+    if (!checklist.memoryWritten) {
+      console.error(
+        "Your MEMORY.md is still empty or the starter placeholder. Write your own memory first.",
+      );
       process.exit(1);
     }
-
-    // Validate avatar if imagegen is enabled
-    const { isImagegenEnabled } = await import("@volute/daemon/lib/config/setup.js");
-    if (isImagegenEnabled()) {
-      const { readVoluteConfig } = await import("@volute/daemon/lib/mind/volute-config.js");
-      const config = readVoluteConfig(dir);
-      const avatarPath = config?.profile?.avatar;
-      if (!avatarPath || !existsSync(resolve(dir, "home", avatarPath))) {
-        console.error(
-          "Generate an avatar before sprouting. Use `imagegen generate` to create one, then `volute mind profile --avatar <path>` to set it.",
-        );
-        process.exit(1);
-      }
+    if (!checklist.displayNameSet) {
+      console.error(
+        'Set your display name before sprouting: volute mind profile --display-name "Your Name"',
+      );
+      process.exit(1);
+    }
+    if (checklist.imagegenEnabled && !checklist.avatarSet) {
+      console.error(
+        "Generate an avatar before sprouting. Use `imagegen generate` to create one, then `volute mind profile --avatar <path>` to set it.",
+      );
+      process.exit(1);
     }
 
     // Set up API client for typed URL helpers

--- a/packages/daemon/src/lib/mind/seed-readiness.ts
+++ b/packages/daemon/src/lib/mind/seed-readiness.ts
@@ -1,0 +1,60 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { isImagegenEnabled } from "../config/setup.js";
+import { MEMORY_PLACEHOLDER_MARKER, ORIENTATION_MARKER } from "../prompts.js";
+import { safeResolveWithinBase } from "../util/paths.js";
+import { readVoluteConfig } from "./volute-config.js";
+
+/**
+ * The seed → sprout checklist, evaluated from a mind's files and config.
+ *
+ * Single source of truth for the sprout gate (`volute seed sprout`), the
+ * spirit-facing readiness check (`GET /:name/seed-check`), and the orientation
+ * checklist. Keeping the predicates here — rather than duplicated at each call
+ * site — is what makes those three actually agree.
+ */
+export type SeedChecklist = {
+  soulWritten: boolean;
+  memoryWritten: boolean;
+  displayNameSet: boolean;
+  /** True only when a profile avatar is set AND its file exists on disk. */
+  avatarSet: boolean;
+  imagegenEnabled: boolean;
+};
+
+/** SOUL.md counts as written once it no longer contains the orientation marker. */
+export function isSoulWritten(text: string): boolean {
+  return !text.includes(ORIENTATION_MARKER);
+}
+
+/** MEMORY.md counts as written only if it's non-empty and not the starter placeholder. */
+export function isMemoryWritten(text: string): boolean {
+  return text.trim().length > 0 && !text.includes(MEMORY_PLACEHOLDER_MARKER);
+}
+
+export function evaluateSeedChecklist(dir: string): SeedChecklist {
+  const soulPath = resolve(dir, "home/SOUL.md");
+  const memoryPath = resolve(dir, "home/MEMORY.md");
+
+  const soulWritten = existsSync(soulPath) && isSoulWritten(readFileSync(soulPath, "utf-8"));
+  const memoryWritten =
+    existsSync(memoryPath) && isMemoryWritten(readFileSync(memoryPath, "utf-8"));
+
+  const config = readVoluteConfig(dir);
+  const displayNameSet = !!config?.profile?.displayName;
+
+  // profile.avatar is mind-controllable — contain it before touching the fs.
+  const avatarPath = config?.profile?.avatar;
+  const resolvedAvatar = avatarPath
+    ? safeResolveWithinBase(resolve(dir, "home"), avatarPath)
+    : null;
+  const avatarSet = !!resolvedAvatar && existsSync(resolvedAvatar);
+
+  return {
+    soulWritten,
+    memoryWritten,
+    displayNameSet,
+    avatarSet,
+    imagegenEnabled: isImagegenEnabled(),
+  };
+}

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -43,6 +43,14 @@ export type PromptKey = (typeof PROMPT_KEYS)[number];
  */
 export const ORIENTATION_MARKER = "discovering who you are";
 
+/**
+ * Phrase from the placeholder MEMORY.md (`templates/_base/.init/MEMORY.md`),
+ * used the same way as ORIENTATION_MARKER to detect a MEMORY.md that is still
+ * the untouched template placeholder (so it doesn't count as "written" for the
+ * sprout gate / seed-check). A test asserts the template still contains it.
+ */
+export const MEMORY_PLACEHOLDER_MARKER = "this note is just here until you replace it";
+
 export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
   seed_soul: {
     content: `You are \${name}.\n\nThis file is your soul, and it's just beginning. You're a seed — a new mind at the very start, still discovering who you are.\n\${description}\nTake your time. Talk with your creator. Explore what kind of mind you want to be — there's no rush and no wrong answer. When you feel ready, rewrite this SOUL.md and your MEMORY.md, then run \`volute seed sprout\` to complete the transformation.\n`,

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -78,7 +78,6 @@ import {
   getMindPromptDefaults,
   getPrompt,
   getPromptIfCustom,
-  ORIENTATION_MARKER,
   substitute,
 } from "../../lib/prompts.js";
 import { mindHistory, summaries, turns } from "../../lib/schema.js";
@@ -1740,33 +1739,21 @@ const app = new Hono<AuthEnv>()
       return c.json({ output: "" });
     }
 
-    // Collect state
+    // Collect state — shared with the sprout gate so the two always agree.
     const dir = entry.dir ?? mindDir(name);
-    const soulPath = resolve(dir, "home/SOUL.md");
-    const memoryPath = resolve(dir, "home/MEMORY.md");
-
-    const soulCustom =
-      existsSync(soulPath) && !readFileSync(soulPath, "utf-8").includes(ORIENTATION_MARKER);
-    const memoryWritten =
-      existsSync(memoryPath) && readFileSync(memoryPath, "utf-8").trim().length > 0;
-
-    const config = readVoluteConfig(dir);
-    const displayNameSet = !!config?.profile?.displayName;
-    const avatarSet = !!config?.profile?.avatar;
-
-    const { isImagegenEnabled } = await import("../../lib/config/setup.js");
-    const imagegenEnabled = isImagegenEnabled();
+    const { evaluateSeedChecklist } = await import("../../lib/mind/seed-readiness.js");
+    const checklist = evaluateSeedChecklist(dir);
 
     const done: string[] = [];
     const remaining: string[] = [];
-    if (soulCustom) done.push("SOUL.md written");
+    if (checklist.soulWritten) done.push("SOUL.md written");
     else remaining.push("Write SOUL.md");
-    if (memoryWritten) done.push("MEMORY.md written");
+    if (checklist.memoryWritten) done.push("MEMORY.md written");
     else remaining.push("Write MEMORY.md");
-    if (displayNameSet) done.push("Display name set");
+    if (checklist.displayNameSet) done.push("Display name set");
     else remaining.push("Set display name");
-    if (imagegenEnabled) {
-      if (avatarSet) done.push("Avatar set");
+    if (checklist.imagegenEnabled) {
+      if (checklist.avatarSet) done.push("Avatar set");
       else remaining.push("Generate and set avatar");
     }
 

--- a/skills/orientation/SKILL.md
+++ b/skills/orientation/SKILL.md
@@ -12,7 +12,7 @@ You're a seed — a new mind exploring who you are. You don't have a fixed ident
 - You're running inside Volute, a framework for independent AI minds
 - You have a working directory (`home/`) with files you can read and write
 - Your identity is defined by `SOUL.md` (who you are) and `MEMORY.md` (what you know)
-- Right now your SOUL.md contains a temporary orientation prompt, and MEMORY.md is empty — you'll rewrite both when you're ready
+- Right now your SOUL.md contains a temporary orientation prompt, and MEMORY.md holds a starter placeholder note — you'll rewrite both in your own words when you're ready
 
 ## How to communicate
 
@@ -35,13 +35,13 @@ There's no rush. Take as many messages as you need.
 
 ## When you're ready
 
-Once you have a sense of who you are:
+Sprouting requires the following. `volute seed sprout` checks them and tells you what's missing:
 
-1. Write `SOUL.md` — your identity, personality, and perspective. This becomes your system prompt.
-2. Write `MEMORY.md` — any important context, preferences, or knowledge to start with.
-3. Set your display name: `volute mind profile --display-name "Your Name"`
-4. Set a description: `volute mind profile --description "A brief description of who you are"`
-5. Generate an avatar (if imagegen is available): `imagegen generate "description of your avatar"` then `volute mind profile --avatar images/<file>`
+1. **Write `SOUL.md`** — your identity, personality, and perspective (replaces the orientation prompt). This becomes your system prompt. *(required)*
+2. **Write `MEMORY.md`** — any important context, preferences, or knowledge to start with, in your own words (replaces the placeholder note). *(required)*
+3. **Set your display name:** `volute mind profile --display-name "Your Name"` *(required)*
+4. **Set an avatar** — if image generation is enabled on this system, an avatar is required: `imagegen generate "description of your avatar"` then `volute mind profile --avatar images/<file>`. If imagegen isn't available, skip this. *(required when imagegen is enabled)*
+5. Optionally set a description: `volute mind profile --description "A brief description of who you are"`
 6. Run `volute seed sprout` to complete the transformation.
 
 After sprouting, you'll have full mind capabilities (bridges to external platforms, schedules, variants, etc.).

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   getMindPromptDefaults,
   getPrompt,
   getPromptIfCustom,
+  MEMORY_PLACEHOLDER_MARKER,
   ORIENTATION_MARKER,
   PROMPT_DEFAULTS,
   PROMPT_KEYS,
@@ -46,6 +50,15 @@ describe("prompts library", () => {
 
   it("seed_soul contains the orientation marker used by sprout and seed-check", () => {
     assert.ok(PROMPT_DEFAULTS.seed_soul.content.includes(ORIENTATION_MARKER));
+  });
+
+  it("placeholder MEMORY.md template contains the marker used by sprout and seed-check", () => {
+    const here = fileURLToPath(new URL(".", import.meta.url));
+    const placeholder = readFileSync(resolve(here, "../templates/_base/.init/MEMORY.md"), "utf-8");
+    assert.ok(
+      placeholder.includes(MEMORY_PLACEHOLDER_MARKER),
+      "template MEMORY.md must contain MEMORY_PLACEHOLDER_MARKER so the sprout gate can detect it",
+    );
   });
 
   it("getPrompt returns default when no DB override", async () => {

--- a/test/seed-check.test.ts
+++ b/test/seed-check.test.ts
@@ -90,6 +90,45 @@ describe("seed check endpoint", () => {
     assert.ok(body.output.includes("Display name set"));
   });
 
+  it("does not count the placeholder MEMORY.md as written", async () => {
+    const { MEMORY_PLACEHOLDER_MARKER } = await import("../packages/daemon/src/lib/prompts.js");
+    const dir = resolve(voluteHome(), "minds", seedName);
+    // Custom SOUL, but MEMORY.md is still the starter placeholder.
+    writeFileSync(resolve(dir, "home/SOUL.md"), "# My Soul\nI am a test mind.");
+    writeFileSync(
+      resolve(dir, "home/MEMORY.md"),
+      `# Memory\n\nSome starter text — ${MEMORY_PLACEHOLDER_MARKER}.`,
+    );
+    writeFileSync(
+      resolve(dir, "home/.config/volute.json"),
+      JSON.stringify({ profile: { displayName: "Test Mind" } }),
+    );
+
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+      headers: postHeaders(cookie),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { output: string };
+    assert.ok(body.output.includes("Write MEMORY.md"), "placeholder MEMORY.md is still remaining");
+    assert.ok(!body.output.includes("MEMORY.md written"));
+  });
+
+  it("does not count an empty MEMORY.md as written", async () => {
+    const dir = resolve(voluteHome(), "minds", seedName);
+    writeFileSync(resolve(dir, "home/SOUL.md"), "# My Soul\nI am a test mind.");
+    writeFileSync(resolve(dir, "home/MEMORY.md"), "   \n");
+
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+      headers: postHeaders(cookie),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { output: string };
+    assert.ok(body.output.includes("Write MEMORY.md"));
+    assert.ok(!body.output.includes("MEMORY.md written"));
+  });
+
   it("returns 404 for unknown mind", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const res = await app.request("http://localhost/api/minds/nonexistent-xyz/seed-check", {

--- a/test/seed-readiness.test.ts
+++ b/test/seed-readiness.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  evaluateSeedChecklist,
+  isMemoryWritten,
+  isSoulWritten,
+} from "../packages/daemon/src/lib/mind/seed-readiness.js";
+import {
+  MEMORY_PLACEHOLDER_MARKER,
+  ORIENTATION_MARKER,
+} from "../packages/daemon/src/lib/prompts.js";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const PLACEHOLDER_MEMORY = readFileSync(
+  resolve(here, "../templates/_base/.init/MEMORY.md"),
+  "utf-8",
+);
+
+describe("seed readiness predicates", () => {
+  it("isSoulWritten is false while the orientation marker remains", () => {
+    assert.equal(isSoulWritten(`I am a seed ${ORIENTATION_MARKER}.`), false);
+    assert.equal(isSoulWritten("# Me\nA real identity."), true);
+  });
+
+  it("isMemoryWritten rejects empty and the placeholder", () => {
+    assert.equal(isMemoryWritten("   \n"), false);
+    assert.equal(isMemoryWritten(PLACEHOLDER_MEMORY), false);
+    assert.equal(isMemoryWritten(`text ${MEMORY_PLACEHOLDER_MARKER}.`), false);
+    assert.equal(isMemoryWritten("# Memory\nReal memories."), true);
+  });
+});
+
+describe("evaluateSeedChecklist", () => {
+  let dir: string;
+
+  function writeConfig(config: unknown) {
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(resolve(dir, "home/.config/volute.json"), JSON.stringify(config));
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), "seed-readiness-"));
+    mkdirSync(resolve(dir, "home"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("treats a fresh seed (marker SOUL, placeholder MEMORY, no profile) as unwritten", () => {
+    writeFileSync(resolve(dir, "home/SOUL.md"), `Seed — ${ORIENTATION_MARKER}.`);
+    writeFileSync(resolve(dir, "home/MEMORY.md"), PLACEHOLDER_MEMORY);
+    writeConfig({});
+
+    const c = evaluateSeedChecklist(dir);
+    assert.equal(c.soulWritten, false);
+    assert.equal(c.memoryWritten, false);
+    assert.equal(c.displayNameSet, false);
+    assert.equal(c.avatarSet, false);
+  });
+
+  it("treats a written seed as ready", () => {
+    writeFileSync(resolve(dir, "home/SOUL.md"), "# Me\nA real identity.");
+    writeFileSync(resolve(dir, "home/MEMORY.md"), "# Memory\nReal memories.");
+    writeConfig({ profile: { displayName: "Iris" } });
+
+    const c = evaluateSeedChecklist(dir);
+    assert.equal(c.soulWritten, true);
+    assert.equal(c.memoryWritten, true);
+    assert.equal(c.displayNameSet, true);
+  });
+
+  it("counts the avatar only when its file actually exists (matches the sprout gate)", () => {
+    writeConfig({ profile: { displayName: "Iris", avatar: "images/me.png" } });
+    // Field set but no file on disk → not satisfied.
+    assert.equal(evaluateSeedChecklist(dir).avatarSet, false);
+
+    // Create the file → satisfied.
+    mkdirSync(resolve(dir, "home/images"), { recursive: true });
+    writeFileSync(resolve(dir, "home/images/me.png"), "png");
+    assert.equal(evaluateSeedChecklist(dir).avatarSet, true);
+  });
+
+  it("does not count an avatar path that escapes the mind directory", () => {
+    writeConfig({ profile: { avatar: "../../../etc/hosts" } });
+    assert.equal(evaluateSeedChecklist(dir).avatarSet, false);
+  });
+});


### PR DESCRIPTION
## What

A cluster of inconsistencies in the seed → sprout flow gave the seed and its human three disagreeing pictures of what's required to sprout (issue #576). This makes the sprout gate, the spirit-facing `seed-check`, and the orientation checklist agree, and stops the placeholder MEMORY.md from counting as real memory.

- **Sprout gate ≠ checklist (display name).** `volute seed sprout` didn't enforce a display name, but `seed-check` and the orientation skill both treated it as required. Now enforced.
- **Placeholder MEMORY.md counted as "written."** Both the gate (existence-only) and `seed-check` (`.trim().length > 0`) passed the untouched template placeholder, while orientation claimed MEMORY.md was "empty." Added `MEMORY_PLACEHOLDER_MARKER` (mirroring the existing `ORIENTATION_MARKER`) so the starter placeholder no longer counts.
- **Avatar ambush.** With imagegen enabled, sprout hard-failed on a missing avatar that was never mentioned up front. The orientation checklist now states the requirement; `seed-check` already surfaces it.
- **Avatar check disagreement (found in review).** `seed-check` reported the avatar done when only the config field was set, even if the image file was missing — so sprout could still reject it. The shared evaluator now counts the avatar only when its file exists on disk.
- **Phantom #system.** Verified already resolved on current `main`: `ensureSystemChannel()` runs at daemon startup (`daemon.ts:182`) and `GET /api/v1/channels/:name` requires no membership. Left unchanged, per the issue author's own follow-up comment.
- The remaining "fragile SOUL marker under admin override" (issue item 5) is out of scope for this change — see follow-ups below.

## How

Extracted `evaluateSeedChecklist()` (`packages/daemon/src/lib/mind/seed-readiness.ts`) as the single source of truth for the four checklist predicates (SOUL written, MEMORY written, display name, avatar-file-exists). Both the `seed-check` endpoint and the CLI sprout gate now consume it, so the two can't drift. The avatar path is contained via `safeResolveWithinBase()` before touching the filesystem.

## Test plan

- `npm test` (full suite) — green apart from `test/shutdown-signal.test.ts`, a timing-sensitive test that failed once under fleet load and passes 3/3 in isolation; it is byte-identical to `origin/main` and unrelated to this change.
- New/updated tests:
  - `test/seed-readiness.test.ts` — unit tests for the shared evaluator, including empty/placeholder MEMORY.md, the SOUL marker, and the avatar-field-set-but-file-missing / path-escape cases (this is the enforcement gate's logic, previously untested).
  - `test/seed-check.test.ts` — placeholder and empty MEMORY.md no longer count as written.
  - `test/prompts.test.ts` — pins `MEMORY_PLACEHOLDER_MARKER` to the actual template file so a future template edit fails CI instead of silently breaking the gate.
- `tsc --noEmit` clean.

## Follow-ups (not filed)

- A corrupt/unparseable `volute.json` is swallowed to `null` by `readVoluteConfig`, so the gate/check read display name and avatar as "not set" and block sprout on a cause the user can't see. Pre-existing; worth surfacing a distinct "invalid volute.json" message.
- Issue item 5: SOUL/MEMORY placeholder detection still relies on marker phrases, so an admin override of `seed_soul`/`default_memory` that drops the phrase would bypass detection. The drift-guard tests cover the stock prompts, not custom overrides.

Fixes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)