### PR TITLE
fix: clock/sleep display papercuts (#454 items 5-8)

### DIFF
--- a/packages/cli/src/commands/clock.ts
+++ b/packages/cli/src/commands/clock.ts
@@ -143,6 +143,10 @@ const listSchedulesCmd = command({
       return;
     }
 
+    const compact = isCompact();
+    const fmtTime = (s: string) => (compact ? compactDateTime(s) : new Date(s).toLocaleString());
+    const scheduleOf = (s: Schedule) => s.cron ?? (s.fireAt ? `at ${fmtTime(s.fireAt)}` : "");
+
     const actionLabel = (s: Schedule) =>
       s.script
         ? `[script] ${s.script}`
@@ -150,17 +154,16 @@ const listSchedulesCmd = command({
           ? `[rotating x${s.messages.length}] ${s.messages[0]}`
           : (s.message ?? "");
 
-    if (isCompact()) {
+    if (compact) {
       for (const s of schedules) {
-        const sched = s.cron ?? (s.fireAt ? `at ${s.fireAt}` : "");
-        console.log(`${s.id}  ${sched}  ${actionLabel(s)}`);
+        console.log(`${s.id}  ${scheduleOf(s)}  ${actionLabel(s)}`);
       }
     } else {
       const idW = Math.max(2, ...schedules.map((s) => s.id.length));
-      const schedW = Math.max(8, ...schedules.map((s) => (s.cron ?? s.fireAt ?? "").length));
+      const schedW = Math.max(8, ...schedules.map((s) => scheduleOf(s).length));
       console.log(`${"ID".padEnd(idW)}  ${"SCHEDULE".padEnd(schedW)}  ENABLED  ACTION`);
       for (const s of schedules) {
-        const sched = s.cron ?? (s.fireAt ? `at ${s.fireAt}` : "");
+        const sched = scheduleOf(s);
         console.log(
           `${s.id.padEnd(idW)}  ${sched.padEnd(schedW)}  ${String(s.enabled).padEnd(7)}  ${actionLabel(s)}`,
         );

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1640,7 +1640,7 @@ const app = new Hono<AuthEnv>()
 
     return c.json(sm.getState(name));
   })
-  // Initiate sleep — admin only
+  // Initiate sleep — mind-or-admin (requireSelf: the mind itself or an admin/system user)
   .post("/:name/sleep", requireSelf(), async (c) => {
     const name = c.req.param("name");
     const entry = await findMind(name);
@@ -1668,7 +1668,7 @@ const app = new Hono<AuthEnv>()
 
     return c.json({ ok: true });
   })
-  // Wake a sleeping mind — admin only
+  // Wake a sleeping mind — mind-or-admin (requireSelf: the mind itself or an admin/system user)
   .post("/:name/wake", requireSelf(), async (c) => {
     const name = c.req.param("name");
     const entry = await findMind(name);
@@ -1690,7 +1690,7 @@ const app = new Hono<AuthEnv>()
 
     return c.json({ ok: true });
   })
-  // Flush queued sleep messages — admin only
+  // Flush queued sleep messages — mind-or-admin (requireSelf: the mind itself or an admin/system user)
   .post("/:name/sleep/messages", requireSelf(), async (c) => {
     const name = c.req.param("name");
     const entry = await findMind(name);

--- a/packages/daemon/src/web/api/schedules.ts
+++ b/packages/daemon/src/web/api/schedules.ts
@@ -179,7 +179,11 @@ const app = new Hono<AuthEnv>()
     const now = new Date();
     const { upcoming, previous } = computeClockEvents(schedules, sleepState, sleepConfig, now);
 
-    return c.json({ sleep: sleepState, sleepConfig, schedules, upcoming, previous });
+    // Cron expressions are interpreted in the daemon host's local timezone, so a
+    // remote viewer needs the daemon IANA TZ to label cron-derived wall times.
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    return c.json({ sleep: sleepState, sleepConfig, schedules, upcoming, previous, timezone });
   })
   // Get sleep config
   .get("/:name/sleep/config", requireSelf(), async (c) => {

--- a/packages/web/src/ui/components/mind/MindClock.svelte
+++ b/packages/web/src/ui/components/mind/MindClock.svelte
@@ -2,7 +2,6 @@
 import { Icon } from "@volute/ui";
 import { type ClockStatus, fetchClockStatus } from "../../lib/client";
 import { formatCron, formatRelativeTime } from "../../lib/clock-format";
-import { activeMinds } from "../../lib/stores.svelte";
 
 type IconKind = "heartbeat" | "dream" | "sleep" | "clock";
 
@@ -76,6 +75,23 @@ function formatAction(s: {
   return lines.join("\n");
 }
 
+// Short label for the daemon timezone (e.g. "EST"), appended to cron wall times
+// so a viewer in another timezone reads them as daemon-local. Empty when the
+// daemon TZ matches the viewer's, since no disambiguation is needed then.
+let tzLabel = $derived.by(() => {
+  const tz = clock?.timezone;
+  if (!tz || tz === Intl.DateTimeFormat().resolvedOptions().timeZone) return undefined;
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      timeZoneName: "short",
+    }).formatToParts(new Date());
+    return parts.find((p) => p.type === "timeZoneName")?.value;
+  } catch {
+    return undefined;
+  }
+});
+
 function formatSleepTime(iso: string): string {
   try {
     return new Date(iso).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
@@ -122,7 +138,7 @@ let rows = $derived.by(() => {
       id: "sleep",
       icon: "sleep",
       color: scheduleColor("sleep"),
-      times: `${formatCron(sc.sleep)} \u2192 ${formatCron(sc.wake)}`,
+      times: `${formatCron(sc.sleep, tzLabel)} \u2192 ${formatCron(sc.wake, tzLabel)}`,
       next: nextSleep ? formatRelativeTime(nextSleep) : "",
       disabled: false,
       tooltip: "",
@@ -132,7 +148,7 @@ let rows = $derived.by(() => {
   // Regular schedules
   for (const s of clock.schedules) {
     let times = "";
-    if (s.cron) times = formatCron(s.cron);
+    if (s.cron) times = formatCron(s.cron, tzLabel);
     else if (s.fireAt) times = formatSleepTime(s.fireAt);
     const nextAt = upcomingMap.get(s.id);
     result.push({
@@ -170,18 +186,6 @@ let currentItem = $derived.by((): SummaryItem | null => {
       color: scheduleColor("sleep"),
       detail: effectiveWake ? `wake ${formatRelativeTime(effectiveWake)}` : "now",
     };
-  }
-  if (activeMinds.has(name) && clock.previous?.length > 0) {
-    const prev = clock.previous[0];
-    const elapsed = Date.now() - new Date(prev.at).getTime();
-    if (elapsed < 30 * 60_000) {
-      return {
-        icon: scheduleIcon(prev.id),
-        label: prev.id,
-        color: scheduleColor(prev.id),
-        detail: "active now",
-      };
-    }
   }
   if (clock.previous?.length > 0) {
     const prev = clock.previous[0];

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -793,6 +793,8 @@ export interface ClockStatus {
     willQueue?: boolean;
   }[];
   previous: { id: string; at: string }[];
+  /** Daemon host IANA timezone — cron wall times are interpreted in it. */
+  timezone: string | null;
 }
 
 export function fetchClockStatus(name: string): Promise<ClockStatus> {

--- a/packages/web/src/ui/lib/clock-format.ts
+++ b/packages/web/src/ui/lib/clock-format.ts
@@ -25,7 +25,12 @@ export function formatRelativeTime(iso: string): string {
   }
 }
 
-export function formatCron(cron: string): string {
+/**
+ * Render a cron expression as a human phrase. Cron wall times are interpreted in
+ * the daemon host's timezone; pass `tz` (a short label like "EST") to append it
+ * to time-of-day phrases so a viewer in another timezone reads them correctly.
+ */
+export function formatCron(cron: string, tz?: string): string {
   const parts = cron.split(" ");
   if (parts.length < 5) return cron;
   const [min, hour, dom, mon, dow] = parts;
@@ -43,8 +48,9 @@ export function formatCron(cron: string): string {
     const m = +min;
     const timeStr =
       hours.length === 1 ? fmtTime(hours[0], m) : hours.map((h) => fmtTime(h, m)).join(", ");
-    if (dow === "*") return `daily at ${timeStr}`;
-    return `${formatDays(dow)} at ${timeStr}`;
+    const suffix = tz ? ` ${tz}` : "";
+    if (dow === "*") return `daily at ${timeStr}${suffix}`;
+    return `${formatDays(dow)} at ${timeStr}${suffix}`;
   }
   return cron;
 }

--- a/test/web-clock-format.test.ts
+++ b/test/web-clock-format.test.ts
@@ -1,6 +1,28 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { messagesToText, textToMessages } from "../packages/web/src/ui/lib/clock-format.js";
+import {
+  formatCron,
+  messagesToText,
+  textToMessages,
+} from "../packages/web/src/ui/lib/clock-format.js";
+
+describe("formatCron", () => {
+  it("renders interval and time-of-day crons", () => {
+    assert.equal(formatCron("*/5 * * * *"), "every 5 minutes");
+    assert.equal(formatCron("0 */2 * * *"), "every 2 hours");
+    assert.equal(formatCron("0 9 * * *"), "daily at 9am");
+    assert.equal(formatCron("30 14 * * 1"), "Mondays at 2:30pm");
+  });
+
+  it("appends the timezone label only to time-of-day phrases", () => {
+    // Wall-clock crons are daemon-local — the label disambiguates them.
+    assert.equal(formatCron("0 9 * * *", "EST"), "daily at 9am EST");
+    assert.equal(formatCron("30 14 * * 1", "EST"), "Mondays at 2:30pm EST");
+    // Interval crons have no time-of-day, so no label is added.
+    assert.equal(formatCron("*/5 * * * *", "EST"), "every 5 minutes");
+    assert.equal(formatCron("0 */2 * * *", "EST"), "every 2 hours");
+  });
+});
 
 describe("schedule message textarea helpers", () => {
   it("messagesToText joins a pool and falls back to message", () => {

--- a/test/web-clock-format.test.ts
+++ b/test/web-clock-format.test.ts
@@ -18,6 +18,10 @@ describe("formatCron", () => {
     // Wall-clock crons are daemon-local — the label disambiguates them.
     assert.equal(formatCron("0 9 * * *", "EST"), "daily at 9am EST");
     assert.equal(formatCron("30 14 * * 1", "EST"), "Mondays at 2:30pm EST");
+    // The label goes once after the joined time list, not per time.
+    assert.equal(formatCron("0 9,17 * * *", "EST"), "daily at 9am, 5pm EST");
+    // ...and after the day phrase, not before it.
+    assert.equal(formatCron("0 9 * * 1,2,3,4,5", "EST"), "weekdays at 9am EST");
     // Interval crons have no time-of-day, so no label is added.
     assert.equal(formatCron("*/5 * * * *", "EST"), "every 5 minutes");
     assert.equal(formatCron("0 */2 * * *", "EST"), "every 2 hours");


### PR DESCRIPTION
Finishes the clock/sleep UX papercuts in #454. Items 1–4 landed in #529 (v0.46 batch); this PR handles the remaining cosmetics (items 5–8).

## Audit

| Item | Status |
|------|--------|
| 1. Trigger-wake status display | Done in #529 |
| 2. "next 24h" horizon filter | Done in #529 |
| 3. will-skip / will-queue annotations | Done in #529 |
| 4. `--wake-at` duration / `HH:MM` / ISO ergonomics | Done in #529 |
| 5. `clock list` prints raw UTC ISO for timers | **Fixed here** |
| 6. `formatCron` renders daemon-TZ crons as browser-local | **Fixed here** |
| 7. `MindClock` "active now" mis-attribution | **Fixed here** |
| 8. Stale "admin only" comments on sleep/wake routes | **Fixed here** |

## Fixes

- **5 — `clock list` timer times** (`packages/cli/src/commands/clock.ts`): timer `fireAt` was printed as raw UTC ISO. Now formatted with the same helper `clock status` uses (`toLocaleString()`, or `compactDateTime()` in mind/compact context) via a shared `scheduleOf()`.

- **6 — daemon timezone labelling** (`schedules.ts`, `client.ts`, `clock-format.ts`, `MindClock.svelte`): cron expressions are interpreted in the daemon host's local timezone, so a remote viewer saw e.g. "daily at 9am" as if it were their own local time. The `clock/status` payload now carries the daemon IANA `timezone`, and `formatCron(cron, tz?)` appends a short TZ label (e.g. "daily at 9am EST") to time-of-day phrases. `MindClock` only passes the label when the daemon TZ differs from the viewer's, so same-timezone users see no extra noise. Interval crons ("every 5 minutes") get no label. The "every hour at :MM" branch is also left unlabeled — the hour is a wildcard so a TZ offset only shifts the minute, which is identical across almost all zones (the rare half-hour/45-min zones are an accepted cosmetic edge). Likewise the appended TZ label reflects the current offset abbreviation, so a schedule firing in a different DST period shows the current period's abbreviation — cosmetic only.

- **7 — `MindClock` "active now"** (`MindClock.svelte`): the summary claimed the most recent schedule (e.g. "heartbeat") was the reason the mind is "active now" — a causal attribution the data doesn't support. Removed that branch (and the now-unused `activeMinds` import); the existing previous-event path already shows `<schedule-id>` + "Xm ago" honestly.

- **8 — stale route comments** (`packages/daemon/src/web/api/minds.ts`): `POST /:name/sleep`, `/:name/wake`, and the adjacent `/:name/sleep/messages` were commented "admin only" but correctly use `requireSelf()` (the mind itself or an admin/system user). Reworded so a future security pass doesn't tighten the guard the wrong way. Included the adjacent flush route since it carried the identical stale comment on the same sleep surface.

## Tests

- Added `formatCron` unit tests (interval + time-of-day rendering, and TZ-label appended only to time-of-day phrases) in `test/web-clock-format.test.ts`.
- Full `npm test`: **2195 pass, 0 fail**. `svelte-check`: 0 errors. Root `tsc --noEmit`: clean.

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
