### PR TITLE
fix: let the spirit reload its identity without restart-looping

### DIFF
--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1399,11 +1399,13 @@ const app = new Hono<AuthEnv>()
     if (!entry) return c.json({ error: "Mind not found" }, 404);
 
     const targetPort = entry.port;
+    // Variants and spirits store their project dir in the DB (worktree /
+    // ~/.volute/system/spirit); only plain minds live at mindDir(name).
+    const projectDir = entry.dir ?? mindDir(name);
     if (entry.parent) {
       if (!entry.dir) return c.json({ error: `Variant ${name} has no directory` }, 404);
-    } else {
-      const dir = mindDir(name);
-      if (!existsSync(dir)) return c.json({ error: "Mind directory missing" }, 404);
+    } else if (!existsSync(projectDir)) {
+      return c.json({ error: "Mind directory missing" }, 404);
     }
 
     if (getMindManager().isRunning(name)) {

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1427,11 +1427,13 @@ const app = new Hono<AuthEnv>()
 
     const baseName = entry.parent ?? name;
     const targetPort = entry.port;
+    // Variants and spirits store their project dir in the DB (worktree /
+    // ~/.volute/system/spirit); only plain minds live at mindDir(name).
+    const projectDir = entry.dir ?? mindDir(name);
     if (entry.parent) {
       if (!entry.dir) return c.json({ error: `Variant ${name} has no directory` }, 404);
-    } else {
-      const dir = mindDir(name);
-      if (!existsSync(dir)) return c.json({ error: "Mind directory missing" }, 404);
+    } else if (!existsSync(projectDir)) {
+      return c.json({ error: "Mind directory missing" }, 404);
     }
 
     // Parse optional context from request body
@@ -1549,9 +1551,9 @@ const app = new Hono<AuthEnv>()
         }
       }
 
-      // Resolve the mind's git repo dir (variant worktree or the base mind dir) so
-      // last-known-good recovery can operate on the right working tree.
-      const repoDir = entry.parent ? entry.dir! : mindDir(name);
+      // Resolve the mind's git repo dir (variant worktree, spirit dir, or the base
+      // mind dir) so last-known-good recovery can operate on the right working tree.
+      const repoDir = projectDir;
 
       try {
         await startMindFullService(name);

--- a/templates/_base/src/lib/daemon-client.ts
+++ b/templates/_base/src/lib/daemon-client.ts
@@ -38,11 +38,21 @@ export async function daemonRestart(context?: {
     return;
   }
   try {
-    await fetch(`http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/restart`, {
-      method: "POST",
-      headers: headers(),
-      body: JSON.stringify({ context }),
-    });
+    const res = await fetch(
+      `http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/restart`,
+      {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ context }),
+      },
+    );
+    // A successful restart usually kills us before this runs. If we get here with a
+    // non-ok status, the restart didn't happen — surface it instead of silently looping.
+    if (!res.ok) {
+      console.error(
+        `[volute] daemonRestart failed: ${res.status} ${await res.text().catch(() => "")}`,
+      );
+    }
   } catch {
     // Daemon may kill us before response arrives — expected
   }

--- a/templates/_base/src/lib/daemon-client.ts
+++ b/templates/_base/src/lib/daemon-client.ts
@@ -53,8 +53,18 @@ export async function daemonRestart(context?: {
         `[volute] daemonRestart failed: ${res.status} ${await res.text().catch(() => "")}`,
       );
     }
-  } catch {
-    // Daemon may kill us before response arrives — expected
+  } catch (err) {
+    // A successful restart usually rejects here — the daemon kills us before the
+    // response arrives — so this is expected on the happy path. It's only worth
+    // surfacing when a restart *didn't* happen (e.g. the daemon is down / refuses
+    // the connection), which leaves the mind stuck on its old identity. Gate it on
+    // VOLUTE_DEBUG so normal restarts stay quiet but the failure is diagnosable.
+    if (process.env.VOLUTE_DEBUG === "1") {
+      console.error(
+        "[volute] daemonRestart request errored (expected if the daemon killed us):",
+        err,
+      );
+    }
   }
 }
 

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -346,7 +346,7 @@ export function createMind(options: {
             // Mind's turn after compaction warning is done — abort the stream to run /compact
             log("mind", `session "${session.name}": aborting stream for compaction`);
             streamAbort.abort(new CompactionAbort());
-          } else if (identityReload.needsReload()) {
+          } else if (identityReload.shouldRequestReload()) {
             options.onIdentityReload?.();
           }
         },

