### PR TITLE
fix: make first-run daemon and spirit failures visible

### DIFF
--- a/packages/daemon/src/lib/config/service-mode.ts
+++ b/packages/daemon/src/lib/config/service-mode.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { voluteSystemDir } from "../mind/registry.js";
 import { exec, execInherit } from "../util/exec.js";
+import { readLogTail } from "../util/log-tail.js";
 
 // --- Constants ---
 
@@ -255,6 +256,39 @@ export function readDaemonConfig(): {
     console.error("Warning: could not read daemon config, using defaults.");
     return { hostname: "127.0.0.1", port: 1618 };
   }
+}
+
+/**
+ * Where the daemon writes its output for a given service mode. Background (`manual`)
+ * and both launchd modes redirect stdio to `daemon.log`; Linux systemd modes send it
+ * to the journal, so tailing `daemon.log` there would surface stale/unrelated content.
+ */
+export function daemonLogSource(
+  mode: ServiceMode,
+): { kind: "file"; path: string } | { kind: "journal"; command: string } {
+  switch (mode) {
+    case "system":
+      return { kind: "journal", command: "journalctl -u volute -n 30 --no-pager" };
+    case "user-systemd":
+      return { kind: "journal", command: "journalctl --user -u volute -n 30 --no-pager" };
+    default:
+      return { kind: "file", path: resolve(voluteSystemDir(), "daemon.log") };
+  }
+}
+
+/**
+ * Lines describing where to find the daemon's log (and, for file-backed modes, a
+ * tail of it) — used by `volute up`/`volute status` to surface a crash cause inline
+ * instead of only printing a path. Each caller prints these on its own stream.
+ */
+export function daemonLogReport(mode: ServiceMode, maxLines = 20): string[] {
+  const src = daemonLogSource(mode);
+  if (src.kind === "journal") {
+    return ["To see the daemon log:", `  ${src.command}`];
+  }
+  const tail = readLogTail(src.path, maxLines);
+  if (tail.length === 0) return [`Check logs: ${src.path}`];
+  return [`Last ${tail.length} lines of ${src.path}:`, ...tail.map((l) => `  ${l}`)];
 }
 
 /** Human-readable label for the service mode */

