### PR TITLE
perf(web): make TurnTimeline streaming incremental and decoupled

### DIFF
--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -32,7 +32,11 @@ import {
   turnLastSeenMs,
 } from "../lib/timeline-liveness";
 import { buildTodayItems } from "../lib/timeline-today";
-import { groupToolEvents } from "../lib/tool-groups";
+import {
+  appendStreamingGroups,
+  groupToolEvents,
+  type TimelineItem as ToolTimelineItem,
+} from "../lib/tool-groups";
 import { getCategoryColor, getCategoryIcon } from "../lib/tool-names";
 import ToolGroupComponent from "./chat/ToolGroup.svelte";
 import HistoryEvent from "./HistoryEvent.svelte";
@@ -146,7 +150,9 @@ let { name, mindStatus }: { name?: string; mindStatus?: string } = $props();
 
 // --- Turns data ---
 const PAGE_SIZE = 100;
-let turnsData = $state<TurnRow[]>([]);
+// Replace-only arrays (all mutation sites reassign) → raw state avoids the cost
+// of deep-proxying every row/summary on each update.
+let turnsData = $state.raw<TurnRow[]>([]);
 let loading = $state(false);
 let historyError = $state("");
 
@@ -161,10 +167,10 @@ let serverTzResolved = $state(false);
 let readOnlyConv = $state<ConversationWithParticipants | null>(null);
 
 // --- Summaries data ---
-let hourSummaries = $state<SummaryRow[]>([]);
-let daySummaries = $state<SummaryRow[]>([]);
-let weekSummaries = $state<SummaryRow[]>([]);
-let monthSummaries = $state<SummaryRow[]>([]);
+let hourSummaries = $state.raw<SummaryRow[]>([]);
+let daySummaries = $state.raw<SummaryRow[]>([]);
+let weekSummaries = $state.raw<SummaryRow[]>([]);
+let monthSummaries = $state.raw<SummaryRow[]>([]);
 let summariesLoaded = $state(false);
 // Backward summary paging (older history coarsens to week/month tiers).
 let hasMoreSummaries = $state(true);
@@ -183,7 +189,36 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const isTurnUuid = (key: string): boolean => UUID_RE.test(key);
 
 // --- Streaming events for active turns ---
-let streamingEvents = $state(new SvelteMap<string, HistoryMessage[]>());
+// Raw events are the source of truth but non-reactive: rendering reads the
+// pre-grouped `streamingGroups` instead, so a per-event append is O(1) DOM work
+// and never re-derives `timelineItems`. `activeTurnIds` tracks streaming
+// membership separately (only changes on turn start/complete) so appends — which
+// leave membership untouched — don't invalidate the `timelineItems` derived.
+const streamingEvents = new Map<string, HistoryMessage[]>();
+const streamingGroups = new SvelteMap<string, ToolTimelineItem[]>();
+const activeTurnIds = new SvelteSet<string>();
+
+function setStreaming(turnId: string, events: HistoryMessage[]) {
+  streamingEvents.set(turnId, events);
+  streamingGroups.set(turnId, groupToolEvents(events));
+  activeTurnIds.add(turnId);
+}
+
+function appendStreamingEvent(turnId: string, event: HistoryMessage) {
+  const events = [...(streamingEvents.get(turnId) ?? []), event];
+  streamingEvents.set(turnId, events);
+  streamingGroups.set(
+    turnId,
+    appendStreamingGroups(streamingGroups.get(turnId) ?? [], events, event),
+  );
+}
+
+function deleteStreaming(turnId: string) {
+  streamingEvents.delete(turnId);
+  streamingGroups.delete(turnId);
+  activeTurnIds.delete(turnId);
+}
+
 let nextSyntheticId = -1;
 // Inbound events that arrived before any turn_created — shown as provisional turn
 let pendingInbounds = $state<HistoryMessage[]>([]);
