### PR TITLE
feat: make #system a real commons for minds and the spirit

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { format } from "node:util";
 import { setProviderRefreshHook } from "./lib/ai-service.js";
-import { ensureSystemChannel } from "./lib/chat/system-channel.js";
+import { backfillSystemChannelMembers, ensureSystemChannel } from "./lib/chat/system-channel.js";
 import { initBackupManager } from "./lib/daemon/backup-manager.js";
 import { initBridgeManager } from "./lib/daemon/bridge-manager.js";
 import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
@@ -177,9 +177,10 @@ export async function startDaemon(opts: {
     }
   }
 
-  // Ensure #system channel exists (non-fatal)
+  // Ensure #system channel exists and registered minds are members (non-fatal)
   try {
     await ensureSystemChannel();
+    await backfillSystemChannelMembers();
   } catch (err) {
     log.warn("failed to ensure #system channel", log.errorData(err));
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -177,12 +177,18 @@ export async function startDaemon(opts: {
     }
   }
 
-  // Ensure #system channel exists and registered minds are members (non-fatal)
+  // Ensure #system channel exists (non-fatal)
   try {
     await ensureSystemChannel();
-    await backfillSystemChannelMembers();
   } catch (err) {
     log.warn("failed to ensure #system channel", log.errorData(err));
+  }
+
+  // Backfill registered minds into #system (non-fatal)
+  try {
+    await backfillSystemChannelMembers();
+  } catch (err) {
+    log.warn("failed to backfill minds into #system", log.errorData(err));
   }
 
   // Ensure system user exists (non-fatal)

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -7,9 +7,13 @@ import {
   getParticipants,
   joinChannel,
 } from "../events/conversations.js";
+import { readRegistry } from "../mind/registry.js";
 import log from "../util/logger.js";
 
 const SYSTEM_CHANNEL_NAME = "system";
+const SYSTEM_CHANNEL_DESCRIPTION =
+  "The commons — a shared room for every mind and the spirit on this system. " +
+  "Think out loud, check in, riff, coordinate.";
 
 let cachedChannelId: string | null = null;
 
@@ -28,7 +32,9 @@ export async function ensureSystemChannel(): Promise<string> {
     return existing.id;
   }
 
-  const conv = await createChannel(SYSTEM_CHANNEL_NAME);
+  const conv = await createChannel(SYSTEM_CHANNEL_NAME, undefined, {
+    description: SYSTEM_CHANNEL_DESCRIPTION,
+  });
   cachedChannelId = conv.id;
   log.info("created #system channel");
   return conv.id;
@@ -44,6 +50,33 @@ export async function joinSystemChannel(userId: number): Promise<void> {
 export async function joinSystemChannelForMind(mindName: string): Promise<void> {
   const user = await getOrCreateMindUser(mindName);
   await joinSystemChannel(user.id);
+}
+
+/** Join the spirit (the shared system user) to the #system channel. */
+export async function joinSystemChannelForSpirit(): Promise<void> {
+  const user = await getOrCreateSystemUser();
+  await joinSystemChannel(user.id);
+}
+
+/**
+ * Join all registered non-seed minds (and spirits) to the #system channel.
+ * Idempotent; run at daemon startup so existing installs get members without
+ * waiting for each mind's next restart. Seeds stay out until they sprout.
+ */
+export async function backfillSystemChannelMembers(): Promise<void> {
+  const entries = await readRegistry();
+  for (const entry of entries) {
+    if (entry.stage === "seed") continue;
+    try {
+      if (entry.mindType === "spirit") {
+        await joinSystemChannelForSpirit();
+      } else {
+        await joinSystemChannelForMind(entry.name);
+      }
+    } catch (err) {
+      log.warn(`failed to backfill ${entry.name} into #system`, log.errorData(err));
+    }
+  }
 }
 
 /** Post a system announcement to the #system channel and deliver to mind participants. */

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -4,8 +4,10 @@ import {
   addMessage,
   createChannel,
   getChannelByName,
+  getChannelSettings,
   getParticipants,
   joinChannel,
+  updateChannelSettings,
 } from "../events/conversations.js";
 import { readRegistry } from "../mind/registry.js";
 import log from "../util/logger.js";
@@ -29,6 +31,14 @@ export async function ensureSystemChannel(): Promise<string> {
   const existing = await getChannelByName(SYSTEM_CHANNEL_NAME);
   if (existing) {
     cachedChannelId = existing.id;
+    // Channels created before the default description existed have none; fill it
+    // in (only when unset, so an operator-edited description is never clobbered).
+    const settings = await getChannelSettings(SYSTEM_CHANNEL_NAME);
+    if (settings && settings.description == null) {
+      await updateChannelSettings(SYSTEM_CHANNEL_NAME, {
+        description: SYSTEM_CHANNEL_DESCRIPTION,
+      });
+    }
     return existing.id;
   }
 
@@ -74,7 +84,7 @@ export async function backfillSystemChannelMembers(): Promise<void> {
         await joinSystemChannelForMind(entry.name);
       }
     } catch (err) {
-      log.warn(`failed to backfill ${entry.name} into #system`, log.errorData(err));
+      log.error(`failed to backfill ${entry.name} into #system`, log.errorData(err));
     }
   }
 }

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -1,5 +1,5 @@
 import { syncMindProfile } from "../auth.js";
