### PR TITLE
fix: surface missing model credentials instead of failing silently

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -38,6 +38,8 @@ const cmd = command({
       name?: string;
       port?: number;
       message?: string;
+      warning?: string;
+      credentialWarning?: string;
     };
 
     if (!res.ok) {
@@ -47,6 +49,8 @@ const cmd = command({
 
     const created = data.name ?? name;
     console.log(`\n${data.message ?? `Created mind: ${created} (port ${data.port})`}`);
+    if (data.warning) console.warn(`\n⚠ ${data.warning}`);
+    if (data.credentialWarning) console.warn(`\n⚠ ${data.credentialWarning}`);
     console.log(`\nStart it, then say hello:`);
     console.log(`  volute mind start ${created}`);
     console.log(`  volute chat send @${created} "hello"`);

--- a/packages/cli/src/commands/mind-status.ts
+++ b/packages/cli/src/commands/mind-status.ts
@@ -39,6 +39,7 @@ const cmd = command({
       channels?: Array<{ type: string; status: string }>;
       variants?: Array<{ name: string; status: string }>;
       hasPages?: boolean;
+      lastNotice?: { kind: string; reason: string; detail: string; created_at: string };
     };
 
     const status = mind.status ?? (mind.running ? "running" : "stopped");
@@ -50,6 +51,13 @@ const cmd = command({
     if (mind.model) console.log(`Model:   ${mind.model}`);
     if (mind.templateStale) {
       console.log(`Template: outdated — run 'volute mind upgrade ${mind.name}'`);
+    }
+
+    // Surface the newest un-drained failure notice so a silent mind explains itself
+    // (e.g. missing credentials, a failed turn) without reading the DB or logs. #573
+    if (mind.lastNotice) {
+      const label = mind.lastNotice.kind === "turn_error" ? "Last turn failed" : "Last issue";
+      console.log(`\n${label}: ${mind.lastNotice.detail}`);
     }
 
     if (mind.channels && mind.channels.length > 0) {

--- a/packages/cli/src/commands/seed-create.ts
+++ b/packages/cli/src/commands/seed-create.ts
@@ -109,12 +109,15 @@ const cmd = command({
       error?: string;
       name?: string;
       port?: number;
+      credentialWarning?: string;
     };
 
     if (!createRes.ok) {
       console.error(createData.error ?? "Failed to create mind");
       process.exit(1);
     }
+
+    if (createData.credentialWarning) console.warn(`\n⚠ ${createData.credentialWarning}`);
 
     // Start the mind
     const startRes = await daemonFetch(

--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -195,9 +195,12 @@ export function providerForMindTemplate(
 /**
  * If a mind of this template/model would spawn without usable model credentials,
  * return an operator-actionable warning explaining it will stay silent and how to
- * fix it; otherwise null. Checks the same sources the daemon injects at spawn
- * (OAuth, stored key, ambient env), so it reflects what the mind will actually get.
- * Non-blocking by design: creation still proceeds, the mind just can't reply yet.
+ * fix it; otherwise null. Checks the same sources the mind's spawn env is built
+ * from: provider OAuth/stored key/ambient env (what the daemon injects), plus the
+ * shared and per-mind env.json — which survive into the mind env, and which the
+ * warning's own remediation (`volute env set`) writes to, so the recommended fix
+ * clears the alarm. Non-blocking by design: creation still proceeds, the mind just
+ * can't reply yet.
  */
 export async function missingCredentialWarning(
   template: string | undefined,
@@ -206,11 +209,16 @@ export async function missingCredentialWarning(
 ): Promise<string | null> {
   const provider = providerForMindTemplate(template, model);
   if (!provider) return null; // provider undeterminable — don't warn on the unverifiable
+  const envVar =
+    PROVIDER_ENV_VAR[provider] ?? `${provider.toUpperCase().replace(/-/g, "_")}_API_KEY`;
   if (await resolveApiKey(provider)) return null;
   // Codex also honors an ambient OPENAI_API_KEY that resolveApiKey may not surface.
   if (provider === "openai-codex" && process.env.OPENAI_API_KEY) return null;
-  const envVar =
-    PROVIDER_ENV_VAR[provider] ?? `${provider.toUpperCase().replace(/-/g, "_")}_API_KEY`;
+  // A key set via `volute env set` (shared or per-mind env.json) is spread into the
+  // mind's spawn env and works without a configured provider. Safe pre-create too:
+  // a missing per-mind env.json reads as empty and the shared env still applies.
+  const { loadMergedEnv } = await import("./config/env.js");
+  if (loadMergedEnv(mindName)[envVar]) return null;
   return (
     `No ${provider} credentials are configured, so ${mindName} will start but stay silent ` +
     `until a key is available. Set one with \`volute env set ${envVar} <key> --mind ${mindName}\`, ` +

--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -161,6 +161,63 @@ function templateForProvider(provider: string): string {
   return "pi";
 }
 
+/** Env var each provider's key is injected under (mirrors mind-manager injection). */
+const PROVIDER_ENV_VAR: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  "openai-codex": "OPENAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  openai: "OPENAI_API_KEY",
+  google: "GEMINI_API_KEY",
+  groq: "GROQ_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  zai: "ZAI_API_KEY",
+};
+
+/**
+ * The provider whose credentials a mind of this template needs at spawn. Mirrors
+ * the credential injection in `MindManager.startMind`: claude → anthropic, codex →
+ * openai-codex, pi → the provider prefix of its `provider:model` id. Returns
+ * undefined when the provider can't be determined (a pi mind whose model we don't
+ * have) — callers treat that as "can't verify, don't warn".
+ */
+export function providerForMindTemplate(
+  template: string | undefined,
+  model?: string,
+): string | undefined {
+  if (!template || template === "claude") return "anthropic";
+  if (template === "codex") return "openai-codex";
+  if (model?.includes(":")) return model.split(":")[0];
+  return undefined;
+}
+
+/**
+ * If a mind of this template/model would spawn without usable model credentials,
+ * return an operator-actionable warning explaining it will stay silent and how to
+ * fix it; otherwise null. Checks the same sources the daemon injects at spawn
+ * (OAuth, stored key, ambient env), so it reflects what the mind will actually get.
+ * Non-blocking by design: creation still proceeds, the mind just can't reply yet.
+ */
+export async function missingCredentialWarning(
+  template: string | undefined,
+  model: string | undefined,
+  mindName: string,
+): Promise<string | null> {
+  const provider = providerForMindTemplate(template, model);
+  if (!provider) return null; // provider undeterminable — don't warn on the unverifiable
+  if (await resolveApiKey(provider)) return null;
+  // Codex also honors an ambient OPENAI_API_KEY that resolveApiKey may not surface.
+  if (provider === "openai-codex" && process.env.OPENAI_API_KEY) return null;
+  const envVar =
+    PROVIDER_ENV_VAR[provider] ?? `${provider.toUpperCase().replace(/-/g, "_")}_API_KEY`;
+  return (
+    `No ${provider} credentials are configured, so ${mindName} will start but stay silent ` +
+    `until a key is available. Set one with \`volute env set ${envVar} <key> --mind ${mindName}\`, ` +
+    `or configure the ${provider} provider in the web dashboard (Settings → Providers).`
+  );
+}
+
 /**
  * Resolve the best template for a given model ID.
  * Anthropic models → "claude", OpenAI Codex models → "codex", everything else → "pi".

--- a/packages/daemon/src/lib/daemon/error-classify.ts
+++ b/packages/daemon/src/lib/daemon/error-classify.ts
@@ -12,14 +12,14 @@ export function classify(raw: string): Classified {
   const s = (raw ?? "").toLowerCase();
 
   if (
-    /\b(401|403)\b|authentication_error|invalid authentication|invalid x-api-key|unauthorized|permission_error/.test(
+    /\b(401|403)\b|authentication_error|invalid authentication|invalid x-api-key|invalid api key|missing api key|no api key|x-api-key header|could not resolve authentication|unauthorized|permission_error|please run \/login/.test(
       s,
     )
   ) {
     return {
       reason: "auth_error",
       detail:
-        "Your last turn failed because your model credentials were rejected (most often an expired token). The daemon refreshes them automatically, so this is normally transient — you're fine to continue.",
+        "Your last turn failed because the model provider rejected your credentials. A one-off is usually a briefly-expired token that the daemon refreshes automatically. If it keeps happening, your API key is likely missing or invalid — an operator needs to set a valid key (e.g. `volute env set ANTHROPIC_API_KEY <key>`) or reconnect the provider in the dashboard.",
     };
   }
 

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { missingCredentialWarning } from "../ai-service.js";
 import { syncMindProfile } from "../auth.js";
 import { joinSystemChannelForMind, joinSystemChannelForSpirit } from "../chat/system-channel.js";
@@ -104,15 +106,16 @@ export async function startMindFull(name: string): Promise<void> {
  * startup notice (deduped so it isn't re-added on every start). This is the
  * authoritative detection: the mind's own turn error is an opaque "process exited"
  * string, so the daemon — which knows the credentials are missing — surfaces the
- * real cause. Template is used to pick the provider; a pi mind's model isn't passed,
- * so pi minds (already guarded at create) are skipped when the provider is ambiguous.
+ * real cause. For pi minds the provider comes from the model in the mind's SDK
+ * config; if that can't be read the check is skipped rather than guessed.
+ * Exported for tests.
  */
-async function recordMissingCredentialsNotice(
+export async function recordMissingCredentialsNotice(
   mind: string,
   template: string | undefined,
 ): Promise<void> {
   const { hasUndeliveredNotice, recordNotice, MIND_LEVEL_SESSION } = await import("./notices.js");
-  const warning = await missingCredentialWarning(template, undefined, mind);
+  const warning = await missingCredentialWarning(template, readMindModel(mind, template), mind);
   if (!warning) return;
   if (await hasUndeliveredNotice(mind, "no_credentials")) return;
   await recordNotice({
@@ -122,6 +125,24 @@ async function recordMissingCredentialsNotice(
     reason: "no_credentials",
     detail: warning,
   });
+}
+
+/**
+ * The model a pi mind will actually run — from `home/.config/config.json`, the same
+ * file mind-manager reads for key injection. Only pi needs it (its provider is the
+ * `provider:` prefix of the model id); claude/codex resolve provider from template.
+ */
+function readMindModel(mind: string, template: string | undefined): string | undefined {
+  if (template !== "pi") return undefined;
+  try {
+    const configPath = resolve(mindDir(mind), "home/.config/config.json");
+    if (!existsSync(configPath)) return undefined;
+    const model: unknown = JSON.parse(readFileSync(configPath, "utf-8")).model;
+    return typeof model === "string" ? model : undefined;
+  } catch (err) {
+    log.warn(`failed to read model for ${mind}`, log.errorData(err));
+    return undefined;
+  }
 }
 
 /**

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -1,3 +1,4 @@
+import { missingCredentialWarning } from "../ai-service.js";
 import { syncMindProfile } from "../auth.js";
 import { joinSystemChannelForMind, joinSystemChannelForSpirit } from "../chat/system-channel.js";
 import { ensureSystemDM, sendSystemMessage } from "../chat/system-chat.js";
@@ -31,6 +32,14 @@ export async function startMindFull(name: string): Promise<void> {
   }).catch((err) => log.error("failed to publish mind_started activity", log.errorData(err)));
 
   if (entry?.parent) return;
+
+  // Missing model credentials make a mind mute — its first turn fails silently inside
+  // its own SDK process (#573). Record a notice so the failure is visible in
+  // `mind status` and the web chat status rather than only in the mind's log. Deduped
+  // per mind so repeated starts don't pile up identical notices.
+  recordMissingCredentialsNotice(baseName, entry?.template).catch((err) =>
+    log.error(`failed to check credentials for ${baseName}`, log.errorData(err)),
+  );
 
   // Seed minds get the server + initial orientation, no schedules or budget
   if (!entry || entry.stage === "seed") {
@@ -88,6 +97,31 @@ export async function startMindFull(name: string): Promise<void> {
   }
 
   notifyExtensionsMindStart(baseName);
+}
+
+/**
+ * If a mind spawned without usable model credentials, record a `no_credentials`
+ * startup notice (deduped so it isn't re-added on every start). This is the
+ * authoritative detection: the mind's own turn error is an opaque "process exited"
+ * string, so the daemon — which knows the credentials are missing — surfaces the
+ * real cause. Template is used to pick the provider; a pi mind's model isn't passed,
+ * so pi minds (already guarded at create) are skipped when the provider is ambiguous.
+ */
+async function recordMissingCredentialsNotice(
+  mind: string,
+  template: string | undefined,
+): Promise<void> {
+  const { hasUndeliveredNotice, recordNotice, MIND_LEVEL_SESSION } = await import("./notices.js");
+  const warning = await missingCredentialWarning(template, undefined, mind);
+  if (!warning) return;
+  if (await hasUndeliveredNotice(mind, "no_credentials")) return;
+  await recordNotice({
+    mind,
+    session: MIND_LEVEL_SESSION,
+    kind: "startup",
+    reason: "no_credentials",
+    detail: warning,
+  });
 }
 
 /**

--- a/packages/daemon/src/lib/daemon/notices.ts
+++ b/packages/daemon/src/lib/daemon/notices.ts
@@ -34,7 +34,7 @@ export type RecordNoticeInput = {
   | { kind: "turn_error"; reason: ErrorReason }
   | { kind: "crash"; reason: "process_crash" }
   | { kind: "budget"; reason: "token_budget" }
-  | { kind: "startup"; reason: "startup_failed" }
+  | { kind: "startup"; reason: "startup_failed" | "no_credentials" }
   | { kind: "extension"; reason: string }
 );
 
@@ -157,6 +157,36 @@ export async function latestFailureNotice(mind: string): Promise<FailureNotice |
     }
     return null;
   }
+}
+
+/**
+ * The most recent undelivered notice for a mind across all sessions, or null.
+ * Every row in the table is undelivered (delivered notices are deleted), so the
+ * highest-id row is the latest issue. Used by `mind status` to surface the newest
+ * failure without the mind having to drain it.
+ */
+export async function latestNotice(mind: string): Promise<Notice | null> {
+  const db = await getDb();
+  const row = await db
+    .select()
+    .from(mindNotices)
+    .where(eq(mindNotices.mind, mind))
+    .orderBy(desc(mindNotices.id))
+    .limit(1)
+    .get();
+  return row ?? null;
+}
+
+/** True if the mind has an undelivered notice with this reason (any session). */
+export async function hasUndeliveredNotice(mind: string, reason: NoticeReason): Promise<boolean> {
+  const db = await getDb();
+  const row = await db
+    .select({ id: mindNotices.id })
+    .from(mindNotices)
+    .where(and(eq(mindNotices.mind, mind), eq(mindNotices.reason, reason)))
+    .limit(1)
+    .get();
+  return row != null;
 }
 
 /**

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -288,6 +288,7 @@ export const mindNotices = sqliteTable(
         | "process_crash"
         | "token_budget"
         | "startup_failed"
+        | "no_credentials"
         // For kind="extension", reason holds the extension id (e.g. "notes").
         | (string & {})
       >()

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -12,7 +12,12 @@ import { zValidator } from "@hono/zod-validator";
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { z } from "zod";
-import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../../lib/ai-service.js";
+import {
+  missingCredentialWarning,
+  qualifyModelId,
+  resolveTemplate,
+  unqualifyModelId,
+} from "../../lib/ai-service.js";
 import { deleteMindUser } from "../../lib/auth.js";
 import { announceToSystem } from "../../lib/chat/system-channel.js";
 import { readSystemsConfig } from "../../lib/config/systems-config.js";
@@ -26,6 +31,7 @@ import {
   drainNotices,
   formatNotices,
   latestFailureNotice,
+  latestNotice,
   recordNotice,
 } from "../../lib/daemon/notices.js";
 import { getTokenBudget } from "../../lib/daemon/token-budget.js";
@@ -1089,6 +1095,17 @@ const app = new Hono<AuthEnv>()
       // Announce to #system channel
       announceToSystem(`${name} has joined`).catch(() => {});
 
+      // Warn (don't block) when the mind will spawn without usable model credentials,
+      // so a mute-on-first-turn mind is caught at creation rather than in silence (#573).
+      // The mind is already created — an advisory check must never fail creation, so
+      // swallow any hiccup and just omit the warning.
+      const credentialWarning = await missingCredentialWarning(template, body.model, name).catch(
+        (err) => {
+          log.warn(`credential check failed for ${name}`, log.errorData(err));
+          return null;
+        },
+      );
+
       return c.json({
         ok: true,
         name,
@@ -1096,6 +1113,7 @@ const app = new Hono<AuthEnv>()
         stage: body.stage ?? "sprouted",
         message: `Created mind: ${name} (port ${port})`,
         ...(gitWarning && { warning: gitWarning }),
+        ...(credentialWarning && { credentialWarning }),
         ...(skillWarnings.length > 0 && { skillWarnings }),
       });
     } catch (err) {
@@ -1345,12 +1363,24 @@ const app = new Hono<AuthEnv>()
       }),
     );
 
+    // Surface the newest un-drained notice (turn error, crash, missing credentials)
+    // so `mind status` can show why a mind is silent (#573). Admin/system only.
+    const notice = await latestNotice(name);
+
     return c.json({
       ...entry,
       ...mindStatus,
       variants: variantStatuses,
       hasPages,
       templateStale: isTemplateStale(entry),
+      ...(notice && {
+        lastNotice: {
+          kind: notice.kind,
+          reason: notice.reason,
+          detail: notice.detail,
+          created_at: notice.created_at,
+        },
+      }),
     });
   })
   // Context info — proxy to mind's /context endpoint

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -894,6 +894,10 @@ const app = new Hono<AuthEnv>()
       // Generate Ed25519 keypair for mind identity
       const { publicKeyPem } = generateIdentity(dest);
 
+      // The model the mind will actually run (request, or default cognition model),
+      // provider-qualified — feeds the credential warning below so pi minds created
+      // from defaults are checked too.
+      let effectiveModel: string | undefined = body.model;
       // Merge default settings into volute.json and config.json
       {
         const { readGlobalConfig: readGlobal } = await import("../../lib/config/setup.js");
@@ -937,6 +941,7 @@ const app = new Hono<AuthEnv>()
 
         // Apply model (and compaction) to SDK config.json
         const modelId = body.model ?? cog?.model;
+        effectiveModel = modelId ? qualifyModelId(modelId) : undefined;
         const sdkConfigPath = resolve(dest, "home/.config/config.json");
         if (modelId || cog?.compaction) {
           const existing = existsSync(sdkConfigPath)
@@ -1099,12 +1104,14 @@ const app = new Hono<AuthEnv>()
       // so a mute-on-first-turn mind is caught at creation rather than in silence (#573).
       // The mind is already created — an advisory check must never fail creation, so
       // swallow any hiccup and just omit the warning.
-      const credentialWarning = await missingCredentialWarning(template, body.model, name).catch(
-        (err) => {
-          log.warn(`credential check failed for ${name}`, log.errorData(err));
-          return null;
-        },
-      );
+      const credentialWarning = await missingCredentialWarning(
+        template,
+        effectiveModel,
+        name,
+      ).catch((err) => {
+        log.warn(`credential check failed for ${name}`, log.errorData(err));
+        return null;
+      });
 
       return c.json({
         ok: true,

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -36,6 +36,13 @@ for (const [k, v] of Object.entries(process.env)) {
   if (!k.startsWith("GIT_") && v !== undefined) cleanEnv[k] = v;
 }
 cleanEnv.VOLUTE_BASE_PORT = String(MIND_BASE_PORT);
+// Give the daemon an anthropic key so the claude test mind is treated as
+// credentialed. Otherwise startMindFull records a `no_credentials` startup
+// notice (#573) for the keyless mind, which is a mind-level notice that bleeds
+// into every session drain and pollutes the notice-count assertions below. These
+// tests model transient turn errors on an otherwise-configured mind, not a mute
+// keyless one. Deterministic across hosts regardless of ambient env.
+if (!cleanEnv.ANTHROPIC_API_KEY) cleanEnv.ANTHROPIC_API_KEY = "sk-ant-e2e-dummy-key";
 
 const TEST_MIND = "e2e-test-mind";
 const PORT = 14200 + Math.floor(Math.random() * 800);

--- a/test/error-classify.test.ts
+++ b/test/error-classify.test.ts
@@ -16,6 +16,22 @@ describe("error classify", () => {
     }
   });
 
+  it("classifies missing / invalid API key errors as actionable auth_error", () => {
+    const cases = [
+      "Invalid API key",
+      "missing API key",
+      "no API key provided",
+      "x-api-key header is required",
+      "Could not resolve authentication method",
+      "Please run /login",
+    ];
+    for (const c of cases) {
+      assert.equal(classify(c).reason, "auth_error", c);
+      // Actionable: points the operator at setting a key / reconnecting the provider.
+      assert.match(classify(c).detail, /volute env set|provider/i, c);
+    }
+  });
+
   it("classifies rate limit and overload errors", () => {
     assert.equal(classify("429 Too Many Requests").reason, "rate_limit");
     assert.equal(classify("rate limit exceeded").reason, "rate_limit");

--- a/test/missing-credentials.test.ts
+++ b/test/missing-credentials.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   missingCredentialWarning,
   providerForMindTemplate,
 } from "../packages/daemon/src/lib/ai-service.js";
+import { mindEnvPath, writeEnv } from "../packages/daemon/src/lib/config/env.js";
+import { drainNotices } from "../packages/daemon/src/lib/daemon/notices.js";
 
 describe("providerForMindTemplate", () => {
   it("maps templates to the provider whose key the mind needs", () => {
@@ -17,25 +21,28 @@ describe("providerForMindTemplate", () => {
   });
 });
 
+// Provider keys resolve from ambient env, so control it explicitly for determinism.
+const KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"];
+let saved: Record<string, string | undefined>;
+
+function stashKeys() {
+  saved = {};
+  for (const k of KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+}
+
+function restoreKeys() {
+  for (const k of KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+}
+
 describe("missingCredentialWarning", () => {
-  // Provider keys resolve from ambient env, so control it explicitly for determinism.
-  const KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
-  let saved: Record<string, string | undefined>;
-
-  beforeEach(() => {
-    saved = {};
-    for (const k of KEYS) {
-      saved[k] = process.env[k];
-      delete process.env[k];
-    }
-  });
-
-  afterEach(() => {
-    for (const k of KEYS) {
-      if (saved[k] === undefined) delete process.env[k];
-      else process.env[k] = saved[k];
-    }
-  });
+  beforeEach(stashKeys);
+  afterEach(restoreKeys);
 
   it("warns, actionably, when a claude mind has no anthropic credentials", async () => {
     const warning = await missingCredentialWarning("claude", undefined, "mute-mind");
@@ -57,9 +64,79 @@ describe("missingCredentialWarning", () => {
     assert.equal(warning, null);
   });
 
+  it("names the pi provider's env var in the warning", async () => {
+    const warning = await missingCredentialWarning("pi", "openrouter:some-model", "pi-mind");
+    assert.ok(warning);
+    assert.match(warning!, /openrouter/i);
+    assert.match(warning!, /volute env set OPENROUTER_API_KEY/);
+  });
+
   it("honors an ambient OPENAI_API_KEY for codex minds", async () => {
     process.env.OPENAI_API_KEY = "sk-openai-test";
     const warning = await missingCredentialWarning("codex", undefined, "codex-mind");
     assert.equal(warning, null);
+  });
+
+  it("honors a key set in the mind's env.json — the warning's own remediation", async () => {
+    const mind = `envjson-mind-${process.pid}`;
+    writeEnv(mindEnvPath(mind), { ANTHROPIC_API_KEY: "sk-ant-from-env-json" });
+    try {
+      const warning = await missingCredentialWarning("claude", undefined, mind);
+      assert.equal(warning, null);
+    } finally {
+      rmSync(mindEnvPath(mind), { force: true });
+    }
+  });
+});
+
+describe("recordMissingCredentialsNotice", () => {
+  beforeEach(stashKeys);
+  afterEach(restoreKeys);
+
+  it("records exactly one deduped no_credentials notice for a keyless claude mind", async () => {
+    const { recordMissingCredentialsNotice } = await import(
+      "../packages/daemon/src/lib/daemon/mind-service.js"
+    );
+    const mind = `nocreds-claude-${process.pid}-${Date.now()}`;
+    await recordMissingCredentialsNotice(mind, "claude");
+    await recordMissingCredentialsNotice(mind, "claude"); // dedup: no second notice
+    const notices = await drainNotices(mind, "main");
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].kind, "startup");
+    assert.equal(notices[0].reason, "no_credentials");
+    assert.match(notices[0].detail, /stay silent/i);
+  });
+
+  it("reads a pi mind's model from its SDK config to resolve the provider", async () => {
+    const { recordMissingCredentialsNotice } = await import(
+      "../packages/daemon/src/lib/daemon/mind-service.js"
+    );
+    const { mindDir } = await import("../packages/daemon/src/lib/mind/registry.js");
+    const mind = `nocreds-pi-${process.pid}-${Date.now()}`;
+    const configDir = resolve(mindDir(mind), "home/.config");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      resolve(configDir, "config.json"),
+      JSON.stringify({ model: "openrouter:some-model" }),
+    );
+    try {
+      await recordMissingCredentialsNotice(mind, "pi");
+      const notices = await drainNotices(mind, "main");
+      assert.equal(notices.length, 1);
+      assert.equal(notices[0].reason, "no_credentials");
+      assert.match(notices[0].detail, /OPENROUTER_API_KEY/);
+    } finally {
+      rmSync(mindDir(mind), { recursive: true, force: true });
+    }
+  });
+
+  it("records nothing for a pi mind whose model can't be determined", async () => {
+    const { recordMissingCredentialsNotice } = await import(
+      "../packages/daemon/src/lib/daemon/mind-service.js"
+    );
+    const mind = `nocreds-pi-nomodel-${process.pid}-${Date.now()}`;
+    await recordMissingCredentialsNotice(mind, "pi");
+    const notices = await drainNotices(mind, "main");
+    assert.equal(notices.length, 0);
   });
 });

--- a/test/missing-credentials.test.ts
+++ b/test/missing-credentials.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  missingCredentialWarning,
+  providerForMindTemplate,
+} from "../packages/daemon/src/lib/ai-service.js";
+
+describe("providerForMindTemplate", () => {
+  it("maps templates to the provider whose key the mind needs", () => {
+    assert.equal(providerForMindTemplate("claude"), "anthropic");
+    assert.equal(providerForMindTemplate(undefined), "anthropic"); // default template
+    assert.equal(providerForMindTemplate("codex"), "openai-codex");
+    assert.equal(providerForMindTemplate("pi", "openrouter:some-model"), "openrouter");
+    // pi without a determinable model → undefined (can't verify, don't warn)
+    assert.equal(providerForMindTemplate("pi"), undefined);
+    assert.equal(providerForMindTemplate("pi", "bare-model"), undefined);
+  });
+});
+
+describe("missingCredentialWarning", () => {
+  // Provider keys resolve from ambient env, so control it explicitly for determinism.
+  const KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("warns, actionably, when a claude mind has no anthropic credentials", async () => {
+    const warning = await missingCredentialWarning("claude", undefined, "mute-mind");
+    assert.ok(warning, "expected a warning when no key is configured");
+    assert.match(warning!, /anthropic/i);
+    assert.match(warning!, /mute-mind/);
+    assert.match(warning!, /volute env set ANTHROPIC_API_KEY/);
+    assert.match(warning!, /stay silent/i);
+  });
+
+  it("does not warn once an anthropic key is present", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-key";
+    const warning = await missingCredentialWarning("claude", undefined, "voiced-mind");
+    assert.equal(warning, null);
+  });
+
+  it("does not warn when the provider can't be determined (pi without model)", async () => {
+    const warning = await missingCredentialWarning("pi", undefined, "pi-mind");
+    assert.equal(warning, null);
+  });
+
+  it("honors an ambient OPENAI_API_KEY for codex minds", async () => {
+    process.env.OPENAI_API_KEY = "sk-openai-test";
+    const warning = await missingCredentialWarning("codex", undefined, "codex-mind");
+    assert.equal(warning, null);
+  });
+});

--- a/test/notices.test.ts
+++ b/test/notices.test.ts
@@ -5,7 +5,10 @@ import {
   clearDeliveredNotices,
   drainNotices,
   formatNotices,
+  hasUndeliveredNotice,
   latestFailureNotice,
+  latestNotice,
+  MIND_LEVEL_SESSION,
   type Notice,
   recordNotice,
 } from "../packages/daemon/src/lib/daemon/notices.js";
@@ -395,5 +398,42 @@ describe("formatNotices", () => {
     assert.match(out, /\[Notes\]/);
     // The failure header precedes the extension block.
     assert.ok(out.indexOf("[Notices]") < out.indexOf("[Notes]"));
+  });
+
+  it("latestNotice returns the newest un-drained notice across sessions", async () => {
+    const mind = uniqueMind();
+    assert.equal(await latestNotice(mind), null);
+    await recordNotice({
+      mind,
+      session: "main",
+      kind: "turn_error",
+      reason: "auth_error",
+      detail: "older",
+    });
+    await recordNotice({
+      mind,
+      session: MIND_LEVEL_SESSION,
+      kind: "startup",
+      reason: "no_credentials",
+      detail: "newest",
+    });
+    const latest = await latestNotice(mind);
+    assert.equal(latest?.detail, "newest");
+    assert.equal(latest?.reason, "no_credentials");
+  });
+
+  it("hasUndeliveredNotice detects (and dedupes) a reason for a mind", async () => {
+    const mind = uniqueMind();
+    assert.equal(await hasUndeliveredNotice(mind, "no_credentials"), false);
+    await recordNotice({
+      mind,
+      session: MIND_LEVEL_SESSION,
+      kind: "startup",
+      reason: "no_credentials",
+      detail: "mute",
+    });
+    assert.equal(await hasUndeliveredNotice(mind, "no_credentials"), true);
+    // A different reason is not matched.
+    assert.equal(await hasUndeliveredNotice(mind, "process_crash"), false);
   });
 });

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -240,6 +240,63 @@ describe("web minds routes", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("GET /:name — surfaces lastNotice to admins only (#573)", async () => {
+    const { mkdirSync, rmSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const { addMind, mindDir, removeMind } = await import(
+      "../packages/daemon/src/lib/mind/registry.js"
+    );
+    const { recordNotice } = await import("../packages/daemon/src/lib/daemon/notices.js");
+    const { initMindManager, tryGetMindManager } = await import(
+      "../packages/daemon/src/lib/daemon/mind-manager.js"
+    );
+    if (!tryGetMindManager()) initMindManager();
+
+    const name = `web-notice-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    mkdirSync(dir, { recursive: true });
+    await addMind(name, 4198, undefined, "claude");
+    await recordNotice({
+      mind: name,
+      session: "",
+      kind: "startup",
+      reason: "no_credentials",
+      detail: "no anthropic key — mind will stay silent",
+    });
+
+    try {
+      const cookie = await setupAuth();
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request(`/api/minds/${name}`, {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as {
+        lastNotice?: { kind: string; reason: string; detail: string; created_at: string };
+      };
+      assert.ok(body.lastNotice, "admin sees lastNotice");
+      assert.equal(body.lastNotice.kind, "startup");
+      assert.equal(body.lastNotice.reason, "no_credentials");
+      assert.match(body.lastNotice.detail, /stay silent/);
+      assert.ok(body.lastNotice.created_at);
+
+      // Non-privileged callers get profile-level fields only — no lastNotice.
+      const user2 = await createUser("regular-user2", "pass");
+      await approveUser(user2.id);
+      const cookie2 = await createSession(user2.id);
+      const res2 = await app.request(`/api/minds/${name}`, {
+        headers: { Cookie: `volute_session=${cookie2}` },
+      });
+      assert.equal(res2.status, 200);
+      const body2 = (await res2.json()) as { lastNotice?: unknown };
+      assert.equal(body2.lastNotice, undefined);
+      await deleteSession(cookie2);
+    } finally {
+      await removeMind(name);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("toPublicMind", () => {


### PR DESCRIPTION
## What

A claude-template mind created with no `ANTHROPIC_API_KEY` (and no OAuth) was created, started, and stayed **mute** — its first turn failed inside its own SDK process with an opaque "process exited" error, invisible in chat, the CLI, and `mind status` (#573). The user sends "hello" and gets nothing, with no signal anywhere.

This surfaces the missing credential at the daemon — which knows the key is absent — in three visible places, without blocking creation:

- **Creation warns (non-blocking):** `missingCredentialWarning` returns an operator-actionable message (`volute env set …` or reconnect the provider), returned as `credentialWarning` on the create response and printed by `mind create` and `seed create`.
- **Start records a notice:** `startMindFull` records a deduped `no_credentials` startup notice when a mind spawns without a usable key, so the cause survives restarts.
- **`mind status` shows it:** the newest un-drained notice is surfaced there (and on `GET /api/minds/:name`, admin/system only).
- **Error classifier is actionable:** the auth-error message now points at `volute env set` / provider reconnect and matches missing/invalid-key phrasings, not just expired-token 401s.

The credential check mirrors mind-manager's actual injection exactly: provider OAuth, stored key, ambient env (`resolveApiKey`), **and** keys set via `volute env set` (shared + per-mind `env.json`) — which the warning's own remediation writes to — so a correctly-configured or OAuth mind never false-alarms. Pi minds resolve their provider from the SDK-config model; when it can't be determined the check is skipped rather than guessed.

## Composability with #595

#573 is the **data source** for #595 (chat status bar): any `startup`/`turn_error` notice recorded here surfaces through #595's `latestFailureNotice()` with no extra wiring. The two GET-route fields are distinct (`lastNotice`, admin-only, here; `lastError` in #595) and compose.

## How

- `missingCredentialWarning` / `providerForMindTemplate` in `ai-service.ts`; `recordMissingCredentialsNotice` (deduped) in `mind-service.ts`.
- `latestNotice` / `hasUndeliveredNotice` + `no_credentials` reason in `notices.ts` / `schema.ts`.
- `lastNotice` returned on `GET /api/minds/:name` **inside the privileged branch only** — non-privileged callers get `toPublicMind` and never see it.

## Test plan

- `npm test` — 2097/2098 pass; the one failure is the known `shutdown-signal.test.ts` flake under fleet contention (passes in isolation, verified).
- `npm run test:e2e` — 53/53 pass. The new `no_credentials` notice initially broke 4 e2e assertions because the e2e test mind is keyless on a host without `ANTHROPIC_API_KEY` (the mind-level notice bled into session drains and the `kind==="startup"` lookup); fixed by crediting the e2e daemon with a dummy anthropic key, matching what those tests model.
- `tsc --noEmit` clean.

Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)