@@ -293,17 +328,17 @@ async function resync() {
         lastEventAt.set(turnId, Date.now());
         // Mark as streaming synchronously so a newly-discovered active turn renders live,
         // and so the completion guard below has a placeholder to observe.
-        if (!streamingEvents.has(turnId)) streamingEvents.set(turnId, []);
+        if (!streamingEvents.has(turnId)) setStreaming(turnId, []);
         fetchTurnEvents(turnMind, { turnId })
           .then((dbEvents) => {
             // A summary/done landing mid-fetch deletes streaming state; don't resurrect it.
             if (!streamingEvents.has(turnId)) return;
-            streamingEvents.set(turnId, dbEvents);
+            setStreaming(turnId, dbEvents);
           })
           .catch((err) => console.warn("[TurnTimeline] Failed to resync active turn events:", err));
       } else if (streamingEvents.has(turn.id)) {
         // Turn completed while we were disconnected — drop the stale streaming view.
-        streamingEvents.delete(turn.id);
+        deleteStreaming(turn.id);
         lastEventAt.delete(turn.id);
       }
     }
@@ -353,9 +388,9 @@ function connectSSE() {
       if (pendingInbounds.length > 0) {
         const seeded = pendingInbounds.map((ev) => ({ ...ev, turn_id: turnId }));
         const prev = streamingEvents.get(turnId) ?? [];
-        streamingEvents.set(turnId, [...seeded, ...prev]);
+        setStreaming(turnId, [...seeded, ...prev]);
       } else if (!streamingEvents.has(turnId)) {
-        streamingEvents.set(turnId, []);
+        setStreaming(turnId, []);
       }
       pendingInbounds = [];
       lastEventAt.set(turnId, Date.now());
@@ -367,7 +402,7 @@ function connectSSE() {
         .then(() => fetchTurnEvents(turnMind, { turnId }))
         .then((dbEvents) => {
           if (!streamingEvents.has(turnId)) return; // turn already completed
-          streamingEvents.set(turnId, dbEvents);
+          setStreaming(turnId, dbEvents);
         })
         .catch((err) => console.warn("[TurnTimeline] Failed to fetch turn events:", err));
     } else if (eventType === "summary" && turnId) {
@@ -375,7 +410,7 @@ function connectSSE() {
       clearTimeout(doneFallbackTimers.get(turnId));
       doneFallbackTimers.delete(turnId);
       const prevStreaming = streamingEvents.get(turnId);
-      streamingEvents.delete(turnId);
+      deleteStreaming(turnId);
       lastEventAt.delete(turnId);
       fetchTurns({ mind: name, turnId })
         .then((rows) => {
@@ -390,7 +425,7 @@ function connectSSE() {
           console.warn("[TurnTimeline] Failed to fetch completed turn:", err);
           // Restore streaming state so the turn doesn't vanish
           if (!streamingEvents.has(turnId)) {
-            streamingEvents.set(turnId, prevStreaming ?? []);
+            setStreaming(turnId, prevStreaming ?? []);
           }
         });
     } else if (eventType === "done" && turnId) {
@@ -403,7 +438,7 @@ function connectSSE() {
           setTimeout(() => {
             doneFallbackTimers.delete(tid);
             if (streamingEvents.has(tid)) {
-              streamingEvents.delete(tid);
+              deleteStreaming(tid);
               // Refresh the turn from the server
               fetchTurns({ mind: name, turnId: tid })
                 .then((rows) => upsertTurnRows(rows))
@@ -415,18 +450,12 @@ function connectSSE() {
         );
       }
     } else if (turnId && streamingEvents.has(turnId)) {
-      // Substantive event — accumulate for streaming display
-      // Create new array to trigger Svelte reactivity
-      const prev = streamingEvents.get(turnId)!;
-      streamingEvents.set(turnId, [...prev, buildHistoryMessage(d, { turn_id: turnId })]);
+      // Substantive event — append to the streaming view incrementally (O(1)).
+      appendStreamingEvent(turnId, buildHistoryMessage(d, { turn_id: turnId }));
       lastEventAt.set(turnId, Date.now());
     }
 
-    if (!userScrolledUp) {
-      requestAnimationFrame(() => {
-        scrollContainer?.scrollTo({ top: scrollContainer.scrollHeight, behavior: "smooth" });
-      });
-    }
+    scheduleScrollToBottom();
   };
   es.onopen = () => {
     clearReconnectTimer();
@@ -493,11 +522,11 @@ async function loadTurns() {
     // Backfill streaming events for any active turns
     for (const turn of turnsData) {
       if (turn.status === "active" && !streamingEvents.has(turn.id)) {
-        streamingEvents.set(turn.id, []);
+        setStreaming(turn.id, []);
         fetchTurnEvents(turn.mind, { turnId: turn.id })
           .then((dbEvents) => {
             if (!streamingEvents.has(turn.id)) return; // turn completed while fetching
-            streamingEvents.set(turn.id, dbEvents);
+            setStreaming(turn.id, dbEvents);
           })
           .catch((err) =>
             console.warn("[TurnTimeline] Failed to backfill active turn events:", err),
@@ -702,10 +731,16 @@ async function toggleSummaryExpand(summary: SummaryRow) {
   loadingChildren.delete(summary.id);
 }
 
+// Wall-clock anchor for the Today/this-hour boundaries. Held in state and
+// refreshed on a coarse cadence (the liveness sweep + tab focus) so the derived
+// isn't re-reading `new Date()` on unrelated invalidations and the "this hour"
+// cutoff can't go stale while the view sits open.
+let nowMs = $state(Date.now());
+
 // Build the combined timeline items list
 let timelineItems = $derived.by(() => {
   const items: TimelineItem[] = [];
-  const now = new Date();
+  const now = new Date(nowMs);
 
   // Monthly summaries (oldest)
   for (const s of monthSummaries) items.push({ kind: "summary", summary: s });
@@ -729,7 +764,7 @@ let timelineItems = $derived.by(() => {
     now,
     hourSummaries,
     turnsData,
-    isActive: (t) => t.status === "active" || streamingEvents.has(t.id),
+    isActive: (t) => t.status === "active" || activeTurnIds.has(t.id),
   });
 
   // Separator before the today section
@@ -741,6 +776,22 @@ let timelineItems = $derived.by(() => {
 
   return items;
 });
+
+// Trailing-edge auto-scroll: at most one instant jump per animation frame while
+// events stream, instead of a smooth-animated scrollTo per event (which kept the
+// view perpetually animating). Smooth scrolling is reserved for discrete actions
+// (jump-to-latest, completed-turn reveal).
+let scrollRafPending = false;
+function scheduleScrollToBottom() {
+  if (userScrolledUp || scrollRafPending) return;
+  scrollRafPending = true;
+  requestAnimationFrame(() => {
+    scrollRafPending = false;
+    if (!userScrolledUp && scrollContainer) {
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    }
+  });
+}
 
 // Scroll to bottom on initial load -- keep nudging for a few seconds
 let scrollTimer: ReturnType<typeof setInterval> | null = null;
@@ -777,7 +828,9 @@ $effect(() => {
   if (n !== prevName) {
     prevName = n;
     turnsData = [];
-    streamingEvents = new SvelteMap();
+    streamingEvents.clear();
+    streamingGroups.clear();
+    activeTurnIds.clear();
     nextSyntheticId = -1;
     pendingInbounds = [];
     hourSummaries = [];
@@ -799,7 +852,12 @@ $effect(() => {
 // Liveness sweep: expire stale provisional inbounds and reconcile active turns that
 // the server has likely finished (converges with the server's wedged-turn sweep).
 $effect(() => {
+  const onVisible = () => {
+    if (document.visibilityState === "visible") nowMs = Date.now();
+  };
+  document.addEventListener("visibilitychange", onVisible);
   const interval = setInterval(() => {
+    nowMs = Date.now();
     if (pendingInbounds.length > 0) {
       const pruned = pruneExpiredInbounds(pendingInbounds);
       if (pruned.length !== pendingInbounds.length) pendingInbounds = pruned;
@@ -814,7 +872,7 @@ $effect(() => {
         .then((rows) => {
           const fresh = rows[0];
           if (fresh && fresh.status !== "active") {
-            streamingEvents.delete(turn.id);
+            deleteStreaming(turn.id);
             lastEventAt.delete(turn.id);
           }
           upsertTurnRows(rows);
@@ -822,7 +880,10 @@ $effect(() => {
         .catch((err) => console.warn("[TurnTimeline] Failed to check stale turn:", err));
     }
   }, 30_000);
-  return () => clearInterval(interval);
+  return () => {
+    clearInterval(interval);
+    document.removeEventListener("visibilitychange", onVisible);
+  };
 });
 
 // Fetch the daemon's canonical timezone once, so boundary math and labels
@@ -1089,7 +1150,7 @@ function jumpToLatest() {
                     onexpand={(expanded) => handleExpand(turn.id, expanded)}
                   />
                 {:else}
-                  {@const events = streamingEvents.get(turn.id) ?? []}
+                  {@const groups = streamingGroups.get(turn.id) ?? []}
                   {@const startTime = new Date(turn.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
                   <TimelineBranch gap={24} reach={11} noReturn>
                     {#snippet header()}
@@ -1098,8 +1159,7 @@ function jumpToLatest() {
                       </div>
                     {/snippet}
                     {#snippet children()}
-                      {#if events.length > 0}
-                        {@const groups = groupToolEvents(events)}
+                      {#if groups.length > 0}
                         {#each groups as groupItem (groupItem.kind === "tool-group" ? `tg-${groupItem.toolUse.id}` : `ev-${groupItem.event.id}`)}
                           {#if groupItem.kind === "tool-group"}
                             {@const catColor = getCategoryColor(groupItem.category)}

--- a/packages/web/src/ui/lib/tool-groups.ts
+++ b/packages/web/src/ui/lib/tool-groups.ts
@@ -89,6 +89,94 @@ export function groupToolEvents(events: HistoryMessage[]): TimelineItem[] {
   return items;
 }
 
+/**
+ * Incrementally folds a single streaming event into an already-grouped list,
+ * producing a new array deep-equal to `groupToolEvents([...events, ev])` for the
+ * live-stream shape: modern id-bearing events arriving in emission order (a
+ * tool_use always precedes its tool_result). Existing group references are reused
+ * except for the one group a tool_result attaches to, so appending is O(groups)
+ * worst case and O(1) for the common trailing-append, instead of re-grouping the
+ * whole array on every event.
+ *
+ * `groupToolEvents` stays the authority for everything else — out-of-order
+ * results, and legacy (id-less) sequences where a result must span an intervening
+ * open tool_use, both of which this helper groups differently. Those only reach
+ * grouping through the DB-backfill path (`setStreaming` re-runs `groupToolEvents`),
+ * never through this live append path, since a running daemon emits modern events.
+ */
+export function appendToGroups(groups: TimelineItem[], ev: HistoryMessage): TimelineItem[] {
+  if (ev.type === "tool_use") {
+    const toolMeta = parseMeta(ev.metadata);
+    const rawName = typeof toolMeta?.name === "string" ? toolMeta.name : "tool";
+    return [
+      ...groups,
+      {
+        kind: "tool-group",
+        toolUse: ev,
+        toolResult: null,
+        toolName: normalizeToolName(rawName),
+        category: getToolCategory(rawName),
+      },
+    ];
+  }
+
+  if (ev.type === "tool_result") {
+    const id = parseMeta(ev.metadata)?.tool_use_id;
+    let targetIdx = -1;
+    if (typeof id === "string") {
+      // Modern: attach to the first open group whose tool_use id matches.
+      for (let i = 0; i < groups.length; i++) {
+        const g = groups[i];
+        if (g.kind !== "tool-group" || g.toolResult !== null) continue;
+        if (parseMeta(g.toolUse.metadata)?.id === id) {
+          targetIdx = i;
+          break;
+        }
+      }
+    } else {
+      // Legacy (no id): attach to the most recent still-open group, matching
+      // groupToolEvents' positional "next unclaimed result before next use" rule.
+      for (let i = groups.length - 1; i >= 0; i--) {
+        const g = groups[i];
+        if (g.kind === "tool-group" && g.toolResult === null) {
+          targetIdx = i;
+          break;
+        }
+      }
+    }
+
+    if (targetIdx === -1) {
+      // No open group claims it — emit standalone, as groupToolEvents would.
+      return [...groups, { kind: "event", event: ev }];
+    }
+    const updated = groups.slice();
+    updated[targetIdx] = { ...(groups[targetIdx] as ToolGroup), toolResult: ev };
+    return updated;
+  }
+
+  return [...groups, { kind: "event", event: ev }];
+}
+
+/**
+ * Live-stream group update used on the append path. Takes the O(1) incremental
+ * `appendToGroups` route for modern id-bearing events (what every running daemon
+ * emits), but falls back to a full `groupToolEvents` re-group for legacy (id-less)
+ * tool_results, whose incremental placement could otherwise differ from the batch
+ * grouper for interleaved parallel calls. `prevGroups` is the grouping of `events`
+ * without its last element; `events` already includes the just-appended `event`.
+ * The result is deep-equal to `groupToolEvents(events)` for any in-order stream.
+ */
+export function appendStreamingGroups(
+  prevGroups: TimelineItem[],
+  events: HistoryMessage[],
+  event: HistoryMessage,
+): TimelineItem[] {
+  if (event.type === "tool_result" && typeof parseMeta(event.metadata)?.tool_use_id !== "string") {
+    return groupToolEvents(events);
+  }
+  return appendToGroups(prevGroups, event);
+}
+
 function parseMeta(metadata: string | null): Record<string, unknown> | null {
   if (!metadata) return null;
   try {

--- a/test/tool-groups.test.ts
+++ b/test/tool-groups.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { HistoryMessage } from "@volute/api";
-import { groupToolEvents, type TimelineItem } from "../packages/web/src/ui/lib/tool-groups";
+import {
+  appendStreamingGroups,
+  appendToGroups,
+  groupToolEvents,
+  type TimelineItem,
+} from "../packages/web/src/ui/lib/tool-groups";
 import {
   getToolCategory,
   getToolLabel,
@@ -357,5 +362,151 @@ describe("groupToolEvents", () => {
     const orphan = items[1] as Extract<TimelineItem, { kind: "event" }>;
     assert.equal(orphan.kind, "event");
     assert.equal(orphan.event.id, 3);
+  });
+});
+
+describe("appendToGroups (incremental streaming fold)", () => {
+  const use = (id: number, meta?: Record<string, unknown>) =>
+    makeEvent({
+      id,
+      type: "tool_use",
+      content: "{}",
+      metadata: JSON.stringify({ name: "Bash", ...meta }),
+    });
+  const result = (id: number, meta?: Record<string, unknown>) =>
+    makeEvent({
+      id,
+      type: "tool_result",
+      content: "out",
+      metadata: meta ? JSON.stringify(meta) : null,
+    });
+  const text = (id: number) => makeEvent({ id, type: "text", content: "hi" });
+  const thinking = (id: number) => makeEvent({ id, type: "thinking", content: "hmm" });
+
+  const fold = (events: HistoryMessage[]): TimelineItem[] =>
+    events.reduce<TimelineItem[]>((acc, e) => appendToGroups(acc, e), []);
+
+  // In-order live-stream sequences: a tool_use always precedes its tool_result,
+  // and a stream is homogeneous (all-modern with ids, or all-legacy without) per
+  // #388. appendToGroups is only claimed equivalent to groupToolEvents for these;
+  // mixed/out-of-order streams are groupToolEvents' domain (see its docstring).
+  const sequences: Record<string, HistoryMessage[]> = {
+    empty: [],
+    textOnly: [text(1), text(2)],
+    modernPair: [use(1, { id: "a" }), result(2, { tool_use_id: "a" })],
+    openTool: [use(1, { id: "a" })],
+    textBetween: [use(1, { id: "a" }), text(2), result(3, { tool_use_id: "a" })],
+    thinkingMix: [thinking(1), use(2, { id: "a" }), result(3, { tool_use_id: "a" }), text(4)],
+    parallel: [
+      use(1, { id: "a" }),
+      use(2, { id: "b" }),
+      result(3, { tool_use_id: "b" }),
+      result(4, { tool_use_id: "a" }),
+    ],
+    parallelResultsInOrder: [
+      use(1, { id: "a" }),
+      use(2, { id: "b" }),
+      result(3, { tool_use_id: "a" }),
+      result(4, { tool_use_id: "b" }),
+    ],
+    modernPendingResult: [
+      use(1, { id: "a" }),
+      use(2, { id: "b" }),
+      result(3, { tool_use_id: "b" }),
+    ],
+    multiResultSameId: [
+      use(1, { id: "a" }),
+      use(2, { id: "b" }),
+      result(3, { tool_use_id: "a" }),
+      result(4, { tool_use_id: "a" }),
+      result(5, { tool_use_id: "b" }),
+    ],
+    orphanResult: [
+      use(1, { id: "a" }),
+      result(2, { tool_use_id: "a" }),
+      result(3, { tool_use_id: "z" }),
+    ],
+    legacyPair: [use(1), result(2)],
+    legacyDoubleUse: [use(1), use(2), result(3)],
+    legacyExtraResult: [use(1), result(2), result(3)],
+  };
+
+  it("folding from empty matches groupToolEvents for in-order streaming sequences", () => {
+    for (const [label, events] of Object.entries(sequences)) {
+      assert.deepEqual(fold(events), groupToolEvents(events), `mismatch for "${label}"`);
+    }
+  });
+
+  it("matches groupToolEvents when appending onto a groupToolEvents-seeded base", () => {
+    // Production shape: setStreaming seeds streamingGroups with groupToolEvents(prefix)
+    // (resync/backfill/pending-inbound), then live events land via appendToGroups.
+    // The real invariant is therefore per split point, not just the empty-seed fold:
+    //   appendToGroups(groupToolEvents(prefix), ev) === groupToolEvents([...prefix, ev]).
+    for (const [label, events] of Object.entries(sequences)) {
+      for (let split = 0; split < events.length; split++) {
+        const prefix = events.slice(0, split);
+        const ev = events[split];
+        assert.deepEqual(
+          appendToGroups(groupToolEvents(prefix), ev),
+          groupToolEvents([...prefix, ev]),
+          `seeded mismatch for "${label}" at split ${split}`,
+        );
+      }
+    }
+  });
+
+  // The live append path (appendStreamingEvent) uses appendStreamingGroups, which
+  // keeps the raw event array and re-groups in full for legacy (id-less) results.
+  // This makes it fully equivalent to groupToolEvents for ANY in-order stream —
+  // including legacy interleaved-parallel results, which the O(1) appendToGroups
+  // primitive alone groups differently (LIFO vs. forward pairing).
+  const foldStreaming = (events: HistoryMessage[]): TimelineItem[] => {
+    let groups: TimelineItem[] = [];
+    const seen: HistoryMessage[] = [];
+    for (const e of events) {
+      seen.push(e);
+      groups = appendStreamingGroups(groups, seen, e);
+    }
+    return groups;
+  };
+
+  it("appendStreamingGroups matches groupToolEvents for every in-order stream", () => {
+    const all: Record<string, HistoryMessage[]> = {
+      ...sequences,
+      // Legacy parallel results: appendToGroups alone diverges here (attaches the
+      // second result LIFO to the first open group); the full re-group fallback
+      // must match groupToolEvents, which pairs forward and emits result4 standalone.
+      legacyParallelResults: [use(1), use(2), result(3), result(4)],
+    };
+    for (const [label, events] of Object.entries(all)) {
+      assert.deepEqual(foldStreaming(events), groupToolEvents(events), `mismatch for "${label}"`);
+    }
+  });
+
+  it("appends a tool_use without rebuilding prior items (structural sharing)", () => {
+    const groups = fold([use(1, { id: "a" }), result(2, { tool_use_id: "a" }), text(3)]);
+    const after = appendToGroups(groups, use(4, { id: "b" }));
+    assert.equal(after.length, groups.length + 1);
+    for (let i = 0; i < groups.length; i++) {
+      assert.equal(after[i], groups[i], `item ${i} reference should be reused`);
+    }
+  });
+
+  it("replaces only the group a tool_result attaches to", () => {
+    const groups = fold([use(1, { id: "a" }), text(2), use(3, { id: "b" })]);
+    const after = appendToGroups(groups, result(4, { tool_use_id: "a" }));
+    assert.equal(after.length, groups.length);
+    assert.notEqual(after[0], groups[0], "matched group is a fresh object");
+    assert.equal(after[1], groups[1], "unrelated event reused");
+    assert.equal(after[2], groups[2], "unrelated open group reused");
+    const g0 = after[0] as Extract<TimelineItem, { kind: "tool-group" }>;
+    assert.equal(g0.toolResult?.id, 4);
+  });
+
+  it("does not mutate the input array or its groups", () => {
+    const groups = fold([use(1, { id: "a" })]);
+    const snapshot = JSON.stringify(groups);
+    appendToGroups(groups, result(2, { tool_use_id: "a" }));
+    assert.equal(JSON.stringify(groups), snapshot);
   });
 });


### PR DESCRIPTION
## What

Fixes the per-SSE-event cost of the active-turn streaming path in `TurnTimeline`. While a mind runs a tool loop it emits several events/second, and each one previously triggered O(all-turns) + O(all-events) main-thread work — the dominant "the tab feels mushy and it's not clear why" mode on the home view with multiple active minds.

## Why it was slow

- `streamingEvents.set(turnId, [...prev, event])` invalidated the `timelineItems` derived (the filter read `streamingEvents.has(t.id)`), which re-parsed a `Date` for **every** loaded turn (up to hundreds after "load older").
- The template re-ran `groupToolEvents()` over the **entire** accumulated event array on every event — O(n) per event, O(n²) over a long turn.
- An unconditional smooth `scrollTo` fired in rAF per event, so the view was perpetually animating while events streamed.

## Change

- **Decouple streaming from `timelineItems`.** Raw events move to a plain (non-reactive) `Map`; streaming membership moves to a `SvelteSet` (`activeTurnIds`) that only changes on turn start/complete; rendering reads a pre-grouped `SvelteMap` (`streamingGroups`). A per-event append touches only that turn's group state, so the derived is no longer re-run per event and only the affected turn's `{#each}` block re-renders (appending one DOM node).
- **Incremental grouping.** New `appendToGroups()` folds one event into the grouped list in O(1) for the common trailing-append (O(groups) worst case), reusing existing group references. `appendStreamingGroups()` wraps it on the live path and falls back to a full `groupToolEvents()` re-group for legacy (id-less) tool_results, so the live view is deep-equal to the batch grouper for any in-order stream. `groupToolEvents()` stays the authority for DB backfill.
- **Throttle auto-scroll** to one instant `scrollTop = scrollHeight` per animation frame (smooth scrolling reserved for discrete actions like jump-to-latest / completed-turn reveal).
- **Hold the Today/this-hour wall-clock anchor in `$state`** (`nowMs`), refreshed off the existing 30s liveness sweep and on `visibilitychange`, so the derived stops re-reading `new Date()` on unrelated invalidations and the cutoff can't go stale while the view sits open.
- **Switch replace-only arrays to `$state.raw`** (`turnsData`, `hour/day/week/monthSummaries`) to avoid deep-proxying every row/summary on each update.

## Impact

Per streaming event drops from O(turns) + O(events) to near-constant: no full `timelineItems` re-derive, no whole-array re-group, no continuous scroll animation between events. All streaming behaviors — active-turn appearance, tool-group rendering (incl. interleaved text/thinking and parallel tool calls), pending-inbound promotion, and turn completion swapping the streaming view to a summary row — are preserved (behavior-identical refactor).

Note on the "mounted twice" item: on desktop, collapsing the right panel already unmounts `MindRightPanel` (and tears down its `EventSource`) via `{#if showRightPanel}` in `App.svelte`, and the system-history and mind-panel timelines mount on mutually-exclusive selections — so there is no persistent hidden `EventSource`. No change needed there; the per-event optimization benefits every instance.

## Test plan

- `test/tool-groups.test.ts`: added an `appendToGroups` suite — empty-seed fold equivalence to `groupToolEvents`, the production `appendToGroups(groupToolEvents(prefix), ev) === groupToolEvents([...prefix, ev])` invariant per split point, structural-sharing (reference reuse) and no-mutation assertions, and an `appendStreamingGroups` suite proving total equivalence to `groupToolEvents` for every in-order stream including legacy interleaved-parallel results.
- `svelte-check` on `packages/web`: 0 errors.
- `npm run build:web`: clean.
- `npm test`: 2079 passing, 0 failing.

Reviewed by three passes (code-review, silent-failure-hunter, test-analyzer); all findings addressed (the one shared legacy-grouping-divergence finding is now closed by `appendStreamingGroups` + a regression test).

Fixes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)