### PR TITLE
fix: stop system rollup fallback doubling the period prefix and dropping mind attribution

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -482,6 +482,54 @@ function buildPeriodicDeterministicSummary(
   }
 }
 
+/**
+ * Matches a deterministic week/month digest header ("Week <key> (notice)\n\n" or
+ * "<key> (notice)\n\n") at the start of a child summary. Built from DIGEST_NOTICE so it can't
+ * drift from the emitted header.
+ */
+const DIGEST_HEADER_PREFIX = new RegExp(
+  `^(?:Week )?\\S+ ${DIGEST_NOTICE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\n\\n`,
+);
+
+/**
+ * Strip a leading deterministic period prefix ("Activity during HH:00: " / "Activity on
+ * YYYY-MM-DD:\n\n") or week/month digest header so the system rollup doesn't double it when its
+ * per-mind children were themselves deterministic. Anchored, so AI-generated children (no such
+ * prefix) pass through untouched.
+ */
+function stripPeriodPrefix(text: string): string {
+  return text
+    .replace(/^Activity during \d{2}:00: /, "")
+    .replace(/^Activity on \d{4}-\d{2}-\d{2}:\n\n/, "")
+    .replace(DIGEST_HEADER_PREFIX, "");
+}
+
+/**
+ * Deterministic fallback for the `_system` rollup. Unlike the per-mind builder, its children
+ * are per-mind period summaries — so it keeps per-mind attribution (`[mind]` for hour/day,
+ * `mind:` digest lines for week/month) and strips each child's own period prefix, applying
+ * the period prefix exactly once (see #566).
+ */
+function buildSystemDeterministicSummary(
+  entries: ChildEntry[],
+  period: TimerPeriod,
+  periodKey: string,
+): string {
+  if (entries.length === 0) return "";
+  const stripped = entries.map((e) => ({ key: e.key, text: stripPeriodPrefix(e.text) }));
+  switch (period) {
+    case "hour":
+      return `Activity during ${periodKey.slice(11)}:00: ${stripped.map((e) => `[${e.key}] ${e.text}`).join(" ")}`;
+    case "day":
+      return `Activity on ${periodKey}:\n\n${stripped.map((e) => `[${e.key}] ${e.text}`).join("\n\n")}`;
+    case "week":
+    case "month":
+      // The digest already attributes per mind (`key: …` lines); stripping keeps a
+      // deterministic daily child's own "Activity on …" prefix out of its digest line.
+      return buildBoundedDigest(stripped, period, periodKey);
+  }
+}
+
 function parseMeta(raw: string | null): Record<string, unknown> {
   if (!raw) return {};
   try {
@@ -774,7 +822,7 @@ export async function summarizeSystem(
     content = aiResult;
     deterministic = false;
   } else {
-    content = buildPeriodicDeterministicSummary(entries, period, periodKey);
+    content = buildSystemDeterministicSummary(entries, period, periodKey);
     deterministic = true;
     if (period === "week" || period === "month") trackProvisionalAttempt(metadata, existingMeta);
   }

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -1112,6 +1112,90 @@ describe("summarizer", () => {
       assert.ok(!row!.content.includes(huge), "oversized child must not appear verbatim");
     });
 
+    it("system hour rollup keeps a single prefix and per-mind attribution (#566)", async () => {
+      const key = "2026-05-11T01";
+      // Per-mind hour children whose deterministic content already carries the hour prefix.
+      await insertSummary("echo", "hour", key, "Activity during 01:00: Received message on @root.");
+      await insertSummary(
+        "fresh",
+        "hour",
+        key,
+        "Activity during 01:00: Received message on @root. Used Bash, Read. Sent response.",
+      );
+
+      await summarizeSystem("hour", key, failAi);
+
+      const row = await getSummary("_system", "hour", key);
+      assert.ok(row, "_system hour summary should exist");
+      // Prefix applied exactly once.
+      const prefixCount = (row!.content.match(/Activity during 01:00:/g) ?? []).length;
+      assert.equal(prefixCount, 1, `expected one prefix, got ${prefixCount}: ${row!.content}`);
+      // Per-mind attribution preserved.
+      assert.match(row!.content, /\[echo\] Received message on @root\./);
+      assert.match(row!.content, /\[fresh\] Received message on @root\. Used Bash, Read\./);
+    });
+
+    it("system day rollup strips child prefixes but leaves AI children intact (#566)", async () => {
+      const key = "2026-05-12";
+      // Deterministic child (carries the day prefix) + AI-style child (no prefix).
+      await insertSummary("echo", "day", key, "Activity on 2026-05-12:\n\nWorked on the router.");
+      await insertSummary("fresh", "day", key, "Explored the codebase and wrote notes.");
+
+      await summarizeSystem("day", key, failAi);
+
+      const row = await getSummary("_system", "day", key);
+      assert.ok(row, "_system day summary should exist");
+      const prefixCount = (row!.content.match(/Activity on 2026-05-12:/g) ?? []).length;
+      assert.equal(prefixCount, 1, `expected one prefix, got ${prefixCount}: ${row!.content}`);
+      assert.match(row!.content, /\[echo\] Worked on the router\./);
+      // AI-style child passes through unmodified (no prefix to strip).
+      assert.match(row!.content, /\[fresh\] Explored the codebase and wrote notes\./);
+    });
+
+    it("system week rollup strips a deterministic child's own digest header (#566)", async () => {
+      // A realistic deterministic per-mind week child carries buildBoundedDigest's own
+      // "Week <key> (notice)" header — not a day prefix. The system week digest must strip that
+      // header so it isn't doubled inside each mind's line (the AI child has no header to strip).
+      await insertSummary(
+        "echo",
+        "week",
+        "2026-W20",
+        "Week 2026-W20 (auto-generated digest — AI summary pending)\n\n2026-05-11: Worked on the router.",
+      );
+      await insertSummary("fresh", "week", "2026-W20", "Explored the codebase.");
+
+      await summarizeSystem("week", "2026-W20", failAi);
+
+      const row = await getSummary("_system", "week", "2026-W20");
+      assert.ok(row, "_system week summary should exist");
+      assert.match(row!.content, /Week 2026-W20/, "system digest keeps its own week header");
+      // The notice belongs only to the system row's own header — the child's copy is stripped.
+      const noticeCount = (row!.content.match(/auto-generated digest/g) ?? []).length;
+      assert.equal(noticeCount, 1, `child digest header must be stripped: ${row!.content}`);
+      assert.match(row!.content, /^echo: 2026-05-11: Worked on the router\./m, "keeps attribution");
+      assert.match(row!.content, /^fresh: Explored the codebase\./m);
+    });
+
+    it("system month rollup strips a deterministic child's own digest header (#566)", async () => {
+      // Month children use the same digest header, sans the "Week " label; strip it too.
+      await insertSummary(
+        "echo",
+        "month",
+        "2026-05",
+        "2026-05 (auto-generated digest — AI summary pending)\n\n2026-05-11: Shipped the feature.",
+      );
+      await insertSummary("fresh", "month", "2026-05", "Reviewed pull requests.");
+
+      await summarizeSystem("month", "2026-05", failAi);
+
+      const row = await getSummary("_system", "month", "2026-05");
+      assert.ok(row, "_system month summary should exist");
+      const noticeCount = (row!.content.match(/auto-generated digest/g) ?? []).length;
+      assert.equal(noticeCount, 1, `child digest header must be stripped: ${row!.content}`);
+      assert.match(row!.content, /^echo: 2026-05-11: Shipped the feature\./m, "keeps attribution");
+      assert.match(row!.content, /^fresh: Reviewed pull requests\./m);
+    });
+
     it("repairProvisionalSummaries heals per-mind and _system rows", async () => {
       const mind = "repair-mind";
       await insertSummary(mind, "day", "2026-06-01", "Day one.");


### PR DESCRIPTION
## What

Fixes the deterministic (non-AI) fallback of the `_system` hour/day/week/month rollup in `summarizer.ts`, which produced malformed summaries when the AI summarizer was unavailable.

Two defects, observed live on the 0.47 integration env (`Activity during 01:00: Activity during 01:00: …`):

1. **Doubled period prefix** — the per-mind children fed into `summarizeSystem` already begin with `Activity during HH:00:` / `Activity on YYYY-MM-DD:`, and the old code called `buildPeriodicDeterministicSummary`, which prepended the same prefix again.
2. **Dropped mind attribution** — that builder joined `entries.map(e => e.text)`, discarding `e.key` (the mind name), so the system row was an anonymous concatenation of every mind's activity.

## Why / approach

The AI path already feeds the model `[mind] text`. This change gives the deterministic fallback the same shape via a dedicated `buildSystemDeterministicSummary`:

- Applies the period prefix exactly once, at the system level.
- Keeps per-mind attribution (`[mind] …` for hour/day; `mind: …` digest lines for week/month).
- Strips each child's own leading prefix via `stripPeriodPrefix` before joining. The regexes are anchored, so AI-generated children (no such prefix) pass through untouched.

`stripPeriodPrefix` also strips a deterministic child's own `Week <key> (auto-generated digest — AI summary pending)` / `<key> (…)` digest header (built from the `DIGEST_NOTICE` constant so it can't drift). Without this, the double-deterministic week/month case — where both the per-mind summary and the system rollup fall back — leaked the child's header and notice into each mind's digest line, the same doubling bug class for the longer periods.

Result: `Activity during 01:00: [echo] Received message on @root. … [fresh] Received message on @root. Used Bash, Read. …`

## Test plan

Extends `test/summarizer.test.ts` deterministic-fallback coverage (AI forced off via `failAi`, asserting the persisted `_system` row):

- **hour**: already-prefixed children yield a single prefix and per-mind `[mind]` attribution.
- **day**: deterministic child's prefix is stripped; an AI-style child (no prefix) passes through unmodified.
- **week**: a realistic `Week <key> (notice)`-headered deterministic child has its header stripped (asserted via a single `auto-generated digest` occurrence) while attribution is kept.
- **month**: same, for the header form without the `Week` label.

- `npm test`: 2071 tests, 0 failures.
- `tsc --noEmit`: clean.

Fixes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
