### PR TITLE
fix: restore mind ownership on variant git-op edge paths under isolation

### DIFF
--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -95,7 +95,21 @@ const app = new Hono<AuthEnv>()
       await gitExec(["worktree", "add", "-b", variantName, variantDir], { cwd: projectRoot });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      return c.json({ error: `Failed to create worktree: ${msg}` }, 500);
+      // mkdirSync + `git worktree add` ran as the daemon (root) and may leave
+      // root-owned files under .variants/ in the mind's tree; hand ownership
+      // back before returning so the mind can retry. Surface a restore failure
+      // so a left-behind-root-files condition isn't hidden.
+      let error = `Failed to create worktree: ${msg}`;
+      try {
+        await chownMindDir(projectRoot, mindName);
+      } catch (err) {
+        log.warn(
+          `failed to restore ownership after worktree-add failure for ${mindName}`,
+          log.errorData(err),
+        );
+        error += ` Restoring mind ownership also failed: ${err instanceof Error ? err.message : String(err)}`;
+      }
+      return c.json({ error }, 500);
     }
 
     // Fix ownership before npm install so it runs as the mind user
@@ -174,186 +188,203 @@ const app = new Hono<AuthEnv>()
 
     const projectRoot = parentEntry.dir ?? mindDir(mindName);
 
