### PR TITLE
test: fix mail-poller delivery assertion after #636 gating change

### DIFF
--- a/test/mail-poller.test.ts
+++ b/test/mail-poller.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
 import { formatEmailContent, MailPoller } from "../packages/daemon/src/lib/daemon/mail-poller.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import { clearConfigCache } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import { addMind, removeMind, setMindRunning } from "../packages/daemon/src/lib/mind/registry.js";
 import { mindHistory } from "../packages/daemon/src/lib/schema.js";
 
@@ -197,16 +200,35 @@ describe("MailPoller.deliver — delivery-failure propagation", () => {
     receivedAt: "2020-01-01T00:00:00.000Z",
   };
 
+  const configDir = () => resolve(process.env.VOLUTE_HOME!, "minds", MIND, "home/.config");
+
   afterEach(async () => {
     const db = await getDb();
     await db.delete(mindHistory).where(eq(mindHistory.mind, MIND));
     await removeMind(MIND);
+    rmSync(resolve(configDir(), "routes.json"), { force: true });
+    clearConfigCache();
   });
 
   function deliver(mind: string): Promise<void> {
     return (
       new MailPoller() as unknown as { deliver(m: string, e: typeof email): Promise<void> }
     ).deliver(mind, email);
+  }
+
+  // Give the fixture the DM route every real mind gets from the default template. Mail is
+  // delivered with `isDM: true`, so a real mind routes it (and never gates it); without a
+  // routes.json the bare fixture would gate the unrouted `mail:` channel, and gated
+  // messages are not recorded as inbound (#636/#420). Routing the DM keeps the inbound row
+  // meaningful as proof that deliverMessage was reached.
+  function routeDMs(): void {
+    mkdirSync(configDir(), { recursive: true });
+    // No `session` needed — matching the DM (so it isn't gated) is all this test requires.
+    writeFileSync(
+      resolve(configDir(), "routes.json"),
+      JSON.stringify({ rules: [{ channel: "*", isDM: true }] }),
+    );
+    clearConfigCache(MIND);
   }
 
   it("throws when deliverMessage reports failure (Finding 1 — false is not success)", async () => {
@@ -219,6 +241,7 @@ describe("MailPoller.deliver — delivery-failure propagation", () => {
 
   it("does not pre-skip a mind with running=false (Finding 2 — sleeping minds queue)", async () => {
     await addMind(MIND, PORT); // running defaults to false, as a sleeping mind is
+    routeDMs(); // a real mind routes its DMs; mail arrives as a DM
     // The old `!entry.running` pre-check returned before deliverMessage, dropping
     // the mail and bypassing sleep-queueing. It must now reach deliverMessage,
     // which records the inbound (and, for a truly sleeping mind, queues it).


### PR DESCRIPTION
## Problem

Main is red from a cross-PR interaction between two independently-green merged PRs:

- **#632** made the mail poller reach `deliverMessage` for `running=false` minds (sleeping minds queue), and its test *proves* delivery was reached by asserting one `inbound` `mind_history` row.
- **#636** stopped recording gated (held, unrouted-channel) messages as `inbound` history.

Composed on main, `test/mail-poller.test.ts` → "does not pre-skip a mind with running=false (Finding 2 — sleeping minds queue)" asserts 1 inbound row and gets 0: the bare fixture mind has no `routes.json`, so its `mail:<addr>` channel is unmatched → gated → per #636 no inbound row is written.

### Interleaving note

The failure was reported as non-deterministic across the fleet (deterministic 3/3 for one agent, green for another, and #638's CI also hit it). The mechanism is the same either way — `willGate()` skips `recordInbound` for the unrouted mail channel — but what varies is the routing config the fixture sees: the bare fixture pins nothing down, so whether an inbound row exists depends on the fixture dir / config-cache state at the moment the test runs. The fix removes that variance by making the fixture hermetic (its own explicit `routes.json`, cache cleared, file removed in `afterEach`).

## This is a test gap, not a mail regression

Mail is delivered with `isDM: true`, and every real mind's default template `routes.json` routes all DMs (`{ "channel": "*", "isDM": true }`). So in production, mail matches that rule and is delivered — never gated — exactly as before #636. #636 changed only *history recording*, not delivery. Only the bare unit fixture (which skips the default `routes.json`) gates the channel.

## Fix

Give the fixture its own explicit DM route — the same one a real mind gets from the default template — so the mail is delivered (not gated) and the inbound row again proves `deliverMessage` was reached. The route is written before delivery, the config cache is cleared, and the file is removed in `afterEach`, so the routing/gating decision is fully controlled within the file. Test-only; no production code touched.

## Verification

- `test/mail-poller.test.ts` solo: 18/18, green on 3 consecutive runs.
- Concurrent batch (`--test-concurrency=4`) of mail-poller + delivery/routing/gated-release files: 165/165, green on 2 consecutive runs.
- Full pre-push suite: 2296 pass / 0 fail.

Refs #636, #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)