### PR TITLE
fix: reconcile variant lifecycle and stop stranding orphaned state

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -277,6 +277,16 @@ export async function startDaemon(opts: {
   const orphanedTurns = await completeOrphanedTurns();
   summarizeOrphanedTurns(orphanedTurns);
 
+  // Reconcile variant rows against disk before starting anything: drop stale rows
+  // whose worktree is gone (e.g. legacy `name@variant` rows) and report orphaned
+  // `.variants/` dirs that have no row (#444).
+  try {
+    const { reconcileVariants } = await import("./lib/mind/variant-cleanup.js");
+    await reconcileVariants();
+  } catch (err) {
+    log.error("failed to reconcile variants", log.errorData(err));
+  }
+
   // Start all minds + variants that were previously running (parallel, concurrency limit of 5)
   // Skip sleeping minds — they only need connectors, not the mind process
   const allMinds = await readAllMinds();

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -2,9 +2,20 @@ import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { getDb } from "../db.js";
-import { minds } from "../schema.js";
+import {
+  activity,
+  channelGates,
+  conversations,
+  deliveryQueue,
+  mindHistory,
+  mindNotices,
+  minds,
+  summaries,
+  turns,
+  users,
+} from "../schema.js";
 
 export type MindType = "mind" | "spirit";
 
@@ -227,6 +238,59 @@ export async function addVariant(
 export async function removeMind(name: string) {
   const db = await getDb();
   await db.delete(minds).where(eq(minds.name, name));
+}
+
+/**
+ * Delete a mind's DB footprint outside the `minds` table: its user row (and,
+ * via FK cascade, its channel memberships, read cursors, and login sessions),
+ * the conversations it owns (cascading to their messages/channels/participants),
+ * and the free-text-keyed rows that have no FK cascade (turns, history, activity,
+ * summaries, notices, channel gates, delivery queue).
+ *
+ * Used when a variant is merged, deleted, or reconciled away — nothing else
+ * references a gone variant, so leaving these rows behind just strands state
+ * attributed to a mind that no longer exists (#444). Messages the mind sent into
+ * shared channels stay as history (they belong to the base channel, not the
+ * mind), but its membership in those channels is removed with the user row.
+ */
+export async function deleteMindDbFootprint(name: string): Promise<void> {
+  const db = await getDb();
+
+  // One transaction so cleanup is all-or-nothing — a partial purge would leave the
+  // exact stranded state this is meant to remove.
+  await db.transaction(async (tx) => {
+    // Genuinely keyed by this (variant) name:
+    // - the mind's user row and the conversations it owns (FK-cascade to their
+    //   messages/channels/participants/reads), and its login sessions.
+    // - activity: start/stop/active events are published under the raw name, so a
+    //   variant accumulates its own rows.
+    // - delivery_queue: `mind` is always the base name, but `target_mind` carries the
+    //   variant name for a message routed to the variant — drop those stranded rows.
+    const owner = await tx
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.username, name), eq(users.user_type, "mind")))
+      .get();
+    if (owner) {
+      await tx.delete(conversations).where(eq(conversations.user_id, owner.id));
+    }
+    await tx.delete(users).where(and(eq(users.username, name), eq(users.user_type, "mind")));
+    await tx.delete(activity).where(eq(activity.mind, name));
+    await tx
+      .delete(deliveryQueue)
+      .where(or(eq(deliveryQueue.mind, name), eq(deliveryQueue.target_mind, name)));
+
+    // Normally keyed by the BASE name: the delivery pipeline records these under
+    // getBaseName() (handleMindEvent/recordInbound), so a live variant produces no
+    // rows here and deleting by the variant name is a no-op for the base mind's data.
+    // Kept as a defensive sweep of legacy `name@variant` rows that older flows, which
+    // persisted under the delivered name, could have left behind.
+    await tx.delete(turns).where(eq(turns.mind, name));
+    await tx.delete(mindHistory).where(eq(mindHistory.mind, name));
+    await tx.delete(summaries).where(eq(summaries.mind, name));
+    await tx.delete(mindNotices).where(eq(mindNotices.mind, name));
+    await tx.delete(channelGates).where(eq(channelGates.mind, name));
+  });
 }
 
 export async function setMindRunning(name: string, running: boolean) {

--- a/packages/daemon/src/lib/mind/variant-cleanup.ts
+++ b/packages/daemon/src/lib/mind/variant-cleanup.ts
@@ -1,9 +1,10 @@
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { resolve } from "node:path";
 import { getMindManager } from "../daemon/mind-manager.js";
 import { gitExec } from "../util/exec.js";
 import log from "../util/logger.js";
 import { chownMindDir } from "./isolation.js";
-import { removeMind } from "./registry.js";
+import { deleteMindDbFootprint, mindDir, readAllMinds, removeMind } from "./registry.js";
 
 /**
  * Clean up a variant's git resources: stop process, remove worktree, delete branch,
@@ -57,6 +58,14 @@ export async function cleanupVariant(
     log.warn(`failed to remove variant ${variantName} from DB`, log.errorData(err));
   }
 
+  // Purge the variant's remaining DB footprint (user, owned conversations, and
+  // free-text-keyed rows) so nothing is left attributed to a gone variant (#444).
+  try {
+    await deleteMindDbFootprint(variantName);
+  } catch (err) {
+    log.warn(`failed to purge DB footprint for variant ${variantName}`, log.errorData(err));
+  }
+
   try {
     await chownMindDir(projectRoot, baseName);
   } catch (err) {
@@ -64,5 +73,60 @@ export async function cleanupVariant(
       `failed to fix ownership during variant cleanup for ${variantName}`,
       log.errorData(err),
     );
+  }
+}
+
+/**
+ * Reconcile variant rows against what's actually on disk (#444). Runs on daemon
+ * startup, before minds are started, to clean up state stranded by older flows:
+ *
+ * - A variant row whose worktree directory is gone (e.g. the legacy `whorl@upgrade`
+ *   row observed in production, whose `.variants/upgrade` dir and branch no longer
+ *   existed) is fully cleaned up — worktree/branch best-effort, row dropped, DB
+ *   footprint purged. Such names can predate today's validation, so this path uses
+ *   parameterized deletes rather than the branch-name-validating routes.
+ * - A `.variants/<name>` directory on disk with no registry row is reported (not
+ *   deleted — it may hold un-merged work), so an operator can investigate.
+ */
+export async function reconcileVariants(): Promise<void> {
+  const all = await readAllMinds();
+  const variants = all.filter((e) => e.parent);
+  const bases = all.filter((e) => !e.parent);
+  const baseDir = (name: string) => bases.find((b) => b.name === name)?.dir ?? mindDir(name);
+
+  for (const v of variants) {
+    if (v.dir && existsSync(v.dir)) continue;
+    log.warn(
+      `reconcile: dropping stale variant row ${v.name} (worktree ${v.dir ?? "<none>"} missing)`,
+    );
+    try {
+      await cleanupVariant(v.name, baseDir(v.parent!), v.dir ?? "");
+    } catch (err) {
+      log.warn(`reconcile: failed to drop stale variant ${v.name}`, log.errorData(err));
+    }
+  }
+
+  const knownDirs = new Set(variants.map((v) => v.dir).filter((d): d is string => Boolean(d)));
+  for (const base of bases) {
+    const variantsDir = resolve(base.dir ?? mindDir(base.name), ".variants");
+    if (!existsSync(variantsDir)) continue;
+    let entries: string[];
+    try {
+      entries = readdirSync(variantsDir);
+    } catch (err) {
+      log.warn(`reconcile: failed to read ${variantsDir}`, log.errorData(err));
+      continue;
+    }
+    for (const name of entries) {
+      const full = resolve(variantsDir, name);
+      if (knownDirs.has(full)) continue;
+      try {
+        if (statSync(full).isDirectory()) {
+          log.warn(`reconcile: orphaned variant worktree on disk with no registry row: ${full}`);
+        }
+      } catch {
+        // Entry vanished between readdir and stat — nothing to report.
+      }
+    }
   }
 }

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -98,8 +98,36 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: `Failed to create worktree: ${msg}` }, 500);
     }
 
