### PR TITLE
test: verify spirit outbound turn attribution

### DIFF
--- a/test/chat-spirit-sender.test.ts
+++ b/test/chat-spirit-sender.test.ts
@@ -165,7 +165,11 @@ describe("spirit as a mind sender via POST /api/v1/chat", () => {
       .where(eq(messages.conversation_id, conversationId))
       .all();
     const voluteMsgs = msgs.filter((m) => m.sender_name === "volute");
-    assert.equal(voluteMsgs.length, 1, "only the spirit's send should exist — no fallback reply");
+    assert.equal(
+      voluteMsgs.length,
+      1,
+      "only the spirit's send should exist — no fallback even with a turn open",
+    );
   });
 
   it("does not trigger a system self-reply loop on the spirit's own send", async () => {

--- a/test/chat-spirit-sender.test.ts
+++ b/test/chat-spirit-sender.test.ts
@@ -11,6 +11,7 @@ import {
   generateMindToken,
   revokeMindToken,
 } from "../packages/daemon/src/lib/daemon/mind-tokens.js";
+import { clearMind, createTurn } from "../packages/daemon/src/lib/daemon/turn-tracker.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { createConversation } from "../packages/daemon/src/lib/events/conversations.js";
 import { addMind, addSpirit } from "../packages/daemon/src/lib/mind/registry.js";
@@ -19,6 +20,7 @@ import {
   messages,
   mindHistory,
   minds,
+  turns,
   users,
 } from "../packages/daemon/src/lib/schema.js";
 import { invalidateMindUserCache } from "../packages/daemon/src/web/middleware/auth.js";
@@ -31,12 +33,15 @@ let convId: string;
 async function cleanup() {
   resetSystemDMCache();
   revokeMindToken("volute");
+  // Drop any in-memory active turn so a prior test can't leak turn attribution.
+  await clearMind("volute");
   const db = await getDb();
   if (convId) {
     await db.delete(messages).where(eq(messages.conversation_id, convId));
     await db.delete(conversations).where(eq(conversations.id, convId));
   }
   await db.delete(mindHistory).where(eq(mindHistory.mind, "volute"));
+  await db.delete(turns).where(eq(turns.mind, "volute"));
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
   }
@@ -128,6 +133,39 @@ describe("spirit as a mind sender via POST /api/v1/chat", () => {
     assert.ok(send, "the spirit's message should be persisted");
     assert.ok(send!.content.includes("warning! done"), "escape fix should have run");
     assert.ok(!send!.content.includes("warning\\! done"), "raw escape should not survive");
+  });
+
+  it("attributes the spirit's outbound to its active turn", async () => {
+    const { token, conversationId } = await setupSpiritDM();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+
+    // Open a sessionless turn for the spirit (keyed `volute:*`). getActiveTurnId
+    // falls back to it when the send carries no X-Volute-Session header, so the
+    // outbound must be tagged with this turn — the attribution that was skipped
+    // entirely while the spirit was misclassified as a non-mind sender.
+    const turnId = await createTurn("volute");
+    assert.ok(turnId, "createTurn should return a turn id");
+
+    const res = await spiritSend(app as never, token, {
+      conversationId,
+      message: "tagged reply",
+    });
+    assert.equal(res.status, 200);
+
+    const db = await getDb();
+    const rows = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const outbound = rows.find((r) => r.type === "outbound" && r.content?.includes("tagged reply"));
+    assert.ok(outbound, "spirit send should be recorded as an outbound");
+    assert.equal(outbound!.turn_id, turnId, "outbound should carry the active turn's id");
+
+    // Exactly one reply — the send itself, no fallback loop even with a turn active.
+    const msgs = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversation_id, conversationId))
+      .all();
+    const voluteMsgs = msgs.filter((m) => m.sender_name === "volute");
+    assert.equal(voluteMsgs.length, 1, "only the spirit's send should exist — no fallback reply");
   });
 
   it("does not trigger a system self-reply loop on the spirit's own send", async () => {


### PR DESCRIPTION
## Root cause / context

Issue #429 reported that the spirit's ("volute") outbound messages bypassed every mind-sender code path — no `mind_history` recording, no bridge routing, no `fixModelEscapes`, no `char_limit`, no turn attribution — because `senderIsMind` in `chat.ts` only matched `user_type === "mind"`, while the spirit's mind token resolves to the shared **system** user.

The **code fix already landed in main** via PR #484 ("spirit never replies to its own messages"), which explicitly carried the #489 changes. In current main:

- `senderIsMind` classifies a system principal whose username is a registered mind, so the spirit now gets `recordOutbound`, `routeOutboundBridge`, `fixModelEscapes`, `char_limit` enforcement, the stale-send hold, and turn attribution (`packages/daemon/src/web/api/volute/chat.ts:118-121`).
- Config lookup uses `resolveMindDir()` instead of `mindDir()` so the spirit's `~/.volute/system/spirit` dir resolves (chat.ts:220).
- The self-reply-loop guard lives at `packages/daemon/src/lib/chat/system-chat.ts:36` (`isSpiritName(replyTarget)` in `shouldGenerateSystemFallback`) — this is what keeps routing the spirit through the mind-sender path loop-free.

## Change

The one deliverable from #429's plan still uncovered was **item 4**: confirm turn attribution end-to-end for the spirit. The existing suite (`test/chat-spirit-sender.test.ts`) already covered outbound recording, the escape fix, and the no-self-reply-loop case, but never asserted `turn_id`.

This PR adds a single test: it opens an active turn for the spirit, sends via `POST /api/v1/chat`, and asserts the spirit's outbound `mind_history` row carries that turn's id — plus that exactly one reply exists (no fallback loop even with a turn active). Test cleanup now also clears the spirit's in-memory turn and the `turns` table between cases.

No production code changes — the behavior was already correct; this closes the verification gap and guards against regression. Titled `test:` (not `fix:`) so it doesn't trigger a spurious release for a no-behavior-change PR.

## Testing

- New test `attributes the spirit's outbound to its active turn` passes.
- Full `npm test` passes (exit 0).

Fixes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)