### PR TITLE
feat: surface mind status in chat — stopped, asleep, or last turn failed

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -15,6 +15,10 @@ export type Mind = {
   port?: number;
   created: string;
   status: "running" | "stopped" | "starting" | "sleeping";
+  /** When status is "sleeping": ISO time of the scheduled wake, if one is set. */
+  wakeAt?: string | null;
+  /** Most recent failure the mind hasn't recovered from (cleared on the next clean turn). */
+  lastError?: MindLastError | null;
   stage?: "seed" | "sprouted";
   template?: string;
   channels: PlatformConnection[];
@@ -25,6 +29,18 @@ export type Mind = {
   description?: string;
   avatar?: string;
   mindType?: "mind" | "spirit";
+};
+
+export type MindLastError = {
+  kind: "turn_error" | "crash" | "startup";
+  reason: string;
+  /**
+   * Full failure detail. Admin/system callers only — omitted for non-privileged
+   * callers because unknown-reason details embed the raw error string, which is
+   * otherwise mind-private (served behind requireSelf).
+   */
+  detail?: string;
+  at: string;
 };
 
 export type PlatformConnection = {
@@ -92,6 +108,7 @@ export type ActivityEventType =
   | "mind_active"
   | "mind_idle"
   | "mind_done"
+  | "mind_error"
   | "mind_sleeping"
   | "mind_waking"
   | "page_updated"

--- a/packages/daemon/src/lib/daemon/notices.ts
+++ b/packages/daemon/src/lib/daemon/notices.ts
@@ -1,6 +1,6 @@
-import { and, asc, eq, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, lte, or, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
-import { mindNotices } from "../schema.js";
+import { mindNotices, turns } from "../schema.js";
 import log from "../util/logger.js";
 import type { ErrorReason } from "./error-classify.js";
 
@@ -91,6 +91,72 @@ export async function drainNotices(
     )
     .orderBy(asc(mindNotices.id))
     .limit(limit);
+}
+
+/** Notice kinds that represent failures (as opposed to budget pauses or extension chatter). */
+const FAILURE_KINDS = ["turn_error", "crash", "startup"] as const;
+
+export type FailureNotice = {
+  kind: "turn_error" | "crash" | "startup";
+  reason: string;
+  detail: string;
+  at: string;
+};
+
+// A persistent read failure silently disables the #574 status surface for every
+// mind (same defect class recordNotice logs at error), but this runs on every
+// minds-list fetch — log once per process instead of spamming.
+let failureReadErrorLogged = false;
+
+/**
+ * The most recent failure notice for a mind with no turn completed since,
+ * across all sessions. Budget and extension notices don't count — they aren't
+ * failures. (The table is a delete-on-clear queue, so rows are pending by
+ * construction; don't add a "delivered" filter.)
+ *
+ * Notice deletion is per-session (a session must drain the notice and then run
+ * a clean turn), so a failure in a session that never runs again would linger
+ * forever. The completed-turn check bounds that: any turn completed after the
+ * notice means the mind is demonstrably able to finish turns, so chat stops
+ * showing the failure (#574). A turn that errors records a fresh notice, which
+ * postdates that turn's own row and keeps the signal up.
+ *
+ * Returns null on DB errors: status enrichment must not take down the minds list.
+ */
+export async function latestFailureNotice(mind: string): Promise<FailureNotice | null> {
+  try {
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(mindNotices)
+      .where(and(eq(mindNotices.mind, mind), inArray(mindNotices.kind, [...FAILURE_KINDS])))
+      .orderBy(desc(mindNotices.id))
+      .limit(1);
+    const n = rows[0];
+    if (!n) return null;
+
+    const recovered = await db
+      .select({ id: turns.id })
+      .from(turns)
+      .where(
+        and(eq(turns.mind, mind), eq(turns.status, "complete"), gt(turns.created_at, n.created_at)),
+      )
+      .limit(1);
+    if (recovered.length > 0) return null;
+
+    return {
+      kind: n.kind as FailureNotice["kind"],
+      reason: n.reason,
+      detail: n.detail,
+      at: n.created_at,
+    };
+  } catch (err) {
+    if (!failureReadErrorLogged) {
+      failureReadErrorLogged = true;
+      nlog.error(`failed to read latest failure notice for ${mind}`, log.errorData(err));
+    }
+    return null;
+  }
 }
 
 /**

--- a/packages/daemon/src/lib/daemon/turn-lifecycle.ts
+++ b/packages/daemon/src/lib/daemon/turn-lifecycle.ts
@@ -275,6 +275,9 @@ export async function handleMindEvent(
       detail,
       raw: event.content ?? null,
     });
+    // Nudge connected web clients to refresh mind status so chat surfaces the
+    // failure immediately (#574).
+    broadcast({ type: "mind_error", mind, summary: detail });
   }
 
   if (event.type === "done") {

--- a/packages/daemon/src/lib/events/activity-events.ts
+++ b/packages/daemon/src/lib/events/activity-events.ts
@@ -11,6 +11,7 @@ export type ActivityEvent = {
     | "mind_active"
     | "mind_idle"
     | "mind_done"
+    | "mind_error"
     | "mind_sleeping"
     | "mind_waking"
     | "page_updated"

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -22,7 +22,12 @@ import {
   startMindFull as startMindFullService,
   stopMindFull as stopMindFullService,
 } from "../../lib/daemon/mind-service.js";
-import { drainNotices, formatNotices, recordNotice } from "../../lib/daemon/notices.js";
+import {
+  drainNotices,
+  formatNotices,
+  latestFailureNotice,
+  recordNotice,
+} from "../../lib/daemon/notices.js";
 import { getTokenBudget } from "../../lib/daemon/token-budget.js";
 import { handleMindEvent, setNoticeDrainWatermark } from "../../lib/daemon/turn-lifecycle.js";
 import { getActiveTurnId } from "../../lib/daemon/turn-tracker.js";
@@ -126,14 +131,24 @@ type ChannelStatus = {
 async function getMindStatus(name: string, port: number, registryRunning?: boolean) {
   const manager = getMindManager();
   let status: "running" | "stopped" | "starting" | "sleeping" = "stopped";
+  let wakeAt: string | null = null;
 
   // Check sleep state first
   try {
     const { getSleepManagerIfReady } = await import("../../lib/daemon/sleep-manager.js");
-    if (getSleepManagerIfReady()?.isSleeping(name)) {
+    const sleepManager = getSleepManagerIfReady();
+    if (sleepManager?.isSleeping(name)) {
       status = "sleeping";
+      const sleepState = sleepManager.getState(name);
+      // A voluntary wake-at is authoritative for the night (initiateSleep nulls
+      // the cron wake when one is set), so prefer it.
+      wakeAt = sleepState.voluntaryWakeAt ?? sleepState.scheduledWakeAt;
     }
-  } catch {}
+  } catch (err) {
+    // A swallowed failure here misreports a sleeping mind as stopped (and chat
+    // would offer Start for a mind that is asleep) — leave a trace.
+    log.warn(`failed to check sleep state for ${name}`, log.errorData(err));
+  }
 
   if (status !== "sleeping" && registryRunning !== false && manager.isRunning(name)) {
     const health = await checkHealth(port);
@@ -153,8 +168,15 @@ async function getMindStatus(name: string, port: number, registryRunning?: boole
     });
   }
 
+  // Undelivered failure notice = the mind failed and hasn't completed a clean
+  // turn since. Chat surfaces this as "last turn failed" (#574); it clears
+  // automatically once the notice drains on the next clean turn.
+  const lastError = await latestFailureNotice(name);
+
   return {
     status,
+    wakeAt,
+    lastError,
     channels,
     displayName: config?.profile?.displayName,
     description: config?.profile?.description,
@@ -178,7 +200,7 @@ function isPrivileged(c: Context<AuthEnv>): boolean {
  * (direct connections to sibling mind servers that bypass the daemon, targeted
  * filesystem probing). Only admin/system callers get the full entry. See #503.
  */
-function toPublicMind(
+export function toPublicMind(
   entry: MindEntry,
   status: MindStatus,
   extras: { hasPages: boolean; lastActiveAt?: string | null },
@@ -189,6 +211,12 @@ function toPublicMind(
     stage: entry.stage,
     mindType: entry.mindType,
     status: status.status,
+    wakeAt: status.wakeAt,
+    // Kind/reason/at only — `detail` can embed the raw error string (unknown
+    // classifications), which is mind-private (served behind requireSelf).
+    lastError: status.lastError
+      ? { kind: status.lastError.kind, reason: status.lastError.reason, at: status.lastError.at }
+      : null,
     channels: status.channels,
     displayName: status.displayName,
     description: status.description,

--- a/packages/web/src/ui/components/chat/Chat.svelte
+++ b/packages/web/src/ui/components/chat/Chat.svelte
@@ -2,8 +2,10 @@
 import type { ContentBlock, Message, Mind, Participant } from "@volute/api";
 import { fetchConversationMessages, sendChat } from "../../lib/client";
 import { subscribe } from "../../lib/connection.svelte";
+import { auth } from "../../lib/stores.svelte";
 import type { ChatEntry } from "../../lib/types";
 import ActivityIndicator from "./ActivityIndicator.svelte";
+import ChatStatusBar from "./ChatStatusBar.svelte";
 import MessageInput from "./MessageInput.svelte";
 import MessageList from "./MessageList.svelte";
 
@@ -43,6 +45,8 @@ let loadingOlder = $state(false);
 let currentConvId: string | null = null;
 let typingSafetyTimer = 0;
 let messageList: MessageList;
+// The DM's target mind, for the status bar (#574). Channels show nothing.
+let dmMind = $derived(convType === "dm" ? minds.find((m) => m.name === name) : undefined);
 let mindParticipants = $derived.by(() => {
   const fromParticipants = participants.filter((p) => p.userType === "mind").map((p) => p.username);
   if (fromParticipants.length > 0) return fromParticipants;
@@ -258,6 +262,12 @@ async function handleSend(
   />
 
   <ActivityIndicator {typingNames} {mindParticipants} {minds} {onOpenMind} />
+
+  <!-- Keyed on the mind name so switching DMs resets in-flight Start state;
+       minds refreshes replace objects but keep the name, so no remount then. -->
+  {#key dmMind?.name}
+    <ChatStatusBar mind={dmMind} isAdmin={auth.user?.role === "admin"} />
+  {/key}
 
   <MessageInput
     {sending}

--- a/packages/web/src/ui/components/chat/ChatStatusBar.svelte
+++ b/packages/web/src/ui/components/chat/ChatStatusBar.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+import type { Mind } from "@volute/api";
+import { startMind } from "../../lib/client";
+import { chatStatus } from "./chat-status";
+
+let { mind, isAdmin }: { mind: Mind | undefined; isAdmin: boolean } = $props();
+
+let starting = $state(false);
+let startError = $state("");
+
+let status = $derived(chatStatus(mind, isAdmin));
+
+async function handleStart() {
+  if (!mind || starting) return;
+  starting = true;
+  startError = "";
+  try {
+    await startMind(mind.name);
+    // Keep the button disabled in its "Starting…" state — the mind_started
+    // activity event refreshes data.minds via SSE, which flips this bar to
+    // "waking up" and then removes it. Re-enabling immediately would invite a
+    // second click and a false "Mind already running" error.
+  } catch (e) {
+    startError = e instanceof Error ? e.message : "Failed to start";
+    starting = false;
+  }
+}
+</script>
+
+{#if status}
+  <div class="status-bar {status.kind}" title={status.detail}>
+    <span class="text">{status.text}</span>
+    {#if status.showStart}
+      <button class="start-btn" onclick={handleStart} disabled={starting}>
+        {starting ? "Starting…" : "Start"}
+      </button>
+    {/if}
+    {#if startError}
+      <span class="start-error">{startError}</span>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .status-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 6px 12px;
+    font-size: 12px;
+    flex-shrink: 0;
+    border-top: 1px solid var(--border);
+    color: var(--text-2);
+  }
+
+  .status-bar.sleeping {
+    color: var(--blue);
+  }
+
+  .status-bar.starting {
+    color: var(--yellow);
+  }
+
+  .status-bar.error {
+    color: var(--red);
+  }
+
+  .start-btn {
+    padding: 2px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--muted-bg);
+    color: var(--text-0);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .start-btn:hover:not(:disabled) {
+    background: var(--bg-2);
+  }
+
+  .start-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .start-error {
+    color: var(--red);
+  }
+</style>

--- a/packages/web/src/ui/components/chat/chat-status.ts
+++ b/packages/web/src/ui/components/chat/chat-status.ts
@@ -1,0 +1,73 @@
+// Derives the chat status bar shown above the composer in DM chats (#574).
+// Pure so it can be unit tested without rendering.
+
+import type { Mind } from "@volute/api";
+
+export type ChatStatusInfo = {
+  kind: "stopped" | "starting" | "sleeping" | "error";
+  text: string;
+  /** Full failure detail, for a tooltip. Only set when kind === "error" and the
+   *  viewer is privileged — the API omits `detail` for non-admin callers. */
+  detail?: string;
+  /** Show the Start button (stopped mind + admin viewer). */
+  showStart: boolean;
+};
+
+/** Short human-facing phrases for classifier reasons (the stored detail is addressed to the mind). */
+const REASON_LABELS: Record<string, string> = {
+  auth_error: "the model credentials were rejected",
+  rate_limit: "the model provider's rate limit was hit",
+  overloaded: "the model provider was overloaded",
+  network: "a network error reaching the model provider",
+};
+
+/**
+ * Status line for a DM chat with `mind`, or null when the mind is healthy
+ * (running with no unrecovered failure). Precedence: stopped > starting >
+ * sleeping > last-turn-failed — process state is more actionable than a stale
+ * failure, and a sleeping mind's notices will drain after it wakes.
+ */
+export function chatStatus(mind: Mind | undefined, isAdmin: boolean): ChatStatusInfo | null {
+  if (!mind) return null;
+  const name = mind.displayName || mind.name;
+
+  if (mind.status === "stopped") {
+    return { kind: "stopped", text: `${name} isn't running`, showStart: isAdmin };
+  }
+  if (mind.status === "starting") {
+    return { kind: "starting", text: `${name} is waking up…`, showStart: false };
+  }
+  if (mind.status === "sleeping") {
+    const wake = formatWakeTime(mind.wakeAt);
+    const text = wake ? `${name} is asleep — waking at ${wake}` : `${name} is asleep`;
+    return { kind: "sleeping", text, showStart: false };
+  }
+  if (mind.lastError) {
+    const err = mind.lastError;
+    let text: string;
+    if (err.kind === "crash") {
+      text = `${name}'s process crashed`;
+    } else if (err.kind === "startup") {
+      text = `${name} failed to start`;
+    } else {
+      const label = REASON_LABELS[err.reason] ?? "an unexpected error";
+      text = `${name}'s last turn failed — ${label}`;
+    }
+    return { kind: "error", text, detail: err.detail, showStart: false };
+  }
+  return null;
+}
+
+/**
+ * "8:00 AM" for a wake later today, "8:00 AM on Tuesday" otherwise.
+ * Null for missing or unparseable times.
+ */
+export function formatWakeTime(wakeAt: string | null | undefined): string | null {
+  if (!wakeAt) return null;
+  const date = new Date(wakeAt);
+  if (Number.isNaN(date.getTime())) return null;
+  const time = date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  if (date.toDateString() === new Date().toDateString()) return time;
+  const day = date.toLocaleDateString("en-US", { weekday: "long" });
+  return `${time} on ${day}`;
+}

--- a/packages/web/src/ui/lib/stores.svelte.ts
+++ b/packages/web/src/ui/lib/stores.svelte.ts
@@ -225,7 +225,10 @@ function handleSSEEvent(event: SSEEvent) {
       item.type === "mind_stopped" ||
       item.type === "mind_sleeping" ||
       item.type === "mind_waking" ||
-      item.type === "profile_updated"
+      item.type === "mind_error" ||
+      item.type === "profile_updated" ||
+      // A clean turn clears a lingering lastError — refresh only when one is showing.
+      (item.type === "mind_done" && data.minds.some((m) => m.name === item.mind && m.lastError))
     ) {
       fetchMinds()
         .then((m) => {

--- a/test/chat-status.test.ts
+++ b/test/chat-status.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Mind } from "../packages/api/src/types.js";
+import { chatStatus, formatWakeTime } from "../packages/web/src/ui/components/chat/chat-status.js";
+
+function mind(overrides: Partial<Mind>): Mind {
+  return {
+    name: "atlas",
+    created: "2026-01-01",
+    status: "running",
+    channels: [],
+    ...overrides,
+  };
+}
+
+describe("chatStatus", () => {
+  it("returns null for a healthy running mind and for no mind", () => {
+    assert.equal(chatStatus(mind({}), true), null);
+    assert.equal(chatStatus(undefined, true), null);
+  });
+
+  it("stopped: shows the Start button only to admins", () => {
+    const admin = chatStatus(mind({ status: "stopped" }), true);
+    assert.equal(admin?.kind, "stopped");
+    assert.equal(admin?.text, "atlas isn't running");
+    assert.equal(admin?.showStart, true);
+
+    const user = chatStatus(mind({ status: "stopped" }), false);
+    assert.equal(user?.showStart, false);
+  });
+
+  it("starting: waking up", () => {
+    const s = chatStatus(mind({ status: "starting" }), false);
+    assert.equal(s?.kind, "starting");
+    assert.equal(s?.text, "atlas is waking up…");
+  });
+
+  it("sleeping: includes the wake time when set, plain otherwise", () => {
+    const noon = new Date();
+    noon.setHours(12, 0, 0, 0);
+    const withWake = chatStatus(mind({ status: "sleeping", wakeAt: noon.toISOString() }), false);
+    assert.equal(withWake?.kind, "sleeping");
+    assert.equal(withWake?.text, "atlas is asleep — waking at 12:00 PM");
+
+    const noWake = chatStatus(mind({ status: "sleeping", wakeAt: null }), false);
+    assert.equal(noWake?.text, "atlas is asleep");
+  });
+
+  it("prefers the display name when set", () => {
+    const s = chatStatus(mind({ status: "stopped", displayName: "Atlas" }), false);
+    assert.equal(s?.text, "Atlas isn't running");
+  });
+
+  it("last turn failed: maps known reasons to short labels and keeps the detail", () => {
+    const s = chatStatus(
+      mind({
+        lastError: {
+          kind: "turn_error",
+          reason: "auth_error",
+          detail: "Your last turn failed because your model credentials were rejected.",
+          at: "2026-07-10 12:00:00",
+        },
+      }),
+      false,
+    );
+    assert.equal(s?.kind, "error");
+    assert.equal(s?.text, "atlas's last turn failed — the model credentials were rejected");
+    assert.match(s?.detail ?? "", /credentials were rejected/);
+  });
+
+  it("last turn failed: unknown reasons get a generic label", () => {
+    const s = chatStatus(
+      mind({
+        lastError: { kind: "turn_error", reason: "unknown", detail: "raw", at: "" },
+      }),
+      false,
+    );
+    assert.equal(s?.text, "atlas's last turn failed — an unexpected error");
+  });
+
+  it("crash and startup failures get their own phrasing", () => {
+    const crash = chatStatus(
+      mind({ lastError: { kind: "crash", reason: "process_crash", detail: "d", at: "" } }),
+      false,
+    );
+    assert.equal(crash?.text, "atlas's process crashed");
+
+    const startup = chatStatus(
+      mind({ lastError: { kind: "startup", reason: "startup_failed", detail: "d", at: "" } }),
+      false,
+    );
+    assert.equal(startup?.text, "atlas failed to start");
+  });
+
+  it("process state outranks a stale failure", () => {
+    const s = chatStatus(
+      mind({
+        status: "sleeping",
+        lastError: { kind: "turn_error", reason: "network", detail: "d", at: "" },
+      }),
+      false,
+    );
+    assert.equal(s?.kind, "sleeping");
+  });
+
+  it("stopped + crash shows the actionable stopped state, not the crash", () => {
+    // The most common combined state: a crashed mind is stopped AND carries a
+    // crash notice. Stopped (with Start) is the actionable line.
+    const s = chatStatus(
+      mind({
+        status: "stopped",
+        lastError: { kind: "crash", reason: "process_crash", detail: "d", at: "" },
+      }),
+      true,
+    );
+    assert.equal(s?.kind, "stopped");
+    assert.equal(s?.showStart, true);
+  });
+
+  it("handles a detail-less lastError (non-admin API projection)", () => {
+    const s = chatStatus(
+      mind({ lastError: { kind: "turn_error", reason: "rate_limit", at: "" } }),
+      false,
+    );
+    assert.equal(s?.text, "atlas's last turn failed — the model provider's rate limit was hit");
+    assert.equal(s?.detail, undefined);
+  });
+});
+
+describe("formatWakeTime", () => {
+  it("returns null for missing or unparseable input", () => {
+    assert.equal(formatWakeTime(null), null);
+    assert.equal(formatWakeTime(undefined), null);
+    assert.equal(formatWakeTime("not-a-date"), null);
+  });
+
+  it("shows just the time for a wake later today", () => {
+    const noon = new Date();
+    noon.setHours(12, 0, 0, 0);
+    assert.equal(formatWakeTime(noon.toISOString()), "12:00 PM");
+  });
+
+  it("adds the weekday for a wake on another day", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 3);
+    future.setHours(12, 0, 0, 0);
+    const expectedDay = future.toLocaleDateString("en-US", { weekday: "long" });
+    assert.equal(formatWakeTime(future.toISOString()), `12:00 PM on ${expectedDay}`);
+  });
+});

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1674,6 +1674,38 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(body2.notices.length, 0);
   });
 
+  it("mind status: GET /api/minds/:name surfaces lastError until recovery (#574)", async () => {
+    await ensureTestMind();
+    const session = "notices-status-surface";
+
+    // A turn starts (text opens a real turn), fails, and completes.
+    await emitEvent(session, { type: "text", content: "attempting a reply" });
+    await emitEvent(session, { type: "error", content: "API Error: 401 authentication_error" });
+    await emitEvent(session, { type: "done" });
+
+    const res1 = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    assert.equal(res1.status, 200);
+    const mind1 = (await res1.json()) as {
+      lastError?: { kind: string; reason: string; detail?: string } | null;
+    };
+    assert.equal(mind1.lastError?.kind, "turn_error");
+    assert.equal(mind1.lastError?.reason, "auth_error");
+    // Privileged (admin) callers get the full detail.
+    assert.ok(mind1.lastError?.detail, "admin projection should include detail");
+
+    // Drain, then a clean turn completes after the failure → recovered.
+    await daemonRequest(`/api/minds/${TEST_MIND}/history/notices?session=${session}`);
+    // A completed turn strictly after the notice is what marks recovery; the
+    // notice timestamps have 1s resolution, so make sure the clock ticks over.
+    await new Promise((r) => setTimeout(r, 1100));
+    await emitEvent(session, { type: "text", content: "recovered reply" });
+    await emitEvent(session, { type: "done" });
+
+    const res2 = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const mind2 = (await res2.json()) as { lastError?: unknown };
+    assert.equal(mind2.lastError, null, "lastError should clear after a clean turn");
+  });
+
   it("failure notices: accumulate across an outage to convey full scope", async () => {
     await ensureTestMind();
     const session = "notices-outage";

--- a/test/notices.test.ts
+++ b/test/notices.test.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { eq } from "drizzle-orm";
 import {
   clearDeliveredNotices,
   drainNotices,
   formatNotices,
+  latestFailureNotice,
   type Notice,
   recordNotice,
 } from "../packages/daemon/src/lib/daemon/notices.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { turns } from "../packages/daemon/src/lib/schema.js";
 
 let counter = 0;
 function uniqueMind(): string {
@@ -153,6 +157,143 @@ describe("notices", () => {
     // The newest must be kept; the oldest trimmed.
     assert.ok(drained.some((n) => n.detail === "n129"));
     assert.ok(!drained.some((n) => n.detail === "n0"));
+  });
+});
+
+describe("latestFailureNotice", () => {
+  it("returns null when the mind has no notices", async () => {
+    assert.equal(await latestFailureNotice(uniqueMind()), null);
+  });
+
+  it("returns the newest failure across sessions", async () => {
+    const mind = uniqueMind();
+    await recordNotice({
+      mind,
+      session: "main",
+      kind: "turn_error",
+      reason: "network",
+      detail: "older",
+    });
+    await recordNotice({
+      mind,
+      session: "other",
+      kind: "crash",
+      reason: "process_crash",
+      detail: "newer",
+    });
+
+    const failure = await latestFailureNotice(mind);
+    assert.equal(failure?.kind, "crash");
+    assert.equal(failure?.reason, "process_crash");
+    assert.equal(failure?.detail, "newer");
+    assert.ok(failure?.at, "should carry the notice timestamp");
+  });
+
+  it("ignores budget and extension notices", async () => {
+    const mind = uniqueMind();
+    await recordNotice({
+      mind,
+      session: "main",
+      kind: "turn_error",
+      reason: "auth_error",
+      detail: "the failure",
+    });
+    await recordNotice({
+      mind,
+      session: "main",
+      kind: "budget",
+      reason: "token_budget",
+      detail: "budget pause",
+    });
+    await recordNotice({
+      mind,
+      session: "",
+      kind: "extension",
+      reason: "notes",
+      detail: "someone commented",
+    });
+
+    const failure = await latestFailureNotice(mind);
+    assert.equal(failure?.detail, "the failure");
+
+    const budgetOnly = uniqueMind();
+    await recordNotice({
+      mind: budgetOnly,
+      session: "main",
+      kind: "budget",
+      reason: "token_budget",
+      detail: "budget pause",
+    });
+    assert.equal(await latestFailureNotice(budgetOnly), null);
+  });
+
+  it("clears once delivered notices are deleted (recovery on a clean turn)", async () => {
+    const mind = uniqueMind();
+    await recordNotice({
+      mind,
+      session: "main",
+      kind: "turn_error",
+      reason: "overloaded",
+      detail: "a 529",
+    });
+    assert.ok(await latestFailureNotice(mind));
+
+    const drained = await drainNotices(mind, "main");
+    await clearDeliveredNotices(mind, "main", Math.max(...drained.map((n) => n.id)));
+    assert.equal(await latestFailureNotice(mind), null);
+  });
+
+  it("clears when another session completes a turn after the failure (cross-session recovery)", async () => {
+    // A failure in a session that never runs again must not pin the status
+    // bar forever: any turn completed after the notice counts as recovery.
+    const mind = uniqueMind();
+    await recordNotice({
+      mind,
+      session: "quiet-channel",
+      kind: "crash",
+      reason: "process_crash",
+      detail: "crashed",
+    });
+    assert.ok(await latestFailureNotice(mind));
+
+    const db = await getDb();
+    await db.insert(turns).values({
+      id: `${mind}-turn-1`,
+      mind,
+      session: "main",
+      status: "complete",
+      created_at: "2999-01-01 00:00:00",
+    });
+    try {
+      assert.equal(await latestFailureNotice(mind), null);
+    } finally {
+      await db.delete(turns).where(eq(turns.mind, mind));
+    }
+  });
+
+  it("a turn completed before the failure does not count as recovery", async () => {
+    const mind = uniqueMind();
+    const db = await getDb();
+    await db.insert(turns).values({
+      id: `${mind}-turn-0`,
+      mind,
+      session: "main",
+      status: "complete",
+      created_at: "2000-01-01 00:00:00",
+    });
+    try {
+      await recordNotice({
+        mind,
+        session: "main",
+        kind: "turn_error",
+        reason: "network",
+        detail: "still broken",
+      });
+      const failure = await latestFailureNotice(mind);
+      assert.equal(failure?.detail, "still broken");
+    } finally {
+      await db.delete(turns).where(eq(turns.mind, mind));
+    }
   });
 });
 

--- a/test/turn-lifecycle.test.ts
+++ b/test/turn-lifecycle.test.ts
@@ -14,6 +14,7 @@ import {
   recordInbound,
   recordOutbound,
 } from "../packages/daemon/src/lib/delivery/message-delivery.js";
+import { subscribe as subscribeActivity } from "../packages/daemon/src/lib/events/activity-events.js";
 import { mindHistory, turns } from "../packages/daemon/src/lib/schema.js";
 
 async function cleanup(mind: string): Promise<void> {
@@ -118,6 +119,28 @@ describe("turn-lifecycle: handleMindEvent", () => {
     assert.ok(
       notices.some((n) => n.kind === "turn_error"),
       "a turn_error notice should be recorded",
+    );
+    await cleanup(mind);
+  });
+
+  it("error broadcasts a mind_error activity event", async () => {
+    const mind = "tl-error-broadcast";
+    const received: { type: string; mind: string }[] = [];
+    const unsubscribe = subscribeActivity((e) => {
+      received.push({ type: e.type, mind: e.mind });
+    });
+    try {
+      await handleMindEvent(mind, {
+        type: "error",
+        session: "s1",
+        content: "boom: something failed",
+      });
+    } finally {
+      unsubscribe();
+    }
+    assert.ok(
+      received.some((e) => e.type === "mind_error" && e.mind === mind),
+      "a mind_error event should be broadcast so web chat can refresh status",
     );
     await cleanup(mind);
   });

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -241,3 +241,39 @@ describe("web minds routes", () => {
     }
   });
 });
+
+describe("toPublicMind", () => {
+  it("strips lastError.detail from the non-privileged projection", async () => {
+    // detail can embed the raw error string (unknown classifications), which is
+    // mind-private — non-admin callers get kind/reason/at only.
+    const { toPublicMind } = await import("../packages/daemon/src/web/api/minds.js");
+    const entry = {
+      name: "proj-test",
+      port: 4100,
+      created: "2026-01-01",
+      running: true,
+      mindType: "mind" as const,
+    };
+    const status = {
+      status: "running" as const,
+      wakeAt: null,
+      lastError: {
+        kind: "turn_error" as const,
+        reason: "unknown",
+        detail: "Your last turn failed with an error: raw-private-text",
+        at: "2026-07-10 12:00:00",
+      },
+      channels: [],
+      displayName: undefined,
+      description: undefined,
+      avatar: undefined,
+    };
+    const pub = toPublicMind(entry, status, { hasPages: false });
+    assert.deepEqual(pub.lastError, {
+      kind: "turn_error",
+      reason: "unknown",
+      at: "2026-07-10 12:00:00",
+    });
+    assert.ok(!JSON.stringify(pub).includes("raw-private-text"));
+  });
+});


### PR DESCRIPTION
## What

Messaging a stopped, asleep, or erroring mind used to look identical to messaging a healthy one — the message posts and no reply ever comes. This adds a status bar directly above the DM chat composer (channels show nothing) covering four states:

- **stopped** — "atlas isn't running", with a **Start** button shown to admins only
- **starting** — "atlas is waking up…"
- **asleep** — "atlas is asleep — waking at 8:00 AM" (wake time from SleepManager; plain "is asleep" when none)
- **last turn failed** — "atlas's last turn failed — the model credentials were rejected" (short label per classifier reason; crash/startup notices get their own phrasing). Auto-clears on recovery, no dismiss affordance.

Sending is never blocked: a sleeping mind queues the message, a stopped mind still accepts it.

## How

- `GET /api/minds(/:name)` now returns `wakeAt` (sleeping minds) and `lastError` via a new `latestFailureNotice()`: the newest `turn_error`/`crash`/`startup` row in `mind_notices` **with no turn completed since**. The completed-turn bound prevents a failure in a session that never runs again from pinning the bar forever; notices are otherwise cleared per-session on the next clean turn (existing mechanism). Budget/extension notices don't count.
- Turn errors now `broadcast({ type: "mind_error" })` so connected clients refresh mind status immediately; the store also refetches on `mind_done` when a `lastError` is currently showing, so the bar clears on recovery.
- `lastError.detail` is **withheld from non-privileged API callers** (`toPublicMind`): unknown classifications embed the raw error string, which is mind-private (otherwise served behind `requireSelf`). Admins get it as a tooltip; the visible line is always derived from `kind`/`reason`.
- UI logic lives in a pure `chat-status.ts` (tested); `ChatStatusBar.svelte` is keyed on the mind name so switching DMs resets in-flight Start state.

Designed so #573 (silent missing-API-key) plugs in for free: any `startup`/`turn_error` notice its detection records surfaces here without further wiring.

## Review

Three review passes (code review, silent-failure hunt, test analysis) ran on the diff; all findings addressed:
- raw error text no longer exposed to non-admin callers
- cross-session stale-failure pinning fixed via the completed-turn bound
- once-per-process `error`-level log when the notice read fails (matches `recordNotice` reasoning); sleep-state check no longer swallows errors silently
- Start button stays disabled after a successful start (prevents a false "already running" on double-click)

Known minor race (accepted): `mind_done` broadcasts before the notice delete lands, so a recovery refetch can very rarely read the stale error once; it self-heals on the next event and the completed-turn bound makes it moot in practice.

## Test plan

- `npm test` — 2095 pass, 0 fail (5 new: `chat-status` derivation incl. precedence + non-admin projection; `latestFailureNotice` incl. cross-session recovery; `toPublicMind` detail stripping; `mind_error` broadcast)
- `npm run test:e2e` — 54 pass, 0 fail (new: `lastError` surfaces on `GET /api/minds/:name` after a failed turn and clears after a clean one, through the real daemon)
- `tsc --noEmit`, `svelte-check` (0 errors), `vite build` clean

Fixes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