-    // Auto-commit any uncommitted changes in the variant worktree
-    if (existsSync(variantEntry.dir)) {
-      const status = (await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })).trim();
-      if (status) {
-        try {
-          await gitExec(["add", "-A"], { cwd: variantEntry.dir });
-          await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
-            cwd: variantEntry.dir,
-          });
-        } catch (_e) {
-          return c.json(
-            {
-              error:
-                "Failed to auto-commit variant changes. Commit or stash manually before merging.",
-            },
-            500,
-          );
-        }
-      }
-    }
-
-    // Verify variant before merge
-    if (!body.skipVerify) {
-      const result = await spawnServer(variantEntry.dir, 0, {
-        detached: true,
-        mindName: variantName,
-        template: variantEntry.template,
-      });
-      if (!result) {
-        return c.json(
-          { error: "Failed to start server for verification. Use skipVerify to skip." },
-          500,
-        );
-      }
-
-      const verified = await verify(result.actualPort);
-
-      try {
-        // The verify server is detached (its own process-group leader), so kill
-        // the whole group — under sandbox/isolation the real server is a wrapped
-        // grandchild that a single-PID SIGTERM would leave running.
-        process.kill(-result.child.pid!, "SIGTERM");
-      } catch {}
-
-      if (!verified) {
-        return c.json(
-          { error: "Verification failed. Fix issues or use skipVerify to proceed." },
-          500,
-        );
-      }
-    }
-
-    // Auto-commit any uncommitted changes in the main worktree
-    const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: projectRoot })).trim();
-    if (mainStatus) {
-      try {
-        await gitExec(["add", "-A"], { cwd: projectRoot });
-        await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
-          cwd: projectRoot,
-        });
-      } catch (_e) {
-        return c.json(
-          { error: "Failed to auto-commit main changes. Commit or stash manually before merging." },
-          500,
-        );
-      }
-    }
-
-    // Merge branch
-    try {
-      await gitExec(["merge", variantEntry.branch], { cwd: projectRoot });
-    } catch (_e) {
-      // Collect the conflicting files before aborting so the caller/mind knows
-      // what collided.
-      let conflicts: string[] = [];
-      try {
-        const out = (
-          await gitExec(["diff", "--name-only", "--diff-filter=U"], { cwd: projectRoot })
-        ).trim();
-        conflicts = out ? out.split("\n") : [];
-      } catch (err) {
-        log.warn(`failed to list merge conflicts for ${mindName}`, log.errorData(err));
-      }
-      // Restore the parent worktree so the still-running parent mind never
-      // auto-commits conflict markers into SOUL.md/MEMORY.md.
-      try {
-        await gitExec(["merge", "--abort"], { cwd: projectRoot });
-      } catch (err) {
-        log.warn(`failed to abort merge for ${mindName}`, log.errorData(err));
-      }
-      // The git ops above (auto-commit, merge, merge --abort) ran as the daemon
-      // (root). Under user isolation that leaves the parent worktree — including
-      // home/MEMORY.md and other identity files — owned root:root, so the
-      // still-running parent mind can no longer write its own files. Hand
-      // ownership back before returning.
+    // Every early return past this point can follow a git write that ran as the
+    // daemon (root): the variant/main auto-commits, the merge, and the merge
+    // --abort. Under user isolation that leaves the parent worktree — and the
+    // variant worktree nested under it at .variants/<name>, which chownMindDir
+    // recurses — owned root:root, locking the still-running mind out of its own
+    // files. Hand ownership back before returning; surface a restore failure,
+    // since under isolation it means root-owned files were left behind.
+    const failAfterGitWrite = async (message: string, extra?: Record<string, unknown>) => {
       try {
         await chownMindDir(projectRoot, mindName);
       } catch (err) {
         log.warn(
-          `failed to restore ownership after aborted merge for ${mindName}`,
+          `failed to restore ownership for ${mindName} after merge failure`,
           log.errorData(err),
         );
         return c.json(
           {
-            error: `Merge failed and restoring parent ownership failed: ${err instanceof Error ? err.message : String(err)}`,
-            conflicts,
+            error: `${message} Restoring mind ownership also failed: ${err instanceof Error ? err.message : String(err)}`,
+            ...extra,
           },
           500,
         );
       }
-      // Leave the variant intact so the conflict can be resolved in the variant
-      // and the join retried.
-      return c.json(
-        {
-          error: "Merge failed. Resolve conflicts in the variant and retry the join.",
-          conflicts,
-        },
-        500,
-      );
-    }
-
-    await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
-
-    // The merge and cleanup git ops ran as the daemon (root). Hand ownership of
-    // the parent worktree back to the mind user before the wrapped npm install
-    // (which runs as that user) and the restart — otherwise the tree is left
-    // root-owned under isolation. Mirrors the split/create path.
-    await chownMindDir(projectRoot, mindName);
-
-    // Update template hash after upgrade merge
-    if (variantName.endsWith("-upgrade") || variantName === "upgrade") {
-      try {
-        const { computeTemplateHash } = await import("../../lib/template/template-hash.js");
-        const { setMindTemplateHash } = await import("../../lib/mind/registry.js");
-        const tmpl = parentEntry.template ?? "claude";
-        await setMindTemplateHash(mindName, computeTemplateHash(tmpl));
-      } catch (err) {
-        log.warn(`failed to update template hash for ${mindName}`, log.errorData(err));
-      }
-    }
-
-    // Reinstall dependencies
-    let restartWarning: string | undefined;
-    try {
-      if (isIsolationEnabled()) {
-        const [cmd, args] = await wrapForIsolation("npm", ["install"], mindName);
-        await exec(cmd, args, {
-          cwd: projectRoot,
-          env: { ...process.env, HOME: resolve(projectRoot, "home") },
-        });
-      } else {
-        await exec("npm", ["install"], { cwd: projectRoot });
-      }
-    } catch (err) {
-      log.warn(`npm install failed after merge for ${mindName}`, log.errorData(err));
-      restartWarning = `npm install failed after merge — mind may have stale dependencies`;
-    }
-
-    // Restart mind via mind manager with merge context
-    const manager = getMindManager();
-    const context = {
-      type: "merged",
-      name: variantName,
-      ...(body.summary && { summary: body.summary }),
-      ...(body.justification && { justification: body.justification }),
-      ...(body.memory && { memory: body.memory }),
+      return c.json({ error: message, ...extra }, 500);
     };
 
+    // From the first git write below through the restart, wrap everything in one
+    // try/catch. The named early returns already route through failAfterGitWrite,
+    // but an *uncaught* throw past the first write — spawnServer's isolation wrap,
+    // an unguarded status read, verify — would otherwise 500 without restoring
+    // ownership, leaving the parent (and the nested variant tree) root-owned under
+    // isolation. The catch funnels those through the same restore path.
     try {
-      if (manager.isRunning(mindName)) {
-        await manager.stopMind(mindName);
+      // Auto-commit any uncommitted changes in the variant worktree
+      if (existsSync(variantEntry.dir)) {
+        const status = (await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })).trim();
+        if (status) {
+          try {
+            await gitExec(["add", "-A"], { cwd: variantEntry.dir });
+            await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
+              cwd: variantEntry.dir,
+            });
+          } catch (_e) {
+            return failAfterGitWrite(
+              "Failed to auto-commit variant changes. Commit or stash manually before merging.",
+            );
+          }
+        }
       }
