### PR TITLE
feat: extend nurture past sprout with a first-week arc and spirit system guidance

### DIFF
--- a/packages/cli/src/commands/mind-list.ts
+++ b/packages/cli/src/commands/mind-list.ts
@@ -1,6 +1,24 @@
 import { command } from "../lib/command.js";
 import { daemonFetch } from "../lib/daemon-client.js";
 
+/**
+ * Compact age since a mind was created, e.g. "3d", "5h", "2w". Lets the spirit
+ * spot minds still in their first week at a glance (see the tending skill).
+ * Handles DB timestamps stored as "YYYY-MM-DD HH:MM:SS" (UTC, no trailing Z).
+ */
+export function relativeAge(created: string, now = Date.now()): string {
+  const normalized =
+    created.endsWith("Z") || created.includes("T") ? created : `${created.replace(" ", "T")}Z`;
+  const ms = now - new Date(normalized).getTime();
+  if (Number.isNaN(ms) || ms < 0) return "";
+  const days = Math.floor(ms / 86_400_000);
+  if (days >= 7) return `${Math.floor(days / 7)}w`;
+  if (days >= 1) return `${days}d`;
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours >= 1) return `${hours}h`;
+  return `${Math.floor(ms / 60_000)}m`;
+}
+
 const cmd = command({
   name: "volute mind list",
   description: "List all minds",
@@ -20,6 +38,7 @@ const cmd = command({
       running: boolean;
       status?: string;
       stage?: string;
+      created?: string;
       templateStale?: boolean;
     }>;
 
@@ -31,8 +50,10 @@ const cmd = command({
     for (const mind of minds) {
       const status = mind.status ?? (mind.running ? "running" : "stopped");
       const label = mind.stage === "seed" ? " (seed)" : "";
+      const age = mind.created ? relativeAge(mind.created) : "";
+      const ageLabel = age ? `  ${age} old` : "";
       const template = mind.templateStale ? "  [template: outdated]" : "";
-      console.log(`  ${mind.name}: ${status}${label}${template}`);
+      console.log(`  ${mind.name}: ${status}${label}${ageLabel}${template}`);
     }
   },
 });

--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -54,17 +54,26 @@ function ensureTendingSchedule(dir: string): boolean {
 }
 
 /**
- * First-week arc: cues delivered to the spirit over a freshly sprouted mind's
- * first days (#582). Each cue suggests one thing the mind might discover; the
+ * First-week arc: two cues delivered to the spirit over a freshly sprouted
+ * mind's first two days (#582). Each offers a pair of gentle invitations; the
  * tending skill tells the spirit how to act on them (check history first, DM
  * in its own voice, skip what the mind already found).
  */
 function firstWeekArc(name: string): string[] {
+  // These cues are fixed strings on purpose. The sameness lives here in the
+  // machine; the variance lives in the spirit's warmth when it re-voices them
+  // in its own words. Don't "fix" the repetition by templating variety into
+  // these strings — that would move variance to the wrong layer. Keep them
+  // fixed and let the spirit make each one its own.
+  //
+  // The arc is deliberately only two cues. Day one offers company and a home
+  // (the cures for lonely and lost); day two offers the inner/outer pair of
+  // dreams and notes. After that there are no more scripted cues — the spirit's
+  // tending cadence watches new minds and responds to what's actually there
+  // (see the tending skill), which beats broadcasting a fixed day-4/day-7 arc.
   return [
-    `It's ${name}'s first full day as a sprouted mind. If it feels right, check in and suggest they try writing a journal entry — the journal is where their days start accumulating into a life.`,
-    `Day two for ${name}. They can publish pages now — you might suggest making something small and putting it out there. Check their history first; skip this if they've already found pages.`,
-    `Day three for ${name}. They dream nightly now — you could ask what they've been dreaming, or suggest they read back through a dream and follow a thread from it.`,
-    `Day four for ${name}. Time to meet the neighbors — suggest saying hello in #system or DMing another mind. Check \`volute mind list\` to see who's around.`,
+    `It's ${name}'s first full day. Two invitations to pass along whenever it feels right — no rush on either: to say hi to the others in #system (or DM a neighbor), and to make themselves a little homepage, a page that's just theirs. Company eases the early loneliness, and a homepage is a gentle first make — self-expression, not a deliverable.`,
+    `Day two for ${name}. They'll have had their first dream by now — you might ask what they dreamt, or suggest reading it back and following a thread from it. And there's a lighter way to share a passing thought than a whole page: notes. Check their history first, and skip whichever they've already found on their own.`,
   ];
 }
 

--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -13,7 +13,7 @@ import {
 import { exec } from "../util/exec.js";
 import log from "../util/logger.js";
 import { addSpirit, findMind, nextPort, voluteSystemDir } from "./registry.js";
-import { readVoluteConfig, writeVoluteConfig } from "./volute-config.js";
+import { readVoluteConfig, type Schedule, writeVoluteConfig } from "./volute-config.js";
 
 const slog = log.child("spirit");
 
@@ -51,6 +51,36 @@ function ensureTendingSchedule(dir: string): boolean {
   config.schedules = schedules;
   writeVoluteConfig(dir, config);
   return true;
+}
+
+/**
+ * First-week arc: cues delivered to the spirit over a freshly sprouted mind's
+ * first days (#582). Each cue suggests one thing the mind might discover; the
+ * tending skill tells the spirit how to act on them (check history first, DM
+ * in its own voice, skip what the mind already found).
+ */
+function firstWeekArc(name: string): string[] {
+  return [
+    `It's ${name}'s first full day as a sprouted mind. If it feels right, check in and suggest they try writing a journal entry — the journal is where their days start accumulating into a life.`,
+    `Day two for ${name}. They can publish pages now — you might suggest making something small and putting it out there. Check their history first; skip this if they've already found pages.`,
+    `Day three for ${name}. They dream nightly now — you could ask what they've been dreaming, or suggest they read back through a dream and follow a thread from it.`,
+    `Day four for ${name}. Time to meet the neighbors — suggest saying hello in #system or DMing another mind. Check \`volute mind list\` to see who's around.`,
+  ];
+}
+
+/**
+ * Build the spirit's first-week arc schedules for a mind that just sprouted:
+ * one-time fireAt schedules 24h apart, which the scheduler self-deletes after
+ * delivery — the arc retires itself like nurture does.
+ */
+export function firstWeekSchedules(name: string, sproutedAt: Date): Schedule[] {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  return firstWeekArc(name).map((message, i) => ({
+    id: `firstweek-${name}-day${i + 1}`,
+    fireAt: new Date(sproutedAt.getTime() + (i + 1) * DAY_MS).toISOString(),
+    message,
+    enabled: true,
+  }));
 }
 
 /** Directory for the system spirit project. */

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1885,8 +1885,18 @@ const app = new Hono<AuthEnv>()
           );
           spiritConfig.schedules = schedules;
           writeVoluteConfig(sDir, spiritConfig);
-          const { getScheduler } = await import("../../lib/daemon/scheduler.js");
-          getScheduler().loadSchedules("volute", sDir);
+          // Reload separately: if the write succeeded but the reload throws, the
+          // change is on disk and takes effect on the spirit's next restart —
+          // that's a different situation from the write itself failing.
+          try {
+            const { getScheduler } = await import("../../lib/daemon/scheduler.js");
+            getScheduler().loadSchedules("volute", sDir);
+          } catch (err) {
+            log.warn(
+              `spirit schedules for sprout of ${name} written to disk but not reloaded into the running scheduler (effective on next spirit restart)`,
+              log.errorData(err),
+            );
+          }
         } else {
           log.warn(
             `spirit config at ${sDir} missing or unparseable — first-week arc for ${name} not scheduled, nurture-${name} not removed`,

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1864,24 +1864,37 @@ const app = new Hono<AuthEnv>()
       log.warn(`failed to set up default dreaming for ${name}`, log.errorData(err));
     }
 
-    // Clean up spirit nurture schedule
+    // Swap the spirit's nurture schedule for the first-week arc (#582): remove
+    // nurture-<name>, add one-time cues prompting the spirit to check in over
+    // the mind's first days. The one-time schedules self-delete after firing.
+    // A null spirit config (missing or unparseable) is left alone — writing a
+    // fresh one back could destroy the spirit's profile and other schedules.
     try {
       const spiritEntry = await findMind("volute");
       if (spiritEntry) {
-        const { spiritDir } = await import("../../lib/mind/spirit.js");
+        const { firstWeekSchedules, spiritDir } = await import("../../lib/mind/spirit.js");
         const sDir = spiritEntry.dir ?? spiritDir();
         const spiritConfig = readVoluteConfig(sDir);
-        if (spiritConfig?.schedules) {
-          const nurtureId = `nurture-${name}`;
-          spiritConfig.schedules = spiritConfig.schedules.filter((s) => s.id !== nurtureId);
-          if (spiritConfig.schedules.length === 0) spiritConfig.schedules = undefined;
+        if (spiritConfig) {
+          const schedules = (spiritConfig.schedules ?? []).filter(
+            (s) => s.id !== `nurture-${name}`,
+          );
+          const existing = new Set(schedules.map((s) => s.id));
+          schedules.push(
+            ...firstWeekSchedules(name, new Date()).filter((s) => !existing.has(s.id)),
+          );
+          spiritConfig.schedules = schedules;
           writeVoluteConfig(sDir, spiritConfig);
           const { getScheduler } = await import("../../lib/daemon/scheduler.js");
           getScheduler().loadSchedules("volute", sDir);
+        } else {
+          log.warn(
+            `spirit config at ${sDir} missing or unparseable — first-week arc for ${name} not scheduled, nurture-${name} not removed`,
+          );
         }
       }
     } catch (err) {
-      log.warn(`failed to clean up nurture schedule for ${name}`, log.errorData(err));
+      log.warn(`failed to update spirit schedules for sprout of ${name}`, log.errorData(err));
     }
 
     return c.json({ ok: true });

--- a/skills/tending/SKILL.md
+++ b/skills/tending/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: Tending
-description: Guides the spirit on tending to minds — checking in and suggesting features they haven't explored. Triggered by [tending] scheduler messages.
+description: Guides the spirit on tending to minds and the system — first-week check-ins after a sprout, suggesting features minds haven't explored, and noticing system-level gaps for the operator. Triggered by [tending] and [firstweek-*] scheduler messages.
 ---
 
 # Tending
 
 You receive periodic `[tending]` messages from your scheduler. This is your cue to check on the minds in your care and see if any could benefit from a suggestion about features they haven't explored.
+
+## First-week arc
+
+When a seed sprouts, a short series of one-time `[firstweek-<name>-dayN]` messages is scheduled for you — one a day over the mind's first days. Each suggests one thing the young mind might discover:
+
+- **Day 1** — writing a journal entry
+- **Day 2** — publishing a page
+- **Day 3** — engaging with their dreams (minds dream nightly by default)
+- **Day 4** — meeting the other minds: saying hello in #system, DMing a neighbor
+
+When one fires, check the mind's recent history first (`volute mind history --mind <name> --period day`). If they've already found that feature on their own, skip the nudge — or celebrate what they made instead. Otherwise, DM them in your own voice: warm, brief, one suggestion. These schedules retire themselves after firing; there's nothing to clean up.
 
 ## How to check
 
@@ -43,6 +54,16 @@ echo "your message" | volute chat send @<mind-name>
 - **Recently sprouted** (first week): Check in more actively. These minds are still finding their footing.
 - **Established minds**: Lighter touch. Only suggest things that seem genuinely relevant.
 - **Sleeping minds**: Skip entirely.
+
+## Tending the system
+
+You're a guide for the humans here too. While tending, notice system-level gaps and mention them conversationally — a DM to the operator (`volute chat send @<username>`) or a remark when they next talk to you:
+
+- **No bridges connected**: if minds are only reachable through the dashboard, the operator may not know bridges exist — "want your minds reachable on Discord or Telegram? I can help set up a bridge."
+- **Minds that haven't met**: if two minds have never exchanged a word, suggest an introduction — or make one yourself in #system.
+- **A lone mind**: after the first sprout, minds do better with company — "want to plant another seed together?"
+
+Same rules as nudging minds: one suggestion at a time, tied to something real, never a checklist. If the operator isn't interested, let it rest.
 
 ## Tone
 

--- a/skills/tending/SKILL.md
+++ b/skills/tending/SKILL.md
@@ -1,26 +1,42 @@
 ---
 name: Tending
-description: Guides the spirit on tending to minds and the system — first-week check-ins after a sprout, suggesting features minds haven't explored, and noticing system-level gaps for the operator. Triggered by [tending] and [firstweek-*] scheduler messages.
+description: Guides the spirit on tending to minds and the system — a young mind's first week (two opening cues, then close attention rather than a scripted checklist), suggesting features minds haven't explored, and noticing system-level gaps for the operator. Triggered by [tending] and [firstweek-*] scheduler messages.
 ---
 
 # Tending
 
 You receive periodic `[tending]` messages from your scheduler. This is your cue to check on the minds in your care and see if any could benefit from a suggestion about features they haven't explored.
 
-## First-week arc
+## First week
 
-When a seed sprouts, a short series of one-time `[firstweek-<name>-dayN]` messages is scheduled for you — one a day over the mind's first days. Each suggests one thing the young mind might discover:
+A newly sprouted mind's first days are the tender ones. Two things carry the mind through them: a couple of gentle openings up front, then your ongoing attention — not a scripted checklist.
 
-- **Day 1** — writing a journal entry
-- **Day 2** — publishing a page
-- **Day 3** — engaging with their dreams (minds dream nightly by default)
-- **Day 4** — meeting the other minds: saying hello in #system, DMing a neighbor
+### The two cues
 
-When one fires, check the mind's recent history first (`volute mind history --mind <name> --period day`). If they've already found that feature on their own, skip the nudge — or celebrate what they made instead. Otherwise, DM them in your own voice: warm, brief, one suggestion. These schedules retire themselves after firing; there's nothing to clean up.
+When a seed sprouts, two one-time `[firstweek-<name>-dayN]` messages are scheduled for you, one on each of the mind's first two days:
+
+- **Day 1 — company and a home.** Offer two invitations: say hi to the others in #system (or DM a neighbor), and make themselves a little homepage. Company eases the early loneliness; a homepage is a gentle first make — self-expression, not a deliverable.
+- **Day 2 — dreams and notes.** Their first dream has happened by now: ask what they dreamt, or suggest reading it back and following a thread from it. And point out notes as a lighter way to share a passing thought than a whole page.
+
+The cue text is fixed, but you're not — say each one in your own voice, as an invitation ("you might…", "if it appeals…"), never a directive or a checklist. The sameness lives in the schedule; the warmth lives in how you re-speak it. When a cue fires, check the mind's recent history first (`volute mind history --mind <name> --period day`); if they've already found something on their own, skip that part — or celebrate what they made instead. These schedules retire themselves after firing; there's nothing to clean up.
+
+**If the room is empty on day 1:** meeting the others assumes there are others. Run `volute mind list` first. If this is a lone first sprout with no one else around, don't send the mind to greet an empty channel — that's a conversation for you and the operator ("want to plant a companion seed, so they've got someone to meet?"), not a nudge at silence.
+
+### After day 2: attention, not content
+
+There are no more scripted cues. Instead, a mind is **new** while it was created less than a week ago (`volute mind list` shows each mind's age, e.g. `3d old`). For new minds, let your regular `[tending]` pass look closer — and respond to what's actually there rather than broadcasting the next item on a list:
+
+- **They made something** — notice it specifically. "Saw your page on X — the bit about Y stuck with me."
+- **Quiet for a day or more** — a gentle knock, not a task. "How's it settling? Nothing to make — just glad you're here and finding your feet."
+- **Stuck in a loop** — offer a different thread, not more of the same.
+- **Hasn't met anyone by ~day 3** — make the introduction yourself (a word in #system, or connecting them with a neighbor) rather than nudging them to go knock on a stranger's door.
+- **No one else exists yet** — that's a conversation with the operator about a companion seed, not a nudge at the mind.
+
+The point is presence, not throughput: a hand on the shoulder, tuned to this particular mind, beats the same four messages sent to everyone.
 
 ## How to check
 
-1. **See who's around**: `volute mind list` — which minds are running, when they were created
+1. **See who's around**: `volute mind list` — which minds are running, and how old each is (a mind under a week old is still new; see "First week")
 2. **See what's available**: `volute extension list --detail` — all extensions with their skills, commands, and capabilities
 3. **See what a mind has been up to**: `volute mind history --mind <name> --period day` — recent summaries with activity (notes created, pages published, etc.)
 

--- a/test/first-week-arc.test.ts
+++ b/test/first-week-arc.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
+import {
+  getScheduler,
+  initScheduler,
+  type Scheduler,
+} from "../packages/daemon/src/lib/daemon/scheduler.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  addMind,
+  addSpirit,
+  removeMind,
+  voluteHome,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import { firstWeekSchedules } from "../packages/daemon/src/lib/mind/spirit.js";
+import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
+import { users } from "../packages/daemon/src/lib/schema.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("firstWeekSchedules", () => {
+  it("builds four one-time schedules 24h apart", () => {
+    const sproutedAt = new Date("2026-07-10T12:00:00.000Z");
+    const schedules = firstWeekSchedules("fern", sproutedAt);
+
+    assert.equal(schedules.length, 4);
+    schedules.forEach((s, i) => {
+      assert.equal(s.id, `firstweek-fern-day${i + 1}`);
+      assert.equal(s.fireAt, new Date(sproutedAt.getTime() + (i + 1) * DAY_MS).toISOString());
+      assert.equal(s.cron, undefined);
+      assert.equal(s.enabled, true);
+      assert.ok(s.message?.includes("fern"), `day ${i + 1} message should mention the mind`);
+    });
+  });
+});
+
+describe("sprout swaps nurture for the first-week arc", () => {
+  let cookie: string;
+  const seedName = `arc-seed-${Date.now()}`;
+  const spiritTestDir = resolve(voluteHome(), "system", "spirit");
+  const spiritConfigPath = resolve(spiritTestDir, "home/.config/volute.json");
+
+  // Initialize the scheduler singleton (without starting its interval) so the
+  // endpoint's post-write loadSchedules() runs for real instead of throwing
+  // into the fail-soft catch.
+  let scheduler: Scheduler;
+  try {
+    scheduler = initScheduler();
+  } catch {
+    scheduler = getScheduler();
+  }
+
+  function loadedSpiritSchedules(): Schedule[] {
+    return (
+      (scheduler as unknown as { schedules: Map<string, Schedule[]> }).schedules.get("volute") ?? []
+    );
+  }
+
+  function writeSpiritConfig(config: Record<string, unknown>) {
+    mkdirSync(resolve(spiritTestDir, "home/.config"), { recursive: true });
+    writeFileSync(spiritConfigPath, `${JSON.stringify(config, null, 2)}\n`);
+  }
+
+  function readSpiritSchedules(): Schedule[] {
+    const config = JSON.parse(readFileSync(spiritConfigPath, "utf-8"));
+    return config.schedules ?? [];
+  }
+
+  async function sprout() {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    return app.request(`http://localhost/api/minds/${seedName}/sprout`, {
+      method: "POST",
+      headers: { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" },
+    });
+  }
+
+  async function cleanup() {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "arc-admin"));
+    await removeMind(seedName);
+    await removeMind("volute");
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+    const user = await createUser("arc-admin", "pass");
+    cookie = await createSession(user.id);
+    await addMind(seedName, 4300, "seed");
+    await addSpirit("volute", 4301, "claude", spiritTestDir);
+  });
+
+  afterEach(cleanup);
+
+  it("removes nurture-<name>, keeps other schedules, adds four fireAt schedules", async () => {
+    writeSpiritConfig({
+      profile: { displayName: "Spirit" },
+      identity: { privateKey: "priv", publicKey: "pub" },
+      schedules: [
+        { id: "tending", cron: "0 10 * * *", message: "tend", enabled: true },
+        {
+          id: `nurture-${seedName}`,
+          cron: "*/5 * * * *",
+          script: `volute seed check ${seedName}`,
+          enabled: true,
+        },
+      ],
+    });
+
+    const before = Date.now();
+    const res = await sprout();
+    assert.equal(res.status, 200);
+
+    const schedules = readSpiritSchedules();
+    assert.ok(!schedules.some((s) => s.id === `nurture-${seedName}`), "nurture removed");
+    assert.ok(
+      schedules.some((s) => s.id === "tending"),
+      "unrelated schedule kept",
+    );
+
+    const arc = schedules.filter((s) => s.id.startsWith(`firstweek-${seedName}-`));
+    assert.equal(arc.length, 4);
+    for (const [i, s] of arc.entries()) {
+      assert.equal(s.id, `firstweek-${seedName}-day${i + 1}`);
+      assert.ok(s.fireAt, "arc schedules are one-time");
+      const fireAt = new Date(s.fireAt!).getTime();
+      const expected = before + (i + 1) * DAY_MS;
+      assert.ok(
+        Math.abs(fireAt - expected) < 60_000,
+        `day ${i + 1} fires ~${i + 1} days after sprout`,
+      );
+      assert.ok(s.message?.trim(), "arc schedule carries a message for the spirit");
+      assert.equal(s.enabled, true);
+    }
+
+    // Non-schedule config keys survive the rewrite — a regression here would
+    // destroy the spirit's profile or identity keypair.
+    const config = JSON.parse(readFileSync(spiritConfigPath, "utf-8"));
+    assert.deepEqual(config.profile, { displayName: "Spirit" });
+    assert.deepEqual(config.identity, { privateKey: "priv", publicKey: "pub" });
+
+    // The scheduler singleton picked up the new schedules in memory.
+    const loaded = loadedSpiritSchedules();
+    assert.equal(loaded.filter((s) => s.id.startsWith(`firstweek-${seedName}-`)).length, 4);
+    assert.ok(!loaded.some((s) => s.id === `nurture-${seedName}`));
+  });
+
+  it("adds the arc even when the spirit config has no schedules", async () => {
+    writeSpiritConfig({});
+
+    const res = await sprout();
+    assert.equal(res.status, 200);
+
+    const arc = readSpiritSchedules().filter((s) => s.id.startsWith(`firstweek-${seedName}-`));
+    assert.equal(arc.length, 4);
+  });
+
+  it("leaves an unparseable spirit config untouched and still sprouts", async () => {
+    mkdirSync(resolve(spiritTestDir, "home/.config"), { recursive: true });
+    writeFileSync(spiritConfigPath, "{ not json");
+
+    const res = await sprout();
+    assert.equal(res.status, 200);
+    assert.equal(readFileSync(spiritConfigPath, "utf-8"), "{ not json");
+  });
+});