-    // Fix ownership before npm install so it runs as the mind user
-    await chownMindDir(projectRoot, mindName);
+    // Everything after the worktree is created is rolled back on failure so a
+    // retry with the same name isn't blocked by a half-created variant (#444).
+    const rollbackSplit = async () => {
+      try {
+        await cleanupVariant(variantName, projectRoot, variantDir, { stop: true });
+      } catch (err) {
+        log.warn(`failed to roll back split of ${variantName}`, log.errorData(err));
+      }
+      // cleanupVariant hands ownership to the variant's base name, which before DB
+      // registration resolves to the variant itself — restore it to the parent mind.
+      try {
+        await chownMindDir(projectRoot, mindName);
+      } catch (err) {
+        log.warn(
+          `failed to restore ${mindName} ownership after split rollback`,
+          log.errorData(err),
+        );
+      }
+    };
+
+    // Fix ownership before npm install so it runs as the mind user. This is the
+    // first step past worktree creation, so a throw here (chownMindDir re-throws
+    // under isolation) must also roll back or it strands the worktree+branch.
+    try {
+      await chownMindDir(projectRoot, mindName);
+    } catch (e: unknown) {
+      await rollbackSplit();
+      const msg = e instanceof Error ? e.message : String(e);
+      return c.json({ error: `Failed to prepare variant ownership: ${msg}` }, 500);
+    }
 
     // Install dependencies
     try {
@@ -113,6 +141,7 @@ const app = new Hono<AuthEnv>()
         await exec("npm", ["install"], { cwd: variantDir });
       }
     } catch (e: unknown) {
+      await rollbackSplit();
       const msg = e instanceof Error ? e.message : String(e);
       return c.json({ error: `npm install failed: ${msg}` }, 500);
     }
