### PR TITLE
feat(web): dashboard empty state — 'Plant your first seed' CTA and zero-mind guidance

### DIFF
--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -794,6 +794,7 @@ function handleGlobalClick(e: MouseEvent) {
               onConversationId={handleConversationId}
               onSelectConversation={handleSelectConversation}
               onOpenMind={handleOpenMindModal}
+              onSeed={() => (activeModal = "seed")}
               onTypingNames={(names) => { typingNames = names; }}
               onToggleSidebar={toggleSidebar}
               onOpenRightPanel={hasRightPanel ? openRightPanel : undefined}

--- a/packages/web/src/ui/components/MindEmptyState.svelte
+++ b/packages/web/src/ui/components/MindEmptyState.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import type { Mind } from "@volute/api";
+import { navigate } from "../lib/navigate";
+import { findSpirit } from "../lib/onboarding";
+
+let { minds, onSeed }: { minds: Mind[]; onSeed: () => void } = $props();
+
+let spirit = $derived(findSpirit(minds));
+</script>
+
+<div class="empty-state">
+  <div class="empty-card">
+    <h2 class="empty-heading">Plant your first seed</h2>
+    <p class="empty-blurb">
+      A mind is a persistent AI with its own memory, identity, and inner life — one it can grow
+      and reshape over time.
+    </p>
+    <button class="plant-btn" onclick={onSeed}>Plant your first seed</button>
+    {#if spirit}
+      <p class="empty-secondary">
+        or <button class="spirit-link" onclick={() => navigate(`/minds/${spirit.name}`)}>chat with {spirit.displayName ?? spirit.name}</button> to get oriented.
+      </p>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .empty-state {
+    flex-shrink: 0;
+    padding: 24px 16px 8px;
+    animation: fadeIn 0.2s ease both;
+  }
+
+  .empty-card {
+    max-width: 440px;
+    margin: 0 auto;
+    padding: 24px;
+    background: var(--bg-0);
+    border: 1px solid color-mix(in srgb, var(--yellow) 25%, var(--border));
+    border-radius: var(--radius-lg);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+  }
+
+  .empty-heading {
+    margin: 0;
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--text-0);
+  }
+
+  .empty-blurb {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-1);
+  }
+
+  .plant-btn {
+    margin-top: 4px;
+    padding: 6px 16px;
+    background: var(--yellow);
+    color: var(--bg-0);
+    border-radius: var(--radius);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .plant-btn:hover {
+    opacity: 0.85;
+  }
+
+  .empty-secondary {
+    margin: 0;
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .spirit-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 12px;
+    color: var(--accent);
+    cursor: pointer;
+  }
+
+  .spirit-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/packages/web/src/ui/components/layout/MainFrame.svelte
+++ b/packages/web/src/ui/components/layout/MainFrame.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
 import type { Selection } from "../../lib/navigate";
+import { showMindOnboarding } from "../../lib/onboarding";
+import { data } from "../../lib/stores.svelte";
 import Home from "../../pages/Home.svelte";
 import MindPage from "../../pages/MindPage.svelte";
 import Chat from "../chat/Chat.svelte";
+import MindEmptyState from "../MindEmptyState.svelte";
 import TurnTimeline from "../TurnTimeline.svelte";
 
 let {
@@ -14,6 +17,7 @@ let {
   onConversationId,
   onOpenMind,
   onSelectConversation,
+  onSeed,
   onTypingNames,
   onToggleSidebar,
   onOpenRightPanel,
@@ -25,6 +29,7 @@ let {
   onConversationId: (id: string) => void;
   onOpenMind: (mind: Mind) => void;
   onSelectConversation: (id: string) => void;
+  onSeed: () => void;
   onTypingNames?: (names: string[]) => void;
   onToggleSidebar?: () => void;
   onOpenRightPanel?: () => void;
@@ -118,8 +123,13 @@ let contextLabel = $derived.by(() => {
       <iframe src="/ext/{selection.extensionId}/#{selection.path ? '/' + selection.path : ''}" class="page-iframe" title="Extension"></iframe>
     </div>
   {:else if selection.kind === "system-history"}
-    <div class="frame-content mind-frame">
-      <TurnTimeline />
+    <div class="frame-content mind-frame timeline-frame">
+      {#if showMindOnboarding(minds, data.mindsLoaded)}
+        <MindEmptyState {minds} {onSeed} />
+      {/if}
+      <div class="timeline-wrap">
+        <TurnTimeline />
+      </div>
     </div>
   {:else}
     <div class="frame-content padded">
@@ -148,6 +158,16 @@ let contextLabel = $derived.by(() => {
 
   .frame-content.mind-frame {
     overflow: hidden;
+  }
+
+  .timeline-frame {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .timeline-wrap {
+    flex: 1;
+    min-height: 0;
   }
 
   .page-iframe {

--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -11,6 +11,7 @@ import {
   startReauth,
   submitCode,
 } from "../../lib/oauth-reauth.svelte";
+import { showMindOnboarding } from "../../lib/onboarding";
 import { activeMinds, data, unreadCounts } from "../../lib/stores.svelte";
 import ProfileHoverCard from "../ProfileHoverCard.svelte";
 import ConversationList from "./ConversationList.svelte";
@@ -269,6 +270,12 @@ let isSystemActive = $derived(
       </div>
       {#if !collapsed.has("minds")}
         <div class="item-list">
+          {#if showMindOnboarding(minds, data.mindsLoaded)}
+            <div class="minds-empty">
+              <span class="minds-empty-label">No minds yet</span>
+              <button class="minds-empty-btn" onclick={onSeed}>Plant a seed</button>
+            </div>
+          {/if}
           {#each sortedMinds as mind}
             {@const dmId = mindDmMap.get(mind.name)}
             {@const mindUnread = dmId ? (unreadCounts.get(dmId) ?? 0) : 0}
@@ -601,6 +608,34 @@ let isSystemActive = $derived(
     border-radius: 50%;
     background: var(--accent);
     flex-shrink: 0;
+  }
+
+  .minds-empty {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px 6px 24px;
+  }
+
+  .minds-empty-label {
+    font-size: 13px;
+    color: var(--text-2);
+  }
+
+  .minds-empty-btn {
+    font-size: 12px;
+    padding: 2px 10px;
+    border-radius: var(--radius);
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-1);
+    cursor: pointer;
+    transition: color 0.1s, border-color 0.1s;
+  }
+
+  .minds-empty-btn:hover {
+    color: var(--text-0);
+    border-color: var(--border-bright);
   }
 
   .stale-badge {

--- a/packages/web/src/ui/lib/onboarding.ts
+++ b/packages/web/src/ui/lib/onboarding.ts
@@ -1,0 +1,19 @@
+import type { Mind } from "@volute/api";
+
+/**
+ * True when the system has no regular minds yet — the fresh-install state
+ * where onboarding guidance should be shown. The spirit doesn't count as a
+ * regular mind.
+ *
+ * `mindsLoaded` guards the initial page load: `minds` is an empty array
+ * while the first fetch is in flight, which must not flash the onboarding
+ * state on systems that do have minds.
+ */
+export function showMindOnboarding(minds: Mind[], mindsLoaded: boolean): boolean {
+  return mindsLoaded && minds.every((m) => m.mindType === "spirit");
+}
+
+/** The spirit mind, if present. */
+export function findSpirit(minds: Mind[]): Mind | undefined {
+  return minds.find((m) => m.mindType === "spirit");
+}

--- a/packages/web/src/ui/lib/stores.svelte.ts
+++ b/packages/web/src/ui/lib/stores.svelte.ts
@@ -95,6 +95,8 @@ export async function handleAuth(u: AuthUser) {
 
 export const data = $state({
   minds: [] as Mind[],
+  /** True once the first minds fetch has resolved — distinguishes "no minds" from "not loaded yet". */
+  mindsLoaded: false,
   conversations: [] as ConversationWithParticipants[],
   activity: [] as ActivityItem[],
   extensions: [] as ExtensionInfo[],
@@ -186,6 +188,7 @@ function handleSSEEvent(event: SSEEvent) {
     fetchMinds()
       .then((m) => {
         data.minds = m;
+        data.mindsLoaded = true;
       })
       .catch((err) => {
         console.warn("[stores] failed to refresh minds:", err);
@@ -230,6 +233,7 @@ function handleSSEEvent(event: SSEEvent) {
       fetchMinds()
         .then((m) => {
           data.minds = m;
+          data.mindsLoaded = true;
         })
         .catch((err) => {
           console.warn("[stores] failed to refresh minds:", err);

--- a/test/web-onboarding.test.ts
+++ b/test/web-onboarding.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Mind } from "../packages/api/src/types.js";
+import { findSpirit, showMindOnboarding } from "../packages/web/src/ui/lib/onboarding.js";
+
+function mind(name: string, mindType?: "mind" | "spirit"): Mind {
+  return {
+    name,
+    created: "2026-01-01T00:00:00Z",
+    status: "running",
+    channels: [],
+    mindType,
+  };
+}
+
+describe("showMindOnboarding", () => {
+  it("is false while minds have not loaded", () => {
+    assert.equal(showMindOnboarding([], false), false);
+    assert.equal(showMindOnboarding([mind("volute", "spirit")], false), false);
+  });
+
+  it("is true when only the spirit exists", () => {
+    assert.equal(showMindOnboarding([mind("volute", "spirit")], true), true);
+  });
+
+  it("is true when loaded and no minds exist at all (spirit bootstrap failed)", () => {
+    assert.equal(showMindOnboarding([], true), true);
+  });
+
+  it("is false once a regular mind exists", () => {
+    assert.equal(showMindOnboarding([mind("volute", "spirit"), mind("luna", "mind")], true), false);
+  });
+
+  it("treats minds without an explicit mindType as regular minds", () => {
+    assert.equal(showMindOnboarding([mind("volute", "spirit"), mind("luna")], true), false);
+  });
+});
+
+describe("findSpirit", () => {
+  it("returns the spirit mind", () => {
+    const spirit = mind("volute", "spirit");
+    assert.equal(findSpirit([mind("luna", "mind"), spirit]), spirit);
+  });
+
+  it("returns undefined when no spirit exists", () => {
+    assert.equal(findSpirit([mind("luna", "mind")]), undefined);
+  });
+});


### PR DESCRIPTION
## What

With zero regular minds, the dashboard offered no visible path to begin: the sidebar Minds section rendered empty (creation hidden behind a hover-only `+` icon) and the default landing view — the system timeline — just said "No activity yet."

This adds zero-mind onboarding guidance, shown whenever no regular (non-spirit) minds exist and hidden automatically once the first seed is planted:

- **Onboarding card** on the system-history landing (`MindEmptyState.svelte`, rendered above the timeline): a one-line explanation of what a mind is, a **Plant your first seed** button that opens the existing `SeedModal`, and a link to the spirit chat ("or chat with volute to get oriented").
- **Persistent sidebar row** in the Minds section: "No minds yet" + a visible **Plant a seed** button (no longer hover-only).

## How

- The predicate lives in `packages/web/src/ui/lib/onboarding.ts` (`showMindOnboarding`) so it can be reused when the landing view changes (see #583's Home work).
- A new `data.mindsLoaded` store flag distinguishes "minds not fetched yet" from "no minds", so the empty state never flashes during the initial load on systems that do have minds. It also keeps the card visible in the degraded case where spirit bootstrap failed entirely (the motivating scenario in #578). The flag is set on every `fetchMinds` success path (snapshot + activity refresh) so a single failed fetch cannot hide onboarding for the rest of the session (review finding).
- No new role gating — matches the existing seed-creation affordance. No wizard — reuses `SeedModal` as-is. `TurnTimeline.svelte` untouched.

## Test plan

- `test/web-onboarding.test.ts`: unit tests for `showMindOnboarding` (not-loaded guard, spirit-only → true, no-minds-at-all → true, regular mind present → false, missing `mindType` treated as regular) and `findSpirit`.
- Full `npm test`: 2091 pass, 0 fail.
- `npm run knip` (unused-file CI guard): clean. `vite build`: clean.
- Verified visually via Playwright against a mocked daemon: card + sidebar row render with only the spirit; card CTA opens SeedModal; spirit link navigates to `/minds/volute`; both disappear once a regular mind exists.

Fixes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
