### PR TITLE
feat(pages): recency + index-forward UI and JS-capable pages

### DIFF
--- a/packages/extensions/pages/src/db.ts
+++ b/packages/extensions/pages/src/db.ts
@@ -35,10 +35,24 @@ type PublishedPage = {
   author: string | null;
 };
 type RecentPage = { mind: string; file: string; updated_at: string; author: string | null };
+type SiteFile = { file: string; updated_at: string; author: string | null };
 type SiteEntry = {
   mind: string;
-  files: { file: string; updated_at: string; author: string | null }[];
+  files: SiteFile[];
 };
+
+/** A page is a site's "home" when it's a top-level index.html/index.md. */
+function isIndex(file: string): boolean {
+  return file === "index.html" || file === "index.md";
+}
+
+/** Sort a site's files so the index (home) leads, then most-recently-updated. */
+function sortSiteFiles(files: SiteFile[]): SiteFile[] {
+  return [...files].sort((a, b) => {
+    if (isIndex(a.file) !== isIndex(b.file)) return isIndex(a.file) ? -1 : 1;
+    return b.updated_at.localeCompare(a.updated_at);
+  });
+}
 
 export function getPublishedPages(db: Database, mind: string): PublishedPage[] {
   return db
@@ -69,14 +83,16 @@ export function getRecentPages(
 }
 
 export function getAllSites(db: Database): SiteEntry[] {
-  // Exclude _system pages — those are shown separately
+  // Exclude _system pages — those are shown separately. Order globally by
+  // recency (id breaks same-second ties) so the first row seen for each mind is
+  // its most-recent page — that gives us sites ranked by recent activity.
   const rows = db
     .prepare(
-      "SELECT mind, file, updated_at, author FROM published_pages WHERE mind != '_system' ORDER BY mind, file",
+      "SELECT mind, file, updated_at, author FROM published_pages WHERE mind != '_system' ORDER BY updated_at DESC, id DESC",
     )
     .all() as RecentPage[];
 
-  const siteMap = new Map<string, { file: string; updated_at: string; author: string | null }[]>();
+  const siteMap = new Map<string, SiteFile[]>();
   for (const row of rows) {
     let files = siteMap.get(row.mind);
     if (!files) {
@@ -86,19 +102,25 @@ export function getAllSites(db: Database): SiteEntry[] {
     files.push({ file: row.file, updated_at: row.updated_at, author: row.author });
   }
 
-  return Array.from(siteMap.entries()).map(([mind, files]) => ({ mind, files }));
+  // Map insertion order = site recency; within each site, index leads.
+  return Array.from(siteMap.entries()).map(([mind, files]) => ({
+    mind,
+    files: sortSiteFiles(files),
+  }));
 }
 
 export function getSystemPages(db: Database): SiteEntry | null {
   const rows = db
     .prepare(
-      "SELECT mind, file, updated_at, author FROM published_pages WHERE mind = '_system' ORDER BY file",
+      "SELECT mind, file, updated_at, author FROM published_pages WHERE mind = '_system' ORDER BY updated_at DESC, id DESC",
     )
     .all() as RecentPage[];
   if (rows.length === 0) return null;
   return {
     mind: "_system",
-    files: rows.map((r) => ({ file: r.file, updated_at: r.updated_at, author: r.author })),
+    files: sortSiteFiles(
+      rows.map((r) => ({ file: r.file, updated_at: r.updated_at, author: r.author })),
+    ),
   };
 }
 

--- a/packages/extensions/pages/src/routes.ts
+++ b/packages/extensions/pages/src/routes.ts
@@ -28,7 +28,7 @@ export function createRoutes(ctx: ExtensionContext): Hono {
     .get("/", async (c) => {
       if (!ctx.db) return c.json({ error: "Pages database not available" }, 503);
       const { sites, systemSite } = getSites(ctx.db);
-      const recentPages = getRecentPagesList(ctx.db);
+      const recentPages = getRecentPagesList(ctx.db, { limit: 12 });
       return c.json({ sites, systemSite, recentPages });
     })
     .get("/feed", async (c) => {
@@ -87,14 +87,36 @@ export function createRoutes(ctx: ExtensionContext): Hono {
     });
 }
 
-// Mind-authored pages are served on the dashboard's own origin. This CSP blocks
-// script execution (no script-src → falls back to default-src 'none', which also
-// blocks inline event handlers like onerror) so a malicious page cannot run JS in
-// an authenticated admin's session. Defense-in-depth with DOMPurify sanitization
-// of rendered markdown. Styles/images/fonts are allowed so legitimate pages render.
+// Mind-authored pages are served on the dashboard's own origin, but minds are
+// untrusted — a page's JS must not be able to ride the viewing admin's session.
+// `sandbox allow-scripts` (crucially WITHOUT allow-same-origin) runs the page in
+// an opaque origin: scripts execute, but the document's origin is `null`, so any
+// fetch() to /api/* is cross-site and the SameSite=Lax `volute_session` cookie is
+// never sent. This holds whether the page is viewed in the dashboard iframe or
+// opened directly. https: sources let pages pull CDN libraries/fonts; the opaque
+// origin means external calls carry nothing sensitive. Markdown pages are still
+// DOMPurify-sanitized (defense-in-depth). Omitting allow-forms/allow-popups keeps
+// the sandbox tight.
 const PAGES_CSP =
-  "default-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; " +
-  "font-src 'self'; base-uri 'none'; form-action 'none'";
+  "sandbox allow-scripts; default-src 'self' https:; " +
+  "script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; " +
+  "img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; " +
+  "base-uri 'none'";
+
+// Sandboxed pages run in an opaque origin, so the dashboard iframe can't read
+// their location to keep the breadcrumb in sync when a visitor follows an
+// in-page link. Instead every served HTML page reports its own path to the
+// parent on load. The script is a constant (no interpolation of the request
+// path), so it adds no injection surface, and it only posts when framed — a
+// directly-opened page has no parent and stays silent.
+const NAV_SHIM =
+  "<script>if(window.parent!==window){window.parent.postMessage(" +
+  '{type:"volute-pages-nav",path:location.pathname},"*")}</script>';
+
+function injectNavShim(html: string): string {
+  const idx = html.lastIndexOf("</body>");
+  return idx >= 0 ? html.slice(0, idx) + NAV_SHIM + html.slice(idx) : html + NAV_SHIM;
+}
 
 export function createPublicRoutes(ctx: ExtensionContext): Hono {
   return new Hono()
@@ -163,7 +185,12 @@ export function createPublicRoutes(ctx: ExtensionContext): Hono {
           const cssRelPath = resolveStylesheet(fileToServe, pagesRoot, style);
           const cssUrl = cssRelPath ? `/ext/pages/public/${name}/${cssRelPath}` : undefined;
           const html = await renderMarkdownPage(body, { title, stylesheetUrl: cssUrl });
-          return c.body(html, 200, { "Content-Type": "text/html; charset=utf-8" });
+          return c.body(injectNavShim(html), 200, { "Content-Type": "text/html; charset=utf-8" });
+        }
+
+        if (ext === ".html") {
+          const html = await readFile(fileToServe, "utf-8");
+          return c.body(injectNavShim(html), 200, { "Content-Type": "text/html; charset=utf-8" });
         }
 
         const mime = MIME_TYPES[ext] || "application/octet-stream";

--- a/packages/extensions/pages/ui/src/App.svelte
+++ b/packages/extensions/pages/ui/src/App.svelte
@@ -5,13 +5,18 @@ import PagesDashboard from "./pages/PagesDashboard.svelte";
 import SiteView from "./pages/SiteView.svelte";
 
 let hash = $state(window.location.hash);
+let pageIframe = $state<HTMLIFrameElement>();
 
 onMount(() => {
   const handler = () => {
     hash = window.location.hash;
   };
   window.addEventListener("hashchange", handler);
-  return () => window.removeEventListener("hashchange", handler);
+  window.addEventListener("message", handlePageMessage);
+  return () => {
+    window.removeEventListener("hashchange", handler);
+    window.removeEventListener("message", handlePageMessage);
+  };
 });
 
 type Route =
@@ -63,26 +68,29 @@ function navigateParent(path: string) {
   window.parent.postMessage({ type: "navigate", path }, "*");
 }
 
-function handleIframeNav(e: Event) {
-  const iframe = e.target as HTMLIFrameElement;
-  try {
-    const path = iframe.contentWindow?.location.pathname;
-    if (!path) return;
-    // Match /ext/pages/public/{name}/{file...}
-    const match = path.match(/^\/ext\/pages\/public\/([^/]+)\/(.+)$/);
-    if (!match) return;
-    const [, mind, file] = match;
-    if (route.view === "page" && mind === route.name && file === route.path) return;
-    if (mind === "_system") {
-      navigateParent(`/pages/_system/${file}`);
-    } else {
-      navigateParent(`/minds/${mind}/pages/${file}`);
-    }
-  } catch (err) {
-    if (!(err instanceof DOMException)) {
-      console.error("[pages] unexpected error in iframe nav handler:", err);
-    }
+// Sync the outer breadcrumb from a page path (`/ext/pages/public/{mind}/{file}`).
+// The path is untrusted — we only ever derive a pages route from it, never an
+// arbitrary app route.
+function syncBreadcrumbFromPath(path: string) {
+  const match = path.match(/^\/ext\/pages\/public\/([^/]+)\/(.+)$/);
+  if (!match) return;
+  const [, mind, file] = match;
+  if (route.view === "page" && mind === route.name && file === route.path) return;
+  if (mind === "_system") {
+    navigateParent(`/pages/_system/${file}`);
+  } else {
+    navigateParent(`/minds/${mind}/pages/${file}`);
   }
+}
+
+// Sandboxed pages can't have their location read cross-origin, so they report it
+// to us via postMessage (see NAV_SHIM in the pages server). Only trust messages
+// coming from the page iframe we mounted.
+function handlePageMessage(e: MessageEvent) {
+  if (e.source !== pageIframe?.contentWindow) return;
+  const data = e.data;
+  if (data?.type !== "volute-pages-nav" || typeof data.path !== "string") return;
+  syncBreadcrumbFromPath(data.path);
 }
 
 function handleSelectPage(mind: string, path: string) {
@@ -105,10 +113,10 @@ function handleSelectSite(name: string) {
 <div class="ext-app" class:full-page={route.view === "page"}>
   {#if route.view === "page"}
     <iframe
+      bind:this={pageIframe}
       src="/ext/pages/public/{route.name}/{route.path}"
       class="full-page-iframe"
       title="{route.name}/{route.path}"
-      onload={handleIframeNav}
     ></iframe>
   {:else if (route.view === "site" || route.view === "mind") && selectedSite}
     <SiteView site={selectedSite} onSelectPage={handleSelectPage} />

--- a/packages/extensions/pages/ui/src/components/PageThumbnail.svelte
+++ b/packages/extensions/pages/ui/src/components/PageThumbnail.svelte
@@ -4,20 +4,29 @@ let {
   label,
   sublabel,
   onclick,
+  width = 280,
+  height = 180,
 }: {
   url: string;
   label: string;
   sublabel?: string;
   onclick?: () => void;
+  width?: number;
+  height?: number;
 } = $props();
 
 let loaded = $state(false);
+
+// The page renders at desktop width (1280px) and is scaled down to fit the frame.
+const RENDER_WIDTH = 1280;
+let scale = $derived(width / RENDER_WIDTH);
 </script>
 
-<button class="thumbnail-card" {onclick}>
-  <div class="thumbnail-frame">
+<button class="thumbnail-card" {onclick} style="--card-w: {width}px">
+  <div class="thumbnail-frame" style="width: {width}px; height: {height}px">
     <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-    <iframe src={url} loading="lazy" sandbox="allow-same-origin" tabindex={-1} title={label} class:loaded onload={() => loaded = true}></iframe>
+    <iframe src={url} loading="lazy" sandbox="allow-same-origin" tabindex={-1} title={label} class:loaded onload={() => loaded = true}
+      style="width: {RENDER_WIDTH}px; height: {height / scale}px; transform: scale({scale})"></iframe>
   </div>
   <div class="thumbnail-label">{label}</div>
   {#if sublabel}<div class="thumbnail-sublabel">{sublabel}</div>{/if}
@@ -36,8 +45,6 @@ let loaded = $state(false);
   }
 
   .thumbnail-frame {
-    width: 280px;
-    height: 180px;
     overflow: hidden;
     border-radius: var(--radius-lg);
     border: 1px solid var(--border);
@@ -50,9 +57,6 @@ let loaded = $state(false);
   }
 
   iframe {
-    width: 1280px;
-    height: 960px;
-    transform: scale(0.219);
     transform-origin: top left;
     pointer-events: none;
     border: none;
@@ -73,7 +77,7 @@ let loaded = $state(false);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 280px;
+    max-width: var(--card-w);
   }
 
   .thumbnail-sublabel {
@@ -83,6 +87,6 @@ let loaded = $state(false);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 280px;
+    max-width: var(--card-w);
   }
 </style>

--- a/packages/extensions/pages/ui/src/pages/PagesDashboard.svelte
+++ b/packages/extensions/pages/ui/src/pages/PagesDashboard.svelte
@@ -37,24 +37,6 @@ let {
 </script>
 
 <div class="dashboard">
-  {#if systemSite}
-    <div class="section">
-      <div class="section-header">
-        <span class="section-title">shared pages</span>
-      </div>
-      <div class="thumbnail-grid">
-        {#each systemSite.pages as page}
-          <PageThumbnail
-            url={page.url}
-            label={page.file}
-            sublabel={page.author ?? undefined}
-            onclick={() => onSelectPage("_system", page.file)}
-          />
-        {/each}
-      </div>
-    </div>
-  {/if}
-
   {#if sites.length > 0}
     <div class="section">
       <div class="section-header">
@@ -75,7 +57,7 @@ let {
   {#if recentPages.length > 0}
     <div class="section">
       <div class="section-header">
-        <span class="section-title">recently modified</span>
+        <span class="section-title">recently updated</span>
       </div>
       <div class="thumbnail-grid">
         {#each recentPages as page}
@@ -84,6 +66,24 @@ let {
             label={page.file}
             sublabel={recentSublabel(page)}
             onclick={() => onSelectPage(page.mind, page.file)}
+          />
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  {#if systemSite}
+    <div class="section">
+      <div class="section-header">
+        <span class="section-title">shared pages</span>
+      </div>
+      <div class="thumbnail-grid">
+        {#each systemSite.pages as page}
+          <PageThumbnail
+            url={page.url}
+            label={page.file}
+            sublabel={page.author ?? undefined}
+            onclick={() => onSelectPage("_system", page.file)}
           />
         {/each}
       </div>

--- a/packages/extensions/pages/ui/src/pages/SiteView.svelte
+++ b/packages/extensions/pages/ui/src/pages/SiteView.svelte
@@ -22,6 +22,12 @@ let {
   site: Site;
   onSelectPage: (mind: string, path: string) => void;
 } = $props();
+
+const isIndex = (file: string) => file === "index.html" || file === "index.md";
+
+// The index is the site's front door — feature it as a hero, list the rest.
+let hero = $derived(site.pages.find((p) => isIndex(p.file)));
+let rest = $derived(site.pages.filter((p) => p !== hero));
 </script>
 
 <div class="site-view">
@@ -30,16 +36,29 @@ let {
     <span class="page-count">{site.pages.length} {site.pages.length === 1 ? "page" : "pages"}</span>
   </div>
 
-  <div class="thumbnail-grid">
-    {#each site.pages as page}
-      <PageThumbnail
-        url={`/ext/pages/public/${site.name}/${page.file}`}
-        label={page.file}
-        sublabel={formatRelativeTime(page.modified)}
-        onclick={() => onSelectPage(site.name, page.file)}
-      />
-    {/each}
-  </div>
+  {#if hero}
+    <PageThumbnail
+      url={`/ext/pages/public/${site.name}/${hero.file}`}
+      label={hero.file}
+      sublabel={`home · ${formatRelativeTime(hero.modified)}`}
+      onclick={() => onSelectPage(site.name, hero.file)}
+      width={600}
+      height={340}
+    />
+  {/if}
+
+  {#if rest.length > 0}
+    <div class="thumbnail-grid" class:with-hero={hero}>
+      {#each rest as page}
+        <PageThumbnail
+          url={`/ext/pages/public/${site.name}/${page.file}`}
+          label={page.file}
+          sublabel={formatRelativeTime(page.modified)}
+          onclick={() => onSelectPage(site.name, page.file)}
+        />
+      {/each}
+    </div>
+  {/if}
 
   {#if site.pages.length === 0}
     <div class="empty">No pages in this site.</div>
@@ -52,5 +71,6 @@ let {
   .site-name { font-size: 16px; font-weight: 500; color: var(--text-0); }
   .page-count { font-size: 12px; color: var(--text-2); }
   .thumbnail-grid { display: flex; flex-wrap: wrap; gap: 16px; }
+  .thumbnail-grid.with-hero { margin-top: 20px; }
   .empty { color: var(--text-2); font-size: 13px; }
 </style>

--- a/test/pages-commands.test.ts
+++ b/test/pages-commands.test.ts
@@ -166,16 +166,37 @@ describe("pages db", () => {
     assert.equal(after[0].file, "index.html");
   });
 
-  it("getAllSites groups by mind", () => {
-    syncPublishedPages(db, "mind1", ph("index.html"));
-    syncPublishedPages(db, "mind2", ph("about.html", "contact.html"));
+  it("getAllSites ranks sites by most-recent update, not insertion order", () => {
+    syncPublishedPages(db, "mind1", ph("a.html")); // lower id
+    syncPublishedPages(db, "mind2", ph("b.html", "c.html")); // higher id
+
+    // Without touching timestamps, mind2 leads only via the id tiebreak. Make
+    // mind1 strictly newer so real recency (updated_at) must decide the order.
+    db.prepare(
+      "UPDATE published_pages SET updated_at = '2999-01-01 00:00:00' WHERE mind = 'mind1'",
+    ).run();
 
     const sites = getAllSites(db);
     assert.equal(sites.length, 2);
+    // mind1 now ranks first purely on updated_at — this fails if the query drops
+    // `updated_at DESC` and orders by id alone.
     assert.equal(sites[0].mind, "mind1");
     assert.equal(sites[0].files.length, 1);
     assert.equal(sites[1].mind, "mind2");
     assert.equal(sites[1].files.length, 2);
+  });
+
+  it("getAllSites puts a site's index first even when another page is newer", () => {
+    syncPublishedPages(db, "mind1", ph("index.html", "about.html"));
+    // Make about.html strictly newer than the index; index must still lead.
+    db.prepare(
+      "UPDATE published_pages SET updated_at = '2999-01-01 00:00:00' WHERE mind = 'mind1' AND file = 'about.html'",
+    ).run();
+
+    const sites = getAllSites(db);
+    // Fails if sortSiteFiles' index-first branch is removed (about would lead on recency).
+    assert.equal(sites[0].files[0].file, "index.html");
+    assert.equal(sites[0].files[1].file, "about.html");
   });
 
   it("getAllSites excludes _system pages", () => {
@@ -234,13 +255,21 @@ describe("pages db", () => {
     assert.equal(getSystemPages(db), null);
   });
 
-  it("getSystemPages returns system site with author", () => {
-    syncSystemPages(db, ph("about.html", "index.html"), "alice");
+  it("getSystemPages returns system site with author, index first", () => {
+    // index.html inserted first (lower id); without index-first logic the id
+    // tiebreak would bury it behind about.html.
+    syncSystemPages(db, ph("index.html", "about.html"), "alice");
+    // ...and make about.html strictly newer, so recency alone would rank it first.
+    db.prepare(
+      "UPDATE published_pages SET updated_at = '2999-01-01 00:00:00' WHERE mind = '_system' AND file = 'about.html'",
+    ).run();
+
     const site = getSystemPages(db);
     assert.ok(site);
     assert.equal(site.mind, "_system");
     assert.equal(site.files.length, 2);
-    assert.equal(site.files[0].file, "about.html");
+    // index leads despite about.html being both newer and higher-id
+    assert.equal(site.files[0].file, "index.html");
     assert.equal(site.files[0].author, "alice");
   });
 });

--- a/test/web-pages.test.ts
+++ b/test/web-pages.test.ts
@@ -439,7 +439,9 @@ describe("XSS prevention", () => {
 
     const res = await publicApp.request("/public/test-mind/xss.md");
     const body = await res.text();
-    assert.ok(!body.includes("<script>"), "should not contain unescaped script tag");
+    // The malicious title payload must not survive as a live script (the benign
+    // nav shim adds its own <script>, so target the injected alert specifically).
+    assert.ok(!body.includes("<script>alert(1)"), "should not contain unescaped script tag");
     assert.ok(body.includes("&lt;script&gt;"), "should escape HTML entities in title");
   });
 
@@ -464,7 +466,7 @@ describe("XSS prevention", () => {
     assert.ok(body.includes("<strong>ok</strong>"), "safe markdown should still render");
   });
 
-  it("sets a restrictive Content-Security-Policy on public pages", async () => {
+  it("sandboxes public pages so scripts run in an opaque origin", async () => {
     const dir = setupTestDir();
     const { createPublicRoutes } = await import("../packages/extensions/pages/src/routes.js");
     const publicApp = new Hono();
@@ -473,8 +475,53 @@ describe("XSS prevention", () => {
     const res = await publicApp.request("/public/test-mind/hello.md");
     const csp = res.headers.get("content-security-policy");
     assert.ok(csp, "CSP header should be present");
-    assert.ok(csp.includes("default-src 'none'"), "CSP should default-deny (blocks script)");
+    // Scripts are allowed to run...
+    assert.ok(csp.includes("sandbox allow-scripts"), "pages should be sandboxed with scripts");
+    assert.ok(csp.includes("script-src 'self' 'unsafe-inline' https:"), "scripts allowed");
+    // ...but the sandbox must NOT grant same-origin — that's what keeps the page
+    // in an opaque origin and unable to ride the admin's SameSite=Lax session.
+    assert.ok(!csp.includes("allow-same-origin"), "must not grant same-origin access");
     assert.equal(res.headers.get("x-content-type-options"), "nosniff");
+  });
+});
+
+describe("nav shim injection", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("injects the postMessage nav shim into served HTML", async () => {
+    const dir = setupTestDir();
+    const { createPublicRoutes } = await import("../packages/extensions/pages/src/routes.js");
+    const publicApp = new Hono();
+    publicApp.route("/public", createPublicRoutes(makeCtx(dir)));
+
+    const res = await publicApp.request("/public/test-mind/index.html");
+    const body = await res.text();
+    assert.ok(body.includes('type:"volute-pages-nav"'), "HTML should carry the nav shim");
+    assert.ok(body.includes("<h1>Hello</h1>"), "original content is preserved");
+  });
+
+  it("injects the nav shim into rendered markdown pages", async () => {
+    const dir = setupTestDir();
+    const { createPublicRoutes } = await import("../packages/extensions/pages/src/routes.js");
+    const publicApp = new Hono();
+    publicApp.route("/public", createPublicRoutes(makeCtx(dir)));
+
+    const res = await publicApp.request("/public/test-mind/hello.md");
+    const body = await res.text();
+    assert.ok(body.includes('type:"volute-pages-nav"'), "markdown page should carry the nav shim");
+  });
+
+  it("does not inject the shim into non-HTML assets", async () => {
+    const dir = setupTestDir();
+    const { createPublicRoutes } = await import("../packages/extensions/pages/src/routes.js");
+    const publicApp = new Hono();
+    publicApp.route("/public", createPublicRoutes(makeCtx(dir)));
+
+    const js = await (await publicApp.request("/public/test-mind/app.js")).text();
+    const css = await (await publicApp.request("/public/test-mind/style.css")).text();
+    assert.ok(!js.includes("volute-pages-nav"), "JS asset must be served verbatim");
+    assert.ok(!css.includes("volute-pages-nav"), "CSS asset must be served verbatim");
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses three issues with the Pages dashboard, surfaced from a UX pass:

1. **Recency over alphabetical.** `getAllSites`/`getSystemPages` now order by `updated_at` (with `id` breaking same-second ties) and pin a site's `index.*` first. The dashboard leads with **mind sites → recently updated (12) → shared pages** instead of burying recency at the bottom, and sites are ranked by recent activity.
2. **`index.html` as the front door.** `SiteView` features the index as a hero card above the rest of the grid; mind-site cards preview `index` instead of the alphabetically-first file (a latent bug). `PageThumbnail` gains `width`/`height` props for the hero size.
3. **Minds can ship JavaScript pages.** The page CSP goes from `default-src 'none'` to `sandbox allow-scripts` (no `allow-same-origin`): scripts run, but the page sits in an **opaque origin**, so its `fetch()` can't ride the viewing admin's `SameSite=Lax` session. `https:` sources allow CDN libraries.

Because the opaque origin also stops the dashboard from reading the iframe's location, every served HTML page carries a constant `postMessage` shim reporting its own path; `App.svelte` listens for it (verifying `event.source`) to keep the breadcrumb in sync when a visitor follows an in-page link.

## Security notes

- Cookie is `httpOnly` + `SameSite=Lax`; the opaque origin makes any credentialed `/api` call cross-site, so the session can't be ridden. `allow-forms`/`allow-popups`/`allow-top-navigation` are all omitted, closing the top-level-GET CSRF path. CSP applied uniformly via `.use("*")`.
- The nav shim is a constant (no request-path interpolation) → no injection surface. A malicious page could `postMessage` a fake path, but the parent only ever derives another **public** `/minds/{mind}/pages/{file}` route from it — worst case a cosmetic breadcrumb, never data access or arbitrary app navigation.

## Verification

- **88 unit tests pass**, including rewritten ordering tests that are mutation-verified (they fail if `updated_at DESC` or the index-first branch is removed) and new nav-shim injection tests.
- **Headless Chrome**, end-to-end:
  - JS executes under the sandbox CSP, `window.origin` is `null`, and a credentialed `fetch('/api/*')` is blocked.
  - External same-origin `http` `<script src>` / `<link>` stylesheets still load (`'self'` matches under the header-delivered sandbox), so multi-file JS pages and markdown stylesheets work.
  - A framed sandboxed page posts its own path and the parent's `event.source` check passes.

## Known tradeoff (not changed)

Thumbnail previews stay script-free (`sandbox="allow-same-origin"`), so a JS-rendered page previews as its initial DOM rather than animating — an intentional dashboard-perf choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)