### PR TITLE
fix(web): surface setup completion warnings in the wizard

### DIFF
--- a/packages/web/src/ui/pages/SetupPage.svelte
+++ b/packages/web/src/ui/pages/SetupPage.svelte
@@ -19,6 +19,7 @@ function initialStep(): Step {
 let step = $state<Step>(initialStep());
 let error = $state("");
 let loading = $state(false);
+let warnings = $state<string[]>([]);
 
 // Step 2: System
 let systemName = $state("");
@@ -280,6 +281,7 @@ async function handleFinish(e: Event) {
 
 async function completeSetup() {
   error = "";
+  warnings = [];
   loading = true;
   try {
     const res = await fetch("/api/setup/complete", {
@@ -294,6 +296,7 @@ async function completeSetup() {
     const data = (await res.json().catch(() => ({}))) as {
       spiritConversationId?: string;
       spiritStarted?: boolean;
+      warnings?: string[];
     };
 
     // Wait for the spirit's welcome message before transitioning
@@ -301,13 +304,23 @@ async function completeSetup() {
       await waitForSpiritReply(data.spiritConversationId);
     }
 
-    auth.setupComplete = true;
-    onComplete();
+    // Setup completed, but individual steps (spirit start, service install, etc.) may
+    // have failed non-fatally. Surface those warnings rather than silently claiming
+    // full success — then let the user proceed. With no warnings, proceed immediately.
+    warnings = data.warnings ?? [];
+    loading = false;
+    if (warnings.length === 0) finishSetup();
+    return;
   } catch (err) {
     error = err instanceof Error ? err.message : "Something went wrong";
     step = "provider";
   }
   loading = false;
+}
+
+function finishSetup() {
+  auth.setupComplete = true;
+  onComplete();
 }
 
 async function waitForSpiritReply(conversationId: string) {
@@ -578,7 +591,13 @@ $effect(() => {
 
     {:else if step === "provider"}
       <div class="step-title">AI providers</div>
-      <div class="step-desc">Connect a provider and choose models for your minds.</div>
+      <div class="step-desc">
+        An AI provider is the engine your minds think with. Connect one and choose which
+        models they can use. Get a key from
+        <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">Anthropic</a>,
+        <a href="https://platform.openai.com/api-keys" target="_blank" rel="noreferrer">OpenAI</a>,
+        or another provider.
+      </div>
 
       <AiProviders
         bind:this={aiProvidersRef}
@@ -607,11 +626,20 @@ $effect(() => {
 
     {:else if step === "starting"}
       <div class="finishing">
-        <div class="spinner"></div>
-        <div class="finishing-text">Setting things up...</div>
-        {#if error}
+        {#if warnings.length > 0}
+          <div class="finishing-text">Setup finished, with some warnings:</div>
+          <ul class="warnings">
+            {#each warnings as w}
+              <li>{w}</li>
+            {/each}
+          </ul>
+          <button class="submit-btn" onclick={finishSetup}>Continue to dashboard</button>
+        {:else if error}
           <div class="error">{error}</div>
           <button class="submit-btn" onclick={completeSetup}>Retry</button>
+        {:else}
+          <div class="spinner"></div>
+          <div class="finishing-text">Setting things up...</div>
         {/if}
       </div>
     {/if}
@@ -734,6 +762,15 @@ $effect(() => {
     color: var(--text-2);
     font-size: 13px;
     margin-bottom: 16px;
+  }
+
+  .step-desc a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .step-desc a:hover {
+    text-decoration: underline;
   }
 
   /* Forms */
@@ -937,6 +974,15 @@ $effect(() => {
     color: var(--text-1);
     font-size: 14px;
     margin-top: 16px;
+  }
+
+  .warnings {
+    text-align: left;
+    margin: 12px 0 20px;
+    padding-left: 20px;
+    color: var(--text-2);
+    font-size: 13px;
+    line-height: 1.6;
   }
 
   .spinner {

--- a/test/web-setup.test.ts
+++ b/test/web-setup.test.ts
@@ -101,4 +101,24 @@ describe("web setup routes", () => {
     });
     assert.equal(res.status, 400);
   });
+
+  it("POST /api/setup/models — rejects empty model list", async () => {
+    const app = createApp();
+    const res = await app.request("/api/setup/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ models: [], spiritModel: "anthropic:claude-sonnet-4" }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it("POST /api/setup/models — rejects missing spirit model", async () => {
+    const app = createApp();
+    const res = await app.request("/api/setup/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ models: ["anthropic:claude-sonnet-4"], spiritModel: "" }),
+    });
+    assert.equal(res.status, 400);
+  });
 });


### PR DESCRIPTION
## What

Two wizard improvements extracted from the #572 exploration (the skip-the-provider-step proposal itself was rejected on product grounds — Volute without a provider is an empty shell, and with #589 merged, pausing mid-wizard is no longer a dead end):

1. **Surface completion warnings.** `/api/setup/complete` already reported non-fatal failures (spirit start, service install, spirit DM creation) in a `warnings[]` array, but the wizard discarded it — a failed spirit start left the user on a "complete" dashboard with no signal anything went wrong. The completion screen now lists those warnings with a "Continue to dashboard" acknowledgment before proceeding. With no warnings, the transition is unchanged (immediate).

2. **Better provider-step copy.** Explain that a provider is the engine minds think with, and link the Anthropic/OpenAI consoles for getting a key — previously there was no explanation of why a key was needed or where to get one.

No backend changes; the provider step remains mandatory.

## Test plan

- New API-level tests in `test/web-setup.test.ts` pinning `/api/setup/models` validation (rejects empty model list, rejects missing spirit model).
- `npm test`: 2050 passed, 0 failed.
- `svelte-check`: 0 errors (SetupPage clean).

Extracted from the #572 exploration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
