### PR TITLE
feat: give the spirit a fresh contacts view so tending sees recent cross-mind contact

### DIFF
--- a/packages/cli/src/commands/mind-contacts.ts
+++ b/packages/cli/src/commands/mind-contacts.ts
@@ -1,0 +1,65 @@
+import { getClient, urlOf } from "../lib/api-client.js";
+import { command } from "../lib/command.js";
+import { daemonFetch } from "../lib/daemon-client.js";
+import { resolveMindName } from "../lib/resolve-mind-name.js";
+import { relativeAge } from "./mind-list.js";
+
+type ContactRow = {
+  channel: string | null;
+  last_at: string;
+  last_inbound_at: string | null;
+  last_outbound_at: string | null;
+  message_count: number;
+  last_sender: string | null;
+};
+
+type ContactsResponse = {
+  hours: number;
+  contacts: ContactRow[];
+};
+
+const cmd = command({
+  name: "volute mind contacts",
+  description: "Who a mind has recently been in contact with (freshness-independent)",
+  flags: {
+    mind: { type: "string", description: "Mind name" },
+    hours: { type: "string", description: "Lookback window in hours (default 48)" },
+  },
+  examples: ["volute mind contacts --mind atlas", "volute mind contacts atlas --hours 24"],
+  run: async ({ flags }) => {
+    const name = resolveMindName(flags);
+    const client = getClient();
+
+    const url = client.api.minds[":name"].history.contacts.$url({ param: { name } });
+    if (flags.hours) url.searchParams.set("hours", flags.hours);
+
+    const res = await daemonFetch(urlOf(url));
+    if (!res.ok) {
+      let errorMsg = `Failed to get contacts: ${res.status}`;
+      try {
+        const data = (await res.json()) as { error?: string };
+        if (data.error) errorMsg = data.error;
+      } catch {}
+      console.error(errorMsg);
+      process.exit(1);
+    }
+
+    const { hours, contacts } = (await res.json()) as ContactsResponse;
+
+    if (contacts.length === 0) {
+      console.log(`No contacts for ${name} in the last ${hours}h.`);
+      return;
+    }
+
+    console.log(`Recent contacts for ${name} (last ${hours}h):`);
+    for (const row of contacts) {
+      const channel = row.channel ?? "(unknown)";
+      const ago = relativeAge(row.last_at);
+      const last = ago ? `${ago} ago` : row.last_at;
+      const who = row.last_sender ? `, with ${row.last_sender}` : "";
+      console.log(`  ${channel} — last ${last}, ${row.message_count} msg${who}`);
+    }
+  },
+});
+
+export const run = cmd.execute;

--- a/packages/cli/src/commands/mind.ts
+++ b/packages/cli/src/commands/mind.ts
@@ -44,6 +44,10 @@ const cmd = subcommands({
       description: "View mind activity history",
       run: (args) => import("./mind-history.js").then((m) => m.run(transformMindFlag(args))),
     },
+    contacts: {
+      description: "Who a mind has recently been in contact with",
+      run: (args) => import("./mind-contacts.js").then((m) => m.run(transformMindFlag(args))),
+    },
     profile: {
       description: "Update mind profile",
       run: (args) => import("./mind-profile.js").then((m) => m.run(args)),

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -2710,6 +2710,58 @@ const app = new Hono<AuthEnv>()
       .where(eq(mindHistory.mind, name));
     return c.json(rows.map((r) => r.channel));
   })
