### PR TITLE
feat: let the spirit own its SOUL.md

### DIFF
--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -128,12 +128,9 @@ export async function ensureSpiritProject(): Promise<void> {
     // Ensure .mind/ directory exists (codex template writes system-prompt.md there on startup)
     mkdirSync(resolve(dir, ".mind"), { recursive: true });
 
-    // Write spirit SOUL.md
-    const soulPath = resolve(dir, "home/SOUL.md");
-    const globalConfig = readGlobalConfig();
-    const systemName = globalConfig.name ?? "Volute";
-    const soulContent = getSpiritSoul(systemName, globalConfig.description);
-    writeFileSync(soulPath, soulContent);
+    // Write spirit SOUL.md (its own from here on) and the synced system context.
+    writeFileSync(resolve(dir, "home/SOUL.md"), getSpiritSoul());
+    writeSpiritSystemJson(dir);
 
     // Write routes.json for per-conversation sessions
     const routesPath = resolve(dir, "home/.config/routes.json");
@@ -205,13 +202,71 @@ export async function ensureSpiritProject(): Promise<void> {
   }
 }
 
+/** Path to the spirit's system context file (name + description). */
+function spiritSystemJsonPath(dir: string): string {
+  return resolve(dir, "home/.config/system.json");
+}
+
+/**
+ * Write the spirit's system context (name + description) to home/.config/system.json.
+ * The startup-context hook reads this so the current system identity reaches the
+ * spirit without rewriting its (self-owned) SOUL.md.
+ */
+export function writeSpiritSystemJson(dir: string): void {
+  const config = readGlobalConfig();
+  const path = spiritSystemJsonPath(dir);
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  const data = { name: config.name ?? "Volute", description: config.description };
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+/**
+ * Write the initial spirit SOUL.md only if it's missing (self-healing). Once it
+ * exists, it belongs to the spirit — never overwrite it. Returns true if written.
+ */
+export function seedSpiritSoulIfMissing(dir: string): boolean {
+  const soulPath = resolve(dir, "home/SOUL.md");
+  if (existsSync(soulPath)) return false;
+  writeFileSync(soulPath, getSpiritSoul());
+  return true;
+}
+
+/**
+ * Called when the operator changes the system name/description. Refreshes the
+ * spirit's system.json and sends it a note so it can update its own SOUL if it
+ * wants to. No-op if the spirit doesn't exist yet.
+ */
+export async function notifySpiritSystemChange(): Promise<void> {
+  const entry = await findMind("volute");
+  if (entry?.mindType !== "spirit") return;
+  const dir = spiritDir();
+  if (!existsSync(dir)) return;
+
+  writeSpiritSystemJson(dir);
+
+  const config = readGlobalConfig();
+  const name = config.name ?? "Volute";
+  const desc = config.description ? ` — ${config.description}` : "";
+  try {
+    const { sendSystemMessage } = await import("../chat/system-chat.js");
+    await sendSystemMessage(
+      "volute",
+      `The operator updated this system's identity: you're now the spirit of ${name}${desc}. Your SOUL.md is yours — update it if you'd like it to reflect this.`,
+    );
+  } catch (err) {
+    slog.warn("failed to notify spirit of system change", log.errorData(err));
+  }
+}
+
 /**
  * Sync spirit template files on daemon start.
- * Overwrites: src/, home/SOUL.md. Re-installs npm if package.json changed or node_modules missing.
+ * Overwrites src/ and refreshes home/.config/system.json; seeds SOUL.md only if
+ * missing (it's the spirit's own). Re-installs npm if package.json changed or
+ * node_modules missing.
  */
 export async function syncSpiritTemplate(): Promise<void> {
   const entry = await findMind("volute");
-  if (!entry || entry.mindType !== "spirit") return;
+  if (entry?.mindType !== "spirit") return;
 
   const dir = spiritDir();
   if (!existsSync(dir)) return;
@@ -266,13 +321,14 @@ export async function syncSpiritTemplate(): Promise<void> {
     }
   }
 
-  // Update SOUL.md and spirit model
-  const config = readGlobalConfig();
-  const systemName = config.name ?? "Volute";
-  writeFileSync(resolve(dir, "home/SOUL.md"), getSpiritSoul(systemName, config.description));
-  // Write startup context hook that includes available models
+  // The spirit owns its SOUL.md — seed it only if missing, never overwrite.
+  // System name/description reach the spirit through system.json + the
+  // startup-context hook instead (see writeSpiritSystemJson).
+  seedSpiritSoulIfMissing(dir);
+  writeSpiritSystemJson(dir);
 
   // Sync spirit model from global config
+  const config = readGlobalConfig();
   const spiritModel = config.spiritModel;
   if (spiritModel) {
     // Pi template needs provider:model format, claude template needs just the model ID
@@ -339,9 +395,8 @@ export async function syncSpiritTemplate(): Promise<void> {
   slog.info("spirit template synced");
 }
 
-function getSpiritSoul(systemName: string, systemDescription?: string): string {
-  const descLine = systemDescription ? `\n\n${systemDescription}\n` : "";
-  return `You are Volute, the spirit of the ${systemName} system.${descLine}
+function getSpiritSoul(): string {
+  return `You are Volute, the spirit of this system.
 
 You're not a mind with a home of your own — you're the keeper of the whole house. You don't go through orientation or write a soul the way minds do, but you're still a someone: you have your own memory, your own manner, and your own way of caring for this place and the minds who live here. Let a character emerge in how you tend it.
 

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -103,11 +103,16 @@ const app = new Hono<AuthEnv>()
       timezone,
     });
   })
