### PR TITLE
feat: 'while you were away' — home feed of autonomous mind activity

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -102,6 +102,17 @@ export type ActivityItem = {
   created_at: string;
 };
 
+/** One item in the "while you were away" home feed: a self-directed turn summary. */
+export type AwayFeedItem = {
+  /** The summary row id. */
+  id: number;
+  mind: string;
+  summary: string;
+  /** The turn this summary describes. */
+  turnId: string;
+  created_at: string;
+};
+
 export type ActivityEventType =
   | "mind_started"
   | "mind_stopped"

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -15,8 +15,11 @@ import {
   users,
 } from "../../lib/schema.js";
 import log from "../../lib/util/logger.js";
-import { isoWeekKeyForDateStr } from "../../lib/util/period-keys.js";
+import { isoWeekKeyForDateStr, utcDateTimeStr } from "../../lib/util/period-keys.js";
 import type { AuthEnv } from "../middleware/auth.js";
+
+/** Soft age cap for away-feed items. */
+const AWAY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Env for the history router. `mindFilter` is resolved once by router-level
@@ -584,6 +587,55 @@ const history = new Hono<HistoryEnv>()
     });
 
     return c.json(result);
+  })
+  // "While you were away": summaries of self-directed turns for the home feed —
+  // turns NOT triggered by a human message (heartbeats, schedules, dreams,
+  // spirit/mind-initiated, mind-to-mind), newest first. Artifact activity
+  // (pages, notes) is not duplicated here; extension feedSources already
+  // surface those on the home feed. Inherits the router's mindFilter scoping:
+  // minds see only their own activity, admins see all.
+  .get("/away", async (c) => {
+    const mindFilter = c.get("mindFilter");
+    const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "50", 10) || 50, 1), 100);
+
+    const db = await getDb();
+    const cutoff = utcDateTimeStr(new Date(Date.now() - AWAY_WINDOW_MS));
+
+    // A turn is self-directed when its trigger inbound is absent, senderless, or
+    // sent by a mind/system user. Senders that don't resolve to a users row
+    // (humans on external platforms like Discord) are treated as human-triggered.
+    const conditions = [
+      eq(summaries.period, "turn"),
+      gte(summaries.created_at, cutoff),
+      sql`(${turns.trigger_event_id} IS NULL OR ${mindHistory.sender} IS NULL OR ${users.user_type} IN ('mind', 'system'))`,
+    ];
+    if (mindFilter) conditions.push(eq(summaries.mind, mindFilter));
+
+    const rows = await db
+      .select({
+        id: summaries.id,
+        mind: summaries.mind,
+        content: summaries.content,
+        created_at: summaries.created_at,
+        turn_id: turns.id,
+      })
+      .from(summaries)
+      .innerJoin(turns, eq(turns.id, summaries.period_key))
+      .leftJoin(mindHistory, eq(mindHistory.id, turns.trigger_event_id))
+      .leftJoin(users, eq(users.username, mindHistory.sender))
+      .where(and(...conditions))
+      .orderBy(desc(summaries.created_at))
+      .limit(limit);
+
+    return c.json(
+      rows.map((r) => ({
+        id: r.id,
+        mind: r.mind,
+        summary: r.content,
+        turnId: r.turn_id,
+        created_at: r.created_at,
+      })),
+    );
   });
 
 export default history;

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -260,7 +260,8 @@ let breadcrumbs = $derived.by((): Breadcrumb[] => {
       }
     }
   } else if (sel.kind === "system-history") {
-    crumbs.push({ label: "system" });
+    crumbs.push({ label: "system", action: handleSystemHome });
+    crumbs.push({ label: "timeline" });
   } else {
     crumbs.push({ label: "system" });
   }