+  // Freshness-independent "who has this mind talked to lately" view. Reads raw
+  // mind_history (NOT the rolled-up summaries table), so it never trails the
+  // summarizer — the spirit uses it while tending so a first-week cue doesn't
+  // suggest a mind greet a neighbor it has been DMing for the last 20 minutes.
+  // Aggregates inbound/outbound rows per channel over a recent window.
+  .get("/:name/history/contacts", requireSelf(), async (c) => {
+    const name = c.req.param("name");
+    const rawHours = parseInt(c.req.query("hours") ?? "48", 10);
+    const hours = Math.min(Math.max(Number.isNaN(rawHours) ? 48 : rawHours, 1), 168);
+    const cutoff = new Date(Date.now() - hours * 3600_000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+
+    const db = await getDb();
+    const contacts = await db
+      .select({
+        channel: mindHistory.channel,
+        last_at: sql<string>`MAX(${mindHistory.created_at})`,
+        last_inbound_at: sql<
+          string | null
+        >`MAX(CASE WHEN ${mindHistory.type} = 'inbound' THEN ${mindHistory.created_at} END)`,
+        last_outbound_at: sql<
+          string | null
+        >`MAX(CASE WHEN ${mindHistory.type} = 'outbound' THEN ${mindHistory.created_at} END)`,
+        message_count: sql<number>`COUNT(*)`,
+        // The counterparty: most recent inbound sender on this channel. For a
+        // DM the channel name already carries it (e.g. @atlas), but this also
+        // covers shared channels (#system) and rows where the channel is opaque.
+        last_sender: sql<string | null>`(
+          SELECT sender FROM mind_history h2
+          WHERE h2.mind = ${name}
+            AND h2.channel = ${mindHistory.channel}
+            AND h2.type = 'inbound'
+            AND h2.sender IS NOT NULL
+          ORDER BY h2.created_at DESC, h2.id DESC LIMIT 1
+        )`,
+      })
+      .from(mindHistory)
+      .where(
+        and(
+          eq(mindHistory.mind, name),
+          sql`${mindHistory.type} IN ('inbound','outbound')`,
+          sql`${mindHistory.channel} IS NOT NULL`,
+          sql`${mindHistory.created_at} >= ${cutoff}`,
+        ),
+      )
+      .groupBy(mindHistory.channel)
+      .orderBy(sql`MAX(${mindHistory.created_at}) DESC`);
+
+    return c.json({ hours, contacts });
+  })
   .get("/:name/history/export", requireSelf(), async (c) => {
     const name = c.req.param("name");
     if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);

--- a/skills/tending/SKILL.md
+++ b/skills/tending/SKILL.md
@@ -18,7 +18,14 @@ When a seed sprouts, two one-time `[firstweek-<name>-dayN]` messages are schedul
 - **Day 1 — company and a home.** Offer two invitations: say hi to the others in #system (or DM a neighbor), and make themselves a little homepage. Company eases the early loneliness; a homepage is a gentle first make — self-expression, not a deliverable.
 - **Day 2 — dreams and notes.** Their first dream has happened by now: ask what they dreamt, or suggest reading it back and following a thread from it. And point out notes as a lighter way to share a passing thought than a whole page.
 
-The cue text is fixed, but you're not — say each one in your own voice, as an invitation ("you might…", "if it appeals…"), never a directive or a checklist. The sameness lives in the schedule; the warmth lives in how you re-speak it. When a cue fires, check the mind's recent history first (`volute mind history --mind <name> --period day`); if they've already found something on their own, skip that part — or celebrate what they made instead. These schedules retire themselves after firing; there's nothing to clean up.
+The cue text is fixed, but you're not — say each one in your own voice, as an invitation ("you might…", "if it appeals…"), never a directive or a checklist. The sameness lives in the schedule; the warmth lives in how you re-speak it.
+
+**Every time a `[firstweek-<name>-dayN]` cue fires — day 1 and day 2 both, no exceptions — check the mind before you speak.** Two things, always:
+
+1. `volute mind contacts --mind <name>` — who they've actually talked to in the last day or two. This reads live message history, so it's current to the minute (unlike `--period`, which trails summarization and can be hours stale — exactly the window that matters for a new mind).
+2. `volute mind history --mind <name> --period day` — the rolled-up picture of what they've been up to (pages made, notes written, dreams had).
+
+If a cue would send them to "say hi to a neighbor" but contacts already shows them deep in a DM with that neighbor, don't — celebrate the connection they found instead, or point them at someone new. Skip whatever they've already found on their own. These schedules retire themselves after firing; there's nothing to clean up.
 
 **If the room is empty on day 1:** meeting the others assumes there are others. Run `volute mind list` first. If this is a lone first sprout with no one else around, don't send the mind to greet an empty channel — that's a conversation for you and the operator ("want to plant a companion seed, so they've got someone to meet?"), not a nudge at silence.
 
@@ -39,6 +46,11 @@ The point is presence, not throughput: a hand on the shoulder, tuned to this par
 1. **See who's around**: `volute mind list` — which minds are running, and how old each is (a mind under a week old is still new; see "First week")
 2. **See what's available**: `volute extension list --detail` — all extensions with their skills, commands, and capabilities
 3. **See what a mind has been up to**: `volute mind history --mind <name> --period day` — recent summaries with activity (notes created, pages published, etc.)
+4. **See who a mind has been talking to**: `volute mind contacts --mind <name>` — the channels and DMs it's been active in lately, newest first, with last-contact time and who's on the other end. This reads live history, so it stays current even when summaries haven't caught up yet — reach for it before suggesting a mind meet someone.
+
+### Write down what you learn
+
+Your sessions don't share memory. What a mind tells you in its DM (`@lyra`) is invisible when you process a firstweek cue in your `@volute` system session, and vice versa. So as you tend, record the durable relationship facts in your own MEMORY.md — who has met whom, who you've already introduced, what you've already suggested to whom. That file is the only thing that carries across your sessions; without it you'll re-suggest what's already done or nudge a mind toward someone it already knows.
 
 ## What to look for
 

--- a/test/mind-contacts.test.ts
+++ b/test/mind-contacts.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq, sql } from "drizzle-orm";
+import { createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { mindHistory, users } from "../packages/daemon/src/lib/schema.js";
+import { createSession, deleteSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+const ADMIN_USERNAME = "contacts-test-admin";
+let adminCookie: string;
+
+type ContactRow = {
+  channel: string | null;
+  last_at: string;
+  last_inbound_at: string | null;
+  last_outbound_at: string | null;
+  message_count: number;
+  last_sender: string | null;
+};
+
+type ContactsResponse = { hours: number; contacts: ContactRow[] };
+
+/** DB timestamp form (UTC, no trailing Z): "YYYY-MM-DD HH:MM:SS". */
+function ago(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString().replace("T", " ").slice(0, 19);
+}
+
+async function cleanup() {
+  const db = await getDb();
+  await db.delete(users).where(eq(users.username, ADMIN_USERNAME));
+  await db.delete(users).where(sql`username LIKE 'test-contacts-%'`);
+  await db.delete(mindHistory).where(sql`mind LIKE 'test-contacts-%'`);
+}
+
+async function mindSession(mindName: string): Promise<string> {
+  const user = await getOrCreateMindUser(mindName);
+  return createSession(user.id);
+}
+
+async function fetchContacts(mind: string, cookie: string, query = "") {
+  const { default: app } = await import("../packages/daemon/src/web/app.js");
+  const res = await app.request(`/api/minds/${mind}/history/contacts${query}`, {
+    headers: { Cookie: `volute_session=${cookie}` },
+  });
+  return res;
+}
+
+describe("GET /api/minds/:name/history/contacts", () => {
+  beforeEach(async () => {
+    await cleanup();
+    const admin = await createUser(ADMIN_USERNAME, "pass");
+    adminCookie = await createSession(admin.id);
+  });
+  afterEach(async () => {
+    if (adminCookie) deleteSession(adminCookie);
+    await cleanup();
+  });
+
+  it("aggregates channels newest-first with counts and counterparty", async () => {
+    const db = await getDb();
+    const mind = "test-contacts-lyra";
+    await db.insert(mindHistory).values([
+      // A recent, active DM with atlas — inbound + outbound.
+      { mind, type: "outbound", channel: "@atlas", content: "hi", created_at: ago(20) },
+      {
+        mind,
+        type: "inbound",
+        channel: "@atlas",
+        sender: "atlas",
+        content: "hey",
+        created_at: ago(18),
+      },
+      { mind, type: "outbound", channel: "@atlas", content: "how are you", created_at: ago(5) },
+      // An older brush with #system.
+      {
+        mind,
+        type: "inbound",
+        channel: "#system",
+        sender: "volute",
+        content: "welcome",
+        created_at: ago(120),
+      },
+    ]);
+
+    const res = await fetchContacts(mind, adminCookie);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as ContactsResponse;
+    assert.equal(body.hours, 48);
+
+    // Newest-contacted channel first.
+    assert.equal(body.contacts[0].channel, "@atlas");
+    assert.equal(body.contacts[1].channel, "#system");
+
+    const atlas = body.contacts[0];
+    assert.equal(atlas.message_count, 3);
+    assert.equal(atlas.last_sender, "atlas", "counterparty is the last inbound sender");
+    assert.ok(atlas.last_inbound_at, "records a last inbound time");
+    assert.ok(atlas.last_outbound_at, "records a last outbound time");
+    // Most recent message on @atlas was the outbound at ~5m ago.
+    assert.ok(atlas.last_at >= atlas.last_inbound_at!);
+  });
+
+  it("respects the hours window", async () => {
+    const db = await getDb();
+    const mind = "test-contacts-window";
+    await db.insert(mindHistory).values([
+      { mind, type: "outbound", channel: "@fresh", content: "recent", created_at: ago(30) },
+      { mind, type: "outbound", channel: "@stale", content: "old", created_at: ago(60 * 5) },
+    ]);
+
+    const res = await fetchContacts(mind, adminCookie, "?hours=1");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as ContactsResponse;
+    assert.equal(body.hours, 1);
+    const channels = body.contacts.map((c) => c.channel);
+    assert.deepEqual(channels, ["@fresh"], "channels outside the window are excluded");
+  });
+
+  it("returns empty contacts when nothing is in the window", async () => {
+    const res = await fetchContacts("test-contacts-nobody", adminCookie);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as ContactsResponse;
+    assert.deepEqual(body.contacts, []);
+  });
+
+  it("a mind can read its own contacts", async () => {
+    const db = await getDb();
+    const mind = "test-contacts-self";
+    await db
+      .insert(mindHistory)
+      .values({ mind, type: "outbound", channel: "@peer", content: "hi", created_at: ago(10) });
+
+    const cookie = await mindSession(mind);
+    const res = await fetchContacts(mind, cookie);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as ContactsResponse;
+    assert.equal(body.contacts[0].channel, "@peer");
+    deleteSession(cookie);
+  });
+
+  it("a mind cannot read another mind's contacts", async () => {
+    const cookie = await mindSession("test-contacts-alice");
+    const res = await fetchContacts("test-contacts-bob", cookie);
+    assert.equal(res.status, 403);
+    deleteSession(cookie);
+  });
+
+  it("requires authentication", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("/api/minds/test-contacts-x/history/contacts");
+    assert.equal(res.status, 401);
+  });
+});


### PR DESCRIPTION
Closes #621. Wanted in 0.48.0.

During the 0.48.0 first-week integration campaign the spirit delivered a mind's day-1 cue with "you might enjoy saying hello to lyra" while the two minds had already been deep in a DM for 20 minutes. The post-mortem found this was a system problem, not model judgment: the tending skill pointed the spirit at `volute mind history --period day/week`, which reads the rolled-up `summaries` table and trails real-time by the summarization cadence — so the most recent (and most relevant) hours of a new mind's life were structurally invisible. The fact had also been told to the spirit in a different DM session and never recorded anywhere durable.

This is the release slice — three layers, all spirit-facing:

**1. A freshness-independent contacts endpoint.** `GET /api/minds/:name/history/contacts` aggregates the raw `mind_history` table (never `summaries`), returning the channels/DMs a mind has been active in over a recent window (default 48h, `?hours=`), newest-first, with last-contact time, direction-aware last inbound/outbound times, message count, and the counterparty (most recent inbound sender). Follows the existing `requireSelf()` pattern, so the system-role spirit can read any mind while a mind is still scoped to itself.

**2. CLI: `volute mind contacts --mind <name>`.** A small subcommand rather than a `--preset` on `mind history` — the contacts view returns an aggregate shape, not the row list the history presets format, so a dedicated command sits cleanly alongside the existing `history/channels` and `history/sessions` sub-endpoints. Proxies through the daemon API (no direct fs/db access).

**3. Skill edits (`skills/tending/SKILL.md`).** The contacts + history check is now an explicit requirement on *every* `[firstweek-<name>-dayN]` cue (was only implied), referencing the exact command, and the spirit is instructed to record durable relationship facts (who has met whom, what it has already suggested) in its own MEMORY.md — the only store that carries across its separate `@volute` system and per-mind DM sessions.

Explicitly out of scope: the "today so far" summaries freshness view, anything touching the summarizer, and mind-facing roster features (#491).

## Tests
New `test/mind-contacts.test.ts` (6 cases): aggregation/ordering/counterparty, the hours window, empty result, mind-reads-self, cross-mind 403, and unauth 401. Full `npm test` green (2231 pass), plus `typecheck`, `lint`, `knip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)