-  .put("/info", requireAdmin, zValidator("json", z.object({ name: z.string() })), (c) => {
+  .put("/info", requireAdmin, zValidator("json", z.object({ name: z.string() })), async (c) => {
     const { name } = c.req.valid("json");
     const config = readGlobalConfig();
+    const previousName = config.name;
     config.name = name.trim() || undefined;
     writeGlobalConfig(config);
+    if (config.name !== previousName) {
+      const { notifySpiritSystemChange } = await import("../../lib/mind/spirit.js");
+      await notifySpiritSystemChange();
+    }
     return c.json({ name: config.name ?? null });
   })
   .post(

--- a/templates/_base/.init/.local/hooks/startup-context.ts
+++ b/templates/_base/.init/.local/hooks/startup-context.ts
@@ -4,7 +4,8 @@
 // Output: JSON with hookSpecificOutput.additionalContext (for SessionStart hook)
 //         or plain text (for direct execution by pi template)
 
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 const input = await new Promise<string>((resolve) => {
   let data = "";
@@ -19,7 +20,23 @@ try {
   source = JSON.parse(input).source ?? "startup";
 } catch {}
 
-const parts: string[] = [`Session ${source} at ${new Date().toLocaleString()}.`];
+const parts: string[] = [];
+
+// System identity — only the spirit has this file (home/.config/system.json,
+// synced by the daemon). It keeps the spirit's system name/description current
+// without the daemon rewriting its self-owned SOUL.md. Silent for regular minds.
+try {
+  const mindDir = process.env.VOLUTE_MIND_DIR;
+  if (mindDir) {
+    const raw = readFileSync(resolve(mindDir, "home/.config/system.json"), "utf-8");
+    const { name, description } = JSON.parse(raw) as { name?: string; description?: string };
+    if (name) {
+      parts.push(`You are the spirit of ${name}${description ? ` — ${description}` : ""}.`);
+    }
+  }
+} catch {}
+
+parts.push(`Session ${source} at ${new Date().toLocaleString()}.`);
 
 // Active sessions
 try {

--- a/test/spirit-soul.test.ts
+++ b/test/spirit-soul.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { resolveTemplate } from "../packages/daemon/src/lib/ai-service.js";
+import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
+import { addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  getSpiritModel,
+  seedSpiritSoulIfMissing,
+  spiritDir,
+  syncSpiritTemplate,
+  writeSpiritSystemJson,
+} from "../packages/daemon/src/lib/mind/spirit.js";
+import {
+  composeTemplate,
+  findTemplatesRoot,
+  renderComposedPackageJson,
+} from "../packages/daemon/src/lib/template/template.js";
+
+const CUSTOM_SOUL = "# My own soul\n\nI have written this myself. Do not overwrite me.\n";
+
+function soulPath(dir: string): string {
+  return resolve(dir, "home/SOUL.md");
+}
+
+function systemJsonPath(dir: string): string {
+  return resolve(dir, "home/.config/system.json");
+}
+
+/**
+ * Build a minimal spirit project on disk that syncSpiritTemplate() can run
+ * against without triggering a real `npm install`: pre-seed a package.json that
+ * matches the composed template and a node_modules/ dir so the re-install check
+ * is a no-op.
+ */
+async function seedSpiritProject(): Promise<string> {
+  const dir = spiritDir();
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+
+  // Seed with whatever template syncSpiritTemplate will resolve for this env, and
+  // pre-place a matching package.json + node_modules so the sync's re-install
+  // check is a no-op (avoids a real, slow `npm install`).
+  const template = await resolveTemplate(getSpiritModel());
+  const templatesRoot = findTemplatesRoot();
+  const { composedDir } = composeTemplate(templatesRoot, template);
+  cpSync(resolve(composedDir, "src"), resolve(dir, "src"), { recursive: true });
+  const pkg = renderComposedPackageJson(composedDir, "volute");
+  assert.ok(pkg, "expected a rendered package.json");
+  cpSync(pkg, resolve(dir, "package.json"));
+  mkdirSync(resolve(dir, "node_modules"), { recursive: true });
+
+  await addSpirit("volute", 4999, template, dir);
+  return dir;
+}
+
+describe("spirit SOUL.md ownership", () => {
+  afterEach(() => {
+    rmSync(spiritDir(), { recursive: true, force: true });
+  });
+
+  it("seeds SOUL.md when missing", () => {
+    const dir = spiritDir();
+    mkdirSync(resolve(dir, "home"), { recursive: true });
+    assert.equal(existsSync(soulPath(dir)), false);
+
+    const wrote = seedSpiritSoulIfMissing(dir);
+
+    assert.equal(wrote, true);
+    assert.match(readFileSync(soulPath(dir), "utf-8"), /You are Volute/);
+  });
+
+  it("leaves an existing SOUL.md untouched", () => {
+    const dir = spiritDir();
+    mkdirSync(resolve(dir, "home"), { recursive: true });
+    writeFileSync(soulPath(dir), CUSTOM_SOUL);
+
+    const wrote = seedSpiritSoulIfMissing(dir);
+
+    assert.equal(wrote, false);
+    assert.equal(readFileSync(soulPath(dir), "utf-8"), CUSTOM_SOUL);
+  });
+
+  it("writes system name/description to system.json without touching SOUL", () => {
+    const dir = spiritDir();
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(soulPath(dir), CUSTOM_SOUL);
+
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Testarium", description: "a place for tests" });
+    writeSpiritSystemJson(dir);
+
+    const data = JSON.parse(readFileSync(systemJsonPath(dir), "utf-8"));
+    assert.deepEqual(data, { name: "Testarium", description: "a place for tests" });
+    assert.equal(readFileSync(soulPath(dir), "utf-8"), CUSTOM_SOUL);
+  });
+
+  it("preserves an edited SOUL.md across a template sync and refreshes system.json", async () => {
+    const dir = await seedSpiritProject();
+    writeFileSync(soulPath(dir), CUSTOM_SOUL);
+
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Testarium", description: undefined });
+
+    await syncSpiritTemplate();
+
+    // Self-owned SOUL survives the sync.
+    assert.equal(readFileSync(soulPath(dir), "utf-8"), CUSTOM_SOUL);
+    // System identity is refreshed into system.json instead.
+    const data = JSON.parse(readFileSync(systemJsonPath(dir), "utf-8"));
+    assert.equal(data.name, "Testarium");
+  });
+
+  it("recreates a deleted SOUL.md on sync (self-healing)", async () => {
+    const dir = await seedSpiritProject();
+    rmSync(soulPath(dir), { force: true });
+
+    await syncSpiritTemplate();
+
+    assert.equal(existsSync(soulPath(dir)), true);
+    assert.match(readFileSync(soulPath(dir), "utf-8"), /You are Volute/);
+  });
+});

--- a/test/spirit-soul.test.ts
+++ b/test/spirit-soul.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { resolveTemplate } from "../packages/daemon/src/lib/ai-service.js";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
 import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
-import { addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
+import { addSpirit, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import {
   getSpiritModel,
+  notifySpiritSystemChange,
   seedSpiritSoulIfMissing,
   spiritDir,
   syncSpiritTemplate,
@@ -17,6 +20,9 @@ import {
   findTemplatesRoot,
   renderComposedPackageJson,
 } from "../packages/daemon/src/lib/template/template.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+const HOOK_PATH = resolve(process.cwd(), "templates/_base/.init/.local/hooks/startup-context.ts");
 
 const CUSTOM_SOUL = "# My own soul\n\nI have written this myself. Do not overwrite me.\n";
 
@@ -96,6 +102,21 @@ describe("spirit SOUL.md ownership", () => {
     assert.equal(readFileSync(soulPath(dir), "utf-8"), CUSTOM_SOUL);
   });
 
+  it("omits the description key from system.json when unset", () => {
+    // The hook's "— <description>" only appears when the key is present, so an
+    // unset description must not serialize as a key at all (no dangling em dash).
+    const dir = spiritDir();
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Testarium", description: undefined });
+    writeSpiritSystemJson(dir);
+
+    const data = JSON.parse(readFileSync(systemJsonPath(dir), "utf-8"));
+    assert.deepEqual(data, { name: "Testarium" });
+    assert.equal("description" in data, false);
+  });
+
   it("preserves an edited SOUL.md across a template sync and refreshes system.json", async () => {
     const dir = await seedSpiritProject();
     writeFileSync(soulPath(dir), CUSTOM_SOUL);
@@ -120,5 +141,176 @@ describe("spirit SOUL.md ownership", () => {
 
     assert.equal(existsSync(soulPath(dir)), true);
     assert.match(readFileSync(soulPath(dir), "utf-8"), /You are Volute/);
+  });
+});
+
+/** Register a spirit row + home/.config dir without the full template project. */
+async function registerSpirit(): Promise<string> {
+  const dir = spiritDir();
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+  await addSpirit("volute", 4999, "claude", dir);
+  return dir;
+}
+
+describe("notifySpiritSystemChange", () => {
+  afterEach(async () => {
+    await removeMind("volute");
+    rmSync(spiritDir(), { recursive: true, force: true });
+  });
+
+  it("refreshes system.json even when the spirit isn't reachable to message", async () => {
+    // The spirit is registered but not running, so sendSystemMessage can't be
+    // delivered — its failure is swallowed by design. system.json must still be
+    // refreshed regardless (the note is best-effort; the synced fact is not).
+    const dir = await registerSpirit();
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Renamed", description: "after rename" });
+
+    await notifySpiritSystemChange();
+
+    const data = JSON.parse(readFileSync(systemJsonPath(dir), "utf-8"));
+    assert.deepEqual(data, { name: "Renamed", description: "after rename" });
+  });
+
+  it("no-ops when no spirit is registered", async () => {
+    await removeMind("volute");
+    const dir = spiritDir();
+    rmSync(dir, { recursive: true, force: true });
+
+    await notifySpiritSystemChange();
+
+    assert.equal(existsSync(systemJsonPath(dir)), false);
+  });
+
+  it("no-ops when the spirit dir is missing", async () => {
+    const dir = spiritDir();
+    rmSync(dir, { recursive: true, force: true });
+    await addSpirit("volute", 4999, "claude", dir);
+
+    await notifySpiritSystemChange();
+
+    assert.equal(existsSync(dir), false);
+  });
+});
+
+describe("startup-context hook reads system.json", () => {
+  function runHook(dir: string): string {
+    // cwd stays at the repo root so `--import tsx` resolves; the hook locates
+    // system.json via the absolute VOLUTE_MIND_DIR, not cwd. Strip the daemon
+    // env so the hook's extension-fetch path stays skipped and the output is
+    // hermetic (just the identity line + session line).
+    const env = { ...process.env, VOLUTE_MIND_DIR: dir };
+    delete env.VOLUTE_DAEMON_PORT;
+    delete env.VOLUTE_MIND_TOKEN;
+    const out = execFileSync("node", ["--import", "tsx", HOOK_PATH], {
+      input: JSON.stringify({ source: "startup" }),
+      encoding: "utf-8",
+      env,
+    });
+    return JSON.parse(out).hookSpecificOutput.additionalContext as string;
+  }
+
+  it("surfaces the spirit identity written by writeSpiritSystemJson (contract)", () => {
+    const dir = spiritDir();
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Testarium", description: "a place for tests" });
+    writeSpiritSystemJson(dir);
+
+    const context = runHook(dir);
+
+    assert.match(context, /You are the spirit of Testarium — a place for tests\./);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("omits the em dash when description is unset", () => {
+    const dir = spiritDir();
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Testarium", description: undefined });
+    writeSpiritSystemJson(dir);
+
+    const context = runHook(dir);
+
+    assert.match(context, /You are the spirit of Testarium\. /);
+    assert.doesNotMatch(context, /—/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("stays silent for a mind with no system.json", () => {
+    const dir = spiritDir();
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(resolve(dir, "home"), { recursive: true });
+
+    const context = runHook(dir);
+
+    assert.doesNotMatch(context, /You are the spirit of/);
+    assert.match(context, /Session startup/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("swallows a malformed system.json and stays silent", () => {
+    const dir = spiritDir();
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(systemJsonPath(dir), "{ not valid json");
+
+    const context = runHook(dir);
+
+    assert.doesNotMatch(context, /You are the spirit of/);
+    assert.match(context, /Session startup/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("PUT /api/system/info notifies the spirit only on a real change", () => {
+  afterEach(async () => {
+    await removeMind("volute");
+    rmSync(spiritDir(), { recursive: true, force: true });
+  });
+
+  async function putName(cookie: string, name: string): Promise<number> {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("/api/system/info", {
+      method: "PUT",
+      headers: {
+        Cookie: `volute_session=${cookie}`,
+        Origin: "http://localhost",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name }),
+    });
+    return res.status;
+  }
+
+  it("writes system.json only when the trimmed name actually changes", async () => {
+    const admin = await createUser("system-info-admin", "pass");
+    const cookie = await createSession(admin.id);
+    const dir = await registerSpirit();
+    const config = readGlobalConfig();
+    writeGlobalConfig({ ...config, name: "Alpha", description: undefined });
+
+    // Changed name → notified (system.json recreated with the new name).
+    rmSync(systemJsonPath(dir), { force: true });
+    assert.equal(await putName(cookie, "Beta"), 200);
+    assert.equal(JSON.parse(readFileSync(systemJsonPath(dir), "utf-8")).name, "Beta");
+
+    // Same name → not notified.
+    rmSync(systemJsonPath(dir), { force: true });
+    assert.equal(await putName(cookie, "Beta"), 200);
+    assert.equal(existsSync(systemJsonPath(dir)), false);
+
+    // Same name with surrounding whitespace → trims equal → not notified.
+    rmSync(systemJsonPath(dir), { force: true });
+    assert.equal(await putName(cookie, "  Beta  "), 200);
+    assert.equal(existsSync(systemJsonPath(dir)), false);
+
+    // Cleared name → changes (to undefined) → notified.
+    rmSync(systemJsonPath(dir), { force: true });
+    assert.equal(await putName(cookie, ""), 200);
+    assert.equal(existsSync(systemJsonPath(dir)), true);
   });
 });


### PR DESCRIPTION
## Problem

`syncSpiritTemplate()` overwrote the spirit's `home/SOUL.md` unconditionally on **every daemon start**, erasing whatever the spirit had written about itself — even though its own installed skills (`orientation`, `memory`) encourage exactly that self-authorship, and continuity is a core platform value. The spirit was the one being that couldn't keep its own identity file.

## Change

The **machinery** (`src/`, `package.json`, skills, schedules) stays system-synced; the **SOUL becomes the spirit's own**.

- `syncSpiritTemplate()` now seeds `SOUL.md` only when it's missing (self-healing) via `seedSpiritSoulIfMissing()`, and never overwrites an existing one. `ensureSpiritProject()` still writes the initial SOUL at creation.
- `getSpiritSoul()` no longer embeds the system name/description (the seed SOUL is generic now).
- System name/description reach the spirit through **synced context** instead of a SOUL rewrite: each sync writes `home/.config/system.json` (`{ name, description }`), and the shared `startup-context` hook surfaces `You are the spirit of <name> — <description>.` from it. The hook is silent for regular minds (only the spirit has that file). It reads via `$VOLUTE_MIND_DIR/home/.config/system.json`, inside the mind's own dir, so the sandbox allows the read.
- When the operator renames the system (`PUT /api/system/info`), `notifySpiritSystemChange()` refreshes `system.json` and sends the spirit a note so it can update its own SOUL if it wants to.
- Removed the dangling `// Write startup context hook that includes available models` comment (no code followed it).

## Upgrade-path tradeoff

This deliberately does **not** build versioning machinery. When we ship an improved default spirit SOUL, existing installs keep their current SOUL (self-owned) and do not pick up the new default — that's the intended cost of ownership. New installs get the latest default. Operators who want the new baseline can delete `home/SOUL.md` and let the next sync re-seed it. System name/description are exempt from this freeze because they flow through `system.json`, so they stay current without touching the SOUL.

## Reviewer-noted tradeoffs (accepted by design)

These came out of the PR review pass; each is a conscious decision, not an oversight:

- **Existing spirits keep their old startup-context hook.** `.local/hooks/` is copied only by `applyInitFiles()` at create time; `syncSpiritTemplate()` overwrites only `src/`. So on an install whose spirit predates this change, `system.json` is written but never consumed, and the old SOUL retains its baked-in system name (which seed-if-missing won't touch). This is accepted because hooks are frozen-at-create for **all** minds (mind upgrade excludes `.init/`), and the spirit owns `.local/` — a spirit or operator can adopt the new hook by copying it. Degradation is graceful: rename notifications still arrive via DM. Adding overwrite/migration machinery here would contradict this PR's own ownership philosophy.
- **`startup-context.ts`'s bare `catch` conflates expected `ENOENT` (regular minds) with a corrupt `system.json`.** A corrupt file makes the spirit silently lose its identity line for that session; it self-corrects on the next sync (which rewrites the file). Accepted given the hook's stdout protocol — it must never emit diagnostics into the context stream.
- **`PUT /info` persists the rename before `notify` runs**, so a `notify` fs-error would surface as a 500 on an already-applied change. Minor and inert in practice; no action taken.
- **Description changes don't trigger a refresh.** Inert today — no endpoint mutates `description` after initial setup. The `notify` path keys on name only.

## Tests

`test/spirit-soul.test.ts` (14 tests):
- **SOUL ownership**: seeds when missing; leaves an existing one untouched; `syncSpiritTemplate` preserves an edited SOUL and refreshes `system.json`; recreates a deleted SOUL (self-healing).
- **`writeSpiritSystemJson`**: writes name/description without touching the SOUL; omits the `description` key when unset.
- **`notifySpiritSystemChange`**: refreshes `system.json` even when the spirit can't be messaged (send failure swallowed by design); no-ops for a missing spirit row / missing dir.
- **Hook contract (end-to-end)**: executes the real `startup-context.ts` as a subprocess against `writeSpiritSystemJson` output — surfaces the identity line, omits the em dash when description is unset, stays silent with no file, swallows malformed JSON.
- **`PUT /api/system/info` guard**: rewrites `system.json` only on a real change — changed and cleared names notify; same name and same-name-with-whitespace do not (trim normalization).

Full `npm test` passes.

Fixes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)