### PR TITLE
feat: surface mind variants in the web dashboard

### DIFF
--- a/packages/ui/src/components/Icon.svelte
+++ b/packages/ui/src/components/Icon.svelte
@@ -25,7 +25,8 @@ let {
     | "folder"
     | "play"
     | "stop"
-    | "restart";
+    | "restart"
+    | "fork";
   class?: string;
 } = $props();
 </script>
@@ -74,4 +75,6 @@ let {
   <svg class={className} viewBox="0 0 16 16" fill="currentColor" stroke="none"><rect x="3" y="3" width="10" height="10" rx="1"/></svg>
 {:else if kind === "restart"}
   <svg class={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8a6 6 0 0 1 10.3-4.2L14 2v4h-4l1.7-1.7A4.5 4.5 0 0 0 3.5 8"/><path d="M14 8a6 6 0 0 1-10.3 4.2L2 14v-4h4l-1.7 1.7A4.5 4.5 0 0 0 12.5 8"/></svg>
+{:else if kind === "fork"}
+  <svg class={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="4" cy="3.5" r="1.5"/><circle cx="12" cy="3.5" r="1.5"/><circle cx="4" cy="12.5" r="1.5"/><path d="M4 5v7"/><path d="M12 5v1.5a3 3 0 0 1-3 3H4"/></svg>
 {/if}

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -10,6 +10,7 @@ import MainFrame from "./components/layout/MainFrame.svelte";
 import UnifiedSidebar from "./components/layout/UnifiedSidebar.svelte";
 import MindRightPanel from "./components/mind/MindRightPanel.svelte";
 import MindSettings from "./components/mind/MindSettings.svelte";
+import MindVariants from "./components/mind/MindVariants.svelte";
 import ChannelBrowserModal from "./components/modals/ChannelBrowserModal.svelte";
 import ContextModal from "./components/modals/ContextModal.svelte";
 import SeedModal from "./components/modals/SeedModal.svelte";
@@ -105,6 +106,7 @@ type ModalType =
   | "mindHistory"
   | "mindFiles"
   | "mindSettings"
+  | "mindVariants"
   | "mindContext"
   | "systemSettings"
   | "systemLogs"
@@ -683,6 +685,7 @@ function handleGlobalClick(e: MouseEvent) {
             if (section === "history") activeModal = "mindHistory";
             else if (section === "files") activeModal = "mindFiles";
             else if (section === "settings") activeModal = "mindSettings";
+            else if (section === "variants") activeModal = "mindVariants";
             else if (section === "context") activeModal = "mindContext";
           }}
           onSelectSystemSection={(section) => {
@@ -878,6 +881,13 @@ function handleGlobalClick(e: MouseEvent) {
         <MindSettings mind={modalMind} />
       </Modal>
     {/if}
+  {/if}
+  {#if activeModal === "mindVariants" && mindModalName}
+    <Modal title="Variants — {mindModalName}" onClose={() => { activeModal = null; mindModalName = null; }}>
+      <div class="modal-scroll-body">
+        <MindVariants name={mindModalName} />
+      </div>
+    </Modal>
   {/if}
   {#if activeModal === "mindContext" && mindModalName}
     <ContextModal mindName={mindModalName} onClose={() => { activeModal = null; mindModalName = null; }} />

--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -407,6 +407,12 @@ let isSystemActive = $derived(
       <Icon kind="gear" class="menu-icon" />
       Settings
     </button>
+    {#if menuMind?.stage !== "seed" && menuMind?.mindType !== "spirit"}
+      <button class="mind-menu-item" onclick={() => handleMenuAction(openMenu!, "variants")}>
+        <Icon kind="fork" class="menu-icon" />
+        Variants
+      </button>
+    {/if}
     {#if menuMind?.status === "running"}
       <button class="mind-menu-item" onclick={() => handleMenuAction(openMenu!, "context")}>
         <Icon kind="document-lines" class="menu-icon" />

--- a/packages/web/src/ui/components/mind/MindVariants.svelte
+++ b/packages/web/src/ui/components/mind/MindVariants.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+import type { Variant } from "@volute/api";
+import { Button, Input, SectionHeader, StatusBadge } from "@volute/ui";
+import { createVariant, deleteVariant, fetchVariants, joinVariant } from "../../lib/client";
+import { formatRelativeTime } from "../../lib/format";
+
+let { name }: { name: string } = $props();
+
+let variants = $state<Variant[]>([]);
+let loading = $state(true);
+let error = $state("");
+// Partial-success notice: the merge landed but a follow-up step (restart /
+// npm install) didn't. Kept separate from `error` so a degraded-but-merged
+// mind doesn't read as a failed operation.
+let warning = $state("");
+
+// Create form
+let newName = $state("");
+let newSoul = $state("");
+let creating = $state(false);
+
+// Per-variant action state (holds the variant name being confirmed / acted on)
+let confirmingJoin = $state<string | null>(null);
+let confirmingDelete = $state<string | null>(null);
+let busy = $state<string | null>(null);
+
+async function load() {
+  loading = true;
+  try {
+    variants = await fetchVariants(name);
+    error = "";
+  } catch (err) {
+    console.error("Failed to load variants:", err);
+    error = err instanceof Error ? err.message : "Failed to load variants";
+  } finally {
+    loading = false;
+  }
+}
+
+$effect(() => {
+  // Re-run when the parent mind changes.
+  void name;
+  load();
+});
+
+async function handleCreate(e: SubmitEvent) {
+  e.preventDefault();
+  const variantName = newName.trim();
+  if (!variantName || creating) return;
+  creating = true;
+  error = "";
+  warning = "";
+  try {
+    await createVariant(name, { name: variantName, soul: newSoul.trim() || undefined });
+    newName = "";
+    newSoul = "";
+    await load();
+  } catch (err) {
+    console.error("Failed to create variant:", err);
+    error = err instanceof Error ? err.message : "Failed to create variant";
+  } finally {
+    creating = false;
+  }
+}
+
+async function handleJoin(variant: string) {
+  busy = variant;
+  error = "";
+  warning = "";
+  try {
+    const res = await joinVariant(name, variant);
+    confirmingJoin = null;
+    // Reload first (the merged variant is now gone), then show any
+    // partial-success notice so it isn't wiped by load().
+    await load();
+    if (res.warning) warning = res.warning;
+  } catch (err) {
+    console.error("Failed to join variant:", err);
+    error = err instanceof Error ? err.message : "Failed to join variant";
+  } finally {
+    busy = null;
+  }
+}
+
+async function handleDelete(variant: string) {
+  busy = variant;
+  error = "";
+  warning = "";
+  try {
+    await deleteVariant(name, variant);
+    confirmingDelete = null;
+    await load();
+  } catch (err) {
+    console.error("Failed to delete variant:", err);
+    error = err instanceof Error ? err.message : "Failed to delete variant";
+  } finally {
+    busy = null;
+  }
+}
+</script>
+
+<div class="variants">
+  <SectionHeader
+    title="Variants"
+    subtitle="Isolated forks of this mind — split off an experiment, then join it back or discard it"
+  />
+
+  <form class="create-form" onsubmit={handleCreate}>
+    <div class="create-row">
+      <Input bind:value={newName} placeholder="variant name" width="180px" disabled={creating} />
+      <Button variant="primary" type="submit" disabled={creating || !newName.trim()}>
+        {creating ? "Splitting…" : "Split"}
+      </Button>
+    </div>
+    <textarea
+      class="soul-input"
+      bind:value={newSoul}
+      placeholder="Optional SOUL.md override for the variant"
+      rows="2"
+      disabled={creating}
+    ></textarea>
+  </form>
+
+  {#if error}
+    <div class="error">{error}</div>
+  {/if}
+
+  {#if warning}
+    <div class="warning">Merge completed, but: {warning}</div>
+  {/if}
+
+  {#if loading}
+    <div class="muted">Loading…</div>
+  {:else if variants.length === 0}
+    <div class="muted">No variants.</div>
+  {:else}
+    <ul class="variant-list">
+      {#each variants as v (v.name)}
+        <li class="variant-row">
+          <div class="variant-main">
+            <span class="variant-name">{v.name}</span>
+            <StatusBadge status={v.status} />
+          </div>
+          <div class="variant-meta">
+            <span class="branch" title="branch">{v.branch}</span>
+            {#if v.port}<span class="port">:{v.port}</span>{/if}
+            {#if v.created}<span class="created">{formatRelativeTime(v.created)}</span>{/if}
+          </div>
+          <div class="variant-actions">
+            {#if confirmingJoin === v.name}
+              <span class="confirm">
+                Join back into {name} and restart?
+                <button class="confirm-yes" onclick={() => handleJoin(v.name)} disabled={busy === v.name}>
+                  {busy === v.name ? "joining…" : "join"}
+                </button>
+                <button class="confirm-no" onclick={() => (confirmingJoin = null)} disabled={busy === v.name}>cancel</button>
+              </span>
+            {:else if confirmingDelete === v.name}
+              <span class="confirm">
+                Discard this variant?
+                <button class="confirm-yes danger" onclick={() => handleDelete(v.name)} disabled={busy === v.name}>
+                  {busy === v.name ? "discarding…" : "discard"}
+                </button>
+                <button class="confirm-no" onclick={() => (confirmingDelete = null)} disabled={busy === v.name}>cancel</button>
+              </span>
+            {:else}
+              <Button variant="secondary" onclick={() => (confirmingJoin = v.name)} disabled={!!busy}>Join</Button>
+              <Button variant="text" onclick={() => (confirmingDelete = v.name)} disabled={!!busy}>Discard</Button>
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .variants {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .create-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .create-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .soul-input {
+    width: 100%;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text-0);
+    font-family: inherit;
+    font-size: 13px;
+    padding: 8px 10px;
+    resize: vertical;
+  }
+
+  .soul-input:focus {
+    outline: none;
+    border-color: var(--border-bright);
+  }
+
+  .error {
+    color: var(--red);
+    font-size: 13px;
+    white-space: pre-wrap;
+  }
+
+  .warning {
+    color: var(--yellow);
+    background: var(--yellow-bg);
+    border-radius: var(--radius);
+    padding: 8px 10px;
+    font-size: 13px;
+    white-space: pre-wrap;
+  }
+
+  .muted {
+    color: var(--text-2);
+    font-size: 14px;
+    padding: 8px 0;
+  }
+
+  .variant-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .variant-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .variant-main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .variant-name {
+    color: var(--text-0);
+    font-weight: 500;
+  }
+
+  .variant-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .branch {
+    font-family: var(--mono, monospace);
+  }
+
+  .variant-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .confirm {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-1);
+  }
+
+  .confirm-yes,
+  .confirm-no {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 2px 4px;
+  }
+
+  .confirm-yes {
+    color: var(--accent);
+  }
+
+  .confirm-yes.danger {
+    color: var(--red);
+  }
+
+  .confirm-no {
+    color: var(--text-2);
+  }
+
+  .confirm-yes:disabled,
+  .confirm-no:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -324,6 +324,25 @@ export function fetchVariants(name: string): Promise<Variant[]> {
   return get(`${V1}/minds/${enc(name)}/variants`);
 }
 
+export function createVariant(
+  name: string,
+  body: { name: string; soul?: string },
+): Promise<{ ok: boolean; variant: { name: string; branch: string; path: string; port: number } }> {
+  return post(`${V1}/minds/${enc(name)}/variants`, body);
+}
+
+export function joinVariant(
+  name: string,
+  variant: string,
+  body?: { summary?: string; justification?: string; memory?: string },
+): Promise<{ ok: boolean; warning?: string }> {
+  return post(`${V1}/minds/${enc(name)}/variants/${enc(variant)}/merge`, body ?? {});
+}
+
+export function deleteVariant(name: string, variant: string): Promise<void> {
+  return del(`${V1}/minds/${enc(name)}/variants/${enc(variant)}`);
+}
+
 // --- Config ---
 
 export function fetchMindConfig(name: string): Promise<MindConfig> {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -688,8 +688,18 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       assert.equal(rootOwned.length, 0, `parent dir has root-owned files: ${rootOwned.join(", ")}`);
     }
 
-    // Clean up the variant so later tests aren't affected.
-    await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-conflict-var`, { method: "DELETE" });
+    // Standalone delete — the "Discard" action the web dashboard now exposes.
+    // The variant is removed from the registry and disk. Doubles as cleanup so
+    // later tests aren't affected.
+    const deleteRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-conflict-var`, {
+      method: "DELETE",
+    });
+    assert.equal(deleteRes.status, 200, `Delete: ${await deleteRes.clone().text()}`);
+    assert.ok(
+      !(await findMind("e2e-conflict-var")),
+      "deleted variant should be gone from the registry",
+    );
+    assert.ok(!existsSync(created.variant.path), "deleted variant worktree should be removed");
   });
 
   // ── Bridge & Chat Integration Tests ──


### PR DESCRIPTION
## What

Surfaces mind variants in the web dashboard. Variants previously had **zero** UI surface — the old `VariantList.svelte` + `fetchVariants()` were dead code and were deleted in #567/#585. This builds the surface fresh.

Adds a **Variants** item to the mind's sidebar context menu (gated to non-seed, non-spirit base minds) that opens a Variants modal on the mind detail view. The modal:

- **Lists** the mind's variants with live status (`running` / `dead` / `no-server` via the shared `StatusBadge`), branch, port, and relative created time.
- **Split** — create a new variant (name + optional `SOUL.md` override).
- **Join** — merge a variant back into the parent and restart it. **Confirm-gated** (inline yes/cancel) because it's destructive.
- **Discard** — delete a variant. Also confirm-gated.
- Surfaces server error messages inline (e.g. merge-conflict text, or a partial-success warning when the merge lands but the restart/npm-install fails).

## How

- New component `packages/web/src/ui/components/mind/MindVariants.svelte`.
- Three thin client wrappers in `packages/web/src/ui/lib/client.ts`: `createVariant`, `joinVariant`, `deleteVariant` (`fetchVariants` already existed).
- New `mindVariants` modal wired into the existing mind-detail modal set in `App.svelte`, and a **Variants** menu item in `UnifiedSidebar.svelte`, matching the existing Files/Settings/Context pattern.
- New `fork` icon in `@volute/ui`'s `Icon.svelte`.

**No API/route changes.** The daemon variants API (`packages/daemon/src/web/api/variants.ts`) already exposes list/create/merge/delete; this surface only reads it. The pre-existing inline-confirm and modal patterns are reused (e.g. `UserManagement.svelte`, `mindFiles`/`mindHistory` modals).

Since Discard is now a first-class user action, the daemon-e2e conflict test's previously fire-and-forget cleanup DELETE is upgraded to an asserted standalone-delete happy path (200 + variant gone from registry and disk). Split/merge/conflict/list were already covered there.

## Scope notes

- The issue also floated a "chat / open the variant's own detail page" link. Variants are deliberately excluded from the minds listing (`readRegistry` filters `parent IS NULL`), so they aren't in the frontend `data.minds` and such a link would 404. That's a backend gap owned by the sibling variant-flow issues (#444/#447), not something to paper over in this PR.
- A diff-vs-parent view was listed as a nice-to-have; left out to keep this focused. Easy follow-up.

## Verification

- `svelte-check` — 0 errors (the one warning is pre-existing in `SummaryNode.svelte`).
- `npm run build:web` — succeeds.
- `biome check` — clean.
- Svelte MCP autofixer — no issues.
- Targeted tests: `web-variants` + `authz-coverage` — 12/12 pass.
- `npm run test:e2e` (daemon-e2e) — 55/55 pass, including the variant split/merge/conflict/delete flow.
- **Visual pass not run** — verifying in-browser needs a live daemon + a mind with real variants, which was too heavy for this fleet run. Instead the component pattern-matches the existing mind-detail tabs (modal shell, `@volute/ui` components, inline-confirm from `UserManagement.svelte`).

Fixes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