--- a/templates/claude/src/lib/hooks/identity-reload.ts
+++ b/templates/claude/src/lib/hooks/identity-reload.ts
@@ -5,6 +5,7 @@ const IDENTITY_FILES = ["SOUL.md", "MEMORY.md", "VOLUTE.md"];
 
 export function createIdentityReloadHook(cwd: string) {
   let reloadNeeded = false;
+  let reloadRequested = false;
 
   const hook: HookCallback = async (input) => {
     const filePath = (input as { tool_input?: { file_path?: string } }).tool_input?.file_path;
@@ -18,9 +19,17 @@ export function createIdentityReloadHook(cwd: string) {
     return {};
   };
 
-  function needsReload(): boolean {
-    return reloadNeeded;
+  // Returns true at most once per process. A reload requests a daemon restart,
+  // which normally kills this process — but if that restart fails (e.g. the
+  // request errors), the process survives with reloadNeeded still set. Latching
+  // on reloadRequested stops us from re-firing the restart on every later turn.
+  function shouldRequestReload(): boolean {
+    if (reloadNeeded && !reloadRequested) {
+      reloadRequested = true;
+      return true;
+    }
+    return false;
   }
 
-  return { hook, needsReload };
+  return { hook, shouldRequestReload };
 }

--- a/test/identity-reload-hook.test.ts
+++ b/test/identity-reload-hook.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createIdentityReloadHook } from "../templates/claude/src/lib/hooks/identity-reload.js";
+
+const cwd = "/home/mind";
+
+// The hook only reads tool_input.file_path; call it with just that shape.
+type FileHook = (input: { tool_input?: { file_path?: string } }) => Promise<unknown>;
+async function fire(hook: FileHook, filePath?: string) {
+  await hook({ tool_input: filePath ? { file_path: filePath } : {} });
+}
+
+describe("identity reload hook", () => {
+  it("does not request a reload without an identity-file edit", async () => {
+    const { hook, shouldRequestReload } = createIdentityReloadHook(cwd);
+    await fire(hook);
+    await fire(hook, "notes/todo.md");
+    assert.equal(shouldRequestReload(), false);
+  });
+
+  it("requests a reload when an identity file changes", async () => {
+    const { hook, shouldRequestReload } = createIdentityReloadHook(cwd);
+    await fire(hook, "MEMORY.md");
+    assert.equal(shouldRequestReload(), true);
+  });
+
+  it("ignores identity-named files outside the mind's cwd", async () => {
+    const { hook, shouldRequestReload } = createIdentityReloadHook(cwd);
+    await fire(hook, "/etc/SOUL.md");
+    assert.equal(shouldRequestReload(), false);
+  });
+
+  it("latches: fires at most once so a failed restart doesn't loop", async () => {
+    const { hook, shouldRequestReload } = createIdentityReloadHook(cwd);
+    await fire(hook, "SOUL.md");
+    assert.equal(shouldRequestReload(), true, "first check should request the reload");
+    assert.equal(shouldRequestReload(), false, "subsequent checks must not re-fire");
+    // A later identity edit must not re-arm the latch either.
+    await fire(hook, "VOLUTE.md");
+    assert.equal(shouldRequestReload(), false, "latch stays closed after the first request");
+  });
+});

--- a/test/web-minds-spirit-restart.test.ts
+++ b/test/web-minds-spirit-restart.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
+import { minds, users } from "../packages/daemon/src/lib/schema.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+// The spirit lives at ~/.volute/system/spirit (stored in the minds table's `dir`
+// column), not at mindDir("volute"). The restart route used to gate on
+// existsSync(mindDir(name)), so the spirit always 404'd "Mind directory missing"
+// and its identity reload never happened (#620). These tests pin the dir gate to
+// the DB-recorded dir. The manager isn't initialized in this test context, so a
+// restart that clears the gate fails later (non-404) instead of spawning a process.
+
+const ADMIN = "spirit-restart-admin";
+const SPIRIT_OK = "test-spirit-ok";
+const SPIRIT_MISSING = "test-spirit-missing";
+
+async function cleanup() {
+  const db = await getDb();
+  await db.delete(users).where(eq(users.username, ADMIN));
+  await db.delete(minds).where(eq(minds.name, SPIRIT_OK));
+  await db.delete(minds).where(eq(minds.name, SPIRIT_MISSING));
+}
+
+function postHeaders(cookie: string) {
+  return { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" };
+}
+
+describe("spirit restart directory gate (#620)", () => {
+  let spiritDir: string;
+
+  beforeEach(async () => {
+    await cleanup();
+    spiritDir = mkdtempSync(join(tmpdir(), "spirit-restart-"));
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    rmSync(spiritDir, { recursive: true, force: true });
+  });
+
+  it("does not 404 when the spirit's recorded dir exists", async () => {
+    const admin = await createUser(ADMIN, "pass");
+    const cookie = await createSession(admin.id);
+    await addSpirit(SPIRIT_OK, 4999, "claude", spiritDir);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await app.request(`http://localhost/api/minds/${SPIRIT_OK}/restart`, {
+      method: "POST",
+      headers: postHeaders(cookie),
+    });
+
+    // Gate cleared: it must not be the "Mind directory missing" 404. (It fails later
+    // because the mind manager isn't initialized in this test context.)
+    assert.notEqual(res.status, 404, `unexpected 404: ${await res.clone().text()}`);
+  });
+
+  it("404s when the spirit's recorded dir is missing", async () => {
+    const admin = await createUser(ADMIN, "pass");
+    const cookie = await createSession(admin.id);
+    await addSpirit(SPIRIT_MISSING, 4998, "claude", join(spiritDir, "does-not-exist"));
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    const res = await app.request(`http://localhost/api/minds/${SPIRIT_MISSING}/restart`, {
+      method: "POST",
+      headers: postHeaders(cookie),
+    });
+
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { error?: string };
+    assert.match(body.error ?? "", /Mind directory missing/);
+  });
+});

--- a/test/web-minds-spirit-restart.test.ts
+++ b/test/web-minds-spirit-restart.test.ts
@@ -1,21 +1,27 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
+import { addSpirit, mindDir } from "../packages/daemon/src/lib/mind/registry.js";
 import { minds, users } from "../packages/daemon/src/lib/schema.js";
 import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 // The spirit lives at ~/.volute/system/spirit (stored in the minds table's `dir`
-// column), not at mindDir("volute"). The restart route used to gate on
+// column), not at mindDir("volute"). The start/restart routes used to gate on
 // existsSync(mindDir(name)), so the spirit always 404'd "Mind directory missing"
-// and its identity reload never happened (#620). These tests pin the dir gate to
-// the DB-recorded dir. The manager isn't initialized in this test context, so a
-// restart that clears the gate fails later (non-404) instead of spawning a process.
+// and (for restart) its identity reload never happened (#620). These tests pin the
+// dir gate to the DB-recorded dir for both routes.
+//
+// The mind manager isn't initialized in this test context, so a request that
+// clears the gate throws when it reaches getMindManager() and Hono turns that into
+// a 500 — which is exactly what lets us assert "gate passed" without spawning a
+// real mind process. We pin that 500 so a 500-from-elsewhere can't masquerade as a
+// cleared gate.
+const GATE_CLEARED_STATUS = 500;
 
 const ADMIN = "spirit-restart-admin";
 const SPIRIT_OK = "test-spirit-ok";
@@ -32,7 +38,7 @@ function postHeaders(cookie: string) {
   return { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" };
 }
 
-describe("spirit restart directory gate (#620)", () => {
+describe("spirit start/restart directory gate (#620)", () => {
   let spiritDir: string;
 
   beforeEach(async () => {
@@ -43,27 +49,39 @@ describe("spirit restart directory gate (#620)", () => {
   afterEach(async () => {
     await cleanup();
     rmSync(spiritDir, { recursive: true, force: true });
+    // Remove the decoy mindDir created by the negative test, if any.
+    rmSync(mindDir(SPIRIT_MISSING), { recursive: true, force: true });
   });
 
-  it("does not 404 when the spirit's recorded dir exists", async () => {
-    const admin = await createUser(ADMIN, "pass");
-    const cookie = await createSession(admin.id);
-    await addSpirit(SPIRIT_OK, 4999, "claude", spiritDir);
-    const { default: app } = await import("../packages/daemon/src/web/app.js");
+  for (const route of ["restart", "start"] as const) {
+    it(`${route}: clears the gate when the spirit's recorded dir exists`, async () => {
+      const admin = await createUser(ADMIN, "pass");
+      const cookie = await createSession(admin.id);
+      await addSpirit(SPIRIT_OK, 4999, "claude", spiritDir);
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${SPIRIT_OK}/restart`, {
-      method: "POST",
-      headers: postHeaders(cookie),
+      const res = await app.request(`http://localhost/api/minds/${SPIRIT_OK}/${route}`, {
+        method: "POST",
+        headers: postHeaders(cookie),
+      });
+
+      // Gate cleared: not the "Mind directory missing" 404. It then fails at
+      // getMindManager() (uninitialized here) → 500, rather than spawning a process.
+      assert.equal(
+        res.status,
+        GATE_CLEARED_STATUS,
+        `unexpected status: ${await res.clone().text()}`,
+      );
     });
+  }
 
-    // Gate cleared: it must not be the "Mind directory missing" 404. (It fails later
-    // because the mind manager isn't initialized in this test context.)
-    assert.notEqual(res.status, 404, `unexpected 404: ${await res.clone().text()}`);
-  });
-
-  it("404s when the spirit's recorded dir is missing", async () => {
+  it("restart: 404s on the DB-recorded dir, not mindDir(name)", async () => {
     const admin = await createUser(ADMIN, "pass");
     const cookie = await createSession(admin.id);
+    // Make mindDir(name) EXIST but point the DB `dir` at a missing path. The old
+    // code gated on mindDir(name) and would have passed here; the fix gates on the
+    // recorded dir, so this must 404 — pinning that the gate reads the DB dir.
+    mkdirSync(mindDir(SPIRIT_MISSING), { recursive: true });
     await addSpirit(SPIRIT_MISSING, 4998, "claude", join(spiritDir, "does-not-exist"));
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 


### PR DESCRIPTION
## Root cause

The system spirit lives at `~/.volute/system/spirit` — its project directory is recorded in the `minds` table's `dir` column, **not** at `mindDir("volute")`. The daemon's restart route (`POST /api/minds/:name/restart`) gated non-variant minds on `existsSync(mindDir(name))`, so every spirit restart returned **404 "Mind directory missing"** and the identity reload never happened.

Worse, the identity-reload hook's `reloadNeeded` flag was never cleared. For a normal mind that doesn't matter (the daemon kills the process on restart), but the spirit's restart 404'd and the process kept running — so every subsequent turn's `onTurnEnd` saw `needsReload() === true` and re-fired the restart. That is the observed loop: 7 restarts in 10 minutes from a single MEMORY.md edit. The reporter's "6 triggers" were re-fires of one write, not six separate writes.

## Change

- **`packages/daemon/src/web/api/minds.ts`** — the restart route resolves the project dir as `entry.dir ?? mindDir(name)` (the same resolution `MindManager.resolveTarget` already uses), covering spirits and variants, and reuses it for the last-known-good `repoDir`. The sibling `POST /:name/start` route had the identical dir-gate bug (so the spirit could never be started via the API/web UI either); it gets the same resolution.
- **`templates/claude/src/lib/hooks/identity-reload.ts`** — `needsReload()` becomes `shouldRequestReload()`, which latches: it returns `true` at most once per process, so a restart that fails to kill the process can't loop.
- **`templates/_base/src/lib/daemon-client.ts`** — `daemonRestart()` logs a non-ok response instead of silently swallowing it (the 404 was previously invisible to the mind), and the request-error `catch` now binds and logs the error under `VOLUTE_DEBUG` so a transport failure (daemon down / connection refused) is diagnosable rather than silent.

### Failure-mode trade-off

A restart that fails at the transport layer logs (under `VOLUTE_DEBUG`) and leaves the mind on its old identity until an operator restart; the latch intentionally does not reset, so it won't retry-loop. On the happy path the daemon kills the mind mid-request, so that same `catch` firing is expected and stays quiet.

## Tests

- `test/identity-reload-hook.test.ts` — the hook fires once for an identity-file edit, ignores non-identity and out-of-cwd files, and latches (no re-fire).
- `test/web-minds-spirit-restart.test.ts` — for both `start` and `restart`, a spirit whose recorded `dir` exists clears the directory gate; the negative case makes `mindDir(name)` exist while the recorded `dir` is missing, so it pins that the gate reads the DB dir (not `mindDir`) rather than passing by accident.

Full suite: 2235 passing, 0 failing.

Fixes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)
