### PR TITLE
fix: make mail poller catch-up loss-proof and log readable errors

### DIFF
--- a/packages/daemon/src/lib/daemon/mail-poller.ts
+++ b/packages/daemon/src/lib/daemon/mail-poller.ts
@@ -271,23 +271,30 @@ export class MailPoller {
   }
 
   private async deliver(mind: string, email: Email): Promise<void> {
-    const entry = await findMind(mind);
-    if (!entry || !entry.running) {
-      mlog.warn(`skipping delivery to ${mind}: ${!entry ? "not found" : "not running"}`);
+    // Deliberate drop for a deleted mind only: no retry can ever succeed, so
+    // don't throw (which would pin the catch-up watermark forever). Do NOT
+    // pre-check `running` — a sleeping mind has running=false, and deliverMessage
+    // queues those for wake; skipping here would drop their mail.
+    if (!(await findMind(mind))) {
+      mlog.warn(`skipping delivery to ${mind}: mind not found`);
       return;
     }
 
     const text = formatEmailContent(email);
 
-    // Let delivery failures propagate: the catch-up path relies on them to retain
-    // its watermark, and the live path logs them at its call site.
-    await deliverMessage(mind, {
+    // deliverMessage never throws — it logs and returns false on failure, true
+    // when delivered/queued/skipped. Throw on false so catch-up retains its
+    // watermark and retries: a transiently-down mind must not lose mail.
+    const delivered = await deliverMessage(mind, {
       content: [{ type: "text", text }],
       channel: `mail:${email.from.address}`,
       sender: email.from.name || email.from.address,
       platform: "Email",
       isDM: true,
     });
+    if (!delivered) {
+      throw new Error(`delivery to ${mind} failed`);
+    }
     mlog.info(`delivered email from ${email.from.address} to ${mind}`);
   }
 }

--- a/packages/daemon/src/lib/daemon/mail-poller.ts
+++ b/packages/daemon/src/lib/daemon/mail-poller.ts
@@ -115,10 +115,11 @@ export class MailPoller {
       this.reconnectAttempts = 0;
       this.reconnectDelay = INITIAL_RECONNECT_MS;
 
-      // Catch up on emails missed during disconnection
+      // Catch up on emails missed during disconnection. The watermark is only
+      // cleared once catch-up fully succeeds (see catchUpAndClear), so a failed
+      // fetch retries on the next reconnect instead of silently dropping mail.
       if (this.disconnectedAt) {
-        this.catchUp(this.disconnectedAt);
-        this.disconnectedAt = null;
+        void this.catchUpAndClear(this.disconnectedAt);
       }
 
       // Periodic keepalive
@@ -139,7 +140,9 @@ export class MailPoller {
     };
 
     this.ws.onclose = () => {
-      mlog.warn("disconnected");
+      // Routine on a box where the upstream recycles connections every 20–40min;
+      // logged at info so a healthy flap cadence doesn't read as a warning stream.
+      mlog.info("disconnected");
       if (!this.disconnectedAt) {
         this.disconnectedAt = new Date().toISOString();
       }
@@ -148,8 +151,9 @@ export class MailPoller {
     };
 
     this.ws.onerror = (err) => {
-      mlog.warn("WebSocket error", log.errorData(err));
-      // onclose will fire after this
+      // onclose fires after this; the every-10th-attempt warn in scheduleReconnect
+      // escalates a genuinely stuck connection. errorData unwraps the ErrorEvent.
+      mlog.info("WebSocket error", log.errorData(err));
     };
   }
 
@@ -178,31 +182,45 @@ export class MailPoller {
     this.reconnectDelay = Math.min(this.reconnectDelay * 2, MAX_RECONNECT_MS);
   }
 
-  /** Fetch emails that arrived while disconnected */
-  private catchUp(since: string): void {
-    if (!this.config) return;
+  /**
+   * Run catch-up and advance the watermark only on full success. On any failure
+   * (fetch error, non-OK response, delivery throw) the watermark is retained so
+   * the next reconnect re-fetches the gap — at-least-once, never dropped.
+   */
+  private async catchUpAndClear(since: string): Promise<void> {
+    try {
+      await this.catchUp(since);
+    } catch (err) {
+      mlog.info("catch-up failed — will retry on next reconnect", log.errorData(err));
+      return;
+    }
+    // Only clear if still on the same connection and no newer disconnect happened
+    // during catch-up; otherwise the fresh gap keeps its watermark for retry.
+    if (this.disconnectedAt === since && this.ws?.readyState === WebSocket.OPEN) {
+      this.disconnectedAt = null;
+    }
+  }
+
+  /** Fetch and deliver emails that arrived while disconnected. Throws on failure. */
+  private async catchUp(since: string): Promise<void> {
+    if (!this.config) throw new Error("systems config missing");
 
     const url = `${this.config.apiUrl}/api/mail/system/poll?since=${encodeURIComponent(since)}`;
 
-    fetch(url, {
+    const res = await fetch(url, {
       headers: { Authorization: `Bearer ${this.config.apiKey}` },
-    })
-      .then(async (res) => {
-        if (!res.ok) {
-          mlog.warn(`catch-up poll failed: HTTP ${res.status}`);
-          return;
-        }
-        const data = (await res.json()) as { emails?: Email[] };
-        if (!Array.isArray(data.emails) || data.emails.length === 0) return;
+    });
+    if (!res.ok) {
+      throw new Error(`catch-up poll failed: HTTP ${res.status}`);
+    }
 
-        mlog.info(`catching up on ${data.emails.length} missed emails`);
-        for (const email of data.emails) {
-          await this.deliver(email.mind, email);
-        }
-      })
-      .catch((err) => {
-        mlog.warn("catch-up error", log.errorData(err));
-      });
+    const data = (await res.json()) as { emails?: Email[] };
+    if (!Array.isArray(data.emails) || data.emails.length === 0) return;
+
+    mlog.info(`catching up on ${data.emails.length} missed emails`);
+    for (const email of data.emails) {
+      await this.deliver(email.mind, email);
+    }
   }
 
   private handleMessage(data: string): void {
@@ -261,18 +279,16 @@ export class MailPoller {
 
     const text = formatEmailContent(email);
 
-    try {
-      await deliverMessage(mind, {
-        content: [{ type: "text", text }],
-        channel: `mail:${email.from.address}`,
-        sender: email.from.name || email.from.address,
-        platform: "Email",
-        isDM: true,
-      });
-      mlog.info(`delivered email from ${email.from.address} to ${mind}`);
-    } catch (err) {
-      mlog.warn(`failed to deliver to ${mind}`, log.errorData(err));
-    }
+    // Let delivery failures propagate: the catch-up path relies on them to retain
+    // its watermark, and the live path logs them at its call site.
+    await deliverMessage(mind, {
+      content: [{ type: "text", text }],
+      channel: `mail:${email.from.address}`,
+      sender: email.from.name || email.from.address,
+      platform: "Email",
+      isDM: true,
+    });
+    mlog.info(`delivered email from ${email.from.address} to ${mind}`);
   }
 }
 

--- a/packages/daemon/src/lib/util/logger.ts
+++ b/packages/daemon/src/lib/util/logger.ts
@@ -33,6 +33,14 @@ function child(cat: string): ChildLogger {
 /** Extract error info preserving stack traces for structured logging. */
 function errorData(err: unknown): Record<string, unknown> {
   if (err instanceof Error) return { error: err.stack ?? err.message };
+  // WHATWG ErrorEvent-shaped objects (e.g. WebSocket `onerror`) are not Error
+  // instances; unwrap their `.error`/`.message` so we don't log "[object ErrorEvent]".
+  if (err && typeof err === "object") {
+    const e = err as { error?: unknown; message?: unknown };
+    if (e.error instanceof Error) return { error: e.error.stack ?? e.error.message };
+    if (typeof e.error === "string" && e.error) return { error: e.error };
+    if (typeof e.message === "string" && e.message) return { error: e.message };
+  }
   return { error: String(err) };
 }
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -49,6 +49,27 @@ describe("logger", () => {
     );
   });
 
+  it("errorData unwraps ErrorEvent-shaped objects instead of [object ErrorEvent]", async () => {
+    const log = (await import("../packages/daemon/src/lib/util/logger.js")).default;
+
+    // Plain Error → stack/message
+    assert.match(log.errorData(new Error("boom")).error as string, /boom/);
+
+    // ErrorEvent-shaped with an inner Error (WebSocket onerror on Node)
+    const withInner = log.errorData({ error: new Error("socket hang up"), message: "" });
+    assert.match(withInner.error as string, /socket hang up/);
+
+    // ErrorEvent-shaped with only a message string
+    const withMessage = log.errorData({ message: "connection reset" });
+    assert.equal(withMessage.error, "connection reset");
+
+    // The regression itself: an object that stringifies to "[object ...]" must
+    // not surface that useless value when it carries a usable message.
+    const eventLike = { type: "error", message: "handshake failed" };
+    assert.equal(log.errorData(eventLike).error, "handshake failed");
+    assert.notEqual(log.errorData(eventLike).error, "[object Object]");
+  });
+
   it("log writes structured JSON to stderr", async () => {
     // Dynamically import to test the actual log module
     const log = (await import("../packages/daemon/src/lib/util/logger.js")).default;

--- a/test/mail-poller.test.ts
+++ b/test/mail-poller.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { formatEmailContent, MailPoller } from "../packages/daemon/src/lib/daemon/mail-poller.js";
 
 describe("MailPoller", () => {
@@ -16,6 +16,88 @@ describe("MailPoller", () => {
     const poller = new MailPoller();
     poller.stop();
     assert.ok(true);
+  });
+});
+
+describe("MailPoller catch-up watermark", () => {
+  const SINCE = "2020-01-01T00:00:00.000Z";
+  const OPEN = 1; // WebSocket.OPEN
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  // Build a poller primed as if it just reconnected after a gap: configured,
+  // with a pending watermark and an open socket ready to have it cleared.
+  function primedPoller(): MailPoller {
+    const poller = new MailPoller();
+    const p = poller as unknown as {
+      config: unknown;
+      disconnectedAt: string | null;
+      ws: unknown;
+      catchUpAndClear(since: string): Promise<void>;
+    };
+    p.config = { apiKey: "k", system: "s", apiUrl: "http://systems.test" };
+    p.disconnectedAt = SINCE;
+    p.ws = { readyState: OPEN };
+    return poller;
+  }
+
+  function watermark(poller: MailPoller): string | null {
+    return (poller as unknown as { disconnectedAt: string | null }).disconnectedAt;
+  }
+
+  it("retains the watermark when the catch-up fetch throws", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("network blip");
+    };
+    const poller = primedPoller();
+    await (poller as unknown as { catchUpAndClear(s: string): Promise<void> }).catchUpAndClear(
+      SINCE,
+    );
+    assert.equal(watermark(poller), SINCE, "failed catch-up must not drop the gap");
+  });
+
+  it("retains the watermark on a non-OK catch-up response", async () => {
+    globalThis.fetch = async () => new Response("nope", { status: 503 });
+    const poller = primedPoller();
+    await (poller as unknown as { catchUpAndClear(s: string): Promise<void> }).catchUpAndClear(
+      SINCE,
+    );
+    assert.equal(watermark(poller), SINCE);
+  });
+
+  it("clears the watermark exactly once after a successful catch-up", async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls++;
+      return new Response(JSON.stringify({ emails: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    const poller = primedPoller();
+    await (poller as unknown as { catchUpAndClear(s: string): Promise<void> }).catchUpAndClear(
+      SINCE,
+    );
+    assert.equal(watermark(poller), null, "success must advance past the fetched gap");
+    assert.equal(calls, 1);
+  });
+
+  it("does not clear if the socket dropped again during catch-up", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ emails: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    const poller = primedPoller();
+    // Simulate a re-disconnect mid-flight: the socket is no longer open.
+    (poller as unknown as { ws: unknown }).ws = { readyState: 3 /* CLOSED */ };
+    await (poller as unknown as { catchUpAndClear(s: string): Promise<void> }).catchUpAndClear(
+      SINCE,
+    );
+    assert.equal(watermark(poller), SINCE, "a fresh gap must keep its watermark for retry");
   });
 });
 

--- a/test/mail-poller.test.ts
+++ b/test/mail-poller.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
+import { and, eq } from "drizzle-orm";
 import { formatEmailContent, MailPoller } from "../packages/daemon/src/lib/daemon/mail-poller.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, removeMind, setMindRunning } from "../packages/daemon/src/lib/mind/registry.js";
+import { mindHistory } from "../packages/daemon/src/lib/schema.js";
 
 describe("MailPoller", () => {
   it("start and stop manage state", () => {
@@ -46,6 +50,39 @@ describe("MailPoller catch-up watermark", () => {
 
   function watermark(poller: MailPoller): string | null {
     return (poller as unknown as { disconnectedAt: string | null }).disconnectedAt;
+  }
+
+  // A 200 response carrying the given missed-email ids, so catch-up actually
+  // invokes deliver() for each one.
+  function emailsResponse(...ids: string[]): Response {
+    const emails = ids.map((id) => ({
+      mind: "m",
+      id,
+      from: { address: "a@b.c", name: null },
+      subject: null,
+      body: "hi",
+      html: null,
+      receivedAt: SINCE,
+    }));
+    return new Response(JSON.stringify({ emails }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Swap the instance's deliver() for a stub; catchUp calls this.deliver, so an
+  // instance property shadows the prototype method.
+  function stubDeliver(
+    poller: MailPoller,
+    fn: (mind: string, email: { id: string }) => Promise<void>,
+  ) {
+    (poller as unknown as { deliver: typeof fn }).deliver = fn;
+  }
+
+  function catchUpAndClear(poller: MailPoller, since: string): Promise<void> {
+    return (poller as unknown as { catchUpAndClear(s: string): Promise<void> }).catchUpAndClear(
+      since,
+    );
   }
 
   it("retains the watermark when the catch-up fetch throws", async () => {
@@ -98,6 +135,106 @@ describe("MailPoller catch-up watermark", () => {
       SINCE,
     );
     assert.equal(watermark(poller), SINCE, "a fresh gap must keep its watermark for retry");
+  });
+
+  it("delivers every missed email and clears the watermark on success", async () => {
+    globalThis.fetch = async () => emailsResponse("a", "b");
+    const poller = primedPoller();
+    const delivered: string[] = [];
+    stubDeliver(poller, async (_mind, email) => {
+      delivered.push(email.id);
+    });
+    await catchUpAndClear(poller, SINCE);
+    assert.deepEqual(delivered, ["a", "b"], "all missed emails must be delivered");
+    assert.equal(watermark(poller), null);
+  });
+
+  it("retains the watermark when a delivery throws mid-catch-up", async () => {
+    // This is the core loss-proofing guarantee: reintroducing a swallowed
+    // try/catch in deliver() (the original #423 bug) would break this test.
+    globalThis.fetch = async () => emailsResponse("a", "b");
+    const poller = primedPoller();
+    let attempts = 0;
+    stubDeliver(poller, async () => {
+      attempts++;
+      throw new Error("delivery boom");
+    });
+    await catchUpAndClear(poller, SINCE);
+    assert.equal(watermark(poller), SINCE, "a failed delivery must retain the gap");
+    assert.equal(attempts, 1, "catch-up must stop at the first failed delivery");
+  });
+
+  it("does not clear if a newer disconnect advanced the watermark during catch-up", async () => {
+    // Exercises the `disconnectedAt === since` clause of the clear-guard: the
+    // socket stays open, but a re-disconnect moved the watermark forward, so the
+    // fresh gap must not be cleared by the older catch-up.
+    const NEWER = "2020-01-02T00:00:00.000Z";
+    let poller!: MailPoller;
+    globalThis.fetch = async () => {
+      (poller as unknown as { disconnectedAt: string | null }).disconnectedAt = NEWER;
+      return emailsResponse();
+    };
+    poller = primedPoller();
+    await catchUpAndClear(poller, SINCE);
+    assert.equal(watermark(poller), NEWER, "the fresher gap's watermark must survive");
+  });
+});
+
+// These exercise the REAL deliver() (not a stub) so they pin the fix's premise:
+// deliverMessage NEVER throws — it returns false on failure — so deliver() must
+// convert that to a throw. No delivery manager is initialized in unit tests, so
+// deliverMessage's routeAndDeliver fails and returns false.
+describe("MailPoller.deliver — delivery-failure propagation", () => {
+  const MIND = "test-mailpoller-deliver";
+  const PORT = 41977;
+  const email = {
+    mind: MIND,
+    id: "e1",
+    from: { address: "sender@x.test", name: "Sender" },
+    subject: "hi",
+    body: "body",
+    html: null,
+    receivedAt: "2020-01-01T00:00:00.000Z",
+  };
+
+  afterEach(async () => {
+    const db = await getDb();
+    await db.delete(mindHistory).where(eq(mindHistory.mind, MIND));
+    await removeMind(MIND);
+  });
+
+  function deliver(mind: string): Promise<void> {
+    return (
+      new MailPoller() as unknown as { deliver(m: string, e: typeof email): Promise<void> }
+    ).deliver(mind, email);
+  }
+
+  it("throws when deliverMessage reports failure (Finding 1 — false is not success)", async () => {
+    await addMind(MIND, PORT);
+    await setMindRunning(MIND, true);
+    // Reintroducing a swallowed try/catch or ignoring the boolean would resolve
+    // here and let catch-up clear the watermark past undelivered mail.
+    await assert.rejects(deliver(MIND), /delivery to .* failed/);
+  });
+
+  it("does not pre-skip a mind with running=false (Finding 2 — sleeping minds queue)", async () => {
+    await addMind(MIND, PORT); // running defaults to false, as a sleeping mind is
+    // The old `!entry.running` pre-check returned before deliverMessage, dropping
+    // the mail and bypassing sleep-queueing. It must now reach deliverMessage,
+    // which records the inbound (and, for a truly sleeping mind, queues it).
+    await assert.rejects(deliver(MIND));
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, MIND), eq(mindHistory.type, "inbound")));
+    assert.equal(rows.length, 1, "a running=false mind must not be skipped before deliverMessage");
+  });
+
+  it("deliberately drops (no throw) for a mind that no longer exists", async () => {
+    // Not-found = deleted mind: no retry can help, so don't throw (that would pin
+    // the watermark forever). Resolving without throwing is the assertion.
+    await deliver("no-such-mailpoller-mind");
   });
 });
 


### PR DESCRIPTION
## Root cause

On a production box where the volute.systems WebSocket recycles every 20–40 minutes, the mail poller (`packages/daemon/src/lib/daemon/mail-poller.ts`) had these defects:

1. **Silent mail loss on failed catch-up.** `onopen` kicked off the async `catchUp(disconnectedAt)` and then cleared `disconnectedAt` on the very next line — synchronously, before the fetch resolved. If the catch-up request failed (network blip right after reconnect, non-OK response), the gap's emails were never re-fetched. The watermark had already been advanced past them.
2. **Delivery failures were dropped even after catch-up fetched the mail.** `deliverMessage()` never throws — it catches everything internally and returns `false` (message-delivery.ts). The old `deliver()` ignored that boolean, so a realistic failure (mind process died after the `findMind` check, `routeAndDeliver` throwing, `recordInbound` failing) returned `false`, catch-up completed, and the watermark advanced past mail that was never delivered.
3. **A `!entry.running` pre-check dropped mail for sleeping minds.** A sleeping mind has `running: false` in the registry (sleep stops its process via `stopMind` → `setMindRunning(false)`). The pre-check skipped delivery for exactly those minds — bypassing `deliverMessage`'s sleep-queueing, which would otherwise queue the mail for wake.
4. **Unreadable disconnect reason.** `onerror` handed the WHATWG `ErrorEvent` to `log.errorData()`, which only special-cases `instanceof Error` and stringifies everything else, so every flap logged `{"error":"[object ErrorEvent]"}` and discarded the real cause.
5. **Log noise.** Each routine flap emitted warn-level "WebSocket error" + "disconnected" lines — a steady warning stream for behavior that is routine when catch-up works.

## Change

- **Loss-proof catch-up:** `catchUp()` is now `async` and throws on any failure (fetch error, non-OK response, delivery failure). A new `catchUpAndClear()` awaits it and clears `disconnectedAt` **only on full success**, so a failed catch-up retains the watermark and the next reconnect re-fetches the gap (at-least-once; the `since` watermark keeps retries idempotent). The clear is additionally guarded on the socket still being open and the watermark unchanged (`this.disconnectedAt === since`), so a re-disconnect mid-catch-up keeps the fresh gap's watermark instead of dropping it.
- **`deliver()` now honors `deliverMessage`'s boolean:** it throws when delivery reports `false`, so a failed delivery during catch-up retains the gap and a live-path failure is surfaced (previously the live `.catch` logged nothing on a `false` return). The `!entry.running` pre-check is removed — a sleeping mind now reaches `deliverMessage`, which queues it for wake (returns `true` → watermark clears, mail safe in the queue).
- **Readable errors:** `logger.errorData()` now unwraps `ErrorEvent`-shaped objects (`.error`/`.message`) so the real cause is logged instead of `[object ErrorEvent]`. This hardens every call site, not just the mail poller.
- **Quieter logs:** single-cycle disconnect/error are logged at `info`; the existing every-10th-failed-attempt `warn` in `scheduleReconnect()` still escalates a genuinely stuck socket.

## Deliberate tradeoffs

- **Not-found (deleted) mind is dropped, not retried.** `deliver()` keeps one explicit early-return: if `findMind` returns nothing, the mind no longer exists and no retry can ever succeed, so it logs and returns without throwing (throwing would pin the watermark forever).
- **A permanently-down mind pins the watermark.** With at-least-once semantics, if one mind stays down, its mail keeps the watermark from advancing, so siblings' mail in the same window is re-delivered as duplicates on each reconnect. This is the accepted cost of never dropping mail; duplicate delivery is preferable to loss.

## Tests

- `test/logger.test.ts`: `errorData` unwraps ErrorEvent-shaped objects (inner `Error`, `.message`-only, and an object that would otherwise stringify to `[object Object]`).
- `test/mail-poller.test.ts` — watermark semantics: a failing catch-up (fetch throw and non-OK response) retains `disconnectedAt`; a catch-up that fetches emails and delivers them all clears it exactly once; a delivery that throws mid-catch-up retains it; a re-disconnect during catch-up (socket closed, or the watermark advanced to a newer value) keeps the fresh gap.
- `test/mail-poller.test.ts` — real `deliver()` path (no stub): `deliverMessage` returning `false` makes `deliver()` throw (Finding 1); a `running: false` mind is **not** pre-skipped — it reaches `deliverMessage` and records the inbound (Finding 2); a non-existent mind is dropped without throwing.

The full sleeping-mind → queued → watermark-cleared path is intentionally not re-tested here: the poller's contract is only "reach `deliverMessage` unfiltered, clear on resolve," which the tests above pin; the actual sleep-queueing is `deliverMessage`'s own responsibility and is covered by `message-delivery.test.ts`'s sleep cases, so exercising the `SleepManager` singleton from a poller unit test would couple the wrong layers.

Full `npm test` passes; the one failure seen in a parallel-fleet run was an unrelated pages-publish mock-server flake that passes solo.

Fixes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
