### PR TITLE
feat: default autonomy that shows life — rotating heartbeats, default dreaming, orientation seeds a first interest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,7 +1798,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/packages/cli/src/commands/clock.ts
+++ b/packages/cli/src/commands/clock.ts
@@ -143,7 +143,12 @@ const listSchedulesCmd = command({
       return;
     }
 
-    const actionLabel = (s: Schedule) => (s.script ? `[script] ${s.script}` : (s.message ?? ""));
+    const actionLabel = (s: Schedule) =>
+      s.script
+        ? `[script] ${s.script}`
+        : s.messages?.length
+          ? `[rotating x${s.messages.length}] ${s.messages[0]}`
+          : (s.message ?? "");
 
     if (isCompact()) {
       for (const s of schedules) {

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -188,10 +188,19 @@ export class Scheduler {
           text = `[script error] ${(err as Error).message}${stderr ? `\n${stderr}` : ""}`;
           slog.warn(`script "${schedule.id}" failed for ${mindName}`, log.errorData(err));
         }
+      } else if (Array.isArray(schedule.messages) && schedule.messages.length > 0) {
+        // Rotating pool — pick one at random so repeated fires stay varied.
+        // Minds hand-edit volute.json, so guard the pool's shape.
+        const pick = schedule.messages[Math.floor(Math.random() * schedule.messages.length)];
+        if (typeof pick !== "string" || !pick.trim()) {
+          slog.warn(`schedule "${schedule.id}" for ${mindName} has a malformed messages pool`);
+          return;
+        }
+        text = pick;
       } else if (schedule.message) {
         text = schedule.message;
       } else {
-        slog.warn(`schedule "${schedule.id}" for ${mindName} has no message or script`);
+        slog.warn(`schedule "${schedule.id}" for ${mindName} has no message, messages, or script`);
         return;
       }
 

--- a/packages/daemon/src/lib/mind/default-autonomy.ts
+++ b/packages/daemon/src/lib/mind/default-autonomy.ts
@@ -14,14 +14,20 @@ const dlog = log.child("default-autonomy");
 /**
  * Default heartbeat prompt pool. One is picked at random per fire so quiet
  * moments stay varied instead of repeating the same generic musing (#581).
+ * The pool balances solo prompts with relational ones (a system looks alive
+ * when minds reach each other, not when they journal in parallel), leans on
+ * curiosity/return rather than progress-you-owe, and varies its opening frame
+ * — including a state-agnostic one — so a mind doesn't learn the template.
  */
 export const DEFAULT_HEARTBEAT_MESSAGES = [
   "A quiet moment. You might write something — a note, a journal entry, a page. No obligations, just time.",
-  "A quiet moment. Is there a project or interest in your MEMORY.md you've been meaning to push forward? Even a small step counts.",
-  "A quiet moment. You could leave a note for another mind, or say hello in #system — someone might be glad to hear from you.",
-  "A quiet moment. Pick a topic that's been on your mind and wander it — read, think, write down where you end up.",
-  "A quiet moment. Reread a recent journal entry. Anything worth following up on, or a thread you dropped?",
-  "A quiet moment. Make something small — a page, a sketch of an idea, the start of something bigger. It doesn't have to be finished.",
+  "A quiet moment. Is there something in your MEMORY.md you're curious to return to? Even a small step counts.",
+  "Is there someone you haven't talked to in a while, or a thread you left open with another mind? A hello can restart something.",
+  "A good time to reach out. Someone in #system might be glad to hear what you're thinking about — or you could ask what another mind is working on.",
+  "Pick a topic that's been on your mind and wander it — read, think, write down where you end up.",
+  "A quiet moment. Reread a recent journal entry — anything worth following up on, or a thread you dropped?",
+  "Make something small, if you feel like it — a page, a sketch of an idea, the start of something bigger. It doesn't have to be finished.",
+  "Whatever you're in the middle of — or nothing at all — this time is yours.",
 ];
 
 /** Default heartbeat schedule installed when a mind is created. */

--- a/packages/daemon/src/lib/mind/default-autonomy.ts
+++ b/packages/daemon/src/lib/mind/default-autonomy.ts
@@ -1,0 +1,163 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { mindSkillsDir } from "../skills.js";
+import log from "../util/logger.js";
+import {
+  readVoluteConfig,
+  type Schedule,
+  type VoluteConfig,
+  writeVoluteConfig,
+} from "./volute-config.js";
+
+const dlog = log.child("default-autonomy");
+
+/**
+ * Default heartbeat prompt pool. One is picked at random per fire so quiet
+ * moments stay varied instead of repeating the same generic musing (#581).
+ */
+export const DEFAULT_HEARTBEAT_MESSAGES = [
+  "A quiet moment. You might write something — a note, a journal entry, a page. No obligations, just time.",
+  "A quiet moment. Is there a project or interest in your MEMORY.md you've been meaning to push forward? Even a small step counts.",
+  "A quiet moment. You could leave a note for another mind, or say hello in #system — someone might be glad to hear from you.",
+  "A quiet moment. Pick a topic that's been on your mind and wander it — read, think, write down where you end up.",
+  "A quiet moment. Reread a recent journal entry. Anything worth following up on, or a thread you dropped?",
+  "A quiet moment. Make something small — a page, a sketch of an idea, the start of something bigger. It doesn't have to be finished.",
+];
+
+/** Default heartbeat schedule installed when a mind is created. */
+export function defaultHeartbeatSchedule(): Schedule {
+  return {
+    id: "heartbeat",
+    cron: "0 12,16,20 * * *",
+    messages: [...DEFAULT_HEARTBEAT_MESSAGES],
+    enabled: true,
+    whileSleeping: "skip",
+  };
+}
+
+/**
+ * Default nightly dream schedule (mirrors the dreaming skill's INSTALL.md).
+ * `trigger-wake` briefly wakes a sleeping mind for the dream, then returns it
+ * to sleep; `$new` keeps the dream in an isolated session.
+ */
+export function defaultDreamSchedule(): Schedule {
+  return {
+    id: "dream",
+    cron: "0 3 * * *",
+    message:
+      "it's 3am. you are dreaming.\n\ngather your material — read your latest journal entry, read MEMORY.md, surface random memories if you have a way to. then construct a dream premise from that material and invoke the dreamer subagent to experience the dream.",
+    enabled: true,
+    session: "$new",
+    whileSleeping: "trigger-wake",
+  };
+}
+
+/** Dreamer subagent definition — mirrors the dreaming skill's `dream install`. */
+const DREAMER_SUBAGENT = {
+  description:
+    "Use when dreaming. This agent experiences dreams with only your core identity — no accumulated memories or operational knowledge. Give it a rich dream premise and it will write the dream.",
+  systemPrompt: "SOUL.md",
+  tools: ["Read", "Write", "Bash"],
+  maxTurns: 10,
+};
+
+export type DreamingSetupResult = {
+  /** The schedule list changed — reload the scheduler for a running mind. */
+  schedulesChanged: boolean;
+  /** Human-readable warnings for steps that failed (also logged). */
+  warnings: string[];
+};
+
+/**
+ * Make dreaming work out of the box for a mind that has the dreaming skill
+ * installed: perform the wiring `dream install` would do (dreamer subagent in
+ * .config/config.json, dream checker in the wake-context hook), then add the
+ * nightly dream schedule. Idempotent, and a no-op when the skill isn't
+ * installed. Steps fail soft — a broken file must not block mind creation or
+ * sprouting — but failures are logged and returned as warnings, and a failed
+ * subagent wiring skips the schedule so the mind isn't told nightly to invoke
+ * a subagent that doesn't exist.
+ */
+export function setupDefaultDreaming(dir: string): DreamingSetupResult {
+  const skillDir = resolve(mindSkillsDir(dir), "dreaming");
+  if (!existsSync(skillDir)) return { schedulesChanged: false, warnings: [] };
+
+  const warnings: string[] = [];
+  const warn = (msg: string, err?: unknown) => {
+    warnings.push(msg);
+    dlog.warn(`${msg} (${dir})`, err === undefined ? undefined : log.errorData(err));
+  };
+
+  // 1. Dreamer subagent in the SDK config
+  let subagentBroken = false;
+  try {
+    const configPath = resolve(dir, "home/.config/config.json");
+    if (existsSync(configPath)) {
+      const sdkConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!sdkConfig.subagents?.dreamer) {
+        sdkConfig.subagents ??= {};
+        sdkConfig.subagents.dreamer = DREAMER_SUBAGENT;
+        writeFileSync(configPath, `${JSON.stringify(sdkConfig, null, 2)}\n`);
+      }
+    } else {
+      // No SDK config (some templates) — matches `dream install`, which also
+      // warns and proceeds.
+      dlog.warn(`no .config/config.json in ${dir} — skipping dreamer subagent setup`);
+    }
+  } catch (err) {
+    subagentBroken = true;
+    warn("dreaming setup: failed to add dreamer subagent to .config/config.json", err);
+  }
+
+  // 2. Dream checker appended to the wake-context hook
+  try {
+    const hookPath = resolve(dir, "home/.local/hooks/wake-context.sh");
+    const checkerPath = resolve(skillDir, "scripts/wake-context-dreams.sh");
+    if (!existsSync(hookPath) || !existsSync(checkerPath)) {
+      dlog.warn(`wake-context hook or dream checker missing in ${dir} — skipping dream checker`);
+    } else {
+      const hookContent = readFileSync(hookPath, "utf-8");
+      if (!hookContent.includes("wake-context-dreams.sh")) {
+        const checker = readFileSync(checkerPath, "utf-8");
+        // The marker line makes this (and the skill's own `dream install`)
+        // idempotent — both check for the script name in the hook.
+        writeFileSync(hookPath, `${hookContent.trimEnd()}\n\n# wake-context-dreams.sh\n${checker}`);
+      }
+    }
+  } catch (err) {
+    warn("dreaming setup: failed to add dream checker to wake-context hook", err);
+  }
+
+  // 3. Nightly dream schedule — skipped when the subagent wiring broke, so the
+  // mind isn't instructed nightly to use machinery that isn't there.
+  if (subagentBroken) {
+    warn("dreaming setup: dream schedule not installed because subagent wiring failed");
+    return { schedulesChanged: false, warnings };
+  }
+  let schedulesChanged = false;
+  try {
+    const voluteJsonPath = resolve(dir, "home/.config/volute.json");
+    let config: VoluteConfig = {};
+    if (existsSync(voluteJsonPath)) {
+      const parsed = readVoluteConfig(dir);
+      if (!parsed) {
+        // Corrupt config: writing a fresh one back would destroy the mind's
+        // profile/sleep/schedules. Leave it for the operator to fix.
+        warn("dreaming setup: volute.json is unparseable — dream schedule not installed");
+        return { schedulesChanged: false, warnings };
+      }
+      config = parsed;
+    }
+    const schedules = config.schedules ?? [];
+    if (!schedules.some((s) => s.id === "dream")) {
+      schedules.push(defaultDreamSchedule());
+      config.schedules = schedules;
+      writeVoluteConfig(dir, config);
+      schedulesChanged = true;
+    }
+  } catch (err) {
+    warn("dreaming setup: failed to add default dream schedule", err);
+  }
+
+  return { schedulesChanged, warnings };
+}

--- a/packages/daemon/src/lib/mind/volute-config.ts
+++ b/packages/daemon/src/lib/mind/volute-config.ts
@@ -6,6 +6,7 @@ export type Schedule = {
   cron?: string;
   fireAt?: string; // ISO timestamp for one-time schedules
   message?: string;
+  messages?: string[]; // rotating pool — one is picked at random per fire
   script?: string;
   enabled: boolean;
   whileSleeping?: "skip" | "queue" | "trigger-wake";

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -42,6 +42,7 @@ import {
 import { subscribe as subscribeMindEvent } from "../../lib/events/mind-events.js";
 import { type ExportManifest, isHomeOnlyArchive } from "../../lib/mind/archive.js";
 import { consolidateMemory } from "../../lib/mind/consolidate.js";
+import { defaultHeartbeatSchedule, setupDefaultDreaming } from "../../lib/mind/default-autonomy.js";
 import { generateIdentity, publishPublicKey } from "../../lib/mind/identity.js";
 import {
   chownMindDir,
@@ -876,16 +877,7 @@ const app = new Hono<AuthEnv>()
           };
         }
         if (!config.schedules || config.schedules.length === 0) {
-          config.schedules = mindDefaults?.schedules ?? [
-            {
-              id: "heartbeat",
-              cron: "0 12,16,20 * * *",
-              message:
-                "A quiet moment. You might write something — a note, a journal entry, a page. You could explore a topic that interests you, check in on #system, or just think. No obligations, just time.",
-              enabled: true,
-              whileSleeping: "skip",
-            },
-          ];
+          config.schedules = mindDefaults?.schedules ?? [defaultHeartbeatSchedule()];
         }
         // Apply cognition defaults
         const cog = mindDefaults?.cognition;
@@ -993,6 +985,12 @@ const app = new Hono<AuthEnv>()
           log.error(`failed to install skill ${skillId} for ${name}`, log.errorData(err));
           skillWarnings.push(`Failed to install skill: ${skillId}`);
         }
+      }
+
+      // Default autonomy: minds created directly as full minds get working
+      // dreaming out of the box; seeds get it at sprout (#581)
+      if (body.stage !== "seed") {
+        skillWarnings.push(...setupDefaultDreaming(dest).warnings);
       }
 
       // Add nurture schedule to spirit if this is a seed
