### PR TITLE
feat: maxMinds config — cap total minds to protect host resources

### DIFF
--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -99,6 +99,14 @@ export type GlobalConfig = {
   disabledExtensions?: string[];
   /** Default settings applied when creating new minds */
   mindDefaults?: MindDefaults;
+  /**
+   * Cap on the total number of base minds (excludes variants and the spirit).
+   * Every mind is a full process (plus SDK subprocesses, npm install, per-mind OS
+   * user under isolation), so unbounded creation can exhaust the host. Unset =
+   * unlimited (the default; preserves existing installs). Not a secret — stays in
+   * the operator-readable config.json.
+   */
+  maxMinds?: number;
   /** Restic-based system backup configuration */
   backup?: BackupConfig;
 };
@@ -320,6 +328,20 @@ export function isImagegenEnabled(): boolean {
   // New: enabled if any provider is configured
   if (ig.providers && Object.keys(ig.providers).length > 0) return true;
   return false;
+}
+
+/**
+ * Enforce the `maxMinds` cap. Returns a human-friendly error message when
+ * creating another mind would meet or exceed the cap — the spirit relays this
+ * verbatim to whoever asked, so keep it actionable — or null when creation is
+ * allowed. `limit` unset (undefined) = unlimited.
+ */
+export function mindLimitError(count: number, limit: number | undefined): string | null {
+  if (limit == null) return null;
+  if (count >= limit) {
+    return `Mind limit reached (${count}/${limit}). An admin can raise maxMinds in Settings.`;
+  }
+  return null;
 }
 
 /** Migrate pre-existing installations that have setup but not setupCompleted. */

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -119,6 +119,16 @@ export async function readRegistry(): Promise<MindEntry[]> {
   return (rows as unknown as RawMindRow[]).map(rowToEntry);
 }
 