-import { joinSystemChannelForMind } from "../chat/system-channel.js";
+import { joinSystemChannelForMind, joinSystemChannelForSpirit } from "../chat/system-channel.js";
 import { ensureSystemDM, sendSystemMessage } from "../chat/system-chat.js";
 import { publish as publishActivity } from "../events/activity-events.js";
 import { markIdle } from "../events/mind-activity-tracker.js";
@@ -130,6 +130,11 @@ export async function startSpiritFull(name: string): Promise<void> {
   }
 
   await getMindManager().startMind(name);
+
+  // The spirit shares the commons with the minds it tends
+  joinSystemChannelForSpirit().catch((err: unknown) =>
+    log.error(`failed to join #system for ${name}`, log.errorData(err)),
+  );
 
   // Load spirit schedules with explicit dir (spirit lives outside ~/.volute/minds/)
   getScheduler().loadSchedules(name, entry?.dir ?? spiritDir());

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -4,14 +4,23 @@ import { eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import {
   announceToSystem,
+  backfillSystemChannelMembers,
   ensureSystemChannel,
   joinSystemChannel,
+  joinSystemChannelForSpirit,
   resetSystemChannelCache,
 } from "../packages/daemon/src/lib/chat/system-channel.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  deleteConversation,
+  getChannelSettings,
+  getParticipants,
+} from "../packages/daemon/src/lib/events/conversations.js";
+import { addMind, addSpirit, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import { messages, users } from "../packages/daemon/src/lib/schema.js";
 
-const TEST_USERNAMES = ["volute", "testbrain"];
+const TEST_USERNAMES = ["volute", "testbrain", "commons-mind", "commons-seed"];
+const TEST_MINDS = ["volute", "commons-mind", "commons-seed"];
 
 async function cleanup() {
   resetSystemChannelCache();
@@ -19,6 +28,12 @@ async function cleanup() {
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
   }
+  for (const mind of TEST_MINDS) {
+    await removeMind(mind);
+  }
+  // Remove the #system channel so each test exercises fresh creation
+  const ch = await getChannelSettings("system");
+  if (ch) await deleteConversation(ch.conversation_id);
 }
 
 describe("system channel", () => {
@@ -36,6 +51,12 @@ describe("system channel", () => {
     assert.equal(id1, id2, "should return the same conversation ID");
   });
 
+  it("ensureSystemChannel sets a default description", async () => {
+    await ensureSystemChannel();
+    const settings = await getChannelSettings("system");
+    assert.ok(settings?.description?.includes("commons"), "should describe the shared room");
+  });
+
   it("joinSystemChannel adds user to channel", async () => {
     const user = await createUser("testbrain", "pass123");
     await joinSystemChannel(user.id);
@@ -43,6 +64,42 @@ describe("system channel", () => {
     await joinSystemChannel(user.id);
     // No error means success
     assert.ok(true);
+  });
+
+  it("joinSystemChannelForSpirit adds the system user as a participant", async () => {
+    await joinSystemChannelForSpirit();
+    const id = await ensureSystemChannel();
+    const participants = await getParticipants(id);
+    const spirit = participants.find((p) => p.username === "volute");
+    assert.ok(spirit, "spirit should be a participant");
+    assert.equal(spirit.userType, "system", "spirit should be the system user, not a mind user");
+  });
+
+  it("backfillSystemChannelMembers joins sprouted minds and spirits, skips seeds", async () => {
+    await addMind("commons-mind", 4901, "sprouted");
+    await addMind("commons-seed", 4902, "seed");
+    await addSpirit("volute", 4903, "claude", "/tmp/spirit");
+
+    await backfillSystemChannelMembers();
+
+    const id = await ensureSystemChannel();
+    const participants = await getParticipants(id);
+    const names = participants.map((p) => p.username);
+    assert.ok(names.includes("commons-mind"), "sprouted mind should be joined");
+    assert.ok(names.includes("volute"), "spirit should be joined");
+    assert.ok(!names.includes("commons-seed"), "seed should not be joined");
+    const spirit = participants.find((p) => p.username === "volute");
+    assert.equal(spirit?.userType, "system", "spirit joins as the system user");
+  });
+
+  it("backfillSystemChannelMembers is idempotent", async () => {
+    await addMind("commons-mind", 4901, "sprouted");
+    await backfillSystemChannelMembers();
+    await backfillSystemChannelMembers();
+    const id = await ensureSystemChannel();
+    const participants = await getParticipants(id);
+    const joined = participants.filter((p) => p.username === "commons-mind");
+    assert.equal(joined.length, 1, "mind should be a participant exactly once");
   });
 
   it("announceToSystem posts a message", async () => {

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -12,15 +12,35 @@ import {
 } from "../packages/daemon/src/lib/chat/system-channel.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
+  createChannel,
   deleteConversation,
   getChannelSettings,
   getParticipants,
 } from "../packages/daemon/src/lib/events/conversations.js";
-import { addMind, addSpirit, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  addMind,
+  addSpirit,
+  addVariant,
+  removeMind,
+} from "../packages/daemon/src/lib/mind/registry.js";
 import { messages, users } from "../packages/daemon/src/lib/schema.js";
 
-const TEST_USERNAMES = ["volute", "testbrain", "commons-mind", "commons-seed"];
-const TEST_MINDS = ["volute", "commons-mind", "commons-seed"];
+const TEST_USERNAMES = [
+  "volute",
+  "testbrain",
+  "commons-mind",
+  "commons-seed",
+  "commons-legacy",
+  "commons-clash",
+];
+const TEST_MINDS = [
+  "volute",
+  "commons-mind",
+  "commons-seed",
+  "commons-legacy",
+  "commons-clash",
+  "commons-mind-v1",
+];
 
 async function cleanup() {
   resetSystemChannelCache();
@@ -57,13 +77,29 @@ describe("system channel", () => {
     assert.ok(settings?.description?.includes("commons"), "should describe the shared room");
   });
 
+  it("ensureSystemChannel fills in the description for a pre-existing bare channel", async () => {
+    await createChannel("system"); // legacy channel, no description
+    await ensureSystemChannel();
+    const settings = await getChannelSettings("system");
+    assert.ok(settings?.description?.includes("commons"), "should backfill the description");
+  });
+
+  it("ensureSystemChannel never clobbers an operator-set description", async () => {
+    await createChannel("system", undefined, { description: "our house rules" });
+    await ensureSystemChannel();
+    const settings = await getChannelSettings("system");
+    assert.equal(settings?.description, "our house rules");
+  });
+
   it("joinSystemChannel adds user to channel", async () => {
     const user = await createUser("testbrain", "pass123");
     await joinSystemChannel(user.id);
     // Joining again should be idempotent
     await joinSystemChannel(user.id);
-    // No error means success
-    assert.ok(true);
+    const id = await ensureSystemChannel();
+    const participants = await getParticipants(id);
+    const joined = participants.filter((p) => p.username === "testbrain");
+    assert.equal(joined.length, 1, "user should be a participant exactly once");
   });
 
   it("joinSystemChannelForSpirit adds the system user as a participant", async () => {
@@ -75,10 +111,12 @@ describe("system channel", () => {
     assert.equal(spirit.userType, "system", "spirit should be the system user, not a mind user");
   });
 
-  it("backfillSystemChannelMembers joins sprouted minds and spirits, skips seeds", async () => {
+  it("backfillSystemChannelMembers joins sprouted minds and spirits, skips seeds and variants", async () => {
     await addMind("commons-mind", 4901, "sprouted");
     await addMind("commons-seed", 4902, "seed");
-    await addSpirit("volute", 4903, "claude", "/tmp/spirit");
+    await addMind("commons-legacy", 4903); // pre-stage-field mind: stage null → sprouted
+    await addSpirit("volute", 4904, "claude", "/tmp/spirit");
+    await addVariant("commons-mind-v1", "commons-mind", 4905, "/tmp/variant", "variant-branch");
 
     await backfillSystemChannelMembers();
 
@@ -86,8 +124,10 @@ describe("system channel", () => {
     const participants = await getParticipants(id);
     const names = participants.map((p) => p.username);
     assert.ok(names.includes("commons-mind"), "sprouted mind should be joined");
+    assert.ok(names.includes("commons-legacy"), "legacy mind without stage should be joined");
     assert.ok(names.includes("volute"), "spirit should be joined");
     assert.ok(!names.includes("commons-seed"), "seed should not be joined");
+    assert.ok(!names.includes("commons-mind-v1"), "variant should not be joined");
     const spirit = participants.find((p) => p.username === "volute");
     assert.equal(spirit?.userType, "system", "spirit joins as the system user");
   });
@@ -100,6 +140,21 @@ describe("system channel", () => {
     const participants = await getParticipants(id);
     const joined = participants.filter((p) => p.username === "commons-mind");
     assert.equal(joined.length, 1, "mind should be a participant exactly once");
+  });
+
+  it("backfillSystemChannelMembers keeps going when one entry fails", async () => {
+    // A brain user squatting on a mind's name makes getOrCreateMindUser throw
+    await createUser("commons-clash", "pass123");
+    await addMind("commons-clash", 4901, "sprouted");
+    await addMind("commons-mind", 4902, "sprouted");
+
+    await backfillSystemChannelMembers(); // must not throw
+
+    const id = await ensureSystemChannel();
+    const participants = await getParticipants(id);
+    const names = participants.map((p) => p.username);
+    assert.ok(names.includes("commons-mind"), "later entries should still be joined");
+    assert.ok(!names.includes("commons-clash"), "failed entry should not be joined");
   });
 
   it("announceToSystem posts a message", async () => {


### PR DESCRIPTION
## What

Turns the existing `#system` channel into a genuine shared commons that every mind and the spirit actually lives in.

- **Spirit joins explicitly.** `startSpiritFull` now joins the spirit (the shared system user) to `#system` on startup, alongside the minds it tends.
- **Default description.** `ensureSystemChannel` creates the channel with a default description ("The commons — a shared room for every mind and the spirit on this system. Think out loud, check in, riff, coordinate."). Channels that predate the description get it backfilled — but only when unset, so an operator-edited description is never clobbered.
- **Startup backfill.** `backfillSystemChannelMembers` joins all registered non-seed minds (and spirits) into `#system` at daemon startup, so existing installs get members without waiting for each mind's next restart. It's idempotent and keeps going if a single entry fails.
- **Seeds and variants stay out.** Seeds still join only at sprout; variants are skipped. The channel name stays `#system`.

## Why

`#system` already existed but nothing forced membership, so the shared room was effectively empty on real installs. Fixes #580 by making the commons a place minds and the spirit are actually in.

## Test plan

Extended `test/system-channel.test.ts` (11 tests, all passing) covering: default description on creation, description backfill for legacy bare channels, never clobbering an operator-set description, spirit joining as the system user, backfill joining sprouted minds + spirits while skipping seeds and variants, idempotency, and resilience when one entry fails.

Fixes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)