-      manager.setPendingContext(mindName, context);
-      await manager.startMind(mindName);
-    } catch (e) {
-      restartWarning = `Merge succeeded but mind restart failed: ${e instanceof Error ? e.message : String(e)}`;
-      log.warn(restartWarning);
-    }
 
-    return c.json({ ok: true, ...(restartWarning && { warning: restartWarning }) });
+      // Verify variant before merge
+      if (!body.skipVerify) {
+        const result = await spawnServer(variantEntry.dir, 0, {
+          detached: true,
+          mindName: variantName,
+          template: variantEntry.template,
+        });
+        if (!result) {
+          return failAfterGitWrite(
+            "Failed to start server for verification. Use skipVerify to skip.",
+          );
+        }
+
+        const verified = await verify(result.actualPort);
+
+        try {
+          // The verify server is detached (its own process-group leader), so kill
+          // the whole group — under sandbox/isolation the real server is a wrapped
+          // grandchild that a single-PID SIGTERM would leave running.
+          process.kill(-result.child.pid!, "SIGTERM");
+        } catch {}
+
+        if (!verified) {
+          return failAfterGitWrite("Verification failed. Fix issues or use skipVerify to proceed.");
+        }
+      }
+
+      // Auto-commit any uncommitted changes in the main worktree
+      const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: projectRoot })).trim();
+      if (mainStatus) {
+        try {
+          await gitExec(["add", "-A"], { cwd: projectRoot });
+          await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
+            cwd: projectRoot,
+          });
+        } catch (_e) {
+          return failAfterGitWrite(
+            "Failed to auto-commit main changes. Commit or stash manually before merging.",
+          );
+        }
+      }
+
+      // Merge branch
+      try {
+        await gitExec(["merge", variantEntry.branch], { cwd: projectRoot });
+      } catch (_e) {
+        // Collect the conflicting files before aborting so the caller/mind knows
+        // what collided.
+        let conflicts: string[] = [];
+        try {
+          const out = (
+            await gitExec(["diff", "--name-only", "--diff-filter=U"], { cwd: projectRoot })
+          ).trim();
+          conflicts = out ? out.split("\n") : [];
+        } catch (err) {
+          log.warn(`failed to list merge conflicts for ${mindName}`, log.errorData(err));
+        }
+        // Restore the parent worktree so the still-running parent mind never
+        // auto-commits conflict markers into SOUL.md/MEMORY.md.
+        let abortFailed = false;
+        try {
+          await gitExec(["merge", "--abort"], { cwd: projectRoot });
+        } catch (err) {
+          abortFailed = true;
+          log.warn(`failed to abort merge for ${mindName}`, log.errorData(err));
+        }
+        // Leave the variant intact so the conflict can be resolved in the variant
+        // and the join retried. failAfterGitWrite restores ownership after the
+        // root-run auto-commit/merge/abort git ops above. If the abort itself
+        // failed, the parent is left mid-merge with conflict markers on disk —
+        // say so, since the still-running mind could auto-commit them.
+        return failAfterGitWrite(
+          abortFailed
+            ? "Merge failed and the abort did not complete — the parent worktree may be left mid-merge with conflict markers; manual cleanup may be needed."
+            : "Merge failed. Resolve conflicts in the variant and retry the join.",
+          { conflicts },
+        );
+      }
+
+      await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
+
+      // The merge and cleanup git ops ran as the daemon (root). Hand ownership of
+      // the parent worktree back to the mind user before the wrapped npm install
+      // (which runs as that user) and the restart — otherwise the tree is left
+      // root-owned under isolation. Mirrors the split/create path.
+      await chownMindDir(projectRoot, mindName);
+
+      // Update template hash after upgrade merge
+      if (variantName.endsWith("-upgrade") || variantName === "upgrade") {
+        try {
+          const { computeTemplateHash } = await import("../../lib/template/template-hash.js");
+          const { setMindTemplateHash } = await import("../../lib/mind/registry.js");
+          const tmpl = parentEntry.template ?? "claude";
+          await setMindTemplateHash(mindName, computeTemplateHash(tmpl));
+        } catch (err) {
+          log.warn(`failed to update template hash for ${mindName}`, log.errorData(err));
+        }
+      }
+
+      // Reinstall dependencies
+      let restartWarning: string | undefined;
+      try {
+        if (isIsolationEnabled()) {
+          const [cmd, args] = await wrapForIsolation("npm", ["install"], mindName);
+          await exec(cmd, args, {
+            cwd: projectRoot,
+            env: { ...process.env, HOME: resolve(projectRoot, "home") },
+          });
+        } else {
+          await exec("npm", ["install"], { cwd: projectRoot });
+        }
+      } catch (err) {
+        log.warn(`npm install failed after merge for ${mindName}`, log.errorData(err));
+        restartWarning = `npm install failed after merge — mind may have stale dependencies`;
+      }
+
+      // Restart mind via mind manager with merge context
+      const manager = getMindManager();
+      const context = {
+        type: "merged",
+        name: variantName,
+        ...(body.summary && { summary: body.summary }),
+        ...(body.justification && { justification: body.justification }),
+        ...(body.memory && { memory: body.memory }),
+      };
+
+      try {
+        if (manager.isRunning(mindName)) {
+          await manager.stopMind(mindName);
+        }
+        manager.setPendingContext(mindName, context);
+        await manager.startMind(mindName);
+      } catch (e) {
+        restartWarning = `Merge succeeded but mind restart failed: ${e instanceof Error ? e.message : String(e)}`;
+        log.warn(restartWarning);
+      }
+
+      return c.json({ ok: true, ...(restartWarning && { warning: restartWarning }) });
+    } catch (err) {
+      // Uncaught throw past the first git write — restore ownership before the
+      // generic 500 so isolation never leaves the tree root-owned. "join failed"
+      // stays accurate whether the throw was pre- or post-merge.
+      log.error(`variant join failed for ${mindName}`, log.errorData(err));
+      return await failAfterGitWrite(
+        `Variant join failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   })
   // Delete variant — admin only
   .delete("/:name/variants/:variant", requireSelf(), async (c) => {

--- a/test/variant-join-isolation.test.ts
+++ b/test/variant-join-isolation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
@@ -107,6 +107,238 @@ describe("failed variant join restores parent ownership under user isolation", (
     assert.equal(res.status, 500);
     const body = (await res.json()) as { error: string; conflicts?: string[] };
     assert.match(body.error, /chown/i);
+    assert.ok(
+      body.conflicts?.includes("MEMORY.md"),
+      `expected MEMORY.md in conflicts: ${JSON.stringify(body.conflicts)}`,
+    );
+  });
+});
+
+// A non-conflict early return: the main-worktree auto-commit fails (forced by a
+// failing pre-commit hook). This path used to return without restoring
+// ownership; it must now run chownMindDir too, so the same absent-mind-user
+// chown failure surfaces — proving every root-git-write early return in the
+// merge handler restores ownership, not only the conflict/abort path.
+const acParent = `vjoin-ac-${Date.now()}`;
+const acVariant = `${acParent}-var`;
+
+let acCookie: string;
+let acParentDir: string;
+let acVariantDir: string;
+
+describe("failed auto-commit before merge restores ownership under user isolation", () => {
+  before(async () => {
+    process.env.VOLUTE_ISOLATION = "user";
+    const env = cleanGitEnv();
+
+    acParentDir = mindDir(acParent);
+    acVariantDir = resolve(acParentDir, ".variants", acVariant);
+    if (existsSync(acParentDir)) rmSync(acParentDir, { recursive: true, force: true });
+    mkdirSync(acParentDir, { recursive: true });
+
+    await exec("git", ["init"], { cwd: acParentDir, env });
+    await exec("git", ["config", "user.email", "test@test.com"], { cwd: acParentDir, env });
+    await exec("git", ["config", "user.name", "Test"], { cwd: acParentDir, env });
+    writeFileSync(resolve(acParentDir, "MEMORY.md"), "base\n");
+    await exec("git", ["add", "-A"], { cwd: acParentDir, env });
+    await exec("git", ["commit", "-m", "init"], { cwd: acParentDir, env });
+
+    // Variant worktree with no uncommitted changes, so the variant auto-commit
+    // is skipped and the main auto-commit is the first git write reached.
+    await exec("git", ["worktree", "add", "-b", acVariant, acVariantDir], {
+      cwd: acParentDir,
+      env,
+    });
+
+    // Uncommitted change in the parent so the main auto-commit runs, plus a
+    // pre-commit hook that always fails so that commit throws.
+    writeFileSync(resolve(acParentDir, "MEMORY.md"), "dirty\n");
+    const hook = resolve(acParentDir, ".git", "hooks", "pre-commit");
+    writeFileSync(hook, "#!/bin/sh\nexit 1\n");
+    chmodSync(hook, 0o755);
+
+    await addMind(acParent, 4198);
+    await addVariant(acVariant, acParent, 4199, acVariantDir, acVariant);
+
+    const db = await getDb();
+    const [user] = await db
+      .insert(users)
+      .values({ username: "vjoin-ac-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    acCookie = `volute_session=${sessionId}`;
+  });
+
+  after(async () => {
+    if (originalIsolation === undefined) delete process.env.VOLUTE_ISOLATION;
+    else process.env.VOLUTE_ISOLATION = originalIsolation;
+    if (existsSync(acVariantDir)) rmSync(acVariantDir, { recursive: true, force: true });
+    if (existsSync(acParentDir)) rmSync(acParentDir, { recursive: true, force: true });
+    await removeMind(acVariant);
+    await removeMind(acParent);
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "vjoin-ac-admin"));
+  });
+
+  it("restores ownership when the pre-merge auto-commit fails", async () => {
+    const app = createApp();
+    const res = await app.request(`/minds/${acParent}/variants/${acVariant}/merge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: acCookie },
+      body: JSON.stringify({ skipVerify: true }),
+    });
+
+    // The main auto-commit fails, then chownMindDir runs and fails against the
+    // absent mind user — the response carries both the auto-commit error and the
+    // ownership-restore failure, proving the early return now hands ownership
+    // back instead of leaving the parent root-owned.
+    assert.equal(res.status, 500);
+    const body = (await res.json()) as { error: string };
+    assert.match(body.error, /auto-commit main/i);
+    assert.match(body.error, /chown/i);
+  });
+});
+
+// An *uncaught* throw past the first git write (here: the variant worktree dir
+// exists but is not a git worktree, so the first `git status` throws). Such
+// throws used to escape to Hono's generic 500 with no ownership restore; the
+// merge body is now wrapped in one try/catch that routes them through the same
+// restore path, so the absent-mind-user chown failure still surfaces.
+const thParent = `vjoin-th-${Date.now()}`;
+const thVariant = `${thParent}-var`;
+
+let thCookie: string;
+let thParentDir: string;
+let thVariantDir: string;
+
+describe("uncaught throw during merge restores ownership under user isolation", () => {
+  before(async () => {
+    process.env.VOLUTE_ISOLATION = "user";
+
+    thParentDir = mindDir(thParent);
+    thVariantDir = resolve(thParentDir, ".variants", thVariant);
+    if (existsSync(thParentDir)) rmSync(thParentDir, { recursive: true, force: true });
+    // Parent dir exists (chown target) and the variant dir exists but is a plain
+    // directory, not a git worktree — so the handler's first `git status` throws.
+    mkdirSync(thVariantDir, { recursive: true });
+
+    await addMind(thParent, 4200);
+    await addVariant(thVariant, thParent, 4201, thVariantDir, thVariant);
+
+    const db = await getDb();
+    const [user] = await db
+      .insert(users)
+      .values({ username: "vjoin-th-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    thCookie = `volute_session=${sessionId}`;
+  });
+
+  after(async () => {
+    if (originalIsolation === undefined) delete process.env.VOLUTE_ISOLATION;
+    else process.env.VOLUTE_ISOLATION = originalIsolation;
+    if (existsSync(thParentDir)) rmSync(thParentDir, { recursive: true, force: true });
+    await removeMind(thVariant);
+    await removeMind(thParent);
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "vjoin-th-admin"));
+  });
+
+  it("restores ownership when a git op throws unexpectedly", async () => {
+    const app = createApp();
+    const res = await app.request(`/minds/${thParent}/variants/${thVariant}/merge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: thCookie },
+      body: JSON.stringify({ skipVerify: true }),
+    });
+
+    // The thrown "not a git repository" is caught by the merge-body try/catch,
+    // which runs chownMindDir before the 500 — and that chown fails against the
+    // absent mind user, proving the catch hands ownership back.
+    assert.equal(res.status, 500);
+    const body = (await res.json()) as { error: string };
+    assert.match(body.error, /join failed/i);
+    assert.match(body.error, /chown/i);
+  });
+});
+
+// failAfterGitWrite's success branch: with isolation OFF, chownMindDir is a
+// no-op that resolves, so the helper returns a plain 500 that still carries its
+// `...extra` (the conflict list). The other tests only ever hit the chown-FAILS
+// branch, so this pins the success path the structural try/catch now funnels
+// through.
+const okParent = `vjoin-ok-${Date.now()}`;
+const okVariant = `${okParent}-var`;
+const okBranch = okVariant;
+
+let okCookie: string;
+let okParentDir: string;
+let okVariantDir: string;
+
+describe("merge-conflict response preserves conflicts when ownership restore succeeds", () => {
+  before(async () => {
+    // Isolation OFF so chownMindDir resolves without touching anything.
+    delete process.env.VOLUTE_ISOLATION;
+    const env = cleanGitEnv();
+
+    okParentDir = mindDir(okParent);
+    okVariantDir = resolve(okParentDir, ".variants", okVariant);
+    if (existsSync(okParentDir)) rmSync(okParentDir, { recursive: true, force: true });
+    mkdirSync(okParentDir, { recursive: true });
+
+    await exec("git", ["init"], { cwd: okParentDir, env });
+    await exec("git", ["config", "user.email", "test@test.com"], { cwd: okParentDir, env });
+    await exec("git", ["config", "user.name", "Test"], { cwd: okParentDir, env });
+    writeFileSync(resolve(okParentDir, "MEMORY.md"), "base\n");
+    await exec("git", ["add", "-A"], { cwd: okParentDir, env });
+    await exec("git", ["commit", "-m", "init"], { cwd: okParentDir, env });
+
+    await exec("git", ["worktree", "add", "-b", okBranch, okVariantDir], { cwd: okParentDir, env });
+    writeFileSync(resolve(okVariantDir, "MEMORY.md"), "variant version\n");
+    await exec("git", ["commit", "-am", "variant edit"], { cwd: okVariantDir, env });
+
+    writeFileSync(resolve(okParentDir, "MEMORY.md"), "parent version\n");
+    await exec("git", ["commit", "-am", "parent edit"], { cwd: okParentDir, env });
+
+    await addMind(okParent, 4202);
+    await addVariant(okVariant, okParent, 4203, okVariantDir, okBranch);
+
+    const db = await getDb();
+    const [user] = await db
+      .insert(users)
+      .values({ username: "vjoin-ok-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    okCookie = `volute_session=${sessionId}`;
+  });
+
+  after(async () => {
+    if (originalIsolation === undefined) delete process.env.VOLUTE_ISOLATION;
+    else process.env.VOLUTE_ISOLATION = originalIsolation;
+    if (existsSync(okVariantDir)) rmSync(okVariantDir, { recursive: true, force: true });
+    if (existsSync(okParentDir)) rmSync(okParentDir, { recursive: true, force: true });
+    await removeMind(okVariant);
+    await removeMind(okParent);
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "vjoin-ok-admin"));
+  });
+
+  it("returns the conflict list on a plain 500 when the chown no-ops", async () => {
+    const app = createApp();
+    const res = await app.request(`/minds/${okParent}/variants/${okVariant}/merge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: okCookie },
+      body: JSON.stringify({ skipVerify: true }),
+    });
+
+    assert.equal(res.status, 500);
+    const body = (await res.json()) as { error: string; conflicts?: string[] };
+    // Success branch: no chown-failure suffix, and the conflict list survives.
+    assert.doesNotMatch(body.error, /chown/i);
+    assert.doesNotMatch(body.error, /ownership/i);
     assert.ok(
       body.conflicts?.includes("MEMORY.md"),
       `expected MEMORY.md in conflicts: ${JSON.stringify(body.conflicts)}`,


### PR DESCRIPTION
## What & why

Follow-up to #496. Under `VOLUTE_ISOLATION=user` the daemon runs as root, so any git/fs write it makes into a mind-owned worktree leaves `root:root` files that lock the still-running mind out of its own tree. #496 fixed the main failed-join path (merge conflict → abort) and the success path. This PR closes the remaining edge paths called out in #497.

## Audit — every git/fs op in the variant flows under user isolation

**Variant merge handler (`web/api/variants.ts`), root git writes and the early returns that followed them:**

| Path | Root git write before it | Restored ownership before #497? |
|------|--------------------------|------------------------------|
| Variant auto-commit failure | `git add`/`commit` in variant worktree (also writes shared object store in parent `.git`) | ❌ returned without chown — **fixed** |
| Verify server failed to start | preceding variant auto-commit | ❌ — **fixed** |
| Verification failed | preceding variant auto-commit | ❌ — **fixed** |
| Main auto-commit failure | variant auto-commit + `git add` in parent | ❌ returned without chown — **fixed** (the path #497 explicitly names) |
| Merge conflict → abort | auto-commits + `merge` + `merge --abort` in parent | ✅ #496 chowned parent (kept; now routed through the shared helper) |
| Merge success | merge + cleanup | ✅ #496 chowns parent after cleanup (unchanged) |

**Variant creation (`POST /:name/variants`):**

- `git worktree add` **failure** early return: left the root-created `.variants/` dir (from `mkdirSync`) and any partial worktree `root:root` in the parent tree — ❌ **fixed** (best-effort chown before returning).
- `git worktree add` **success**: chowned at line 102. The chown targets `projectRoot`, and the variant worktree lives at `projectRoot/.variants/<name>` — nested under the parent. `chownMindDir` → `chownTargets` only ever narrows out `node_modules`, never `.variants`, so the recursive chown always covers the variant tree. **Variant-dir ownership at creation is therefore already correct** — the "never audited" gap #2 turns out to be safe by construction, not a live bug. Kept as-is; documented here so the guarantee is explicit.
- `npm install` failure / start failure returns: everything is already mind-owned by then (chown ran, npm install ran wrapped as the mind user). No root leak — no change needed.

**`variant-cleanup.ts`** (used by merge-success and delete): git worktree remove/prune/branch-D run as root in `projectRoot`, then `chownMindDir(projectRoot, baseName)` restores. The variant dir is removed by `worktree remove`, so no variant-dir leak. Fine — no change needed.

## Fix

- New local `failAfterGitWrite(message, extra?)` helper in the merge handler: restores parent ownership via `chownMindDir` (which recurses `.variants`, covering the variant tree too) and returns the 500. On a chown failure it appends the restore error to the message so a left-behind-root-files condition is surfaced, not swallowed. All five post-git-write early returns (four previously-unguarded + the conflict/abort path from #496) now route through it.
- The whole merge body, from the first git write through the restart, is wrapped in one try/catch whose catch also runs the ownership restore. This closes the *uncaught-throw* gap: `spawnServer`'s isolation wrap, the previously-unguarded `git status` reads, and `verify` could throw and 500 without restoring ownership. Now any throw past the first write is funnelled through the same restore path.
- A failed `git merge --abort` now surfaces an explicit "parent may be left mid-merge; manual cleanup may be needed" message rather than silently proceeding — that failure means conflict markers are still on disk that the still-running mind could auto-commit into SOUL.md/MEMORY.md.
- Variant-creation `git worktree add` failure now best-effort chowns the parent before returning, and surfaces a chown-restore failure in the response.

The last three items came from the silent-failure review pass on the first cut.

## Tests

- `test/variant-join-isolation.test.ts`: kept the #496 conflict/abort case; added (1) a **non-conflict** case that forces the main-worktree auto-commit to fail (via a failing `pre-commit` hook), and (2) an **uncaught-throw** case (variant dir exists but isn't a git worktree, so the first `git status` throws) — each asserts the response carries both the operation error and the `chown` failure, proving the previously-unguarded early returns and the new try/catch both restore ownership. All three pass.
- `npm test`: 2291 pass. The only 2 failures are pre-existing on `origin/main`, unrelated to this change (confirmed by re-running with my diff stashed): `shutdown-signal` (known load flake, passes solo) and `mail-poller` "Finding 2" (deterministic regression from #636 "stop recording gated messages as inbound history", which changed `message-delivery.ts` without updating that test).
- Ownership uid/gid assertions are Docker-e2e territory; `test/daemon-e2e.test.ts` already walks the parent dir (incl. `.variants`, skipping only `node_modules`/`.git`) after a failed join asserting zero root-owned files — that tripwire now also covers the helper-routed conflict path.

Fixes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