+/**
+ * Count minds that count toward the `maxMinds` cap: base minds only. Variants
+ * (transient worktrees) and the spirit are excluded. `readRegistry` already
+ * filters out variants (parent is null) and non-mind/spirit rows.
+ */
+export async function countCappedMinds(): Promise<number> {
+  const entries = await readRegistry();
+  return entries.filter((e) => e.mindType !== "spirit").length;
+}
+
 /** Read ALL minds (base + variants) from DB. */
 export async function readAllMinds(): Promise<MindEntry[]> {
   const db = await getDb();

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -66,6 +66,7 @@ import {
 import { commitSrcChanges, rollbackSrcChanges } from "../../lib/mind/last-known-good.js";
 import {
   addMind,
+  countCappedMinds,
   ensureVoluteHome,
   findMind,
   findVariants,
@@ -880,6 +881,15 @@ const app = new Hono<AuthEnv>()
     if (nameErr) return c.json({ error: nameErr }, 400);
 
     if (await findMind(name)) return c.json({ error: `Mind already exists: ${name}` }, 409);
+
+    // Cap total minds to protect host resources. Central enforcement here covers
+    // `volute mind create`, `volute seed create`, and spirit-driven seeds alike;
+    // the error text is relayed verbatim to whoever asked.
+    {
+      const { mindLimitError, readGlobalConfig } = await import("../../lib/config/setup.js");
+      const limitError = mindLimitError(await countCappedMinds(), readGlobalConfig().maxMinds);
+      if (limitError) return c.json({ error: limitError }, 409);
+    }
 
     ensureVoluteHome();
     const dest = mindDir(name);

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -36,7 +36,7 @@ import {
   writeSystemsConfig,
 } from "../../lib/config/systems-config.js";
 import { getMindManager } from "../../lib/daemon/mind-manager.js";
-import { findMind } from "../../lib/mind/registry.js";
+import { countCappedMinds, findMind } from "../../lib/mind/registry.js";
 import {
   generateImage,
   getDefaultModel as getImagegenDefaultModel,
@@ -110,6 +110,26 @@ const app = new Hono<AuthEnv>()
     writeGlobalConfig(config);
     return c.json({ name: config.name ?? null });
   })
+  // Current cap on total minds and how many currently count toward it.
+  .get("/max-minds", requireAdmin, async (c) => {
+    return c.json({
+      maxMinds: readGlobalConfig().maxMinds ?? null,
+      count: await countCappedMinds(),
+    });
+  })
+  // Set (positive integer) or clear (null) the cap. null = unlimited.
+  .put(
+    "/max-minds",
+    requireAdmin,
+    zValidator("json", z.object({ maxMinds: z.number().int().positive().nullable() })),
+    async (c) => {
+      const { maxMinds } = c.req.valid("json");
+      const config = readGlobalConfig();
+      config.maxMinds = maxMinds ?? undefined;
+      writeGlobalConfig(config);
+      return c.json({ maxMinds: maxMinds ?? null, count: await countCappedMinds() });
+    },
+  )
   .post(
     "/register",
     requireAdmin,

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -484,6 +484,17 @@ export async function updateSystemName(name: string): Promise<void> {
   await put(`${V1}/system/info`, { name });
 }
 
+export type MaxMinds = { maxMinds: number | null; count: number };
+
+export function fetchMaxMinds(): Promise<MaxMinds> {
+  return get(`${V1}/system/max-minds`);
+}
+
+export async function saveMaxMinds(maxMinds: number | null): Promise<MaxMinds> {
+  await put(`${V1}/system/max-minds`, { maxMinds });
+  return fetchMaxMinds();
+}
+
 export function systemRegister(name: string): Promise<{ system: string }> {
   return post(`${V1}/system/register`, { name });
 }

--- a/packages/web/src/ui/pages/Settings.svelte
+++ b/packages/web/src/ui/pages/Settings.svelte
@@ -4,7 +4,9 @@ import AiProviders from "../components/system/AiProviders.svelte";
 import ImagegenProviders from "../components/system/ImagegenProviders.svelte";
 import {
   fetchAiDefaults,
+  fetchMaxMinds,
   saveAiDefaults,
+  saveMaxMinds,
   systemLogin,
   systemLogout,
   systemRegister,
@@ -38,6 +40,11 @@ let defaultsLoaded = $state(false);
 
 let aiProvidersRef: AiProviders;
 
+// Mind limit (maxMinds). Empty input = unlimited.
+let maxMindsInput = $state("");
+let mindCount = $state(0);
+let maxMindsError = $state("");
+
 onMount(async () => {
   aiProvidersRef.load();
   try {
@@ -47,8 +54,36 @@ onMount(async () => {
   } catch {
     // will show via AiProviders load error
   }
+  try {
+    const limit = await fetchMaxMinds();
+    maxMindsInput = limit.maxMinds == null ? "" : String(limit.maxMinds);
+    mindCount = limit.count;
+  } catch {
+    // non-fatal; section just shows empty
+  }
   defaultsLoaded = true;
 });
+
+async function saveMindLimit() {
+  maxMindsError = "";
+  const trimmed = maxMindsInput.trim();
+  let value: number | null = null;
+  if (trimmed !== "") {
+    const n = Number(trimmed);
+    if (!Number.isInteger(n) || n < 1) {
+      maxMindsError = "Enter a whole number of 1 or more, or leave blank for unlimited.";
+      return;
+    }
+    value = n;
+  }
+  try {
+    const result = await saveMaxMinds(value);
+    maxMindsInput = result.maxMinds == null ? "" : String(result.maxMinds);
+    mindCount = result.count;
+  } catch (err) {
+    maxMindsError = err instanceof Error ? err.message : "Failed to save limit";
+  }
+}
 
 // Auto-save when defaults change (after initial load)
 $effect(() => {
@@ -104,6 +139,29 @@ async function handleSystemLogout() {
       onblur={saveLocalName}
       onkeydown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
     />
+  </div>
+
+  <!-- Mind Limit -->
+  <div class="section">
+    <div class="section-header">
+      <span class="section-title">Mind Limit</span>
+      <span class="section-subtitle">
+        Cap on total minds ({mindCount} in use). Blank = unlimited.
+      </span>
+    </div>
+    <input
+      type="number"
+      min="1"
+      step="1"
+      class="system-input"
+      bind:value={maxMindsInput}
+      placeholder="Unlimited"
+      onblur={saveMindLimit}
+      onkeydown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+    />
+    {#if maxMindsError}
+      <div class="error">{maxMindsError}</div>
+    {/if}
   </div>
 
   <!-- System Registration -->

--- a/packages/web/src/ui/pages/Settings.svelte
+++ b/packages/web/src/ui/pages/Settings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input } from "@volute/ui";
 import { onMount } from "svelte";
 import AiProviders from "../components/system/AiProviders.svelte";
 import ImagegenProviders from "../components/system/ImagegenProviders.svelte";
@@ -44,6 +45,10 @@ let aiProvidersRef: AiProviders;
 let maxMindsInput = $state("");
 let mindCount = $state(0);
 let maxMindsError = $state("");
+// Only true once the current cap loaded. Guards the onblur autosave from
+// PUTting {maxMinds: null} — silently clearing an existing cap — after a failed
+// load renders the field blank.
+let maxMindsLoaded = $state(false);
 
 onMount(async () => {
   aiProvidersRef.load();
@@ -58,13 +63,18 @@ onMount(async () => {
     const limit = await fetchMaxMinds();
     maxMindsInput = limit.maxMinds == null ? "" : String(limit.maxMinds);
     mindCount = limit.count;
-  } catch {
-    // non-fatal; section just shows empty
+    maxMindsLoaded = true;
+  } catch (err) {
+    // Surface it: a blank field must not read as "no cap", or the autosave
+    // below would clear a cap the admin never saw.
+    maxMindsError = err instanceof Error ? err.message : "Failed to load mind limit";
   }
   defaultsLoaded = true;
 });
 
 async function saveMindLimit() {
+  // Never overwrite the cap from a field that never loaded (see maxMindsLoaded).
+  if (!maxMindsLoaded) return;
   maxMindsError = "";
   const trimmed = maxMindsInput.trim();
   let value: number | null = null;
@@ -149,15 +159,16 @@ async function handleSystemLogout() {
         Cap on total minds ({mindCount} in use). Blank = unlimited.
       </span>
     </div>
-    <input
+    <Input
       type="number"
       min="1"
       step="1"
-      class="system-input"
+      style="width:100%"
       bind:value={maxMindsInput}
       placeholder="Unlimited"
+      disabled={!maxMindsLoaded}
       onblur={saveMindLimit}
-      onkeydown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+      onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
     />
     {#if maxMindsError}
       <div class="error">{maxMindsError}</div>

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import {
   addMind,
+  addSpirit,
   addVariant,
+  countCappedMinds,
   daemonLoopback,
   findMind,
   findVariants,
@@ -167,6 +169,33 @@ describe("variants", () => {
     const base = await readRegistry();
     assert.ok(base.some((e) => e.name === testMind));
     assert.ok(!base.some((e) => e.name === splitName));
+  });
+});
+
+describe("countCappedMinds", () => {
+  const capMind = `cap-test-${Date.now()}`;
+  const capVariant = `${capMind}-v1`;
+  const capSpirit = `cap-spirit-${Date.now()}`;
+
+  afterEach(async () => {
+    try {
+      await removeMind(capMind);
+    } catch {}
+    try {
+      await removeMind(capSpirit);
+    } catch {}
+  });
+
+  it("counts a base mind but excludes its variants and the spirit", async () => {
+    const before = await countCappedMinds();
+    await addMind(capMind, 4100);
+    assert.equal(await countCappedMinds(), before + 1, "base mind counts");
+
+    await addVariant(capVariant, capMind, 4101, "/fake/v1", "v1");
+    assert.equal(await countCappedMinds(), before + 1, "variant does not count");
+
+    await addSpirit(capSpirit, 4102, "claude", "/fake/spirit");
+    assert.equal(await countCappedMinds(), before + 1, "spirit does not count");
   });
 });
 

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -6,6 +6,7 @@ import {
   _resetConfigCache,
   type GlobalConfig,
   isSetupComplete,
+  mindLimitError,
   readGlobalConfig,
   setupStatus,
   setupUrl,
@@ -173,5 +174,28 @@ describe("setupUrl", () => {
   it("brackets a bare IPv6 hostname", () => {
     writeGlobalConfig({ hostname: "::1", port: 1618 });
     assert.equal(setupUrl(), "http://[::1]:1618");
+  });
+});
+
+describe("mindLimitError", () => {
+  it("allows creation when the limit is unset (unlimited)", () => {
+    assert.equal(mindLimitError(0, undefined), null);
+    assert.equal(mindLimitError(9999, undefined), null);
+  });
+
+  it("allows creation while under the cap", () => {
+    assert.equal(mindLimitError(0, 5), null);
+    assert.equal(mindLimitError(4, 5), null);
+  });
+
+  it("rejects at the cap with an actionable message", () => {
+    const err = mindLimitError(5, 5);
+    assert.ok(err);
+    assert.match(err, /Mind limit reached \(5\/5\)/);
+    assert.match(err, /admin can raise maxMinds/i);
+  });
+
+  it("rejects over the cap", () => {
+    assert.ok(mindLimitError(6, 5));
   });
 });

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -230,6 +230,21 @@ describe("web minds routes", () => {
     }
   });
 
+  it("PUT /api/system/max-minds — rejects non-positive and non-integer caps (400)", async () => {
+    // The Zod schema is the real trust boundary: a cap of 0 would silently block
+    // ALL mind creation, so 0/-1/1.5 must never persist.
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    for (const bad of [0, -1, 1.5]) {
+      const res = await app.request("http://localhost/api/system/max-minds", {
+        method: "PUT",
+        headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
+        body: JSON.stringify({ maxMinds: bad }),
+      });
+      assert.equal(res.status, 400, `maxMinds: ${bad} should be rejected`);
+    }
+  });
+
   it("PUT /api/system/max-minds — non-admin gets 403", async () => {
     await setupAuth();
     const user2 = await createUser("regular-user", "pass");
@@ -244,6 +259,21 @@ describe("web minds routes", () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ maxMinds: 5 }),
+    });
+    assert.equal(res.status, 403);
+    await deleteSession(cookie2);
+  });
+
+  it("GET /api/system/max-minds — non-admin gets 403", async () => {
+    // requireAdmin guards GET too, but authz-coverage.test.ts only protects
+    // /:name routes, so exercise this literal route directly.
+    await setupAuth();
+    const user2 = await createUser("regular-user2", "pass");
+    await approveUser(user2.id);
+    const cookie2 = await createSession(user2.id);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("http://localhost/api/system/max-minds", {
+      headers: { Cookie: `volute_session=${cookie2}` },
     });
     assert.equal(res.status, 403);
     await deleteSession(cookie2);

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -161,6 +161,94 @@ describe("web minds routes", () => {
     await deleteSession(cookie2);
   });
 
+  it("POST / — 409 when at the maxMinds cap, with an actionable message", async () => {
+    const cookie = await setupAuth();
+    const { addMind, countCappedMinds, removeMind } = await import(
+      "../packages/daemon/src/lib/mind/registry.js"
+    );
+    const { readGlobalConfig, writeGlobalConfig, _resetConfigCache } = await import(
+      "../packages/daemon/src/lib/config/setup.js"
+    );
+    const existing = `cap-existing-${Date.now()}`;
+    const savedConfig = readGlobalConfig();
+    await addMind(existing, 4100);
+    try {
+      const count = await countCappedMinds();
+      writeGlobalConfig({ ...savedConfig, maxMinds: count });
+
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("http://localhost/api/minds", {
+        method: "POST",
+        headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
+        body: JSON.stringify({ name: `cap-over-${Date.now()}` }),
+      });
+      assert.equal(res.status, 409);
+      const body = (await res.json()) as { error?: string };
+      assert.match(body.error ?? "", /Mind limit reached/);
+      assert.match(body.error ?? "", /maxMinds/);
+    } finally {
+      writeGlobalConfig(savedConfig);
+      _resetConfigCache();
+      await removeMind(existing);
+    }
+  });
+
+  it("GET/PUT /api/system/max-minds — roundtrips the cap and reports the count", async () => {
+    const cookie = await setupAuth();
+    const { readGlobalConfig, writeGlobalConfig } = await import(
+      "../packages/daemon/src/lib/config/setup.js"
+    );
+    const savedConfig = readGlobalConfig();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    try {
+      const putRes = await app.request("http://localhost/api/system/max-minds", {
+        method: "PUT",
+        headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
+        body: JSON.stringify({ maxMinds: 42 }),
+      });
+      assert.equal(putRes.status, 200);
+      const putBody = (await putRes.json()) as { maxMinds: number | null; count: number };
+      assert.equal(putBody.maxMinds, 42);
+      assert.equal(typeof putBody.count, "number");
+
+      const getRes = await app.request("http://localhost/api/system/max-minds", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(getRes.status, 200);
+      assert.equal(((await getRes.json()) as { maxMinds: number | null }).maxMinds, 42);
+
+      // null clears the cap (unlimited)
+      const clearRes = await app.request("http://localhost/api/system/max-minds", {
+        method: "PUT",
+        headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
+        body: JSON.stringify({ maxMinds: null }),
+      });
+      assert.equal(clearRes.status, 200);
+      assert.equal(((await clearRes.json()) as { maxMinds: number | null }).maxMinds, null);
+    } finally {
+      writeGlobalConfig(savedConfig);
+    }
+  });
+
+  it("PUT /api/system/max-minds — non-admin gets 403", async () => {
+    await setupAuth();
+    const user2 = await createUser("regular-user", "pass");
+    await approveUser(user2.id);
+    const cookie2 = await createSession(user2.id);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("http://localhost/api/system/max-minds", {
+      method: "PUT",
+      headers: {
+        Cookie: `volute_session=${cookie2}`,
+        Origin: "http://localhost",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ maxMinds: 5 }),
+    });
+    assert.equal(res.status, 403);
+    await deleteSession(cookie2);
+  });
+
   it("GET /:name/history/export — 404 for missing mind", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");


### PR DESCRIPTION
## What

Adds an optional `maxMinds` cap on the total number of minds, enforced centrally in the daemon's mind-creation route so unbounded creation can't exhaust the host. Closes the resource-exhaustion path called out in #438 (which also blocks relaxing seed creation beyond admins in #433).

## Changes

- **Config**: new `maxMinds?: number` on `GlobalConfig` (`config/setup.ts`). Not a secret — stays in the operator-readable `config.json`.
- **Enforcement**: `POST /api/minds` now checks the cap before doing any filesystem/git/npm work. At or over the cap it returns **409** with an actionable message: `Mind limit reached (N/N). An admin can raise maxMinds in Settings.` Because both `volute mind create` and `volute seed create` (including spirit-driven seeds) proxy through this one route, they all share the guardrail, and the error text is what the CLI prints and the spirit relays verbatim.
- **Counting**: `countCappedMinds()` in the registry counts base minds only, reusing `readRegistry` (which already excludes variants). A pure `mindLimitError(count, limit)` helper holds the decision logic so it's unit-testable.
- **Settings UI + API**: `GET`/`PUT /api/system/max-minds` (admin-only) read and set the cap and report the current count. A "Mind Limit" field in Settings shows `{count} in use` and lets an admin set the cap or clear it (blank = unlimited).

## Decisions

- **Default = unlimited unless explicitly set.** This preserves existing installs (no surprise cap on upgrade) and keeps the change simple — no wiring a default through the several setup entry points. Admins opt into a cap from Settings (or config). The issue floated a default of 10 for new setups; I chose unlimited-unless-set as the lower-risk, simpler option, which the task brief explicitly endorsed. The substantive protection — the enforcement mechanism — is fully in place and one toggle away.
- **Variants are excluded from the cap** (per the issue's open question). They're transient worktrees; a separate `maxVariantsPerMind` can come later if needed.
- **The spirit is excluded** from the count (it's infrastructure, not a user-created mind).
- **Sleeping minds still count** — they hold a registry row and can wake at any time. Counting registry rows (not running processes) handles this for free.
- **Scope**: enforcement is on the create route only, matching the issue. The admin-only `import` route (restoring an exported mind) is left uncapped.
- **Soft limit (accepted).** The count-then-create check is TOCTOU-racy: two concurrent creates can both pass a cap of N, briefly landing at N+1. This is an accepted soft limit — creation is admin/spirit-driven and low-frequency, and the goal is preventing unbounded growth, not hard-serializing creation.

## Tests

- `setup.test.ts` — `mindLimitError`: unlimited when unset, allowed under cap, rejected with the actionable message at/over cap.
- `registry.test.ts` — `countCappedMinds` counts a base mind but excludes its variants and the spirit.
- `web-minds.test.ts` — `POST /api/minds` returns 409 with the message when at the cap; `GET`/`PUT /api/system/max-minds` roundtrip and report the count; `PUT` rejects `0`/`-1`/`1.5` (400, the Zod schema is the trust boundary); non-admin `GET` and `PUT` both get 403.

Full `npm test` passes (via the pre-push hook). `tsc`, `svelte-check`, and `biome` are clean.

Fixes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)