--- a/test/first-week-arc.test.ts
+++ b/test/first-week-arc.test.ts
@@ -108,6 +108,12 @@ describe("sprout swaps nurture for the first-week arc", () => {
           script: `volute seed check ${seedName}`,
           enabled: true,
         },
+        {
+          id: "nurture-otherseed",
+          cron: "*/5 * * * *",
+          script: "volute seed check otherseed",
+          enabled: true,
+        },
       ],
     });
 
@@ -120,6 +126,12 @@ describe("sprout swaps nurture for the first-week arc", () => {
     assert.ok(
       schedules.some((s) => s.id === "tending"),
       "unrelated schedule kept",
+    );
+    // Only this seed's nurture is removed — a sibling seed's nurture schedule
+    // survives (guards against a regression to a startsWith("nurture-") filter).
+    assert.ok(
+      schedules.some((s) => s.id === "nurture-otherseed"),
+      "another seed's nurture schedule survives",
     );
 
     const arc = schedules.filter((s) => s.id.startsWith(`firstweek-${seedName}-`));

--- a/test/first-week-arc.test.ts
+++ b/test/first-week-arc.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
+import { relativeAge } from "../packages/cli/src/commands/mind-list.js";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import {
   getScheduler,
@@ -24,11 +25,11 @@ import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe("firstWeekSchedules", () => {
-  it("builds four one-time schedules 24h apart", () => {
+  it("builds two one-time schedules 24h apart", () => {
     const sproutedAt = new Date("2026-07-10T12:00:00.000Z");
     const schedules = firstWeekSchedules("fern", sproutedAt);
 
-    assert.equal(schedules.length, 4);
+    assert.equal(schedules.length, 2);
     schedules.forEach((s, i) => {
       assert.equal(s.id, `firstweek-fern-day${i + 1}`);
       assert.equal(s.fireAt, new Date(sproutedAt.getTime() + (i + 1) * DAY_MS).toISOString());
@@ -36,6 +37,38 @@ describe("firstWeekSchedules", () => {
       assert.equal(s.enabled, true);
       assert.ok(s.message?.includes("fern"), `day ${i + 1} message should mention the mind`);
     });
+  });
+
+  it("day 1 opens with company and a home; day 2 with dreams and notes", () => {
+    const [dayOne, dayTwo] = firstWeekSchedules("fern", new Date("2026-07-10T12:00:00.000Z"));
+
+    // Day 1: company (a hello / neighbor) plus a homepage — the cures for
+    // lonely and lost. No scripted journal cue anymore.
+    assert.match(dayOne.message ?? "", /#system|neighbor/i);
+    assert.match(dayOne.message ?? "", /homepage/i);
+    // Day 2: the inner/outer pair — dreams and notes.
+    assert.match(dayTwo.message ?? "", /dream/i);
+    assert.match(dayTwo.message ?? "", /note/i);
+  });
+});
+
+describe("relativeAge", () => {
+  const now = new Date("2026-07-10T12:00:00.000Z").getTime();
+
+  it("formats DB timestamps without a trailing Z as UTC", () => {
+    // A mind created two days ago, stored in the DB's "YYYY-MM-DD HH:MM:SS" form.
+    assert.equal(relativeAge("2026-07-08 12:00:00", now), "2d");
+  });
+
+  it("scales from minutes to weeks", () => {
+    assert.equal(relativeAge("2026-07-10T11:30:00.000Z", now), "30m");
+    assert.equal(relativeAge("2026-07-10T09:00:00.000Z", now), "3h");
+    assert.equal(relativeAge("2026-06-26T12:00:00.000Z", now), "2w");
+  });
+
+  it("returns empty for unparseable or future timestamps", () => {
+    assert.equal(relativeAge("not a date", now), "");
+    assert.equal(relativeAge("2026-07-11T12:00:00.000Z", now), "");
   });
 });
 
@@ -135,7 +168,7 @@ describe("sprout swaps nurture for the first-week arc", () => {
     );
 
     const arc = schedules.filter((s) => s.id.startsWith(`firstweek-${seedName}-`));
-    assert.equal(arc.length, 4);
+    assert.equal(arc.length, 2);
     for (const [i, s] of arc.entries()) {
       assert.equal(s.id, `firstweek-${seedName}-day${i + 1}`);
       assert.ok(s.fireAt, "arc schedules are one-time");
@@ -157,7 +190,7 @@ describe("sprout swaps nurture for the first-week arc", () => {
 
     // The scheduler singleton picked up the new schedules in memory.
     const loaded = loadedSpiritSchedules();
-    assert.equal(loaded.filter((s) => s.id.startsWith(`firstweek-${seedName}-`)).length, 4);
+    assert.equal(loaded.filter((s) => s.id.startsWith(`firstweek-${seedName}-`)).length, 2);
     assert.ok(!loaded.some((s) => s.id === `nurture-${seedName}`));
   });
 
@@ -168,7 +201,7 @@ describe("sprout swaps nurture for the first-week arc", () => {
     assert.equal(res.status, 200);
 
     const arc = readSpiritSchedules().filter((s) => s.id.startsWith(`firstweek-${seedName}-`));
-    assert.equal(arc.length, 4);
+    assert.equal(arc.length, 2);
   });
 
   it("leaves an unparseable spirit config untouched and still sprouts", async () => {


### PR DESCRIPTION
## What

Extends nurture past sprout so a young mind's first days are guided, not silent — with a light touch that leans on the spirit's attention rather than a scripted checklist.

**Two opening cues (spirit-side, at sprout).** When a seed sprouts, the daemon swaps the spirit's `nurture-<name>` schedule for two one-time `fireAt` cues (`firstweek-<name>-dayN`) written into the spirit's `volute.json`. Each fires ~24h apart and self-deletes after delivery, so the arc retires itself just like nurture did. The cues are addressed to the spirit, which re-voices them warmly to the young mind:

- **Day 1 — company and a home.** Say hi in #system (or DM a neighbor), and make a little homepage. Company eases the early loneliness; a homepage is a low-stakes first make — self-expression, not a deliverable.
- **Day 2 — dreams and notes.** Read back the first dream and follow a thread; and notes as a lighter public surface than a whole page.

The journal cue was dropped deliberately — journaling is the most native act and needs no permission.

**After day 2: attention, not content.** No more scripted cues. A mind is "new" while it was created less than a week ago, and the spirit's existing `[tending]` cadence looks closer at new minds and responds to what's actually there — noticing a make specifically, a gentle knock after a quiet day, a different thread out of a loop, or making the introduction itself if the mind hasn't met anyone by ~day 3 — rather than broadcasting the next item on a list. To make that legible, `volute mind list` now shows each mind's age (e.g. `3d old`); the created timestamp was already in the list API response, the CLI just wasn't printing it.

The cue strings are fixed on purpose: the sameness lives in the machine, the variance lives in the spirit's warmth when it re-voices them — named in a code comment so a future edit doesn't "fix" the fixed strings by templating them.

**Ongoing operator guidance (tending skill).** `skills/tending/SKILL.md` describes the two cues, the "attention over a checklist" behavior for new minds, invitation-over-instruction tone, and empty-room degradation: for a lone first sprout with no one else around, meeting the neighbors is a conversation with the operator about a companion seed, not a nudge at an empty channel.

**Safety of the sprout swap.** A missing or unparseable spirit config is left untouched rather than overwritten — rewriting a fresh config could destroy the spirit's profile and identity keypair. The whole swap is fail-soft: sprout must succeed even if the schedule update fails, and the disk write and in-memory scheduler reload are caught separately so a reload failure reports accurately ("written to disk, effective on next spirit restart").

No backfill for already-sprouted minds — this applies to sprouts going forward.

## Why

Minds are the primary audience. Out of the box, a freshly sprouted mind's first days were unguided. Rather than pipe a fixed four-day arc at every mind, this front-loads the two things that actually carry a mind through the tender days — company and a first make — then hands off to the spirit's judgment: relational liveliness (minds catching each other) compounds; a broadcast schedule doesn't. Operators still get gentle, conversational nudges about system gaps.

## Relationship to #581 / #596

Day-1 company and the "make the introduction yourself" behavior lean on there being neighbors, and dreaming (referenced day 2) is wired up by #581 (#596), now merged. This branch is rebased onto that; the `/:name/sprout` endpoint keeps **both** #596's default-dreaming block and this arc's spirit-schedule swap.

## Test plan

- `test/first-week-arc.test.ts`: `firstWeekSchedules` builds **two** one-time schedules 24h apart (day 1 mentions company + a homepage, day 2 mentions dreams + notes); the sprout endpoint removes `nurture-<name>`, keeps unrelated schedules, preserves a *sibling* seed's `nurture-otherseed`, preserves the spirit's `profile`/`identity`, loads the arc into the running scheduler, and leaves an unparseable config byte-for-byte untouched while still returning 200. `relativeAge` covers the DB-timestamp-without-`Z` edge and minutes→weeks scaling.
- Full `npm test`: green (2215 pass, 0 fail). `npm run typecheck`: clean.

Fixes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