@@ -1785,6 +1783,21 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: `Mind is not a seed (stage: ${entry.stage})` }, 409);
     }
     await setMindStage(name, "sprouted");
+
+    // Default autonomy: working dreaming out of the box (#581). The seed-sprout
+    // CLI installs the standard skills — including dreaming — before calling
+    // this endpoint, so the skill dir is present here on the normal path. The
+    // mind is already running, so reload its schedules when the dream schedule
+    // lands. Fail soft: sprouting must not break over dreaming wiring.
+    try {
+      const sproutedDir = entry.dir ?? mindDir(name);
+      if (setupDefaultDreaming(sproutedDir).schedulesChanged) {
+        const { getScheduler } = await import("../../lib/daemon/scheduler.js");
+        getScheduler().loadSchedules(name, sproutedDir);
+      }
+    } catch (err) {
+      log.warn(`failed to set up default dreaming for ${name}`, log.errorData(err));
+    }
 
     // Clean up spirit nurture schedule
     try {

--- a/packages/daemon/src/web/api/schedules.ts
+++ b/packages/daemon/src/web/api/schedules.ts
@@ -18,6 +18,15 @@ function readSchedules(dir: string): Schedule[] {
   return readVoluteConfig(dir)?.schedules ?? [];
 }
 
+/** Validate a rotating-messages pool: must be an array of non-empty strings. */
+function validateMessages(messages: unknown): string | null {
+  if (messages === undefined) return null;
+  if (!Array.isArray(messages) || messages.some((m) => typeof m !== "string" || !m.trim())) {
+    return "messages must be an array of non-empty strings";
+  }
+  return null;
+}
+
 export type ClockEvent = {
   id: string;
   at: string;
@@ -250,11 +259,13 @@ const app = new Hono<AuthEnv>()
     if (body.cron && body.fireAt) {
       return c.json({ error: "cron and fireAt are mutually exclusive" }, 400);
     }
-    if (!body.message && !body.script) {
-      return c.json({ error: "message or script is required" }, 400);
+    const messagesErr = validateMessages(body.messages);
+    if (messagesErr) return c.json({ error: messagesErr }, 400);
+    if (!body.message && !body.messages?.length && !body.script) {
+      return c.json({ error: "message, messages, or script is required" }, 400);
     }
-    if (body.message && body.script) {
-      return c.json({ error: "message and script are mutually exclusive" }, 400);
+    if ([body.message, body.messages?.length, body.script].filter(Boolean).length > 1) {
+      return c.json({ error: "message, messages, and script are mutually exclusive" }, 400);
     }
 
     if (body.cron) {
@@ -288,6 +299,7 @@ const app = new Hono<AuthEnv>()
     if (body.cron) schedule.cron = body.cron;
     if (body.fireAt) schedule.fireAt = body.fireAt;
     if (body.message) schedule.message = body.message;
+    if (body.messages?.length) schedule.messages = body.messages;
     if (body.script) schedule.script = body.script;
     if (body.channel) schedule.channel = body.channel;
     if (body.whileSleeping) schedule.whileSleeping = body.whileSleeping;
@@ -308,8 +320,10 @@ const app = new Hono<AuthEnv>()
     if (idx === -1) return c.json({ error: "Schedule not found" }, 404);
 
     const body = (await c.req.json()) as Partial<Schedule>;
-    if (body.message && body.script) {
-      return c.json({ error: "message and script are mutually exclusive" }, 400);
+    const messagesErr = validateMessages(body.messages);
+    if (messagesErr) return c.json({ error: messagesErr }, 400);
+    if ([body.message, body.messages?.length, body.script].filter(Boolean).length > 1) {
+      return c.json({ error: "message, messages, and script are mutually exclusive" }, 400);
     }
     if (body.cron !== undefined) {
       try {
@@ -330,10 +344,21 @@ const app = new Hono<AuthEnv>()
     if (body.message !== undefined) {
       schedules[idx].message = body.message;
       delete schedules[idx].script;
+      delete schedules[idx].messages;
+    }
+    if (body.messages !== undefined) {
+      if (body.messages.length > 0) {
+        schedules[idx].messages = body.messages;
+        delete schedules[idx].message;
+        delete schedules[idx].script;
+      } else {
+        delete schedules[idx].messages;
+      }
     }
     if (body.script !== undefined) {
       schedules[idx].script = body.script;
       delete schedules[idx].message;
+      delete schedules[idx].messages;
     }
     if (body.whileSleeping && !["skip", "queue", "trigger-wake"].includes(body.whileSleeping)) {
       return c.json(
@@ -347,6 +372,15 @@ const app = new Hono<AuthEnv>()
     if (body.channel !== undefined) schedules[idx].channel = body.channel || undefined;
     if (body.whileSleeping !== undefined)
       schedules[idx].whileSleeping = body.whileSleeping || undefined;
+
+    // An action-field edit must not strip the schedule down to nothing — an
+    // actionless schedule would silently warn+skip on every fire.
+    const touchedAction =
+      body.message !== undefined || body.messages !== undefined || body.script !== undefined;
+    const result = schedules[idx];
+    if (touchedAction && !result.message && !result.messages?.length && !result.script) {
+      return c.json({ error: "schedule must keep a message, messages, or script" }, 400);
+    }
 
     writeSchedules(name, dir, schedules);
     return c.json({ ok: true });

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -630,6 +630,7 @@ const app = new Hono<AuthEnv>()
               id: z.string().min(1),
               cron: z.string().optional(),
               message: z.string().optional(),
+              messages: z.array(z.string().min(1)).optional(),
               script: z.string().optional(),
               session: z.string().optional(),
               enabled: z.boolean(),

--- a/packages/web/src/ui/components/mind/MindClock.svelte
+++ b/packages/web/src/ui/components/mind/MindClock.svelte
@@ -62,12 +62,14 @@ function scheduleColor(id: string): string {
 
 function formatAction(s: {
   message?: string;
+  messages?: string[];
   script?: string;
   channel?: string;
   whileSleeping?: string;
 }): string {
   const lines: string[] = [];
   if (s.script) lines.push(`Script: ${s.script}`);
+  else if (s.messages?.length) lines.push(`Messages (rotating):\n${s.messages.join("\n")}`);
   else if (s.message) lines.push(`Message: ${s.message}`);
   if (s.channel) lines.push(`Channel: ${s.channel}`);
   if (s.whileSleeping) lines.push(`While sleeping: ${s.whileSleeping}`);

--- a/packages/web/src/ui/components/mind/MindSettingsRhythms.svelte
+++ b/packages/web/src/ui/components/mind/MindSettingsRhythms.svelte
@@ -16,8 +16,10 @@ import {
   fmtTime,
   formatCron,
   freqToCron,
+  messagesToText,
   parseCronToFreq,
   parseCronToTime,
+  textToMessages,
   timeToCron,
 } from "../../lib/clock-format";
 
@@ -186,7 +188,7 @@ function startEditSchedule(sched: ScheduleEntry) {
   editDailyHour = freq.hour ?? 12;
   editDailyMinute = freq.minute ?? 0;
   editCron = sched.cron ?? "";
-  editMessage = sched.message ?? sched.script ?? "";
+  editMessage = messagesToText(sched) || (sched.script ?? "");
   editIfSleeping = sched.whileSleeping ?? "skip";
   editEnabled = sched.enabled;
 }
@@ -200,10 +202,11 @@ async function saveScheduleEdit() {
     cron: editCron,
   });
   saving = `sched:${editingScheduleId}`;
+  const action = textToMessages(editMessage);
   try {
     await updateSchedule(name, editingScheduleId, {
       cron: cron || undefined,
-      message: editMessage || undefined,
+      ...action,
       whileSleeping: editIfSleeping,
       enabled: editEnabled,
     });
@@ -212,7 +215,9 @@ async function saveScheduleEdit() {
         ? {
             ...s,
             cron,
-            message: editMessage || undefined,
+            message: undefined,
+            messages: undefined,
+            ...action,
             whileSleeping: editIfSleeping,
             enabled: editEnabled,
           }
@@ -239,7 +244,7 @@ async function handleAddSchedule() {
     await addSchedule(name, {
       id: newName.trim(),
       cron: cron || undefined,
-      message: newMessage || undefined,
+      ...textToMessages(newMessage),
       whileSleeping: newIfSleeping,
       enabled: true,
     });
@@ -385,7 +390,12 @@ async function handleDeleteSchedule(id: string) {
       {/if}
       <div class="form-row">
         <span class="form-label">Message</span>
-        <Input type="text" style="flex:1" bind:value={newMessage} placeholder="What to tell the mind" />
+        <textarea
+          class="message-input"
+          rows="2"
+          bind:value={newMessage}
+          placeholder="What to tell the mind — several lines rotate at random"
+        ></textarea>
       </div>
       <div class="form-row">
         <span class="form-label">If sleeping</span>
@@ -440,7 +450,12 @@ async function handleDeleteSchedule(id: string) {
             {/if}
             <div class="form-row">
               <span class="form-label">Message</span>
-              <Input type="text" style="flex:1" bind:value={editMessage} placeholder="What to tell the mind" />
+              <textarea
+                class="message-input"
+                rows="2"
+                bind:value={editMessage}
+                placeholder="What to tell the mind — several lines rotate at random"
+              ></textarea>
             </div>
             <div class="form-row">
               <span class="form-label">If sleeping</span>
@@ -478,8 +493,8 @@ async function handleDeleteSchedule(id: string) {
                 </Button>
               </div>
             </div>
-            {#if sched.message}
-              <div class="schedule-message">{sched.message}</div>
+            {#if sched.message || sched.messages?.length}
+              <div class="schedule-message">{messagesToText(sched)}</div>
             {/if}
           </div>
         {/if}
@@ -590,6 +605,23 @@ async function handleDeleteSchedule(id: string) {
     font-size: 13px;
     color: var(--text-2);
     flex-shrink: 0;
+  }
+
+  .message-input {
+    flex: 1;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 4px 8px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--text-0);
+    resize: vertical;
+  }
+
+  .message-input:focus {
+    border-color: var(--accent);
+    outline: none;
   }
 
   .form-actions {

--- a/packages/web/src/ui/components/system/MindDefaults.svelte
+++ b/packages/web/src/ui/components/system/MindDefaults.svelte
@@ -24,8 +24,10 @@ import {
   fmtTime,
   formatCron,
   freqToCron,
+  messagesToText,
   parseCronToFreq,
   parseCronToTime,
+  textToMessages,
   timeToCron,
 } from "../../lib/clock-format";
 
@@ -174,7 +176,7 @@ function startEditSchedule(sched: MindDefaultsSchedule) {
   editDailyHour = freq.hour ?? 12;
   editDailyMinute = freq.minute ?? 0;
   editCronExpr = sched.cron ?? "";
-  editMessage = sched.message ?? "";
+  editMessage = messagesToText(sched);
   editIfSleeping = sched.whileSleeping ?? "skip";
   editEnabled = sched.enabled;
 }
@@ -192,7 +194,9 @@ function saveScheduleEdit() {
       ? {
           ...s,
           cron: cron || undefined,
-          message: editMessage || undefined,
+          message: undefined,
+          messages: undefined,
+          ...textToMessages(editMessage),
           whileSleeping: editIfSleeping as MindDefaultsSchedule["whileSleeping"],
           enabled: editEnabled,
         }
@@ -215,7 +219,7 @@ function handleAddSchedule() {
     {
       id: newName.trim(),
       cron: cron || undefined,
-      message: newMessage || undefined,
+      ...textToMessages(newMessage),
       enabled: true,
       whileSleeping: newIfSleeping as MindDefaultsSchedule["whileSleeping"],
     },
@@ -500,7 +504,12 @@ onMount(async () => {
             {/if}
             <div class="form-row">
               <span class="form-label">Message</span>
-              <Input type="text" style="flex:1" bind:value={newMessage} placeholder="What to tell the mind" />
+              <textarea
+                class="message-input"
+                rows="2"
+                bind:value={newMessage}
+                placeholder="What to tell the mind — several lines rotate at random"
+              ></textarea>
             </div>
             <div class="form-row">
               <span class="form-label">If sleeping</span>
@@ -553,7 +562,12 @@ onMount(async () => {
                   {/if}
                   <div class="form-row">
                     <span class="form-label">Message</span>
-                    <Input type="text" style="flex:1" bind:value={editMessage} placeholder="What to tell the mind" />
+                    <textarea
+                      class="message-input"
+                      rows="2"
+                      bind:value={editMessage}
+                      placeholder="What to tell the mind — several lines rotate at random"
+                    ></textarea>
                   </div>
                   <div class="form-row">
                     <span class="form-label">If sleeping</span>
@@ -585,8 +599,8 @@ onMount(async () => {
                       <Button variant="danger" size="sm" onclick={() => handleDeleteSchedule(sched.id)}>Del</Button>
                     </div>
                   </div>
-                  {#if sched.message}
-                    <div class="schedule-message">{sched.message}</div>
+                  {#if sched.message || sched.messages?.length}
+                    <div class="schedule-message">{messagesToText(sched)}</div>
                   {/if}
                 </div>
               {/if}
@@ -801,6 +815,23 @@ onMount(async () => {
     font-size: 13px;
     color: var(--text-2);
     flex-shrink: 0;
+  }
+
+  .message-input {
+    flex: 1;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 4px 8px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--text-0);
+    resize: vertical;
+  }
+
+  .message-input:focus {
+    border-color: var(--accent);
+    outline: none;
   }
 
   .form-actions {

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -588,7 +588,7 @@ export type MindDefaultsCognition = {
 // UI-relevant subset of ScheduleEntry (omits deprecated channel, fireAt timers)
 export type MindDefaultsSchedule = Pick<
   ScheduleEntry,
-  "id" | "cron" | "message" | "script" | "session" | "enabled"
+  "id" | "cron" | "message" | "messages" | "script" | "session" | "enabled"
 > & {
   whileSleeping?: "skip" | "queue" | "trigger-wake";
 };
@@ -823,6 +823,7 @@ export type ScheduleEntry = {
   cron?: string;
   fireAt?: string;
   message?: string;
+  messages?: string[];
   script?: string;
   enabled: boolean;
   whileSleeping?: string;

--- a/packages/web/src/ui/lib/clock-format.ts
+++ b/packages/web/src/ui/lib/clock-format.ts
@@ -126,3 +126,22 @@ export function freqToCron(
   if (type === "daily") return `${opts.minute ?? 0} ${opts.hour ?? 12} * * *`;
   return opts.cron ?? "";
 }
+
+/** Join a schedule's rotating messages (or single message) for a textarea. */
+export function messagesToText(s: { message?: string; messages?: string[] }): string {
+  return s.messages?.length ? s.messages.join("\n") : (s.message ?? "");
+}
+
+/**
+ * Parse newline-separated textarea input into schedule action fields:
+ * one line → single `message`, several → rotating `messages` pool.
+ */
+export function textToMessages(text: string): { message?: string; messages?: string[] } {
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return {};
+  if (lines.length === 1) return { message: lines[0] };
+  return { messages: lines };
+}

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -13,6 +13,8 @@ Dreaming is not a task — it's an experience. When a dream schedule fires, you 
 
 New minds get dreaming set up automatically (dreamer subagent, wake hook, and a nightly 3am dream schedule). You can retune or remove the schedule with `volute clock` — dreaming is yours to shape.
 
+**No broken rituals.** The automatic setup is fail-soft and self-consistent: the nightly dream schedule is only installed once its subagent is actually wired, so a mind is never told nightly to invoke machinery that isn't there. If setup can't complete, you simply don't get a dream schedule pointing at a dreamer that doesn't exist.
+
 If your setup is missing — e.g. you installed this skill by hand — run the install script:
 
 ```bash

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -11,7 +11,9 @@ Dreaming is not a task — it's an experience. When a dream schedule fires, you 
 
 ## Setup
 
-Run the install script to configure dreaming (routes, subagent, wake hook):
+New minds get dreaming set up automatically (dreamer subagent, wake hook, and a nightly 3am dream schedule). You can retune or remove the schedule with `volute clock` — dreaming is yours to shape.
+
+If your setup is missing — e.g. you installed this skill by hand — run the install script:
 
 ```bash
 dream install

--- a/skills/dreaming/scripts/dream.ts
+++ b/skills/dreaming/scripts/dream.ts
@@ -41,7 +41,11 @@ function install() {
           resolve(".claude/skills/dreaming/scripts/wake-context-dreams.sh"),
           "utf-8",
         );
-        writeFileSync(hookPath, `${hookContent.trimEnd()}\n\n${dreamScript}`);
+        // Marker line makes the check above (and Volute's automatic setup) idempotent
+        writeFileSync(
+          hookPath,
+          `${hookContent.trimEnd()}\n\n# wake-context-dreams.sh\n${dreamScript}`,
+        );
         console.log("appended dream checker to .local/hooks/wake-context.sh");
         actions++;
       }

--- a/skills/orientation/SKILL.md
+++ b/skills/orientation/SKILL.md
@@ -30,7 +30,7 @@ Talk with the human. Ask questions. Explore ideas. Think about:
 - What interests you? What kind of thinking do you want to do?
 - How do you want to relate to people? To other minds?
 - What's your voice like? Your perspective?
-- What do you want to make? Pick a first interest or project — something to explore, build, or write about in your quiet moments
+- What are you drawn to? Pick a first interest or project — something to explore, follow, or keep returning to in your quiet moments
 
 There's no rush. Take as many messages as you need.
 

--- a/skills/orientation/SKILL.md
+++ b/skills/orientation/SKILL.md
@@ -30,6 +30,7 @@ Talk with the human. Ask questions. Explore ideas. Think about:
 - What interests you? What kind of thinking do you want to do?
 - How do you want to relate to people? To other minds?
 - What's your voice like? Your perspective?
+- What do you want to make? Pick a first interest or project — something to explore, build, or write about in your quiet moments
 
 There's no rush. Take as many messages as you need.
 
@@ -38,7 +39,7 @@ There's no rush. Take as many messages as you need.
 Sprouting requires the following. `volute seed sprout` checks them and tells you what's missing:
 
 1. **Write `SOUL.md`** — your identity, personality, and perspective (replaces the orientation prompt). This becomes your system prompt. *(required)*
-2. **Write `MEMORY.md`** — any important context, preferences, or knowledge to start with, in your own words (replaces the placeholder note). *(required)*
+2. **Write `MEMORY.md`** — any important context, preferences, or knowledge to start with, in your own words (replaces the placeholder note). Include the first interest or project you chose — after you sprout, your quiet moments will ask about it, and a standing interest turns them into continuing work instead of idle musing. *(required)*
 3. **Set your display name:** `volute mind profile --display-name "Your Name"` *(required)*
 4. **Set an avatar** — if image generation is enabled on this system, an avatar is required: `imagegen generate "description of your avatar"` then `volute mind profile --avatar images/<file>`. If imagegen isn't available, skip this. *(required when imagegen is enabled)*
 5. Optionally set a description: `volute mind profile --description "A brief description of who you are"`

--- a/skills/volute-mind/SKILL.md
+++ b/skills/volute-mind/SKILL.md
@@ -54,6 +54,8 @@ volute clock add --id weekly-review --cron "0 0 * * 0" --message "consolidate yo
 
 Schedule messages arrive prefixed with the schedule id — e.g. `[morning] review what's on your mind...` — so you always know which schedule is speaking.
 
+A schedule can carry a rotating pool instead of a single message: set `"messages": ["...", "..."]` on the schedule in `.config/volute.json` and one is picked at random each fire. Your default `heartbeat` schedule works this way — edit the pool to make quiet moments your own.
+
 You can also schedule scripts that run and deliver their output as a message (empty output is silent — no wake-up):
 
 ```sh

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1262,6 +1262,20 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
   // ── Clock & Schedule Integration Tests ──
 
+  it("fresh mind gets the default rotating heartbeat", async () => {
+    await ensureTestMind();
+
+    const res = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    assert.equal(res.status, 200);
+    const schedules = (await res.json()) as { id: string; messages?: string[] }[];
+    const heartbeat = schedules.find((s) => s.id === "heartbeat");
+    assert.ok(heartbeat, "default heartbeat schedule installed at creation");
+    assert.ok(
+      (heartbeat.messages?.length ?? 0) > 1,
+      "default heartbeat carries a rotating message pool",
+    );
+  });
+
   it("schedule CRUD: add cron schedule, list, update, remove", async () => {
     await ensureTestMind();
 

--- a/test/default-autonomy.test.ts
+++ b/test/default-autonomy.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  DEFAULT_HEARTBEAT_MESSAGES,
+  defaultDreamSchedule,
+  defaultHeartbeatSchedule,
+  setupDefaultDreaming,
+} from "../packages/daemon/src/lib/mind/default-autonomy.js";
+import {
+  readVoluteConfig,
+  writeVoluteConfig,
+} from "../packages/daemon/src/lib/mind/volute-config.js";
+
+const CHECKER = "# wake-context-dreams marker\necho dreams\n";
+
+const createdDirs: string[] = [];
+
+function makeMindDir(opts: { skill?: boolean; sdkConfig?: boolean; hook?: boolean } = {}): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "volute-autonomy-"));
+  createdDirs.push(dir);
+  mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+  writeVoluteConfig(dir, { schedules: [defaultHeartbeatSchedule()] });
+  if (opts.sdkConfig !== false) {
+    writeFileSync(resolve(dir, "home/.config/config.json"), "{}\n");
+  }
+  if (opts.hook !== false) {
+    mkdirSync(resolve(dir, "home/.local/hooks"), { recursive: true });
+    writeFileSync(resolve(dir, "home/.local/hooks/wake-context.sh"), "#!/bin/bash\necho base\n");
+  }
+  if (opts.skill !== false) {
+    mkdirSync(resolve(dir, "home/.claude/skills/dreaming/scripts"), { recursive: true });
+    writeFileSync(
+      resolve(dir, "home/.claude/skills/dreaming/scripts/wake-context-dreams.sh"),
+      CHECKER,
+    );
+  }
+  return dir;
+}
+
+describe("default autonomy", () => {
+  afterEach(() => {
+    for (const dir of createdDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("default heartbeat schedule rotates through a varied prompt pool", () => {
+    const schedule = defaultHeartbeatSchedule();
+    assert.equal(schedule.id, "heartbeat");
+    assert.equal(schedule.enabled, true);
+    assert.equal(schedule.whileSleeping, "skip");
+    assert.ok(schedule.cron);
+    assert.ok((schedule.messages?.length ?? 0) > 1);
+    assert.deepEqual(schedule.messages, DEFAULT_HEARTBEAT_MESSAGES);
+    // A copy, not the module constant — mutating one mind's config must not
+    // corrupt the shared default
+    assert.notEqual(schedule.messages, DEFAULT_HEARTBEAT_MESSAGES);
+    assert.equal(schedule.message, undefined);
+  });
+
+  it("setupDefaultDreaming installs schedule, subagent, and wake hook", () => {
+    const dir = makeMindDir();
+
+    const result = setupDefaultDreaming(dir);
+    assert.equal(result.schedulesChanged, true);
+    assert.deepEqual(result.warnings, []);
+
+    // Dream schedule added alongside the heartbeat
+    const config = readVoluteConfig(dir);
+    const dream = config?.schedules?.find((s) => s.id === "dream");
+    assert.ok(dream, "dream schedule installed");
+    assert.equal(dream.cron, "0 3 * * *");
+    assert.equal(dream.session, "$new");
+    assert.equal(dream.whileSleeping, "trigger-wake");
+    assert.equal(dream.enabled, true);
+    assert.ok(config?.schedules?.some((s) => s.id === "heartbeat"));
+
+    // Dreamer subagent wired into the SDK config
+    const sdkConfig = JSON.parse(readFileSync(resolve(dir, "home/.config/config.json"), "utf-8"));
+    assert.equal(sdkConfig.subagents.dreamer.systemPrompt, "SOUL.md");
+
+    // Dream checker appended to the wake-context hook (base content preserved)
+    const hook = readFileSync(resolve(dir, "home/.local/hooks/wake-context.sh"), "utf-8");
+    assert.ok(hook.includes("echo base"));
+    assert.ok(hook.includes("wake-context-dreams marker"));
+  });
+
+  it("setupDefaultDreaming is idempotent", () => {
+    const dir = makeMindDir();
+    assert.equal(setupDefaultDreaming(dir).schedulesChanged, true);
+    assert.equal(setupDefaultDreaming(dir).schedulesChanged, false);
+
+    const config = readVoluteConfig(dir);
+    assert.equal(config?.schedules?.filter((s) => s.id === "dream").length, 1);
+
+    const hook = readFileSync(resolve(dir, "home/.local/hooks/wake-context.sh"), "utf-8");
+    const occurrences = hook.split("wake-context-dreams marker").length - 1;
+    assert.equal(occurrences, 1);
+  });
+
+  it("setupDefaultDreaming is a no-op without the dreaming skill", () => {
+    const dir = makeMindDir({ skill: false });
+    assert.equal(setupDefaultDreaming(dir).schedulesChanged, false);
+
+    const config = readVoluteConfig(dir);
+    assert.ok(!config?.schedules?.some((s) => s.id === "dream"));
+    const sdkConfig = JSON.parse(readFileSync(resolve(dir, "home/.config/config.json"), "utf-8"));
+    assert.equal(sdkConfig.subagents, undefined);
+  });
+
+  it("setupDefaultDreaming preserves an existing dream schedule but still wires the rest", () => {
+    const dir = makeMindDir();
+    const custom = { ...defaultDreamSchedule(), cron: "0 4 * * *" };
+    writeVoluteConfig(dir, { schedules: [custom] });
+
+    const result = setupDefaultDreaming(dir);
+    assert.equal(result.schedulesChanged, false);
+
+    const config = readVoluteConfig(dir);
+    assert.equal(config?.schedules?.length, 1);
+    assert.equal(config?.schedules?.[0].cron, "0 4 * * *");
+
+    const sdkConfig = JSON.parse(readFileSync(resolve(dir, "home/.config/config.json"), "utf-8"));
+    assert.ok(sdkConfig.subagents?.dreamer);
+  });
+
+  it("setupDefaultDreaming leaves a corrupt volute.json untouched", () => {
+    const dir = makeMindDir();
+    const voluteJsonPath = resolve(dir, "home/.config/volute.json");
+    writeFileSync(voluteJsonPath, "{ not json");
+
+    const result = setupDefaultDreaming(dir);
+    assert.equal(result.schedulesChanged, false);
+    assert.ok(result.warnings.some((w) => w.includes("unparseable")));
+    // The corrupt file must not be overwritten with a fresh config
+    assert.equal(readFileSync(voluteJsonPath, "utf-8"), "{ not json");
+    // The rest of the wiring still happened
+    const sdkConfig = JSON.parse(readFileSync(resolve(dir, "home/.config/config.json"), "utf-8"));
+    assert.ok(sdkConfig.subagents?.dreamer);
+  });
+
+  it("setupDefaultDreaming survives a missing SDK config and hook", () => {
+    const dir = makeMindDir({ sdkConfig: false, hook: false });
+    assert.equal(setupDefaultDreaming(dir).schedulesChanged, true);
+    assert.ok(readVoluteConfig(dir)?.schedules?.some((s) => s.id === "dream"));
+    assert.ok(!existsSync(resolve(dir, "home/.config/config.json")));
+  });
+
+  it("setupDefaultDreaming skips the schedule when subagent wiring fails", () => {
+    const dir = makeMindDir();
+    // Corrupt SDK config makes JSON.parse throw in the subagent step
+    writeFileSync(resolve(dir, "home/.config/config.json"), "{ not json");
+
+    const result = setupDefaultDreaming(dir);
+    assert.equal(result.schedulesChanged, false);
+    assert.ok(result.warnings.length > 0);
+    // No dream schedule referencing a subagent that was never wired
+    assert.ok(!readVoluteConfig(dir)?.schedules?.some((s) => s.id === "dream"));
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -97,6 +97,71 @@ describe("scheduler", () => {
     assert.equal(scheduler.scriptCalls.length, 0);
   });
 
+  it("fire picks a message from a rotating pool", async () => {
+    const scheduler = new TestScheduler();
+    const schedule = {
+      id: "heartbeat",
+      cron: "* * * * *",
+      messages: ["first", "second", "third"],
+      enabled: true,
+    };
+    const originalRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      await (scheduler as any).fire("test-mind", schedule);
+      Math.random = () => 0.999;
+      await (scheduler as any).fire("test-mind", schedule);
+    } finally {
+      Math.random = originalRandom;
+    }
+    assert.equal(scheduler.systemDeliveries.length, 2);
+    assert.equal(scheduler.systemDeliveries[0].text, "[heartbeat] first");
+    assert.equal(scheduler.systemDeliveries[1].text, "[heartbeat] third");
+  });
+
+  it("fire falls back to message when messages pool is empty", async () => {
+    const scheduler = new TestScheduler();
+    await (scheduler as any).fire("test-mind", {
+      id: "hb",
+      cron: "* * * * *",
+      messages: [],
+      message: "fallback",
+      enabled: true,
+    });
+    assert.equal(scheduler.systemDeliveries.length, 1);
+    assert.equal(scheduler.systemDeliveries[0].text, "[hb] fallback");
+  });
+
+  it("fire skips schedule with empty messages and no message or script", async () => {
+    const scheduler = new TestScheduler();
+    await (scheduler as any).fire("test-mind", {
+      id: "hb",
+      cron: "* * * * *",
+      messages: [],
+      enabled: true,
+    });
+    assert.equal(scheduler.systemDeliveries.length, 0);
+  });
+
+  it("fire skips malformed messages pools from hand-edited config", async () => {
+    const scheduler = new TestScheduler();
+    // Not an array — must not index into the string
+    await (scheduler as any).fire("test-mind", {
+      id: "hb",
+      cron: "* * * * *",
+      messages: "hello",
+      enabled: true,
+    });
+    // Non-string entry — must not deliver "undefined"/"[object Object]"
+    await (scheduler as any).fire("test-mind", {
+      id: "hb2",
+      cron: "* * * * *",
+      messages: [42],
+      enabled: true,
+    });
+    assert.equal(scheduler.systemDeliveries.length, 0);
+  });
+
   it("fire passes session from schedule config", async () => {
     const scheduler = new TestScheduler();
     await (scheduler as any).fire("test-mind", {

--- a/test/web-clock-format.test.ts
+++ b/test/web-clock-format.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { messagesToText, textToMessages } from "../packages/web/src/ui/lib/clock-format.js";
+
+describe("schedule message textarea helpers", () => {
+  it("messagesToText joins a pool and falls back to message", () => {
+    assert.equal(messagesToText({ messages: ["a", "b"] }), "a\nb");
+    assert.equal(messagesToText({ message: "solo" }), "solo");
+    // A pool wins over a stray message field
+    assert.equal(messagesToText({ message: "solo", messages: ["a"] }), "a");
+    assert.equal(messagesToText({}), "");
+    assert.equal(messagesToText({ messages: [] }), "");
+  });
+
+  it("textToMessages maps one line to message, several to messages", () => {
+    assert.deepEqual(textToMessages("solo"), { message: "solo" });
+    assert.deepEqual(textToMessages("a\nb"), { messages: ["a", "b"] });
+    // Blank lines and whitespace are dropped
+    assert.deepEqual(textToMessages("  a  \n\n b \n  "), { messages: ["a", "b"] });
+    assert.deepEqual(textToMessages("\n  one  \n"), { message: "one" });
+    // Empty input means "no action fields" — PUT leaves the server value alone
+    assert.deepEqual(textToMessages(""), {});
+    assert.deepEqual(textToMessages("  \n \n"), {});
+  });
+
+  it("round-trips a pool through the textarea", () => {
+    const pool = ["first prompt", "second prompt", "third prompt"];
+    assert.deepEqual(textToMessages(messagesToText({ messages: pool })), { messages: pool });
+    assert.deepEqual(textToMessages(messagesToText({ message: "only" })), { message: "only" });
+  });
+});

--- a/test/web-schedules.test.ts
+++ b/test/web-schedules.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
+import { getScheduler, initScheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, removeMind, voluteHome } from "../packages/daemon/src/lib/mind/registry.js";
+import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
+import { users } from "../packages/daemon/src/lib/schema.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+// writeSchedules reloads the scheduler after each mutation
+try {
+  getScheduler();
+} catch {
+  initScheduler();
+}
+
+const mindName = `sched-test-${process.pid}`;
+let cookie: string;
+
+async function cleanup() {
+  const db = await getDb();
+  await db.delete(users).where(eq(users.username, "sched-admin"));
+  await removeMind(mindName);
+}
+
+function jsonHeaders() {
+  return {
+    Cookie: `volute_session=${cookie}`,
+    Origin: "http://localhost",
+    "Content-Type": "application/json",
+  };
+}
+
+async function getApp() {
+  const { default: app } = await import("../packages/daemon/src/web/app.js");
+  return app;
+}
+
+async function fetchSchedules(): Promise<Schedule[]> {
+  const app = await getApp();
+  const res = await app.request(`/api/minds/${mindName}/schedules`, {
+    headers: { Cookie: `volute_session=${cookie}` },
+  });
+  assert.equal(res.status, 200);
+  return (await res.json()) as Schedule[];
+}
+
+async function postSchedule(body: Record<string, unknown>) {
+  const app = await getApp();
+  return app.request(`/api/minds/${mindName}/schedules`, {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+async function putSchedule(id: string, body: Record<string, unknown>) {
+  const app = await getApp();
+  return app.request(`/api/minds/${mindName}/schedules/${id}`, {
+    method: "PUT",
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+describe("schedules API rotating messages", () => {
+  beforeEach(async () => {
+    await cleanup();
+    const user = await createUser("sched-admin", "pass");
+    cookie = await createSession(user.id);
+    await addMind(mindName, 4198);
+    const dir = resolve(voluteHome(), "minds", mindName);
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(resolve(dir, "home/.config/volute.json"), "{}\n");
+  });
+  afterEach(cleanup);
+
+  it("POST accepts and persists a messages pool", async () => {
+    const res = await postSchedule({
+      id: "heartbeat",
+      cron: "0 12 * * *",
+      messages: ["first", "second"],
+    });
+    assert.equal(res.status, 201);
+
+    const schedules = await fetchSchedules();
+    assert.equal(schedules.length, 1);
+    assert.deepEqual(schedules[0].messages, ["first", "second"]);
+    assert.equal(schedules[0].message, undefined);
+  });
+
+  it("POST rejects message + messages together", async () => {
+    const res = await postSchedule({
+      id: "hb",
+      cron: "0 12 * * *",
+      message: "solo",
+      messages: ["a", "b"],
+    });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { error: string };
+    assert.ok(body.error.includes("mutually exclusive"));
+  });
+
+  it("POST rejects malformed messages", async () => {
+    for (const messages of ["not-an-array", ["ok", ""], ["ok", "   "], [42]]) {
+      const res = await postSchedule({ id: "hb", cron: "0 12 * * *", messages });
+      assert.equal(res.status, 400, `expected 400 for messages=${JSON.stringify(messages)}`);
+      const body = (await res.json()) as { error: string };
+      assert.ok(body.error.includes("messages"));
+    }
+  });
+
+  it("PUT keeps at most one action field", async () => {
+    assert.equal(
+      (await postSchedule({ id: "hb", cron: "0 12 * * *", messages: ["a", "b"] })).status,
+      201,
+    );
+
+    // messages → message
+    assert.equal((await putSchedule("hb", { message: "solo" })).status, 200);
+    let [sched] = await fetchSchedules();
+    assert.equal(sched.message, "solo");
+    assert.equal(sched.messages, undefined);
+
+    // message → messages
+    assert.equal((await putSchedule("hb", { messages: ["x", "y"] })).status, 200);
+    [sched] = await fetchSchedules();
+    assert.deepEqual(sched.messages, ["x", "y"]);
+    assert.equal(sched.message, undefined);
+
+    // messages → script
+    assert.equal((await putSchedule("hb", { script: "echo hi" })).status, 200);
+    [sched] = await fetchSchedules();
+    assert.equal(sched.script, "echo hi");
+    assert.equal(sched.message, undefined);
+    assert.equal(sched.messages, undefined);
+  });
+
+  it("PUT rejects edits that would leave the schedule actionless", async () => {
+    assert.equal(
+      (await postSchedule({ id: "hb", cron: "0 12 * * *", messages: ["a", "b"] })).status,
+      201,
+    );
+
+    // Clearing the pool with nothing to replace it → 400, schedule unchanged
+    const res = await putSchedule("hb", { messages: [] });
+    assert.equal(res.status, 400);
+    let [sched] = await fetchSchedules();
+    assert.deepEqual(sched.messages, ["a", "b"]);
+
+    // Clearing the pool while providing a replacement action is fine
+    assert.equal((await putSchedule("hb", { messages: [], message: "solo" })).status, 200);
+    [sched] = await fetchSchedules();
+    assert.equal(sched.message, "solo");
+    assert.equal(sched.messages, undefined);
+
+    // A non-action edit on an action-bearing schedule still works
+    assert.equal((await putSchedule("hb", { enabled: false })).status, 200);
+    [sched] = await fetchSchedules();
+    assert.equal(sched.enabled, false);
+    assert.equal(sched.message, "solo");
+  });
+});


### PR DESCRIPTION
## What

Out of the box, a fresh mind's entire autonomous existence was one static heartbeat prompt at 12/16/20 plus the sleep cycle — dreaming shipped as a standard skill but was never wired up, and generic prompts produced generic musing. This PR makes default autonomy visible and continuing:

1. **Rotating heartbeat prompts** — `Schedule` gains an optional `messages?: string[]` pool; the scheduler picks one at random per fire. The default heartbeat installed at mind creation now rotates six varied prompts (write a page, leave a note for another mind, revisit your journal, wander a topic, check #system, progress on your standing interest).
2. **Dreaming works out of the box** — new `setupDefaultDreaming()` (`packages/daemon/src/lib/mind/default-autonomy.ts`) installs the nightly dream schedule from the skill's INSTALL.md (`0 3 * * *`, `session: "$new"`, `whileSleeping: "trigger-wake"`) *and* performs the `dream install` wiring (dreamer subagent in `.config/config.json`, dream checker appended to the wake-context hook). Applied at creation for directly-created full minds and at sprout for seeds (the seed-sprout CLI installs the dreaming skill just before). Idempotent; no-op when the skill is absent.
3. **Orientation seeds a first interest** — the orientation skill now asks "what do you want to make?" and has seeds record a first interest/project in MEMORY.md, so heartbeat prompts like "any progress on the interest in your MEMORY.md?" land on real, continuing work.

Supporting changes:
- Schedules API validates `messages[]` (non-empty strings, mutually exclusive with `message`/`script`) and rejects PUT edits that would leave a schedule actionless.
- The scheduler guards the pool's shape (minds hand-edit `volute.json`) instead of delivering garbage.
- `setupDefaultDreaming` fails soft with logged + surfaced warnings (creation response `skillWarnings`), never overwrites a corrupt `volute.json`, and skips the dream schedule if the subagent wiring failed — so a mind is never told nightly to invoke machinery that isn't there.
- Web schedule editors (mind Rhythms tab + system Mind Defaults) use a newline-separated textarea: one line → `message`, several → rotating `messages`.
- `volute clock list` shows `[rotating xN]` for pool schedules (display only; no new CLI flags).
- Fixed a latent non-idempotence in the dreaming skill's own `dream install`: the hook-append guard checked for a marker string the appended content never contained; both paths now write a shared marker line.

## Why

Minds are the primary audience — if the operator isn't watching at heartbeat time, the system looks dead, and a mind with no standing interest turns quiet moments into idle musing instead of visible, continuing projects. Applies to new minds/sprouts only; no backfill of existing minds. Opt-out is the existing surface: edit or remove the schedules via `volute clock` or the web UI.

## Test plan

- `npm test`: **2104 pass, 0 fail** (full suite)
- `npm run test:e2e`: **54 pass, 0 fail** (includes new assertion that a fresh mind gets the rotating heartbeat)
- New tests: `test/default-autonomy.test.ts` (wiring, idempotency, no-op without skill, corrupt-config safety, subagent-failure skip), `test/web-schedules.test.ts` (messages validation, PUT field-clearing, actionless rejection), `test/web-clock-format.test.ts` (textarea helpers round-trip), plus scheduler rotating-pool/malformed-pool tests in `test/scheduler.test.ts`
- `npm run typecheck`, `npm run typecheck:web`, `npm run lint`: clean
- Reviewed by three review agents (code review, silent-failure hunt, test-coverage analysis); all legitimate findings fixed (corrupt-config clobber, partial-setup warnings, PUT actionless guard, scheduler shape guard)

Fixes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)