### PR TITLE
fix: atomic record+promote on gated release (dropped from #636 merge)

### DIFF
--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -7,9 +7,10 @@ import { linkInboundToActiveTurn } from "../daemon/turn-tracker.js";
 import { getDb } from "../db.js";
 import { getParticipants } from "../events/conversations.js";
 import { onMindEvent } from "../events/mind-activity-tracker.js";
+import { publish as publishMindEvent } from "../events/mind-events.js";
 import { findMind, getBaseName, mindDir, voluteHome } from "../mind/registry.js";
 import { readVoluteConfig } from "../mind/volute-config.js";
-import { channelGates, deliveryQueue } from "../schema.js";
+import { channelGates, deliveryQueue, mindHistory } from "../schema.js";
 import { type AvatarBlock, renderAvatarBlock } from "../util/avatar-image.js";
 import log from "../util/logger.js";
 import {
@@ -471,30 +472,50 @@ export class DeliveryManager {
       return;
     }
 
-    // Promote per-row so each carries its freshly-resolved session (bug 1 fix). Bounded
-    // to GATED_RELEASE_LIMIT_PER_CHANNEL per channel, so this loop is small.
+    // Record inbound history AND promote to pending atomically, oldest-first. Gated
+    // messages are never recorded on arrival (#420), so this is the sole "the mind received
+    // this" write — and the background redrive sweep reads `pending` rows independently, so
+    // the inbound row MUST be committed before the row becomes pending. One transaction per
+    // row makes that ordering crash-safe: a failure rolls back both, leaving the row `gated`
+    // (retried on the next release) rather than delivered-without-history or duplicated.
+    const orderedPromote = [...promote].sort((a, b) => a.id - b.id);
     try {
       const db = await getDb();
-      for (const p of promote) {
-        await db
-          .update(deliveryQueue)
-          .set({ status: "pending", session: p.session, attempts: 0, next_attempt_at: null })
-          .where(eq(deliveryQueue.id, p.id));
+      for (const p of orderedPromote) {
+        await db.transaction(async (tx) => {
+          await tx.insert(mindHistory).values({
+            mind: baseName,
+            type: "inbound",
+            channel: p.channel,
+            sender: p.sender,
+            content: p.content,
+          });
+          await tx
+            .update(deliveryQueue)
+            .set({ status: "pending", session: p.session, attempts: 0, next_attempt_at: null })
+            .where(eq(deliveryQueue.id, p.id));
+        });
       }
       dlog.info(`released ${promote.length} gated message(s) for ${baseName} after route change`);
     } catch (err) {
-      dlog.warn(`failed to promote gated rows for ${baseName}`, log.errorData(err));
+      // This is the ONLY recording point for gated traffic — a permanent failure here is a
+      // silent history gap, so surface it loudly with enough context to find the messages.
+      dlog.error(
+        `failed to record+promote gated rows for ${baseName} (channels: ${[...byChannel.keys()].join(", ")})`,
+        log.errorData(err),
+      );
       return;
     }
 
-    // Now that these messages are actually being delivered, record their inbound history —
-    // gated messages are never recorded on arrival (#420), so this is where the truthful
-    // "the mind received this" row is written. Oldest-first so history reads in order; the
-    // next turn's linkPendingInbound tags them to the turn they trigger. Recorded before
-    // redrive so the rows exist before the mind processes the delivery.
-    const { recordInbound } = await import("./message-delivery.js");
-    for (const p of [...promote].sort((a, b) => a.id - b.id)) {
-      await recordInbound(baseName, p.channel, p.sender, p.content);
+    // Publish the inbound events after commit so live streams reflect the released backlog.
+    for (const p of orderedPromote) {
+      publishMindEvent(baseName, {
+        mind: baseName,
+        type: "inbound",
+        channel: p.channel,
+        content: p.content ?? undefined,
+        sender: p.sender ?? undefined,
+      });
     }
 
     if (truncationNotes.length > 0) await this.sendReleaseSummary(mindName, truncationNotes);

--- a/test/gated-release.test.ts
+++ b/test/gated-release.test.ts
@@ -136,6 +136,38 @@ describe("gated-channel release (#537)", () => {
         "messages are archived (history preserved)",
       );
     });
+
+    it("renders the channel_invite prompt's platform/participant details block", async () => {
+      const name = createMind({ rules: [] });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      const invites: string[] = [];
+      manager.setNotifier(async (_mind, text) => {
+        if (text.includes("[New channel:")) invites.push(text);
+      });
+
+      // A gated message carrying platform + participantCount exercises the `details`
+      // branch of the getPrompt("channel_invite", …) rendering (#420 item 4).
+      await manager.routeAndDeliver(name, {
+        channel: "discord:general",
+        sender: "alice",
+        content: "hello",
+        platform: "discord",
+        participantCount: 3,
+      });
+
+      assert.equal(invites.length, 1, "one invite fired");
+      assert.ok(invites[0].includes("Platform: discord"), "renders the Platform line");
+      assert.ok(invites[0].includes("Participants: 3"), "renders the Participants line");
+      assert.ok(invites[0].includes("Preview: hello"), "still renders the preview after details");
+      // The decline hint (real command) must be present — pins the prompt to reality.
+      assert.ok(
+        invites[0].includes("volute chat channels decline discord:general"),
+        "renders the real decline command",
+      );
+    });
   });
 
   describe("declineChannel", () => {
@@ -220,6 +252,37 @@ describe("gated-channel release (#537)", () => {
       assert.equal(after.length, 1, "the released message is recorded as inbound exactly once");
       assert.equal(after[0].channel, "discord:general");
       assert.equal(after[0].content, "hello there");
+    });
+
+    it("a declined channel never produces an inbound row, even after a rule later matches (#420)", async () => {
+      const name = createMind({ rules: [] });
+      cleanup.push(name);
+      const m = makeManager();
+      manager = m.manager;
+
+      await manager.declineChannel(name, "discord:spam");
+      for (let i = 0; i < 3; i++) await gate(manager, name, "discord:spam", `spam ${i}`);
+
+      // Add a rule that WOULD match, then release. Declined channels are skipped, so the
+      // rows stay archived and no inbound history is ever written for them.
+      writeRoutes(name, {
+        rules: [{ channel: "discord:*", session: "inbox" }],
+        default: "main",
+      });
+      await manager.releaseGated(name);
+
+      const spamRows = (await rows(name)).filter((r) => r.channel === "discord:spam");
+      assert.equal(
+        spamRows.filter((r) => r.status === "pending").length,
+        0,
+        "declined channel is not promoted on release",
+      );
+      const db = await getDb();
+      const inbound = await db
+        .select()
+        .from(mindHistory)
+        .where(and(eq(mindHistory.mind, name), eq(mindHistory.type, "inbound")));
+      assert.equal(inbound.length, 0, "a declined channel writes no inbound history");
     });
 
     it("expands a $new route to a generated session on release, not the literal '$new'", async () => {

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -194,6 +194,26 @@ describe("deliverMessage flush recording", () => {
     assert.equal(rows.length, 0, "no inbound history row for a gated message");
   });
 
+  it("records an inbound when an explicit session bypasses gating (#420)", async () => {
+    await addMind(FLUSH_MIND, FLUSH_PORT);
+    // Gating is on and no rule matches #unrouted, but an explicit payload.session skips
+    // route matching entirely — the message is delivered, not gated, so it must be recorded.
+    writeRoutes(FLUSH_MIND, { gateUnmatched: true, rules: [] });
+    await deliverMessage(FLUSH_MIND, {
+      channel: "#unrouted",
+      sender: "alice",
+      content: "hi",
+      session: "main",
+    });
+
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, FLUSH_MIND), eq(mindHistory.type, "inbound")));
+    assert.equal(rows.length, 1, "an explicit-session message is recorded despite gating on");
+  });
+
   it("skips re-recording the inbound on the flush path (isFlush)", async () => {
     await addMind(FLUSH_MIND, FLUSH_PORT);
     const events: MindEvent[] = [];


### PR DESCRIPTION
## Why this exists

#636 was squash-merged **before** its final review-fix commit (`7be9e4b7`) landed on the PR branch, so main's #636 squash captured only the first commit. The follow-up — which addressed the HIGH finding from the review pass — was dropped. Confirmed: `git grep "db.transaction"` on `origin/main`'s `delivery-manager.ts` was empty. This PR restores exactly that dropped commit (cherry-picked; its parent content is already in main via the squash, so it applied cleanly).

## What was missing / what this restores

- **HIGH — atomic record-then-promote in `releaseGated` (the actual fix for the race #636 introduced).** Before this, `releaseGated` flipped a held row to `pending` and committed, *then* recorded its inbound history in a later loop. Because gated messages are no longer recorded on arrival, that release-time write is the **only** recording point — and the background `redriveTimer` reads `pending` rows independently. In the window between promote and record, the sweep can deliver a message before its history row exists (delivered-without-history; the turn's `linkPendingInbound` finds nothing to tag). The fix records the inbound row **and** promotes to `pending` in a single `db.transaction` per row, so the row is never `pending` before its history is committed, and a crash rolls back both (no orphan → no duplicate on the next release). SSE inbound events publish after commit.
- **MEDIUM — failure logging.** The release-path DB failure is now `log.error` with mind + channel context (it's the sole recording point for gated traffic; a permanent failure is a findable history gap).
- **Tests.** Declined channel writes zero inbound rows even after a later matching rule; the `channel_invite` prompt's Platform/Participants details block renders; explicit-session messages bypass gating and are still recorded.

Until this lands, main can deliver gated-then-released messages ahead of their history commit.

## Verification

Full pre-push suite: **2299 pass / 0 fail**. Cherry-pick applied with no conflicts; `db.transaction` verified present; typecheck clean. This content already passed the pr-review-toolkit pass on #636, so no new review pass.

Refs #420, #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)