--- a/packages/daemon/src/lib/util/log-tail.ts
+++ b/packages/daemon/src/lib/util/log-tail.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Read the last `maxLines` non-empty lines of a log file.
+ *
+ * Used by CLI commands (`volute up`, `volute status`) to surface the actual
+ * cause of a failed/crashed daemon inline instead of only printing a log path.
+ *
+ * A missing file (ENOENT) is benign and yields `[]`. Any other read failure
+ * (e.g. EACCES on a root-owned log read by a non-root operator) is itself a
+ * cause worth surfacing — issue #575 is about *not* swallowing first-run
+ * failures — so it's returned as a single diagnostic line rather than hidden.
+ *
+ * `daemon.log` is size-bounded by RotatingLog, so reading it whole is fine.
+ */
+export function readLogTail(logFile: string, maxLines = 20): string[] {
+  let content: string;
+  try {
+    content = readFileSync(logFile, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    const reason = (err as NodeJS.ErrnoException).code ?? (err as Error).message;
+    return [`(could not read ${logFile}: ${reason})`];
+  }
+  return content
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .slice(-maxLines);
+}

--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -467,7 +467,8 @@ setup.post("/complete", async (c) => {
       log.info("spirit started successfully during setup");
     } catch (err) {
       log.warn("spirit start failed during setup (non-fatal)", log.errorData(err));
-      warnings.push("Spirit failed to start — it will retry on next daemon restart.");
+      const reason = err instanceof Error ? err.message : String(err);
+      warnings.push(`The spirit couldn't start: ${reason} — it will retry on next daemon restart.`);
     }
 
     // Create DM between admin and spirit

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import { command } from "@volute/cli/lib/command.js";
 import { getAuthToken } from "@volute/cli/lib/daemon-client.js";
 import {
+  daemonLogReport,
   getDaemonUrl,
   getServiceMode,
   LAUNCHD_PLIST_LABEL,
@@ -49,6 +50,9 @@ const cmd = command({
 
     if (!running) {
       console.log("Status: not running");
+      // Surface where the daemon log lives (and a tail of it, for file-backed modes)
+      // so a crash cause is visible without hunting for the path.
+      for (const line of daemonLogReport(mode, 15)) console.log(line);
       return;
     }
 

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, openSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { command } from "@volute/cli/lib/command.js";
 import {
+  daemonLogReport,
   getServiceMode,
   modeLabel,
   pollHealth,
@@ -13,6 +14,20 @@ import { voluteHome, voluteSystemDir } from "@volute/daemon/lib/mind/registry.js
 
 export type { GlobalConfig } from "@volute/daemon/lib/config/setup.js";
 export { readGlobalConfig };
+
+export type DaemonExit = { code: number | null; signal: NodeJS.Signals | null };
+
+/**
+ * Build the message shown when the daemon never becomes healthy. When the child
+ * process exited early we name the signal/exit code; otherwise it's a timeout.
+ */
+export function formatStartupFailure(exit: DaemonExit | null, timeoutMs: number): string {
+  if (exit) {
+    const cause = exit.signal ? `signal ${exit.signal}` : `exit code ${exit.code}`;
+    return `Daemon exited (${cause}) before becoming healthy.`;
+  }
+  return `Daemon started but did not become healthy within ${Math.round(timeoutMs / 1000)}s.`;
+}
 
 const cmd = command({
   name: "volute up",
@@ -41,6 +56,7 @@ const cmd = command({
         console.log(`Volute daemon running on ${h}:${p}`);
       } else {
         console.error("Service started but daemon did not become healthy within 30s.");
+        for (const line of daemonLogReport(mode)) console.error(line);
         process.exit(1);
       }
       return;
@@ -139,6 +155,21 @@ const cmd = command({
     });
     child.unref();
 
+    // A spawn failure (e.g. the node binary is unlaunchable) emits 'error'; without a
+    // listener Node re-throws it as an unhandled crash — the exact ugly first-run
+    // failure #575 is about. Surface it cleanly instead.
+    child.on("error", (err) => {
+      console.error(`Failed to launch daemon: ${err.message}`);
+      process.exit(1);
+    });
+
+    // Track an early exit so we can report a daemon that dies immediately instead of
+    // waiting out the full health-poll timeout.
+    let exitInfo: DaemonExit | null = null;
+    child.on("exit", (code, signal) => {
+      exitInfo = { code, signal };
+    });
+
     // Poll health endpoint to confirm startup (always HTTP on localhost)
     // When TLS is enabled, the internal HTTP listener is on port + 1
     const pollPort = useTailscale ? port + 1 : port;
@@ -147,6 +178,7 @@ const cmd = command({
     const start = Date.now();
 
     while (Date.now() - start < maxWait) {
+      if (exitInfo) break; // daemon died before becoming healthy — stop waiting
       try {
         const res = await fetch(url);
         if (res.ok) {
@@ -164,8 +196,8 @@ const cmd = command({
       await new Promise((r) => setTimeout(r, 500));
     }
 
-    // Kill the daemon since it never became healthy
-    if (child.pid) {
+    // Kill the daemon if it's still alive but never became healthy.
+    if (!exitInfo && child.pid) {
       try {
         process.kill(-child.pid, "SIGTERM");
       } catch {
@@ -175,8 +207,14 @@ const cmd = command({
       }
     }
 
-    console.error("Daemon started but did not become healthy within 30s.");
-    console.error(`Check logs: ${logFile}`);
+    // exitInfo is only ever assigned inside the child's `exit` callback, which
+    // TypeScript's control-flow analysis can't track — hence the explicit read.
+    const exited = exitInfo as DaemonExit | null;
+    console.error(formatStartupFailure(exited, maxWait));
+
+    // Surface the actual failure (npm/permission/port errors) inline instead of only a path.
+    // This path only runs in `manual` mode, so the log is always daemon.log (== logFile).
+    for (const line of daemonLogReport(mode)) console.error(line);
     process.exit(1);
   },
 });

--- a/test/log-tail.test.ts
+++ b/test/log-tail.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { readLogTail } from "../packages/daemon/src/lib/util/log-tail.js";
+
+describe("readLogTail", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "log-tail-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true });
+  });
+
+  it("returns an empty array for a missing file (benign ENOENT)", () => {
+    assert.deepEqual(readLogTail(join(dir, "nope.log")), []);
+  });
+
+  it("surfaces a non-ENOENT read error instead of pretending the log is empty", () => {
+    // Reading a directory throws EISDIR — a real failure that must not be swallowed.
+    const subdir = join(dir, "a-directory");
+    mkdirSync(subdir);
+    const result = readLogTail(subdir);
+    assert.equal(result.length, 1);
+    assert.match(result[0], /could not read .*a-directory/);
+  });
+
+  it("returns all lines when fewer than maxLines", () => {
+    const p = join(dir, "test.log");
+    writeFileSync(p, "one\ntwo\nthree\n");
+    assert.deepEqual(readLogTail(p, 10), ["one", "two", "three"]);
+  });
+
+  it("returns only the last maxLines", () => {
+    const p = join(dir, "test.log");
+    writeFileSync(p, ["a", "b", "c", "d", "e"].join("\n"));
+    assert.deepEqual(readLogTail(p, 2), ["d", "e"]);
+  });
+
+  it("ignores blank lines (including a trailing newline)", () => {
+    const p = join(dir, "test.log");
+    writeFileSync(p, "first\n\n  \nlast\n");
+    assert.deepEqual(readLogTail(p, 10), ["first", "last"]);
+  });
+
+  it("surfaces an error line written to the log", () => {
+    const p = join(dir, "daemon.log");
+    writeFileSync(p, "starting up\nError: EADDRINUSE: address already in use :::1618\n");
+    const tail = readLogTail(p, 20);
+    assert.ok(tail.some((l) => l.includes("EADDRINUSE")));
+  });
+});

--- a/test/service-mode.test.ts
+++ b/test/service-mode.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { createServer, type Server } from "node:http";
 import { describe, it } from "node:test";
 import {
+  daemonLogReport,
+  daemonLogSource,
   getDaemonUrl,
   getServiceMode,
   HEALTH_POLL_TIMEOUT,
@@ -137,6 +139,41 @@ describe("modeLabel", () => {
     assert.equal(modeLabel("user-systemd"), "user service (systemd)");
     assert.equal(modeLabel("user-launchd"), "user service (launchd)");
     assert.equal(modeLabel("manual"), "manual");
+  });
+});
+
+describe("daemonLogSource", () => {
+  it("points systemd modes at the journal, not daemon.log", () => {
+    const sys = daemonLogSource("system");
+    assert.equal(sys.kind, "journal");
+    assert.match((sys as { command: string }).command, /journalctl -u volute/);
+
+    const userSys = daemonLogSource("user-systemd");
+    assert.equal(userSys.kind, "journal");
+    assert.match((userSys as { command: string }).command, /journalctl --user -u volute/);
+  });
+
+  it("uses daemon.log for manual and launchd modes", () => {
+    for (const mode of ["manual", "user-launchd", "system-launchd"] as ServiceMode[]) {
+      const src = daemonLogSource(mode);
+      assert.equal(src.kind, "file", `${mode} should be file-backed`);
+      assert.ok((src as { path: string }).path.endsWith("daemon.log"));
+    }
+  });
+});
+
+describe("daemonLogReport", () => {
+  it("returns a journalctl pointer for systemd modes", () => {
+    const lines = daemonLogReport("system");
+    assert.equal(lines[0], "To see the daemon log:");
+    assert.match(lines[1], /journalctl -u volute/);
+  });
+
+  it("falls back to a log path when the file is absent", () => {
+    // In the test harness VOLUTE_HOME is a fresh temp dir, so daemon.log doesn't exist.
+    const lines = daemonLogReport("manual");
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /^Check logs: .*daemon\.log$/);
   });
 });
 

--- a/test/up-startup-failure.test.ts
+++ b/test/up-startup-failure.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatStartupFailure } from "../src/commands/up.js";
+
+describe("formatStartupFailure", () => {
+  it("reports a timeout when the daemon never exited", () => {
+    assert.equal(
+      formatStartupFailure(null, 30_000),
+      "Daemon started but did not become healthy within 30s.",
+    );
+  });
+
+  it("names the exit code when the daemon died with one", () => {
+    assert.equal(
+      formatStartupFailure({ code: 1, signal: null }, 30_000),
+      "Daemon exited (exit code 1) before becoming healthy.",
+    );
+  });
+
+  it("names the signal when the daemon was killed by one", () => {
+    assert.equal(
+      formatStartupFailure({ code: null, signal: "SIGKILL" }, 30_000),
+      "Daemon exited (signal SIGKILL) before becoming healthy.",
+    );
+  });
+
+  it("prefers the signal over the exit code when both are present", () => {
+    assert.equal(
+      formatStartupFailure({ code: 0, signal: "SIGTERM" }, 30_000),
+      "Daemon exited (signal SIGTERM) before becoming healthy.",
+    );
+  });
+
+  it("renders the timeout in seconds", () => {
+    assert.equal(
+      formatStartupFailure(null, 5_000),
+      "Daemon started but did not become healthy within 5s.",
+    );
+  });
+});


### PR DESCRIPTION
## What

Makes first-run failures visible instead of swallowing them, per #575.

**`volute up`** — a daemon that starts and then dies immediately now reports the cause inline:
- Attaches a `child.on("error")` listener so a spawn failure prints `Failed to launch daemon: <msg>` instead of crashing with an unhandled `'error'` event.
- Tracks `child.on("exit")` so we stop waiting the full 30s and report `Daemon exited (signal X / exit code N) before becoming healthy` when it dies early.
- Tails the last ~20 lines of the daemon log inline (npm/permission/port errors) rather than only printing `Check logs: <path>`.

**`volute status`** — when the daemon isn't running it now shows where the log lives and, for file-backed modes, a tail of it — so a crash cause is visible without hunting for the path.

**Setup** — the spirit-start-failure warning now includes the real error reason (`The spirit couldn't start: <reason> — …`) so the setup wizard surfaces *why* it failed, not just *that* it failed.

## Key decisions

- Added a mode-aware `daemonLogSource` / `daemonLogReport` helper in `service-mode.ts`. Linux systemd services run `volute up --foreground` and log to **journald**, not `daemon.log` — so on those installs we point at `journalctl -u volute` instead of tailing a stale/unrelated `daemon.log`. `manual` and both launchd modes redirect stdio to `daemon.log`, so those get an inline tail.
- `readLogTail` only swallows `ENOENT` (benign "no log yet"); any other read failure (e.g. `EACCES` on a root-owned log read by a non-root operator) is surfaced as a diagnostic line rather than pretending the log is empty — this is exactly the class of invisible failure #575 targets.

## Relationship to #592

#592 keeps the wizard surfacing the backend's `warnings[]` on the completion screen. This PR complements that: it ensures the spirit-start warning actually carries the failure reason, so what #592 renders is useful. The CLI `volute setup` flow delegates `/complete` to the web wizard (there is no CLI-side spirit start), so there was no separate CLI output path to wire. Nothing here depends on #592's skip-path / `aiConfigured` plumbing.

## Test plan

- New `test/log-tail.test.ts` — `readLogTail`: missing file → `[]`, non-ENOENT error surfaced, truncation, blank-line filtering, real error-line surfacing.
- New `test/up-startup-failure.test.ts` — `formatStartupFailure`: timeout vs exit-code vs signal message selection.
- New cases in `test/service-mode.test.ts` — `daemonLogSource`/`daemonLogReport`: systemd → journalctl pointer, manual/launchd → daemon.log, absent-file fallback.
- `npm test`: 2088 passed, 0 failed. `tsc --noEmit`: clean. `biome check`: clean. `svelte-check`: clean.

## Review

Ran code-reviewer, silent-failure-hunter, and pr-test-analyzer. Fixed three legitimate silent-failure findings: gated the log tail on service mode so systemd installs aren't shown a stale `daemon.log` (pointed at journalctl instead); stopped `readLogTail` swallowing non-ENOENT read errors; and added the missing `child.on("error")` spawn-failure handler. Extracted `formatStartupFailure` as a pure, tested helper per the test-analyzer's suggestion.

Fixes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)