### PR TITLE
perf(web): don't rebuild the realtime layer on every message send

### DIFF
--- a/packages/web/src/ui/components/chat/Chat.svelte
+++ b/packages/web/src/ui/components/chat/Chat.svelte
@@ -216,8 +216,12 @@ async function handleSend(
       files: files.length > 0 ? files : undefined,
     });
     const resultConvId = result.conversationId;
+    // Only notify the parent when the conversation is actually new. Firing on
+    // every send used to rebuild the whole realtime layer (SSE reconnect +
+    // full refetch); the live stream already delivers messages incrementally.
+    const isNewConversation = resultConvId !== currentConvId;
     currentConvId = resultConvId;
-    onConversationId(resultConvId);
+    if (isNewConversation) onConversationId(resultConvId);
   } catch (err) {
     console.error("Failed to send message:", err);
     entries = [


### PR DESCRIPTION
## What

`Chat.handleSend` notified the parent (`onConversationId`) after **every** successful send. In `App.svelte` that runs `handleConversationId` → `connectActivity()`, which tears down and reconnects the `/api/v1/events` SSE stream and delivers a fresh snapshot — refetching minds (a health-check HTTP request per running mind), extensions, and AI providers, and rebuilding all unread counts.

So one sent message = SSE reconnect + ~4 API calls + N health checks + a broad re-render, and it got worse with more active minds. This makes the UI feel laggy right after every send.

The fix gates the notification: `Chat.svelte` only calls `onConversationId` when the conversation is genuinely new (`resultConvId !== currentConvId`). Sends to an existing conversation — the hot path — now ride the live stream with no reconnect and no refetch; their messages already arrive incrementally via the conversation SSE events.

## Why this (and not removing `connectActivity` from `handleConversationId`)

The issue's plan suggested also dropping the `connectActivity()` call in `handleConversationId` in favor of a targeted conversation-list refresh. Verifying against current `main` showed that would be a correctness regression:

The daemon SSE endpoint (`packages/daemon/src/web/api/v1/events.ts`) subscribes to conversations **statically at connect time** — it iterates the user's conversations once and calls `subscribeConversation(conv.id, …)` per id. There is no conversation-created event and no dynamic re-subscription, and `Chat.svelte` receives live messages solely through that global stream. A conversation created *after* connect therefore only begins streaming after a reconnect. Removing the reconnect on the new-conversation path would leave the mind's first reply undelivered until the next reconnect (navigate-away-and-back, network blip, etc.).

So a brand-new conversation still notifies the parent once and keeps the existing `connectActivity()` reconnect — that reconnect is *required*, not incidental. New conversations and channel joins are rare; the per-send storm was the actual bug, and it's gone.

## Impact (reasoned)

- Message to an existing conversation (the overwhelming majority of sends): **0** SSE reconnects, **0** `/api/minds` / `/api/extensions` / provider calls, **0** health checks. Previously every one of these fired on every send.
- First message to a new DM / channel join: unchanged (one reconnect, as before and as required for SSE subscription).

## Test plan

- `npx svelte-check` on `packages/web`: 0 errors.
- `npm run build:web`: succeeds.
- Full `npm test`: 2084 pass, 0 fail.
- Manual reasoning traced end-to-end: existing-conversation send skips notify; new-DM first send (`currentConvId === null`) still notifies and reconnects so the reply streams; `currentConvId` is still assigned unconditionally and the send error path is untouched.

## Review

Reviewed by code-reviewer, silent-failure-hunter, and pr-test-analyzer. The code-reviewer's critical finding (removing the new-conversation reconnect breaks live delivery) drove the scope-down to the single guard above; an earlier draft that swapped in a lighter `refreshConversations()` helper was reverted because it left new conversations unsubscribed on the live stream and its unread-seeding relied on an `unreadCount` field the `/api/v1/conversations` endpoint never returns.

Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)