### PR TITLE
fix(chat): honor --participants when creating a channel

### DIFF
--- a/packages/daemon/src/web/api/volute/channels.ts
+++ b/packages/daemon/src/web/api/volute/channels.ts
@@ -5,6 +5,7 @@ import { getOrCreateMindUser, getUserByUsername } from "../../../lib/auth.js";
 import {
   addMessage,
   createChannel,
+  deleteConversation,
   formatChannelSettings,
   getChannelByName,
   getChannelSettings,
@@ -32,6 +33,7 @@ const createSchema = z
       .min(1)
       .max(50)
       .regex(/^[a-z0-9][a-z0-9-]*$/, "Channel names must be lowercase alphanumeric with hyphens"),
+    participantNames: z.array(z.string().min(1)).optional(),
   })
   .merge(channelSettingsSchema);
 
@@ -56,10 +58,25 @@ const app = new Hono<AuthEnv>()
     const user = c.get("user");
     const body = c.req.valid("json");
 
+    const { name, participantNames, ...settings } = body;
+
+    // Resolve every requested participant up front so an unknown name fails
+    // cleanly instead of silently dropping members after the channel exists.
+    const participantIds: number[] = [];
+    for (const username of participantNames ?? []) {
+      let member = await getUserByUsername(username);
+      if (!member && (await findMind(username))) {
+        member = await getOrCreateMindUser(username);
+      }
+      if (!member) {
+        return c.json({ error: `User not found: ${username}` }, 404);
+      }
+      participantIds.push(member.id);
+    }
+
+    let ch: Awaited<ReturnType<typeof createChannel>>;
     try {
-      const { name, ...settings } = body;
-      const ch = await createChannel(name, user.id, settings);
-      return c.json({ ...ch, channel_name: name }, 201);
+      ch = await createChannel(name, user.id, settings);
     } catch (err: unknown) {
       const cause =
         err instanceof Error
@@ -70,6 +87,26 @@ const app = new Hono<AuthEnv>()
       }
       throw err;
     }
+
+    try {
+      for (const id of participantIds) {
+        await joinChannel(ch.id, id);
+      }
+    } catch (err) {
+      console.error("[channels] join failed during channel create:", err);
+      // Don't leave a half-populated channel behind on a join failure.
+      try {
+        await deleteConversation(ch.id);
+      } catch (cleanupErr) {
+        console.error(
+          `[channels] failed to roll back channel ${ch.id} after join failure:`,
+          cleanupErr,
+        );
+      }
+      throw err;
+    }
+
+    return c.json({ ...ch, channel_name: name }, 201);
   })
   .get("/:name", async (c) => {
     const name = c.req.param("name");

--- a/test/web-v1-channels.test.ts
+++ b/test/web-v1-channels.test.ts
@@ -7,10 +7,12 @@ import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   createChannel,
   deleteConversation,
+  getChannelByName,
   getChannelSettings,
   getMessages,
   getParticipants,
 } from "../packages/daemon/src/lib/events/conversations.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import { users } from "../packages/daemon/src/lib/schema.js";
 import channelsRoute from "../packages/daemon/src/web/api/volute/channels.js";
 import { authMiddleware, createSession } from "../packages/daemon/src/web/middleware/auth.js";
@@ -103,6 +105,94 @@ describe("web v1 channels routes", () => {
     assert.equal(body.channel_name, "dev");
 
     await deleteConversation(body.id);
+  });
+
+  it("POST /api/v1/channels — adds participantNames (users and minds) as members", async () => {
+    const cookie = await setupAuth();
+    const app = createApp();
+
+    const bob = await createUser("bob", "pass");
+    // Register a mind with no pre-existing users row, so the route must
+    // resolve it via the registry fallback (findMind → getOrCreateMindUser).
+    await addMind("test-mind", 4999);
+
+    try {
+      const res = await app.request("/api/v1/channels", {
+        method: "POST",
+        headers: {
+          Cookie: `volute_session=${cookie}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "squad", participantNames: ["bob", "test-mind"] }),
+      });
+      assert.equal(res.status, 201);
+      const body = await res.json();
+
+      // The mind's user row was created on demand by the route.
+      const mindUser = await getOrCreateMindUser("test-mind");
+
+      const participants = await getParticipants(body.id);
+      // Creator + the two requested participants.
+      assert.equal(participants.length, 3);
+      assert.ok(participants.some((p) => p.userId === userId));
+      assert.ok(participants.some((p) => p.userId === bob.id));
+      assert.ok(participants.some((p) => p.userId === mindUser.id));
+
+      await deleteConversation(body.id);
+    } finally {
+      await removeMind("test-mind");
+    }
+  });
+
+  it("POST /api/v1/channels — dedupes the creator and repeated participant names", async () => {
+    const cookie = await setupAuth();
+    const app = createApp();
+
+    const bob = await createUser("bob", "pass");
+
+    const res = await app.request("/api/v1/channels", {
+      method: "POST",
+      headers: {
+        Cookie: `volute_session=${cookie}`,
+        "Content-Type": "application/json",
+      },
+      // Include the creator and a duplicate name; joins are idempotent so this
+      // must succeed with a single row each — not roll the channel back.
+      body: JSON.stringify({ name: "dupes", participantNames: ["ch-admin", "bob", "bob"] }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+
+    const participants = await getParticipants(body.id);
+    // Creator + bob, each exactly once.
+    assert.equal(participants.length, 2);
+    assert.ok(participants.some((p) => p.userId === userId));
+    assert.ok(participants.some((p) => p.userId === bob.id));
+
+    await deleteConversation(body.id);
+  });
+
+  it("POST /api/v1/channels — 404 for unknown participant, channel not created", async () => {
+    const cookie = await setupAuth();
+    const app = createApp();
+
+    await createUser("bob", "pass");
+
+    const res = await app.request("/api/v1/channels", {
+      method: "POST",
+      headers: {
+        Cookie: `volute_session=${cookie}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "ghosted", participantNames: ["bob", "ghost"] }),
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.match(body.error, /ghost/);
+
+    // The channel must not have been created, even though "bob" resolved.
+    const ch = await getChannelByName("ghosted");
+    assert.equal(ch, null);
   });
 
   it("POST /api/v1/channels — 409 for duplicate name", async () => {


### PR DESCRIPTION
## Summary

`volute chat create --channel <name> --participants a,b` created the channel but silently ignored the participants — the daemon's channel-create route dropped `participantNames` (pre-existing since #195). The route now resolves every participant name up front (users table → mind registry fallback, matching the `v1/conversations` pattern), returns 404 before creating the channel if any name is unknown, joins all resolved participants after create, and rolls the channel back (best-effort, logged) if a join fails so no half-populated channel is left behind.

## Review

Three-reviewer pass completed: code-reviewer clean (verified authz unchanged — participantNames grants nothing the invite flow doesn't; parameterized queries throughout); silent-failure-hunter sound (its two suggested observability log lines are included); pr-test-analyzer no critical gaps (its suggested creator/duplicate idempotency test is included).

## Test plan

- New tests in `test/web-v1-channels.test.ts`: multi-participant create (brain + mind via registry fallback), unknown-participant 404 with channel-not-created (valid name preceding invalid), creator/duplicate dedup (idempotent joins, no rollback)
- Full `npm test`: 2087 pass / 0 fail; pre-push hook suite also green

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)