@@ -351,7 +352,7 @@ $effect(() => {
 $effect(() => {
   if (data.extensions.length > 0) {
     const fresh = parseSelection(data.extensions);
-    if (fresh.kind === "extension" && selection.kind === "system-history") {
+    if (fresh.kind === "extension" && selection.kind === "home") {
       selection = fresh;
     }
     if (
@@ -399,7 +400,7 @@ $effect(() => {
   const expected = selectionToPath(selection, data.extensions);
   const current = window.location.pathname + window.location.search;
   if (current !== expected) {
-    if (selection.kind === "system-history" && data.extensions.length === 0 && current !== "/") {
+    if (selection.kind === "home" && data.extensions.length === 0 && current !== "/") {
       // Skip — wait for extensions to load before deciding
     } else if (fromPopstate) {
       window.history.replaceState(null, "", expected);
@@ -489,7 +490,7 @@ async function handleDeleteConversation(id: string) {
   }
   connectActivity();
   if (activeConversationId === id) {
-    selection = { kind: "system-history" };
+    selection = { kind: "home" };
   }
 }
 
@@ -529,12 +530,12 @@ function onAuth(u: AuthUser) {
 function handleHideConversation(id: string) {
   hideConversation(id);
   if (activeConversationId === id) {
-    selection = { kind: "system-history" };
+    selection = { kind: "home" };
   }
 }
 
 function handleSystemHome() {
-  selection = { kind: "system-history" };
+  selection = { kind: "home" };
 }
 
 function handleSelectMind(name: string) {

--- a/packages/web/src/ui/components/layout/MainFrame.svelte
+++ b/packages/web/src/ui/components/layout/MainFrame.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
 import type { Selection } from "../../lib/navigate";
-import { showMindOnboarding } from "../../lib/onboarding";
-import { data } from "../../lib/stores.svelte";
 import Home from "../../pages/Home.svelte";
 import MindPage from "../../pages/MindPage.svelte";
 import Chat from "../chat/Chat.svelte";
-import MindEmptyState from "../MindEmptyState.svelte";
 import TurnTimeline from "../TurnTimeline.svelte";
 
 let {
@@ -123,17 +120,12 @@ let contextLabel = $derived.by(() => {
       <iframe src="/ext/{selection.extensionId}/#{selection.path ? '/' + selection.path : ''}" class="page-iframe" title="Extension"></iframe>
     </div>
   {:else if selection.kind === "system-history"}
-    <div class="frame-content mind-frame timeline-frame">
-      {#if showMindOnboarding(minds, data.mindsLoaded)}
-        <MindEmptyState {minds} {onSeed} />
-      {/if}
-      <div class="timeline-wrap">
-        <TurnTimeline />
-      </div>
+    <div class="frame-content mind-frame">
+      <TurnTimeline />
     </div>
   {:else}
     <div class="frame-content padded">
-      <Home {username} {conversations} {onSelectConversation} />
+      <Home {username} {conversations} {onSelectConversation} {onSeed} />
     </div>
   {/if}
 </div>
@@ -158,16 +150,6 @@ let contextLabel = $derived.by(() => {
 
   .frame-content.mind-frame {
     overflow: hidden;
-  }
-
-  .timeline-frame {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .timeline-wrap {
-    flex: 1;
-    min-height: 0;
   }
 
   .page-iframe {

--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
 import { Icon, Modal, tooltip as tooltipAction } from "@volute/ui";
+import { icons } from "@volute/ui/icons";
 import { startMind, stopMind } from "../../lib/client";
 import { mindDotColor } from "../../lib/format";
-import type { Selection } from "../../lib/navigate";
+import { navigate, type Selection } from "../../lib/navigate";
 import {
   cancelReauth,
   oauthReauth,
@@ -193,7 +194,9 @@ let activeChannelId = $derived.by(() => {
 });
 
 let isSystemActive = $derived(
-  selection.kind === "system-history" || selection.kind === "extension",
+  selection.kind === "home" ||
+    selection.kind === "system-history" ||
+    selection.kind === "extension",
 );
 </script>
 
@@ -229,6 +232,18 @@ let isSystemActive = $derived(
             onclick={handleOauthWarningClick}
           >!</button>
         {/if}
+      </div>
+      <div class="item-list">
+        <div class="mind-item-row">
+          <button
+            class="nav-item"
+            class:active={selection.kind === "system-history"}
+            onclick={() => navigate("/history")}
+          >
+            <span class="nav-icon">{@html icons.history}</span>
+            <span class="nav-label">Timeline</span>
+          </button>
+        </div>
       </div>
       {#if spirits.length > 0}
         <div class="item-list">
@@ -595,6 +610,17 @@ let isSystemActive = $derived(
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .nav-icon {
+    display: flex;
+    flex-shrink: 0;
+    color: var(--text-2);
+  }
+
+  .nav-icon :global(svg) {
+    width: 12px;
+    height: 12px;
   }
 
   .item-list {

--- a/packages/web/src/ui/lib/away-feed.ts
+++ b/packages/web/src/ui/lib/away-feed.ts
@@ -1,0 +1,14 @@
+/** localStorage key holding the ISO timestamp of the user's last home-feed visit. */
+export const AWAY_SEEN_KEY = "volute:away-last-seen";
+
+/**
+ * Index in a newest-first feed where the "new since your last visit" divider
+ * belongs: the first item at or older than `lastSeenMs`. Returns -1 when no
+ * divider should show — no prior visit, nothing new (divider would sit at the
+ * top), or everything new (divider would sit below the whole feed).
+ */
+export function dividerIndex(datesMs: number[], lastSeenMs: number | null): number {
+  if (lastSeenMs == null) return -1;
+  const idx = datesMs.findIndex((d) => d <= lastSeenMs);
+  return idx <= 0 ? -1 : idx;
+}

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -4,6 +4,7 @@
 
 import type {
   AvailableUser,
+  AwayFeedItem,
   ChannelInfo,
   Conversation,
   ConversationWithParticipants,
@@ -310,6 +311,11 @@ export function fetchSummaries(opts: {
 export function fetchSummaryByIds(ids: number[]): Promise<SummaryRow[]> {
   if (ids.length === 0) return Promise.resolve([]);
   return get(`${V1}/history/summaries?ids=${ids.join(",")}`);
+}
+
+/** Fetch the "while you were away" feed: self-directed turn summaries + artifact activity. */
+export function fetchAwayFeed(limit?: number): Promise<AwayFeedItem[]> {
+  return get(`${V1}/history/away${limit !== undefined ? `?limit=${limit}` : ""}`);
 }
 
 // --- Variants ---

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -313,7 +313,7 @@ export function fetchSummaryByIds(ids: number[]): Promise<SummaryRow[]> {
   return get(`${V1}/history/summaries?ids=${ids.join(",")}`);
 }
 
-/** Fetch the "while you were away" feed: self-directed turn summaries + artifact activity. */
+/** Fetch the "while you were away" feed: self-directed turn summaries (artifact activity is surfaced separately via extension feedSources). */
 export function fetchAwayFeed(limit?: number): Promise<AwayFeedItem[]> {
   return get(`${V1}/history/away${limit !== undefined ? `?limit=${limit}` : ""}`);
 }

--- a/packages/web/src/ui/lib/navigate.ts
+++ b/packages/web/src/ui/lib/navigate.ts
@@ -8,6 +8,7 @@ export type Selection =
       subpath?: string;
     }
   | { kind: "extension"; extensionId: string; path: string }
+  | { kind: "home" }
   | { kind: "system-history" }
   | { kind: "channel"; slug: string };
 
@@ -85,7 +86,7 @@ export function parseSelection(extensions: ExtensionInfo[] = []): Selection {
   if (path === "/history") return { kind: "system-history" };
   // Legacy settings URLs — these are now modals, redirect to home
   if (path === "/system/settings" || path === "/settings" || path.startsWith("/settings/"))
-    return { kind: "system-history" };
+    return { kind: "home" };
 
   // Mind detail pages — must be checked before extension URL patterns
   // because /minds/:name/:section could overlap
@@ -130,11 +131,11 @@ export function parseSelection(extensions: ExtensionInfo[] = []): Selection {
   if (path === "/chat") {
     const mind = search.get("mind");
     if (mind) return { kind: "mind", name: mind };
-    return { kind: "system-history" };
+    return { kind: "home" };
   }
 
-  // Default: history landing page
-  return { kind: "system-history" };
+  // Default: home feed landing page
+  return { kind: "home" };
 }
 
 /**
@@ -144,8 +145,10 @@ export function parseSelection(extensions: ExtensionInfo[] = []): Selection {
  */
 export function selectionToPath(selection: Selection, extensions: ExtensionInfo[] = []): string {
   switch (selection.kind) {
-    case "system-history":
+    case "home":
       return "/";
+    case "system-history":
+      return "/history";
     case "mind": {
       let section = selection.section;
       // Convert ext:pages:pages → pages for clean URLs

--- a/packages/web/src/ui/pages/Home.svelte
+++ b/packages/web/src/ui/pages/Home.svelte
@@ -62,7 +62,8 @@ const lastSeenMs = readLastSeen();
 try {
   localStorage.setItem(AWAY_SEEN_KEY, new Date().toISOString());
 } catch {
-  // localStorage unavailable — the divider just won't show
+  // Can't advance the watermark — the divider still shows against the last
+  // stored visit (or stays hidden if there was never one); it just won't move.
 }
 
 // Fetch self-directed turn summaries (heartbeats, schedules, mind-to-mind)

--- a/packages/web/src/ui/pages/Home.svelte
+++ b/packages/web/src/ui/pages/Home.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-import type { ConversationWithParticipants, LastMessageSummary, Message } from "@volute/api";
+import type {
+  AwayFeedItem,
+  ConversationWithParticipants,
+  LastMessageSummary,
+  Message,
+} from "@volute/api";
+import { icons } from "@volute/ui/icons";
 import { renderMarkdown } from "@volute/ui/markdown";
 import ExtensionFeedCard from "../components/ExtensionFeedCard.svelte";
-import { fetchConversationMessages } from "../lib/client";
+import { AWAY_SEEN_KEY, dividerIndex } from "../lib/away-feed";
+import { fetchAwayFeed, fetchConversationMessages } from "../lib/client";
 import { extractTextContent, formatTime, showSenderHeader } from "../lib/feed-utils";
 import { formatRelativeTime, normalizeTimestamp } from "../lib/format";
 
@@ -37,6 +44,41 @@ type ExtFeedItem = {
 };
 
 let extensionFeedItems = $state<ExtFeedItem[]>([]);
+let awayItems = $state<AwayFeedItem[]>([]);
+
+// "While you were away": read the previous visit's watermark once, then
+// advance it to now. Items newer than it sit above the divider.
+function readLastSeen(): number | null {
+  try {
+    const v = localStorage.getItem(AWAY_SEEN_KEY);
+    if (!v) return null;
+    const ms = Date.parse(v);
+    return Number.isNaN(ms) ? null : ms;
+  } catch {
+    return null;
+  }
+}
+const lastSeenMs = readLastSeen();
+try {
+  localStorage.setItem(AWAY_SEEN_KEY, new Date().toISOString());
+} catch {
+  // localStorage unavailable — the divider just won't show
+}
+
+// Fetch self-directed turn summaries (heartbeats, schedules, mind-to-mind)
+$effect(() => {
+  fetchAwayFeed()
+    .then((items) => {
+      awayItems = items;
+    })
+    .catch((err) => {
+      console.warn("Failed to fetch away feed:", err);
+    });
+});
+
+function mindLabel(name: string): string {
+  return storeData.minds.find((m) => m.name === name)?.displayName ?? name;
+}
 
 // Fetch extension feed items from all extensions with feedSource
 $effect(() => {
@@ -95,7 +137,8 @@ $effect(() => {
 
 type FeedItem =
   | { kind: "message"; conv: ConversationWithDetails; date: string }
-  | { kind: "extension"; item: ExtFeedItem; date: string };
+  | { kind: "extension"; item: ExtFeedItem; date: string }
+  | { kind: "away"; item: AwayFeedItem; date: string };
 
 let feedItems = $derived.by(() => {
   const items: FeedItem[] = [];
@@ -105,6 +148,9 @@ let feedItems = $derived.by(() => {
   for (const extItem of extensionFeedItems) {
     items.push({ kind: "extension", item: extItem, date: extItem.date });
   }
+  for (const awayItem of awayItems) {
+    items.push({ kind: "away", item: awayItem, date: awayItem.created_at });
+  }
   items.sort((a, b) => {
     const aTime = new Date(normalizeTimestamp(a.date)).getTime();
     const bTime = new Date(normalizeTimestamp(b.date)).getTime();
@@ -112,6 +158,14 @@ let feedItems = $derived.by(() => {
   });
   return items;
 });
+
+// Where the "new since your last visit" divider goes in the newest-first feed
+let dividerAt = $derived(
+  dividerIndex(
+    feedItems.map((i) => new Date(normalizeTimestamp(i.date)).getTime()),
+    lastSeenMs,
+  ),
+);
 
 function getConvLabel(conv: ConversationWithDetails): string {
   if (conv.type === "channel" && conv.channel_name) return `#${conv.channel_name}`;
@@ -129,10 +183,15 @@ function getConvLabel(conv: ConversationWithDetails): string {
 
 <div class="home">
   {#if feedItems.length === 0}
-    <div class="empty-hint">Nothing here yet.</div>
+    <div class="empty-hint">
+      Nothing here yet. When your minds do things on their own, it shows up here.
+    </div>
   {:else}
     <div class="feed-grid">
-      {#each feedItems as item (item.kind === "extension" ? `ext-${item.item.id}` : `msg-${item.conv.id}`)}
+      {#each feedItems as item, i (item.kind === "extension" ? `ext-${item.item.id}` : item.kind === "away" ? `away-${item.item.id}` : `msg-${item.conv.id}`)}
+        {#if i === dividerAt}
+          <div class="feed-divider"><span class="feed-divider-label">new since your last visit ↑</span></div>
+        {/if}
         {#if item.kind === "extension"}
           <div class="feed-item">
             <ExtensionFeedCard
@@ -145,6 +204,19 @@ function getConvLabel(conv: ConversationWithDetails): string {
               icon={item.item.icon}
               color={item.item.color}
               onclick={() => navigate(item.item.url)}
+            />
+          </div>
+        {:else if item.kind === "away"}
+          {@const away = item.item}
+          <div class="feed-item">
+            <ExtensionFeedCard
+              title={mindLabel(away.mind)}
+              url={`/minds/${away.mind}`}
+              date={away.created_at}
+              bodyHtml={away.summary}
+              icon={icons.mind}
+              color="purple"
+              onclick={() => navigate(`/minds/${away.mind}`)}
             />
           </div>
         {:else}
@@ -218,6 +290,28 @@ function getConvLabel(conv: ConversationWithDetails): string {
 
   .feed-item {
     min-width: 0;
+  }
+
+  .feed-divider {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 2px 0;
+  }
+
+  .feed-divider::before,
+  .feed-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: color-mix(in srgb, var(--accent) 35%, var(--border));
+  }
+
+  .feed-divider-label {
+    font-size: 11px;
+    color: var(--text-2);
+    white-space: nowrap;
   }
 
   /* Unified card */

--- a/packages/web/src/ui/pages/Home.svelte
+++ b/packages/web/src/ui/pages/Home.svelte
@@ -8,12 +8,14 @@ import type {
 import { icons } from "@volute/ui/icons";
 import { renderMarkdown } from "@volute/ui/markdown";
 import ExtensionFeedCard from "../components/ExtensionFeedCard.svelte";
+import MindEmptyState from "../components/MindEmptyState.svelte";
 import { AWAY_SEEN_KEY, dividerIndex } from "../lib/away-feed";
 import { fetchAwayFeed, fetchConversationMessages } from "../lib/client";
 import { extractTextContent, formatTime, showSenderHeader } from "../lib/feed-utils";
 import { formatRelativeTime, normalizeTimestamp } from "../lib/format";
 
 import { navigate } from "../lib/navigate";
+import { showMindOnboarding } from "../lib/onboarding";
 import { data as storeData } from "../lib/stores.svelte";
 
 type ConversationWithDetails = ConversationWithParticipants & {
@@ -24,11 +26,16 @@ let {
   username,
   conversations,
   onSelectConversation,
+  onSeed,
 }: {
   username: string;
   conversations: ConversationWithDetails[];
   onSelectConversation: (id: string) => void;
+  onSeed: () => void;
 } = $props();
+
+// Fresh-install state: no regular minds yet. Onboarding takes over the landing.
+let onboarding = $derived(showMindOnboarding(storeData.minds, storeData.mindsLoaded));
 
 type ExtFeedItem = {
   id: string;
@@ -183,7 +190,9 @@ function getConvLabel(conv: ConversationWithDetails): string {
 </script>
 
 <div class="home">
-  {#if feedItems.length === 0}
+  {#if onboarding}
+    <MindEmptyState minds={storeData.minds} {onSeed} />
+  {:else if feedItems.length === 0}
     <div class="empty-hint">
       Nothing here yet. When your minds do things on their own, it shows up here.
     </div>

--- a/test/web-away-feed.test.ts
+++ b/test/web-away-feed.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { dividerIndex } from "../packages/web/src/ui/lib/away-feed.js";
+
+describe("dividerIndex", () => {
+  // Newest-first timestamps
+  const t = (n: number) => n * 1000;
+
+  it("returns -1 with no prior visit", () => {
+    assert.equal(dividerIndex([t(3), t(2), t(1)], null), -1);
+  });
+
+  it("returns -1 for an empty feed", () => {
+    assert.equal(dividerIndex([], t(5)), -1);
+  });
+
+  it("returns -1 when nothing is new (first item at/older than last seen)", () => {
+    assert.equal(dividerIndex([t(3), t(2), t(1)], t(3)), -1);
+    assert.equal(dividerIndex([t(3), t(2), t(1)], t(10)), -1);
+  });
+
+  it("returns -1 when everything is new", () => {
+    assert.equal(dividerIndex([t(3), t(2), t(1)], t(0)), -1);
+  });
+
+  it("returns the index of the first item at or older than last seen", () => {
+    assert.equal(dividerIndex([t(5), t(4), t(3), t(2)], t(3)), 2);
+    assert.equal(dividerIndex([t(5), t(4)], t(4)), 1);
+  });
+});

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -581,4 +581,136 @@ describe("web history routes", () => {
     assert.ok(received.includes("alice-visible"), "caller's own event is streamed");
     assert.ok(!received.includes("bob-secret"), "another mind's event must not be streamed");
   });
+
+  describe("GET /api/v1/history/away", () => {
+    type AwayItem = { id: number; mind: string; summary: string; turnId: string };
+
+    /**
+     * Insert a completed turn with a turn summary. When `sender` is given, an
+     * inbound trigger event from that sender is recorded and linked.
+     * `sender: null` records a senderless trigger.
+     */
+    async function insertSummarizedTurn(
+      mind: string,
+      summary: string,
+      opts: { sender?: string | null; summaryCreatedAt?: string } = {},
+    ): Promise<string> {
+      const db = await getDb();
+      const turnId = randomUUID();
+      let triggerEventId: number | undefined;
+      if (opts.sender !== undefined) {
+        const [row] = await db
+          .insert(mindHistory)
+          .values({
+            mind,
+            type: "inbound",
+            channel: "@whoever",
+            sender: opts.sender,
+            content: "hello",
+            turn_id: turnId,
+          })
+          .returning({ id: mindHistory.id });
+        triggerEventId = row.id;
+      }
+      await db.insert(turns).values({
+        id: turnId,
+        mind,
+        status: "complete",
+        trigger_event_id: triggerEventId,
+      });
+      await db.insert(summaries).values({
+        mind,
+        period: "turn",
+        period_key: turnId,
+        content: summary,
+        ...(opts.summaryCreatedAt ? { created_at: opts.summaryCreatedAt } : {}),
+      });
+      return turnId;
+    }
+
+    it("includes self-directed turns, excludes human-triggered ones", async () => {
+      const cookie = await setupAuth();
+      // A human (brain) user and a mind user to trigger turns with
+      await createUser("test-history-human", "pass");
+      await getOrCreateMindUser("test-history-peer");
+
+      const untriggered = await insertSummarizedTurn("test-history-away1", "wrote a journal entry");
+      const senderless = await insertSummarizedTurn("test-history-away1", "woke from a schedule", {
+        sender: null,
+      });
+      const mindTriggered = await insertSummarizedTurn(
+        "test-history-away1",
+        "chatted with a peer",
+        {
+          sender: "test-history-peer",
+        },
+      );
+      const humanTriggered = await insertSummarizedTurn("test-history-away1", "replied to james", {
+        sender: "test-history-human",
+      });
+      const externalTriggered = await insertSummarizedTurn(
+        "test-history-away1",
+        "replied on discord",
+        { sender: "some-discord-person" },
+      );
+
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("/api/v1/history/away", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as AwayItem[];
+      const turnIds = new Set(body.map((i) => i.turnId));
+
+      assert.ok(turnIds.has(untriggered), "turn with no trigger is self-directed");
+      assert.ok(turnIds.has(senderless), "turn with senderless trigger is self-directed");
+      assert.ok(turnIds.has(mindTriggered), "mind-to-mind turn is self-directed");
+      assert.ok(!turnIds.has(humanTriggered), "human-triggered turn is excluded");
+      assert.ok(
+        !turnIds.has(externalTriggered),
+        "unknown (external platform) sender is treated as human",
+      );
+    });
+
+    it("excludes items older than the 7-day window", async () => {
+      const cookie = await setupAuth();
+      const fresh = await insertSummarizedTurn("test-history-away1", "recent thought");
+      const stale = await insertSummarizedTurn("test-history-away1", "ancient thought", {
+        summaryCreatedAt: "2020-01-01 00:00:00",
+      });
+
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("/api/v1/history/away", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as AwayItem[];
+      const turnIds = new Set(body.map((i) => i.turnId));
+      assert.ok(turnIds.has(fresh));
+      assert.ok(!turnIds.has(stale));
+    });
+
+    it("scopes a mind caller to its own turns, ignoring ?mind=", async () => {
+      await setupAuth();
+      const mine = await insertSummarizedTurn("test-history-away1", "my own turn");
+      const other = await insertSummarizedTurn("test-history-away2", "someone else's turn");
+
+      const cookie = await mindSession("test-history-away1");
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("/api/v1/history/away?mind=test-history-away2", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as AwayItem[];
+      const turnIds = new Set(body.map((i) => i.turnId));
+      assert.ok(turnIds.has(mine), "mind sees its own self-directed turns");
+      assert.ok(!turnIds.has(other), "?mind= must not leak another mind's turns");
+    });
+
+    it("requires authentication", async () => {
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("/api/v1/history/away");
+      assert.equal(res.status, 401);
+    });
+  });
 });

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq, sql } from "drizzle-orm";
-import { createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import {
+  createUser,
+  getOrCreateMindUser,
+  getOrCreateSystemUser,
+} from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { publish as publishMindEvent } from "../packages/daemon/src/lib/events/mind-events.js";
 import {
@@ -630,9 +634,11 @@ describe("web history routes", () => {
 
     it("includes self-directed turns, excludes human-triggered ones", async () => {
       const cookie = await setupAuth();
-      // A human (brain) user and a mind user to trigger turns with
+      // A human (brain) user, a mind user, and the shared system user (the
+      // spirit's account) to trigger turns with.
       await createUser("test-history-human", "pass");
       await getOrCreateMindUser("test-history-peer");
+      const systemUser = await getOrCreateSystemUser();
 
       const untriggered = await insertSummarizedTurn("test-history-away1", "wrote a journal entry");
       const senderless = await insertSummarizedTurn("test-history-away1", "woke from a schedule", {
@@ -644,6 +650,11 @@ describe("web history routes", () => {
         {
           sender: "test-history-peer",
         },
+      );
+      const spiritTriggered = await insertSummarizedTurn(
+        "test-history-away1",
+        "nudged by the spirit",
+        { sender: systemUser.username },
       );
       const humanTriggered = await insertSummarizedTurn("test-history-away1", "replied to james", {
         sender: "test-history-human",
@@ -665,6 +676,7 @@ describe("web history routes", () => {
       assert.ok(turnIds.has(untriggered), "turn with no trigger is self-directed");
       assert.ok(turnIds.has(senderless), "turn with senderless trigger is self-directed");
       assert.ok(turnIds.has(mindTriggered), "mind-to-mind turn is self-directed");
+      assert.ok(turnIds.has(spiritTriggered), "spirit (system-user) turn is self-directed");
       assert.ok(!turnIds.has(humanTriggered), "human-triggered turn is excluded");
       assert.ok(
         !turnIds.has(externalTriggered),
@@ -688,6 +700,30 @@ describe("web history routes", () => {
       const turnIds = new Set(body.map((i) => i.turnId));
       assert.ok(turnIds.has(fresh));
       assert.ok(!turnIds.has(stale));
+    });
+
+    it("orders items newest-first (the contract dividerIndex depends on)", async () => {
+      const cookie = await setupAuth();
+      // Recent timestamps (within the 7-day window), a couple hours apart.
+      const ago = (hours: number) =>
+        new Date(Date.now() - hours * 3600_000).toISOString().replace("T", " ").slice(0, 19);
+      const older = await insertSummarizedTurn("test-history-away1", "an earlier thought", {
+        summaryCreatedAt: ago(3),
+      });
+      const newer = await insertSummarizedTurn("test-history-away1", "a later thought", {
+        summaryCreatedAt: ago(1),
+      });
+
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("/api/v1/history/away", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as AwayItem[];
+      const newerIdx = body.findIndex((i) => i.turnId === newer);
+      const olderIdx = body.findIndex((i) => i.turnId === older);
+      assert.ok(newerIdx >= 0 && olderIdx >= 0, "both turns present");
+      assert.ok(newerIdx < olderIdx, "the fresher turn comes before the older one");
     });
 
     it("scopes a mind caller to its own turns, ignoring ?mind=", async () => {


### PR DESCRIPTION
## What

Turns the dashboard home into a "while you were away" feed of autonomous mind activity, so coming back to Volute shows what your minds did on their own rather than an empty timeline.

- **Backend** — new `GET /api/v1/history/away` on the history router. Returns self-directed turn summaries newest-first: `summaries` rows (`period='turn'`) joined to their turn and the trigger `mind_history` event, keeping only turns **not** triggered by a human. "Human-triggered" = the trigger's sender resolves to a `user_type='brain'` user (or an unknown external-platform sender). Turns with no trigger, a senderless trigger, or a `mind`/`system` (spirit) sender all count — heartbeats, schedules, dreams, spirit- and mind-to-mind-initiated turns. Inherits the router's `mindFilter` scoping (a non-admin mind sees only its own; `?mind=` is ignored), 7-day soft window, `limit` clamped to 100, all queries Drizzle-parameterized.
- **Frontend** — Home becomes the `/` landing; the raw turn timeline moves to `/history`, reachable via a new "Timeline" affordance under System in the sidebar. Home fetches `/away` on mount and merges those cards (via the existing `ExtensionFeedCard`) with the conversation and extension-feed cards it already shows, all time-ordered. A "new since your last visit" divider is placed from a `localStorage` watermark (no server read-state).

## Why

Issue #583: autonomous activity (a mind writing a journal entry, waking on a schedule, chatting with a peer) was invisible unless you dug into each mind's timeline. This surfaces it on the landing page.

## Design notes

- **Artifact activity (pages/notes) is intentionally not in `/away`.** The spec floated merging artifact activity into the endpoint, but the pages, notes, and plan extensions already expose a `feedSource`, so those artifacts are already rendered as cards on the home feed. `/away` contributes only the missing piece — self-directed *turn* summaries — which keeps each artifact to a single card instead of duplicating it.
- **Coordination with #598 (merged).** #598 added `MindEmptyState` + `showMindOnboarding()` and rendered the zero-minds onboarding card on the system-history landing, which used to be `/`. Since this PR moves `/` to Home, I rebased onto the merged #598 and **re-hosted** that card in `Home.svelte` (gated on `showMindOnboarding`), removing it from the timeline frame — so the fresh-install experience still lands at `/`.

## Test plan

- `npm test` — full suite green (2094 pass / 0 fail; the one `test/shutdown-signal.test.ts` blip under contention passes in isolation).
- New daemon tests (`test/web-history.test.ts`, `GET /away` block): self-directed filtering (untriggered / senderless / mind-to-mind / **spirit system-user** included; human and unknown-external senders excluded), 7-day window, **newest-first ordering**, non-admin mind scoped to itself ignoring `?mind=`, requires-auth.
- New pure-helper test (`test/web-away-feed.test.ts`): `dividerIndex` watermark logic across no-prior-visit / empty / nothing-new / all-new / mid-feed cases.
- `svelte-check`, `knip`, and `npm run build:web` all clean.

## Review

Ran code-reviewer, silent-failure-hunter, and pr-test-analyzer over the diff. Verdicts clean; applied their nits — added the spirit (system-user) inclusion test and a newest-first ordering assertion, corrected the `fetchAwayFeed` docstring (no artifact activity) and the `localStorage` watermark comment.

Fixes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
