### PR TITLE
perf(web): lazily mount collapsed-turn peek popover content

### DIFF
--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -21,6 +21,13 @@ import {
 import { extractTextContent } from "../lib/feed-utils";
 import { formatRelativeTime } from "../lib/format";
 import { navigate } from "../lib/navigate";
+import {
+  activityColor,
+  activityNavUrl,
+  activityPeekBody,
+  peekKey,
+  shouldRenderPeek,
+} from "../lib/peek";
 import { parseISOWeek, summaryBounds, wallNow } from "../lib/period-keys";
 import { activeMinds } from "../lib/stores.svelte";
 import { mergeOlderSummaries, nextSummaryPage } from "../lib/summary-paging";
@@ -190,6 +197,13 @@ let pendingInbounds = $state<HistoryMessage[]>([]);
 // Fallback timers for done events that may not be followed by a summary
 const doneFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let expandedTurns = $state(new Set<string>());
+// Peek popovers (collapsed-turn hover cards) render markdown / mount live iframes,
+// so their content is mounted lazily on first hover and then kept (frozen) to avoid
+// eagerly rendering hundreds of hidden popovers on the initial timeline paint (#541).
+let revealedPeeks = new SvelteSet<string>();
+function revealPeek(key: string) {
+  revealedPeeks.add(key);
+}
 
 function buildHistoryMessage(
   d: Record<string, unknown>,
@@ -970,42 +984,46 @@ function jumpToLatest() {
               {#if !expandedTurns.has(turn.id) && turn.status !== "active" && (turn.conversations.length > 0 || turn.activities.length > 0)}
                 <div class="turn-peek-icons">
                   {#each turn.conversations as conv (conv.id)}
+                    {@const chatKey = peekKey("chat", turn.id, conv.id)}
                     <div class="peek-anchor">
-                      <button class="peek-btn" aria-label="View conversation" onclick={(e) => e.stopPropagation()}>
+                      <button class="peek-btn" aria-label="View conversation" onmouseenter={() => revealPeek(chatKey)} onfocus={() => revealPeek(chatKey)} onclick={(e) => e.stopPropagation()}>
                         <Icon kind="chat" />
                       </button>
                       <div class="peek-popover" role="button" tabindex="0"
                         onclick={(e) => { e.stopPropagation(); openConversation(conv, turn); }}
                         onkeydown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); openConversation(conv, turn); } }}
                       >
-                        <div class="peek-card peek-card-chat">
-                          <div class="peek-card-header">
-                            <Icon kind="chat" class="peek-card-icon" />
-                            <span class="peek-card-label">{conv.label}</span>
-                            <span class="peek-card-meta">{conv.messages.length} msg{conv.messages.length === 1 ? '' : 's'}</span>
+                        {#if shouldRenderPeek(revealedPeeks, chatKey)}
+                          <div class="peek-card peek-card-chat">
+                            <div class="peek-card-header">
+                              <Icon kind="chat" class="peek-card-icon" />
+                              <span class="peek-card-label">{conv.label}</span>
+                              <span class="peek-card-meta">{conv.messages.length} msg{conv.messages.length === 1 ? '' : 's'}</span>
+                            </div>
+                            <div class="peek-card-body">
+                              {#each conv.messages.slice(-5) as msg (msg.id)}
+                                <div class="peek-msg">
+                                  <span class="peek-msg-sender" class:peek-msg-sender-user={msg.role === "user"}>{msg.sender_name ?? (msg.role === "user" ? "user" : turn.mind)}</span>
+                                  {#if msg.role === "assistant"}
+                                    <span class="peek-msg-md markdown-body">{@html renderMarkdown(extractTextContent(msg.content))}</span>
+                                  {:else}
+                                    <span>{extractTextContent(msg.content)}</span>
+                                  {/if}
+                                </div>
+                              {/each}
+                            </div>
                           </div>
-                          <div class="peek-card-body">
-                            {#each conv.messages.slice(-5) as msg (msg.id)}
-                              <div class="peek-msg">
-                                <span class="peek-msg-sender" class:peek-msg-sender-user={msg.role === "user"}>{msg.sender_name ?? (msg.role === "user" ? "user" : turn.mind)}</span>
-                                {#if msg.role === "assistant"}
-                                  <span class="peek-msg-md markdown-body">{@html renderMarkdown(extractTextContent(msg.content))}</span>
-                                {:else}
-                                  <span>{extractTextContent(msg.content)}</span>
-                                {/if}
-                              </div>
-                            {/each}
-                          </div>
-                        </div>
+                        {/if}
                       </div>
                     </div>
                   {/each}
                   {#each turn.activities as act (act.id)}
-                    {@const actColor = typeof act.metadata?.color === 'string' ? act.metadata.color : 'yellow'}
+                    {@const actKey = peekKey("activity", turn.id, act.id)}
+                    {@const actColor = activityColor(act.metadata)}
                     {@const actIcon = typeof act.metadata?.icon === 'string' ? sanitizeSvg(act.metadata.icon) : ''}
-                    {@const actUrl = typeof act.metadata?.iframeUrl === 'string' ? act.metadata.iframeUrl : typeof act.metadata?.slug === 'string' ? `/minds/${typeof act.metadata?.author === 'string' ? act.metadata.author : turn.mind}/notes/${act.metadata.slug}` : ''}
+                    {@const actUrl = activityNavUrl(act.metadata, turn.mind)}
                     <div class="peek-anchor">
-                      <button class="peek-btn" style:color="var(--{actColor})" aria-label="View activity" onclick={(e) => { e.stopPropagation(); if (actUrl) navigate(actUrl); }}>
+                      <button class="peek-btn" style:color="var(--{actColor})" aria-label="View activity" onmouseenter={() => revealPeek(actKey)} onfocus={() => revealPeek(actKey)} onclick={(e) => { e.stopPropagation(); if (actUrl) navigate(actUrl); }}>
                         {#if actIcon}
                           {@html actIcon}
                         {:else}
@@ -1013,28 +1031,31 @@ function jumpToLatest() {
                         {/if}
                       </button>
                       <div class="peek-popover">
-                        <div class="peek-card" style:border-color="color-mix(in srgb, var(--{actColor}) 25%, var(--border))">
-                          <div class="peek-card-header" style:border-bottom-color="color-mix(in srgb, var(--{actColor}) 25%, var(--border))">
-                            {#if actIcon}
-                              <span class="peek-card-icon" style:color="var(--{actColor})">{@html actIcon}</span>
-                            {:else}
-                              <Icon kind="document-lines" class="peek-card-icon" />
-                            {/if}
-                            <span class="peek-card-label">{act.summary}</span>
-                          </div>
-                          {#if typeof act.metadata?.iframeUrl === 'string' && act.metadata.iframeUrl}
-                            <div class="peek-card-body peek-card-iframe">
-                              <iframe
-                                src={act.metadata.iframeUrl}
-                                title={act.summary}
-                                sandbox="allow-same-origin"
-                                role="presentation"
-                              ></iframe>
+                        {#if shouldRenderPeek(revealedPeeks, actKey)}
+                          {@const actBody = activityPeekBody(act.metadata)}
+                          <div class="peek-card" style:border-color="color-mix(in srgb, var(--{actColor}) 25%, var(--border))">
+                            <div class="peek-card-header" style:border-bottom-color="color-mix(in srgb, var(--{actColor}) 25%, var(--border))">
+                              {#if actIcon}
+                                <span class="peek-card-icon" style:color="var(--{actColor})">{@html actIcon}</span>
+                              {:else}
+                                <Icon kind="document-lines" class="peek-card-icon" />
+                              {/if}
+                              <span class="peek-card-label">{act.summary}</span>
                             </div>
-                          {:else if typeof act.metadata?.bodyHtml === 'string' && act.metadata.bodyHtml}
-                            <div class="peek-card-body markdown-body">{@html renderMarkdown(act.metadata.bodyHtml)}</div>
-                          {/if}
-                        </div>
+                            {#if actBody.kind === "iframe"}
+                              <div class="peek-card-body peek-card-iframe">
+                                <iframe
+                                  src={actBody.url}
+                                  title={act.summary}
+                                  sandbox="allow-same-origin"
+                                  role="presentation"
+                                ></iframe>
+                              </div>
+                            {:else if actBody.kind === "markdown"}
+                              <div class="peek-card-body markdown-body">{@html renderMarkdown(actBody.source)}</div>
+                            {/if}
+                          </div>
+                        {/if}
                       </div>
                     </div>
                   {/each}

--- a/packages/web/src/ui/lib/peek.ts
+++ b/packages/web/src/ui/lib/peek.ts
@@ -1,0 +1,54 @@
+import type { TurnActivity } from "@volute/api";
+
+/**
+ * Stable key for a collapsed-turn peek popover, used to track which popovers
+ * have been revealed (hovered) so their content is mounted lazily.
+ */
+export function peekKey(
+  kind: "chat" | "activity",
+  turnId: string,
+  itemId: string | number,
+): string {
+  return `${kind}:${turnId}:${itemId}`;
+}
+
+export type ActivityPeekBody =
+  | { kind: "iframe"; url: string }
+  | { kind: "markdown"; source: string }
+  | { kind: "none" };
+
+/**
+ * Decide what an activity peek popover should render. Pure — the caller only
+ * renders markdown / mounts the iframe when the popover is actually revealed.
+ */
+export function activityPeekBody(metadata: TurnActivity["metadata"]): ActivityPeekBody {
+  const iframeUrl = typeof metadata?.iframeUrl === "string" ? metadata.iframeUrl : "";
+  if (iframeUrl) return { kind: "iframe", url: iframeUrl };
+  const bodyHtml = typeof metadata?.bodyHtml === "string" ? metadata.bodyHtml : "";
+  if (bodyHtml) return { kind: "markdown", source: bodyHtml };
+  return { kind: "none" };
+}
+
+/** Navigation target for the activity peek button. */
+export function activityNavUrl(metadata: TurnActivity["metadata"], fallbackMind: string): string {
+  // A string iframeUrl always wins, even when empty (→ no navigation),
+  // matching the original inline `typeof === "string"` precedence.
+  if (typeof metadata?.iframeUrl === "string") return metadata.iframeUrl;
+  const slug = typeof metadata?.slug === "string" ? metadata.slug : "";
+  if (!slug) return "";
+  const author = typeof metadata?.author === "string" ? metadata.author : fallbackMind;
+  return `/minds/${author}/notes/${slug}`;
+}
+
+/** Accent color name for the activity peek button/card. */
+export function activityColor(metadata: TurnActivity["metadata"]): string {
+  return typeof metadata?.color === "string" ? metadata.color : "yellow";
+}
+
+/**
+ * Whether a peek popover's content should be mounted. Content mounts on first
+ * reveal and stays mounted (frozen) — hidden popovers render nothing (#541).
+ */
+export function shouldRenderPeek(revealed: ReadonlySet<string>, key: string): boolean {
+  return revealed.has(key);
+}

--- a/test/web-peek.test.ts
+++ b/test/web-peek.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  activityColor,
+  activityNavUrl,
+  activityPeekBody,
+  peekKey,
+  shouldRenderPeek,
+} from "../packages/web/src/ui/lib/peek";
+
+describe("peekKey", () => {
+  it("builds stable, kind-scoped keys", () => {
+    assert.equal(peekKey("chat", "turn-1", "conv-9"), "chat:turn-1:conv-9");
+    assert.equal(peekKey("activity", "turn-1", 42), "activity:turn-1:42");
+  });
+
+  it("does not collide across kinds or turns for the same item id", () => {
+    assert.notEqual(peekKey("chat", "turn-1", "x"), peekKey("activity", "turn-1", "x"));
+    assert.notEqual(peekKey("activity", "turn-1", 1), peekKey("activity", "turn-2", 1));
+  });
+
+  it("does not collide for colon-bearing item ids on the same turn (turn ids are UUIDs)", () => {
+    assert.notEqual(
+      peekKey("chat", "turn-1", "discord:a/b"),
+      peekKey("chat", "turn-1", "discord:a/c"),
+    );
+  });
+});
+
+describe("activityPeekBody", () => {
+  it("prefers a live iframe when iframeUrl is present", () => {
+    assert.deepEqual(activityPeekBody({ iframeUrl: "/x", bodyHtml: "# hi" }), {
+      kind: "iframe",
+      url: "/x",
+    });
+  });
+
+  it("falls back to markdown when only bodyHtml is present", () => {
+    assert.deepEqual(activityPeekBody({ bodyHtml: "# hi" }), {
+      kind: "markdown",
+      source: "# hi",
+    });
+  });
+
+  it("renders nothing when neither is present", () => {
+    assert.deepEqual(activityPeekBody(null), { kind: "none" });
+    assert.deepEqual(activityPeekBody({ color: "blue" }), { kind: "none" });
+  });
+
+  it("ignores non-string metadata fields", () => {
+    assert.deepEqual(activityPeekBody({ iframeUrl: 5, bodyHtml: 7 }), {
+      kind: "none",
+    });
+  });
+});
+
+describe("activityNavUrl", () => {
+  it("navigates to the iframe url when present", () => {
+    assert.equal(activityNavUrl({ iframeUrl: "/pages/a" }, "mind"), "/pages/a");
+  });
+
+  it("builds a note url from slug, defaulting author to the mind", () => {
+    assert.equal(activityNavUrl({ slug: "my-note" }, "echo"), "/minds/echo/notes/my-note");
+    assert.equal(
+      activityNavUrl({ slug: "my-note", author: "iris" }, "echo"),
+      "/minds/iris/notes/my-note",
+    );
+  });
+
+  it("returns empty when there is nothing to navigate to", () => {
+    assert.equal(activityNavUrl(null, "mind"), "");
+    assert.equal(activityNavUrl({ color: "red" }, "mind"), "");
+  });
+
+  it("an explicit empty-string iframeUrl wins over slug (no navigation, matching original inline logic)", () => {
+    assert.equal(activityNavUrl({ iframeUrl: "", slug: "my-note" }, "echo"), "");
+  });
+});
+
+describe("activityColor", () => {
+  it("uses the metadata color when a string", () => {
+    assert.equal(activityColor({ color: "green" }), "green");
+  });
+
+  it("defaults to yellow", () => {
+    assert.equal(activityColor(null), "yellow");
+    assert.equal(activityColor({ color: 3 }), "yellow");
+  });
+});
+
+// Guard the core perf property: hidden popovers render no content. The component
+// gates each popover's markdown/iframe behind `shouldRenderPeek(revealedPeeks,
+// peekKey(...))` — the same function exercised here — so an empty reveal set
+// yields zero renders for any number of collapsed peeks.
+describe("lazy peek reveal gating (shouldRenderPeek)", () => {
+  it("renders no popover content until a peek is revealed", () => {
+    const revealed = new Set<string>();
+    const keys = Array.from({ length: 500 }, (_, i) =>
+      i % 2 === 0 ? peekKey("chat", `turn-${i}`, `conv-${i}`) : peekKey("activity", `turn-${i}`, i),
+    );
+    const rendered = keys.filter((k) => shouldRenderPeek(revealed, k));
+    assert.equal(rendered.length, 0);
+  });
+
+  it("renders only the revealed peek, leaving siblings hidden", () => {
+    const revealed = new Set<string>();
+    const a = peekKey("chat", "turn-1", "conv-1");
+    const b = peekKey("activity", "turn-1", 2);
+    revealed.add(a);
+    assert.equal(shouldRenderPeek(revealed, a), true);
+    assert.equal(shouldRenderPeek(revealed, b), false);
+  });
+});


### PR DESCRIPTION
## What

Collapsed-turn peek popovers in `TurnTimeline` (the hover cards on the timeline rail for a turn's conversations and activities) eagerly rendered their full content — `renderMarkdown()` for chat messages and note bodies, plus **live iframes** for page/iframe activities — for every collapsed turn on the initial timeline paint, even though every popover is `display: none` until its 18px peek button is hovered.

On a home-view timeline with hundreds of loaded turns (especially after "load older"), that meant hundreds of hidden markdown renders and eager iframe network loads + document parses for content the user may never look at.

## Change

- Popover content is now gated behind a reveal set (`SvelteSet<string>` keyed by `peekKey(kind, turnId, itemId)`). Content mounts on the peek button's first `mouseenter`/`focus` and stays mounted (frozen) afterwards — so repeat hovers are instant and hover UX is preserved exactly. The button is the anchor's only hoverable in-flow box (the popover is absolutely positioned and hidden), so the reveal always fires before the popover can become visible; there is no blank-popover path.
- The inline activity-peek `{@const}` metadata logic is extracted to pure helpers in `packages/web/src/ui/lib/peek.ts`: `activityPeekBody` (iframe/markdown/none precedence), `activityNavUrl`, `activityColor`, `peekKey`, and `shouldRenderPeek` (the gating decision the component itself calls, so the tests exercise the real product code path).

## Impact

- Initial timeline paint: zero `renderMarkdown()` calls and zero iframe loads for hidden peeks (previously O(loaded turns × peeks); each iframe is a full subdocument fetch + parse).
- Per-hover cost is unchanged from the old steady state; after first reveal the card behaves exactly as before.
- No streaming-path changes — this stays clear of the active-turn streaming work in #594 (verified hunk-by-hunk: imports, one state declaration, and the two collapsed-turn peek template blocks only).

## Test plan

- New `test/web-peek.test.ts` (15 tests): helper branch coverage (iframe-over-markdown precedence, slug/author fallback, non-string metadata rejection, explicit pin of the `iframeUrl: ""` → no-navigation original behavior, colon-bearing id key non-collision) plus a gating property test asserting 500 hidden peeks produce zero content renders via the same `shouldRenderPeek` the component uses.
- `svelte-check` on packages/web: 0 errors (one pre-existing unrelated warning).
- `npm run build:web`: clean.
- `npm test`: 2099 passing, 0 failing.
- Reviewed by three passes (code-reviewer, silent-failure-hunter, pr-test-analyzer); all legitimate findings addressed (restored exact `typeof`-gated `activityNavUrl` precedence, de-tautologized the gating test by wiring `shouldRenderPeek` into the component).

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)