@@ -125,7 +154,13 @@ const app = new Hono<AuthEnv>()
     const variantPort = body.port ?? (await nextPort());
 
     // Register variant in DB
-    await addVariant(variantName, mindName, variantPort, variantDir, variantName);
+    try {
+      await addVariant(variantName, mindName, variantPort, variantDir, variantName);
+    } catch (e: unknown) {
+      await rollbackSplit();
+      const msg = e instanceof Error ? e.message : String(e);
+      return c.json({ error: `Failed to register variant: ${msg}` }, 500);
+    }
 
     // Start variant via mind manager unless noStart. The pending context becomes the
     // variant's first message — orientation about who it is and where it came from.
@@ -135,6 +170,7 @@ const app = new Hono<AuthEnv>()
         manager.setPendingContext(variantName, { type: "split", parent: mindName });
         await manager.startMind(variantName);
       } catch (e: unknown) {
+        await rollbackSplit();
         const msg = e instanceof Error ? e.message : String(e);
         return c.json({ error: `Variant created but failed to start: ${msg}` }, 500);
       }

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -692,6 +692,51 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-conflict-var`, { method: "DELETE" });
   });
 
+  it("variants: a failed split rolls back its worktree/branch and frees the name", {
+    timeout: 300000,
+  }, async () => {
+    await ensureTestMind();
+    const parentDir = mindDir(TEST_MIND);
+    const parent = await findMind(TEST_MIND);
+    assert.ok(parent, "test mind should be registered");
+
+    // Force a failure AFTER the worktree + npm install: registering the variant with
+    // the parent's already-used port trips the unique-port constraint (addVariant's
+    // upsert only reconciles the name), so the handler must roll back.
+    const branch = "e2e-rollback-var";
+    const variantPath = resolve(parentDir, ".variants", branch);
+    const failRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: branch, port: parent.port, noStart: true }),
+    });
+    assert.equal(failRes.status, 500, `Split should fail: ${await failRes.clone().text()}`);
+    const failBody = (await failRes.json()) as { error: string };
+    assert.match(failBody.error, /register variant/i);
+
+    // Rollback removed the worktree, deleted the branch, and left no registry row —
+    // so the name is free to retry.
+    assert.ok(!existsSync(variantPath), "worktree should be rolled back");
+    assert.ok(!(await findMind(branch)), "no registry row should remain");
+    const branchList = execFileSync("git", ["branch", "--list", branch], {
+      cwd: parentDir,
+      encoding: "utf-8",
+    }).trim();
+    assert.equal(branchList, "", `branch should be deleted, got: ${branchList}`);
+
+    // A retry with the same name now succeeds.
+    const retryRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: branch, noStart: true }),
+    });
+    assert.equal(retryRes.status, 200, `Retry split: ${await retryRes.clone().text()}`);
+    assert.ok(existsSync(variantPath), "retry should recreate the worktree");
+    assert.ok(await findMind(branch), "retry should register the variant");
+
+    await daemonRequest(`/api/minds/${TEST_MIND}/variants/${branch}`, { method: "DELETE" });
+  });
+
   // ── Bridge & Chat Integration Tests ──
 
   /** Ensure the test mind exists in the registry (creates via API if not). */

--- a/test/variant-cleanup.test.ts
+++ b/test/variant-cleanup.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  addMind,
+  addVariant,
+  deleteMindDbFootprint,
+  findMind,
+  removeMind,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import { reconcileVariants } from "../packages/daemon/src/lib/mind/variant-cleanup.js";
+import {
+  activity,
+  channelGates,
+  channels,
+  conversationParticipants,
+  conversations,
+  deliveryQueue,
+  messages,
+  mindHistory,
+  mindNotices,
+  minds,
+  summaries,
+  turns,
+  users,
+} from "../packages/daemon/src/lib/schema.js";
+import log from "../packages/daemon/src/lib/util/logger.js";
+
+const base = `cleanup-base-${Date.now()}`;
+const variant = `${base}-v`;
+
+async function mindUserId(name: string): Promise<number | undefined> {
+  const db = await getDb();
+  const row = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(and(eq(users.username, name), eq(users.user_type, "mind")))
+    .get();
+  return row?.id;
+}
+
+/** Insert the footprint genuinely keyed by a variant's own name. */
+async function seedVariantFootprint(): Promise<number> {
+  const db = await getDb();
+  const [user] = await db
+    .insert(users)
+    .values({ username: variant, password_hash: "!mind", role: "user", user_type: "mind" })
+    .returning({ id: users.id });
+
+  const convId = `conv-${variant}`;
+  await db.insert(conversations).values({ id: convId, type: "dm", user_id: user.id });
+  await db.insert(channels).values({ conversation_id: convId, name: variant });
+  await db.insert(messages).values({ conversation_id: convId, role: "user", content: "hi" });
+  await db.insert(conversationParticipants).values({ conversation_id: convId, user_id: user.id });
+
+  // Start/stop activity is published under the raw name — genuinely variant-keyed.
+  await db.insert(activity).values({ type: "mind_started", mind: variant, summary: "s" });
+  // delivery_queue keys `mind` by the base name and `target_mind` by the variant.
+  await db
+    .insert(deliveryQueue)
+    .values({ mind: base, target_mind: variant, session: "main", payload: "{}" });
+  return user.id;
+}
+
+/** Insert rows the delivery pipeline keys by the BASE name (never the variant). */
+async function seedBaseKeyed(): Promise<void> {
+  const db = await getDb();
+  await db.insert(turns).values({ id: `turn-${base}`, mind: base });
+  await db.insert(mindHistory).values({ mind: base, type: "inbound", content: "x" });
+  await db
+    .insert(summaries)
+    .values({ mind: base, period: "day", period_key: "2026-07-11", content: "c" });
+  await db
+    .insert(mindNotices)
+    .values({ mind: base, session: "main", kind: "crash", reason: "unknown", detail: "d" });
+  await db.insert(channelGates).values({ mind: base, channel: "#x", state: "declined" });
+}
+
+describe("deleteMindDbFootprint", () => {
+  afterEach(async () => {
+    const db = await getDb();
+    await deleteMindDbFootprint(variant).catch(() => {});
+    await db.delete(conversations).where(eq(conversations.id, `conv-${variant}`));
+    await db.delete(conversations).where(eq(conversations.id, `shared-${base}`));
+    await db.delete(turns).where(eq(turns.mind, base));
+    await db.delete(mindHistory).where(eq(mindHistory.mind, base));
+    await db.delete(summaries).where(eq(summaries.mind, base));
+    await db.delete(mindNotices).where(eq(mindNotices.mind, base));
+    await db.delete(channelGates).where(eq(channelGates.mind, base));
+    await db.delete(activity).where(eq(activity.mind, base));
+    await db.delete(deliveryQueue).where(eq(deliveryQueue.mind, base));
+    await db.delete(users).where(eq(users.username, `owner-${base}`));
+    await removeMind(base).catch(() => {});
+  });
+
+  it("purges the variant's user, owned conversations, activity, and targeted deliveries", async () => {
+    const userId = await seedVariantFootprint();
+
+    await deleteMindDbFootprint(variant);
+
+    const db = await getDb();
+    assert.equal(await mindUserId(variant), undefined, "variant user gone");
+    assert.equal(
+      (await db.select().from(conversations).where(eq(conversations.user_id, userId))).length,
+      0,
+      "owned conversation gone",
+    );
+    assert.equal(
+      (
+        await db
+          .select()
+          .from(messages)
+          .where(eq(messages.conversation_id, `conv-${variant}`))
+      ).length,
+      0,
+      "owned messages gone (cascade)",
+    );
+    assert.equal(
+      (await db.select().from(activity).where(eq(activity.mind, variant))).length,
+      0,
+      "variant activity gone",
+    );
+    assert.equal(
+      (await db.select().from(deliveryQueue).where(eq(deliveryQueue.target_mind, variant))).length,
+      0,
+      "variant-targeted delivery gone",
+    );
+  });
+
+  it("leaves the base mind's base-keyed rows and shared-channel history untouched", async () => {
+    const db = await getDb();
+    const variantUserId = await seedVariantFootprint();
+    await seedBaseKeyed();
+
+    // A shared channel owned by another user, holding a message the variant sent and a
+    // participant row for the variant. The message must survive (it belongs to the
+    // channel); the variant's membership goes with its user row.
+    const [owner] = await db
+      .insert(users)
+      .values({ username: `owner-${base}`, password_hash: "!x", role: "user", user_type: "brain" })
+      .returning({ id: users.id });
+    const sharedId = `shared-${base}`;
+    await db.insert(conversations).values({ id: sharedId, type: "channel", user_id: owner.id });
+    await db.insert(channels).values({ conversation_id: sharedId, name: `shared-${base}` });
+    await db.insert(messages).values({
+      conversation_id: sharedId,
+      role: "assistant",
+      sender_name: variant,
+      content: "yo",
+    });
+    await db
+      .insert(conversationParticipants)
+      .values({ conversation_id: sharedId, user_id: variantUserId });
+
+    await deleteMindDbFootprint(variant);
+
+    // Base-keyed rows survive.
+    assert.equal((await db.select().from(turns).where(eq(turns.mind, base))).length, 1);
+    assert.equal((await db.select().from(mindHistory).where(eq(mindHistory.mind, base))).length, 1);
+    assert.equal((await db.select().from(summaries).where(eq(summaries.mind, base))).length, 1);
+    assert.equal((await db.select().from(mindNotices).where(eq(mindNotices.mind, base))).length, 1);
+    assert.equal(
+      (await db.select().from(channelGates).where(eq(channelGates.mind, base))).length,
+      1,
+    );
+
+    // Shared channel + the variant's message survive; its membership does not.
+    assert.equal(
+      (await db.select().from(conversations).where(eq(conversations.id, sharedId))).length,
+      1,
+      "shared conversation survives",
+    );
+    assert.equal(
+      (await db.select().from(messages).where(eq(messages.conversation_id, sharedId))).length,
+      1,
+      "variant's shared-channel message survives as history",
+    );
+    assert.equal(
+      (
+        await db
+          .select()
+          .from(conversationParticipants)
+          .where(eq(conversationParticipants.user_id, variantUserId))
+      ).length,
+      0,
+      "variant membership removed with its user row",
+    );
+  });
+});
+
+describe("reconcileVariants", () => {
+  const tmpDirs: string[] = [];
+  afterEach(async () => {
+    const db = await getDb();
+    await db.delete(minds).where(eq(minds.parent, base));
+    await removeMind(`${base}@legacy`).catch(() => {});
+    await removeMind(base).catch(() => {});
+    for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("drops a variant row whose worktree directory is gone", async () => {
+    await addMind(base, 4300);
+    await addVariant(variant, base, 4301, "/does/not/exist/gone", variant);
+
+    await reconcileVariants();
+
+    assert.equal(await findMind(variant), undefined);
+  });
+
+  it("keeps a variant whose worktree still exists", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "variant-live-"));
+    tmpDirs.push(dir);
+    await addMind(base, 4300);
+    await addVariant(variant, base, 4301, dir, variant);
+
+    await reconcileVariants();
+
+    assert.ok(await findMind(variant), "live variant should be kept");
+  });
+
+  it("drops a legacy row whose name predates current validation (e.g. name@variant)", async () => {
+    // addVariant would reject the `@`; insert the row directly like the old flow left it.
+    const db = await getDb();
+    await addMind(base, 4300);
+    await db
+      .insert(minds)
+      .values({ name: `${base}@legacy`, port: 4302, parent: base, dir: "/gone/legacy" });
+
+    await reconcileVariants();
+
+    assert.equal(await findMind(`${base}@legacy`), undefined);
+  });
+
+  it("reports an orphaned .variants dir with no registry row without deleting it", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "variant-orphan-"));
+    tmpDirs.push(dir);
+    const orphan = resolve(dir, ".variants", "orphan");
+    mkdirSync(orphan, { recursive: true });
+    const db = await getDb();
+    // Base mind row must carry a real dir so reconcile scans its .variants/.
+    await db.insert(minds).values({ name: base, port: 4300, dir });
+
+    const warnings: string[] = [];
+    const origWarn = log.warn;
+    (log as { warn: typeof log.warn }).warn = (msg: string) => {
+      warnings.push(msg);
+    };
+    try {
+      await reconcileVariants();
+    } finally {
+      (log as { warn: typeof log.warn }).warn = origWarn;
+    }
+
+    assert.ok(existsSync(orphan), "orphan dir must not be deleted");
+    assert.ok(
+      warnings.some((w) => w.includes(orphan)),
+      "reconcile should report the orphaned worktree",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Several variant lifecycle paths stranded state that nothing ever cleaned up (#444):

1. **Split had no rollback.** If ownership setup, `npm install`, DB registration, or `startMind` failed after the git worktree was created, the handler returned 500 but the worktree, branch, and (sometimes) the registry row already existed. Retrying the same name then hit the 409 guards ("Name already in use" / "directory already exists"), forcing manual cleanup.
2. **Join/delete orphaned the variant's DB footprint.** `cleanupVariant` deleted only the `minds` row. The variant's `users` row and the conversations it owned remained forever, attributed to a mind that no longer existed.
3. **Stale rows survived from older flows.** Live evidence on bardo: a `whorl@upgrade` row (legacy `name@variant` naming) still pointed at a `.variants/upgrade` directory and branch that no longer existed. Its `@` name wouldn't even pass today's validation, so the normal routes couldn't operate on it.

## Fixes

- **Split rollback** (`web/api/variants.ts`): every step after the worktree is created — ownership setup (which re-throws under user isolation), npm install, DB registration, and start — now rolls back with a best-effort `cleanupVariant` before returning the error, then restores parent-mind ownership of the project root (`cleanupVariant` chowns to the variant's base name, which before DB registration resolves to the variant itself). A retry with the same name now succeeds.
- **DB footprint purge** (`mind/registry.ts` `deleteMindDbFootprint`, called from `cleanupVariant`): removes, in a single transaction, the variant's `users` row (cascading to its channel memberships, read cursors, and sessions), the conversations it owns (cascading to their messages/channels/participants), its `activity` rows, and any `delivery_queue` rows targeted at it. Turns/history/summaries/notices/channel-gates are keyed by the **base** name in the delivery pipeline (`handleMindEvent`/`recordInbound` normalize via `getBaseName`), so purging by the variant name never touches base-mind data; those deletes are kept as an explicitly-documented defensive sweep of legacy `name@variant` rows. Messages the variant sent into shared channels stay as history (they belong to the base channel) while its membership is removed.
- **Startup reconciliation sweep** (`mind/variant-cleanup.ts` `reconcileVariants`, wired into `daemon.ts` before minds start): drops variant rows whose worktree directory is gone — including legacy `name@variant` rows, via parameterized deletes that don't depend on branch-name validation — and reports `.variants/<name>` directories on disk that have no registry row (reported, not deleted, since they may hold un-merged work).

Parent-mind delete already looped variants through `cleanupVariant`, so their worktrees/branches were removed; that path now also purges each variant's DB footprint via the same helper.

## Tests

`test/variant-cleanup.test.ts` (unit):
- `deleteMindDbFootprint` purges the variant-keyed footprint (user, owned conversations + cascades, activity, targeted deliveries) and — seeding rows with production keying — asserts the base mind's base-keyed rows and a shared-channel message the variant sent both survive, while the variant's membership is removed.
- `reconcileVariants` drops a variant whose worktree is gone, keeps one whose worktree exists, drops a directly-inserted legacy `name@legacy` row, and reports (without deleting) an orphaned `.variants/` dir.

`test/daemon-e2e.test.ts`: a failed split (forced via a unique-port collision at registration, after worktree + npm install) rolls back the worktree and branch, leaves no registry row, and frees the name for a retry that succeeds.

Full `npm test`, `npm run test:e2e`, and `tsc --noEmit` pass.

Fixes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
