### PR TITLE
fix: dedupe sprout notice and tolerate empty scheduler state

### DIFF
--- a/packages/daemon/src/lib/delivery/message-delivery.ts
+++ b/packages/daemon/src/lib/delivery/message-delivery.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { getSleepManagerIfReady } from "../daemon/sleep-manager.js";
 import { getDb } from "../db.js";
+import { addMessage, listConversationsForMind } from "../events/conversations.js";
 import { publish as publishMindEvent } from "../events/mind-events.js";
 import { findMind, getBaseName } from "../mind/registry.js";
 import { activity, messages, mindHistory } from "../schema.js";
@@ -56,6 +57,22 @@ export async function recordInbound(
   });
 
   return insertedId;
+}
+
+/**
+ * Deliver the "[seed has sprouted]" notice to a freshly-sprouted mind.
+ *
+ * The mind's history (via recordInbound) is conversation-agnostic, so it's recorded
+ * exactly once; the notice is then fanned out to each of the mind's active conversations.
+ */
+export async function deliverSproutedNotice(mind: string): Promise<void> {
+  await recordInbound(mind, "system", "system", "[seed has sprouted]");
+  const convs = await listConversationsForMind(mind);
+  for (const conv of convs) {
+    await addMessage(conv.id, "assistant", "system", [
+      { type: "text", text: "[seed has sprouted]" },
+    ]);
+  }
 }
 
 /**

--- a/packages/daemon/src/lib/util/json-state.ts
+++ b/packages/daemon/src/lib/util/json-state.ts
@@ -6,7 +6,10 @@ export function loadJsonMap(path: string): Map<string, number> {
   const map = new Map<string, number>();
   try {
     if (existsSync(path)) {
-      const data = JSON.parse(readFileSync(path, "utf-8"));
+      const raw = readFileSync(path, "utf-8").trim();
+      // An empty/zero-length file is an expected condition (fresh install), not corruption.
+      if (!raw) return map;
+      const data = JSON.parse(raw);
       for (const [key, value] of Object.entries(data)) {
         if (typeof value === "number") map.set(key, value);
       }

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -39,10 +39,9 @@ import { handleMindEvent, setNoticeDrainWatermark } from "../../lib/daemon/turn-
 import { getActiveTurnId } from "../../lib/daemon/turn-tracker.js";
 import { getDb } from "../../lib/db.js";
 import { getDeliveryManager } from "../../lib/delivery/delivery-manager.js";
-import { recordInbound } from "../../lib/delivery/message-delivery.js";
+import { deliverSproutedNotice } from "../../lib/delivery/message-delivery.js";
 import { broadcast } from "../../lib/events/activity-events.js";
 import {
-  addMessage,
   getConversation,
   getMessages,
   getMessagesPaginated,
@@ -1534,16 +1533,10 @@ const app = new Hono<AuthEnv>()
         manager.setPendingContext(name, context);
       }
 
-      // Inject "[seed has sprouted]" system message into active volute conversations
+      // Inject "[seed has sprouted]" system message into active volute conversations.
       if (context?.type === "sprouted" && !entry.parent) {
         try {
-          const mindConvs = await listConversationsForMind(baseName);
-          for (const conv of mindConvs) {
-            await recordInbound(baseName, "system", "system", "[seed has sprouted]");
-            await addMessage(conv.id, "assistant", "system", [
-              { type: "text", text: "[seed has sprouted]" },
-            ]);
-          }
+          await deliverSproutedNotice(baseName);
         } catch (err) {
           log.error(`failed to inject sprouted message for ${baseName}`, log.errorData(err));
         }

--- a/test/json-state.test.ts
+++ b/test/json-state.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { loadJsonMap, saveJsonMap } from "../packages/daemon/src/lib/util/json-state.js";
+
+describe("loadJsonMap", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "json-state-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns an empty map when the file is missing", () => {
+    const map = loadJsonMap(join(dir, "missing.json"));
+    assert.equal(map.size, 0);
+  });
+
+  it("returns an empty map for a zero-length file without throwing", () => {
+    const path = join(dir, "empty.json");
+    writeFileSync(path, "");
+    // An empty file is an expected condition (fresh install), not a parse error.
+    const map = loadJsonMap(path);
+    assert.equal(map.size, 0);
+  });
+
+  it("returns an empty map for a whitespace-only file", () => {
+    const path = join(dir, "blank.json");
+    writeFileSync(path, "  \n\t ");
+    const map = loadJsonMap(path);
+    assert.equal(map.size, 0);
+  });
+
+  it("loads numeric entries and skips non-numeric values", () => {
+    const path = join(dir, "state.json");
+    writeFileSync(path, JSON.stringify({ a: 1, b: 2, c: "nope" }));
+    const map = loadJsonMap(path);
+    assert.equal(map.size, 2);
+    assert.equal(map.get("a"), 1);
+    assert.equal(map.get("b"), 2);
+    assert.equal(map.has("c"), false);
+  });
+
+  it("recovers to an empty map on corrupt JSON", () => {
+    const path = join(dir, "corrupt.json");
+    writeFileSync(path, "{not valid json");
+    const map = loadJsonMap(path);
+    assert.equal(map.size, 0);
+  });
+
+  it("round-trips through saveJsonMap", () => {
+    const path = join(dir, "roundtrip.json");
+    const original = new Map([
+      ["x", 10],
+      ["y", 20],
+    ]);
+    saveJsonMap(path, original);
+    const loaded = loadJsonMap(path);
+    assert.deepEqual([...loaded.entries()].sort(), [
+      ["x", 10],
+      ["y", 20],
+    ]);
+  });
+});

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -2,17 +2,24 @@ import assert from "node:assert/strict";
 import { createServer, type Server } from "node:http";
 import { afterEach, describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { extractTextContent } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import {
   deliverBatch,
   deliverMessage,
+  deliverSproutedNotice,
   linkToolResultToTurn,
   recordInbound,
   recordOutbound,
   resolveSleepAction,
 } from "../packages/daemon/src/lib/delivery/message-delivery.js";
 import { publish as publishActivity } from "../packages/daemon/src/lib/events/activity-events.js";
+import {
+  createConversation,
+  deleteConversation,
+  getMessages,
+} from "../packages/daemon/src/lib/events/conversations.js";
 import { type MindEvent, subscribe } from "../packages/daemon/src/lib/events/mind-events.js";
 import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import {
@@ -21,6 +28,7 @@ import {
   messages,
   mindHistory,
   turns,
+  users,
 } from "../packages/daemon/src/lib/schema.js";
 
 describe("extractTextContent", () => {
@@ -505,5 +513,45 @@ describe("linkToolResultToTurn", () => {
     const db = await getDb();
     const row = await db.select().from(mindHistory).where(eq(mindHistory.id, outId!)).get();
     assert.equal(row!.turn_id, LINK_TURN_ID, "existing turn_id must be preserved");
+  });
+});
+
+describe("deliverSproutedNotice", () => {
+  const SPROUT_MIND = "sprout-notice-mind";
+
+  afterEach(async () => {
+    const db = await getDb();
+    await db.delete(mindHistory).where(eq(mindHistory.mind, SPROUT_MIND));
+    await db.delete(users).where(eq(users.username, SPROUT_MIND));
+  });
+
+  it("records the notice in mind history exactly once regardless of conversation count", async () => {
+    const mindUser = await getOrCreateMindUser(SPROUT_MIND);
+    // The mind participates in two active conversations — the source of the earlier
+    // double-injection bug (recordInbound was called once per conversation).
+    const convA = await createConversation({ participantIds: [mindUser.id] });
+    const convB = await createConversation({ participantIds: [mindUser.id] });
+
+    await deliverSproutedNotice(SPROUT_MIND);
+
+    const db = await getDb();
+    const historyRows = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, SPROUT_MIND), eq(mindHistory.type, "inbound")));
+    assert.equal(historyRows.length, 1, "sprouted notice must appear in history exactly once");
+    assert.equal(historyRows[0].content, "[seed has sprouted]");
+
+    // The notice still fans out to each conversation.
+    for (const conv of [convA, convB]) {
+      const msgs = await getMessages(conv.id);
+      const sprouted = msgs.filter(
+        (m) => (m.content[0] as { text?: string })?.text === "[seed has sprouted]",
+      );
+      assert.equal(sprouted.length, 1, "each conversation gets the notice once");
+    }
+
+    await deleteConversation(convA.id);
+    await deleteConversation(convB.id);
   });
 });

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -542,16 +542,38 @@ describe("deliverSproutedNotice", () => {
     assert.equal(historyRows.length, 1, "sprouted notice must appear in history exactly once");
     assert.equal(historyRows[0].content, "[seed has sprouted]");
 
-    // The notice still fans out to each conversation.
+    // The notice still fans out to each conversation, as an assistant/system message.
     for (const conv of [convA, convB]) {
       const msgs = await getMessages(conv.id);
       const sprouted = msgs.filter(
         (m) => (m.content[0] as { text?: string })?.text === "[seed has sprouted]",
       );
       assert.equal(sprouted.length, 1, "each conversation gets the notice once");
+      assert.equal(sprouted[0].role, "assistant");
+      assert.equal(sprouted[0].sender_name, "system");
     }
 
     await deleteConversation(convA.id);
     await deleteConversation(convB.id);
+  });
+
+  it("records the notice once even when the mind has no conversations", async () => {
+    // History is conversation-agnostic: a sprout is logged once regardless of whether
+    // the mind is in any conversation yet. The old per-conversation loop recorded none.
+    await getOrCreateMindUser(SPROUT_MIND);
+
+    await deliverSproutedNotice(SPROUT_MIND);
+
+    const db = await getDb();
+    const historyRows = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, SPROUT_MIND), eq(mindHistory.type, "inbound")));
+    assert.equal(
+      historyRows.length,
+      1,
+      "sprouted notice must be recorded once with no conversations",
+    );
+    assert.equal(historyRows[0].content, "[seed has sprouted]");
   });
 });


### PR DESCRIPTION
Fixes two papercuts found in the 0.48.0 verification campaign.

## 1. Empty `scheduler-state.json` logged a parse error

The first daemon restart after a fresh install printed
`[state] failed to load .../scheduler-state.json: SyntaxError: Unexpected end of JSON input`.
An empty (or whitespace-only) state file is an expected condition, not corruption. `loadJsonMap` now trims the file and returns an empty map when it's blank, so only genuinely corrupt JSON still warns.

## 2. `[seed has sprouted]` recorded twice in mind history

The sprout injection loop in `web/api/minds.ts` called `recordInbound` once per active conversation. `recordInbound` writes to the mind's conversation-agnostic `mind_history` table, so a mind in two conversations got two identical history entries at the same timestamp.

Fixed at the source: extracted `deliverSproutedNotice` in `lib/delivery/message-delivery.ts`, which records the history entry exactly once and then fans the notice out to each conversation via `addMessage`.

### Intentional behavior change

Decoupling the history record from the conversation loop also changes the zero-conversation case: a mind that sprouts with no active conversations now gets exactly one `[seed has sprouted]` history row, where the old loop recorded none. This is the correct semantics — `mind_history` is conversation-agnostic, so a sprout should be logged once regardless of how many conversations the mind is in. Covered by a dedicated test.

## Tests

- New `test/json-state.test.ts`: empty, whitespace-only, missing, valid, and corrupt files; save/load round-trip.
- New cases in `test/message-delivery.test.ts`: `deliverSproutedNotice` records history exactly once across multiple conversations (and fans out as an assistant/system message to each), and records exactly once when the mind has no conversations.

Full suite (`npm test`) green: 2235 pass, 0 fail.

Fixes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)