### PR TITLE
feat: variant purpose at split time + auto-created parent↔variant DM

### DIFF
--- a/drizzle/0013_variant_purpose.sql
+++ b/drizzle/0013_variant_purpose.sql
@@ -1,0 +1,3 @@
+-- Purpose/intent captured at split time, recorded on the variant's row so it can
+-- orient the variant, feed the variant list UI, and default the join message.
+ALTER TABLE `minds` ADD `purpose` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1775700000000,
       "tag": "0012_channel_gates",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1775800000000,
+      "tag": "0013_variant_purpose",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cli/src/commands/split.ts
+++ b/packages/cli/src/commands/split.ts
@@ -8,6 +8,7 @@ const cmd = command({
   flags: {
     from: { type: "string", description: "Parent mind to split from" },
     soul: { type: "string", description: "Custom SOUL.md content" },
+    purpose: { type: "string", description: "Why this variant exists — what it's exploring" },
     port: { type: "number", description: "Port for variant server" },
     "no-start": { type: "boolean", description: "Don't start the variant" },
     json: { type: "boolean", description: "Output JSON result" },
@@ -15,7 +16,7 @@ const cmd = command({
   run: async ({ args, flags }) => {
     const mindName = resolveMindName({ mind: flags.from });
     const variantName = args.name!;
-    const { soul, port, json } = flags;
+    const { soul, purpose, port, json } = flags;
     const noStart = flags["no-start"];
 
     if (!json) console.log("Creating variant via daemon...");
@@ -32,6 +33,7 @@ const cmd = command({
         body: JSON.stringify({
           name: variantName,
           ...(soul && { soul }),
+          ...(purpose && { purpose }),
           ...(port && { port }),
           ...(noStart && { noStart }),
         }),
@@ -41,7 +43,7 @@ const cmd = command({
     const data = (await res.json()) as {
       ok?: boolean;
       error?: string;
-      variant?: { name: string; branch: string; path: string; port: number };
+      variant?: { name: string; branch: string; path: string; port: number; purpose?: string };
     };
 
     if (!res.ok) {
@@ -56,6 +58,7 @@ const cmd = command({
       console.log(`  Branch: ${data.variant?.branch}`);
       console.log(`  Path:   ${data.variant?.path}`);
       console.log(`  Port:   ${data.variant?.port}`);
+      if (data.variant?.purpose) console.log(`  Purpose: ${data.variant.purpose}`);
     }
   },
 });

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -112,6 +112,35 @@ function mindPidPath(name: string): string {
   return resolve(stateDir(name), "mind.pid");
 }
 
+/**
+ * Build the system message delivered to a mind for a pending context: the merge/split/
+ * sprout/upgrade/restart notice plus any changes/justification/memory the caller attached.
+ * For a split, the variant's purpose (when set) is appended so it learns why it exists.
+ * Pure and exported so the message shape is testable without spawning a mind.
+ */
+export async function buildPendingContextMessage(
+  name: string,
+  context: Record<string, unknown>,
+): Promise<string> {
+  const parts: string[] = [];
+  if (context.type === "merge" || context.type === "merged") {
+    parts.push(await getPrompt("merge_message", { name: String(context.name ?? "") }));
+  } else if (context.type === "split") {
+    parts.push(await getPrompt("split_message", { name, parent: String(context.parent ?? "") }));
+    if (context.purpose) parts.push(`Why you were split off: ${String(context.purpose)}`);
+  } else if (context.type === "sprouted") {
+    parts.push(await getPrompt("sprout_message"));
+  } else if (context.type === "upgraded") {
+    parts.push(await getPrompt("upgrade_message"));
+  } else {
+    parts.push(await getPrompt("restart_message"));
+  }
+  if (context.summary) parts.push(`Changes: ${context.summary}`);
+  if (context.justification) parts.push(`Why: ${context.justification}`);
+  if (context.memory) parts.push(`Context: ${context.memory}`);
+  return parts.join("\n");
+}
+
 export class MindManager {
   private minds = new Map<string, TrackedMind>();
   private stopping = new Set<string>();
@@ -548,23 +577,7 @@ export class MindManager {
 
     this.pendingContext.delete(name);
 
-    const parts: string[] = [];
-    if (context.type === "merge" || context.type === "merged") {
-      parts.push(await getPrompt("merge_message", { name: String(context.name ?? "") }));
-    } else if (context.type === "split") {
-      parts.push(await getPrompt("split_message", { name, parent: String(context.parent ?? "") }));
-    } else if (context.type === "sprouted") {
-      parts.push(await getPrompt("sprout_message"));
-    } else if (context.type === "upgraded") {
-      parts.push(await getPrompt("upgrade_message"));
-    } else {
-      parts.push(await getPrompt("restart_message"));
-    }
-    if (context.summary) parts.push(`Changes: ${context.summary}`);
-    if (context.justification) parts.push(`Why: ${context.justification}`);
-    if (context.memory) parts.push(`Context: ${context.memory}`);
-
-    const content = parts.join("\n");
+    const content = await buildPendingContextMessage(name, context);
 
     // Persist to system DM conversation and deliver directly to mind
     let conversationId: string | undefined;

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -42,6 +42,8 @@ export type MindEntry = {
   parent?: string;
   dir?: string;
   branch?: string;
+  /** Why a variant was split off — set at split time, orients the variant and the UI. */
+  purpose?: string;
   mindType: MindType;
   createdBy?: string;
 };
@@ -95,6 +97,7 @@ type RawMindRow = {
   dir: string | null;
   branch: string | null;
   stage: string | null;
+  purpose: string | null;
   template: string | null;
   template_hash: string | null;
   running: number;
@@ -115,6 +118,7 @@ function rowToEntry(row: RawMindRow): MindEntry {
     parent: row.parent ?? undefined,
     dir: row.dir ?? undefined,
     branch: row.branch ?? undefined,
+    purpose: row.purpose ?? undefined,
     mindType: (row.mind_type as MindType) ?? "mind",
     createdBy: row.created_by ?? undefined,
   };
@@ -225,14 +229,21 @@ export async function addVariant(
   port: number,
   dir: string,
   branch: string,
+  purpose?: string,
 ) {
   const err = validateMindName(name);
   if (err) throw new Error(err);
   const db = await getDb();
-  await db.insert(minds).values({ name, port, parent, dir, branch }).onConflictDoUpdate({
-    target: minds.name,
-    set: { port, parent, dir, branch },
-  });
+  // On name conflict every field is overwritten, so an omitted purpose resets it to
+  // null. The split route pre-checks name uniqueness (409), so in practice this update
+  // path is only hit re-registering the same variant, where clobbering is intended.
+  await db
+    .insert(minds)
+    .values({ name, port, parent, dir, branch, purpose: purpose ?? null })
+    .onConflictDoUpdate({
+      target: minds.name,
+      set: { port, parent, dir, branch, purpose: purpose ?? null },
+    });
 }
 
 export async function removeMind(name: string) {

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -17,6 +17,7 @@ export const minds = sqliteTable(
     dir: text("dir"),
     branch: text("branch"),
     stage: text("stage"),
+    purpose: text("purpose"),
     template: text("template"),
     template_hash: text("template_hash"),
     running: integer("running").notNull().default(0),

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -1,7 +1,10 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { Hono } from "hono";
+import { getOrCreateMindUser } from "../../lib/auth.js";
+import { sendSystemMessage } from "../../lib/chat/system-chat.js";
 import { getMindManager } from "../../lib/daemon/mind-manager.js";
+import { createConversation, findDMConversation } from "../../lib/events/conversations.js";
 import { chownMindDir, isIsolationEnabled, wrapForIsolation } from "../../lib/mind/isolation.js";
 import {
   addVariant,
@@ -19,6 +22,35 @@ import { exec, gitExec } from "../../lib/util/exec.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
 import { type AuthEnv, requireSelf } from "../middleware/auth.js";
+
+/**
+ * Establish the parent↔variant relationship as a conversation, not just plumbing:
+ * open a DM between the two mind identities so they have a thread to talk in while
+ * the variant lives, and notify the running parent that it now has a variant to
+ * check in on (with the purpose, if one was given). The variant learns why it
+ * exists from its own split birth-context message.
+ */
+export async function establishVariantDialogue(
+  parent: string,
+  variant: string,
+  purpose?: string,
+): Promise<void> {
+  const parentUser = await getOrCreateMindUser(parent);
+  const variantUser = await getOrCreateMindUser(variant);
+
+  const existing = await findDMConversation([parentUser.id, variantUser.id]);
+  if (!existing) {
+    await createConversation({ participantIds: [parentUser.id, variantUser.id] });
+  }
+
+  const purposeLine = purpose ? ` Its purpose: ${purpose}.` : "";
+  await sendSystemMessage(
+    parent,
+    `You've split off a variant, ${variant} — a parallel version of you exploring on its own.${purposeLine} ` +
+      `Reach it at @${variant} to check in on how the experiment is going, and merge its work back with ` +
+      `\`volute mind join ${variant}\` when you're ready.`,
+  );
+}
 
 const app = new Hono<AuthEnv>()
   .get("/:name/variants", async (c) => {
@@ -63,7 +95,7 @@ const app = new Hono<AuthEnv>()
         403,
       );
 
-    let body: { name: string; soul?: string; port?: number; noStart?: boolean };
+    let body: { name: string; soul?: string; port?: number; noStart?: boolean; purpose?: string };
     try {
       body = await c.req.json();
     } catch {
@@ -72,6 +104,8 @@ const app = new Hono<AuthEnv>()
 
     const variantName = body.name;
     if (!variantName) return c.json({ error: "Variant name required" }, 400);
+
+    const purpose = body.purpose?.trim() || undefined;
 
     const err = validateBranchName(variantName);
     if (err) return c.json({ error: err }, 400);
@@ -169,19 +203,24 @@ const app = new Hono<AuthEnv>()
 
     // Register variant in DB
     try {
-      await addVariant(variantName, mindName, variantPort, variantDir, variantName);
+      await addVariant(variantName, mindName, variantPort, variantDir, variantName, purpose);
     } catch (e: unknown) {
       await rollbackSplit();
       const msg = e instanceof Error ? e.message : String(e);
       return c.json({ error: `Failed to register variant: ${msg}` }, 500);
     }
 
-    // Start variant via mind manager unless noStart. The pending context becomes the
-    // variant's first message — orientation about who it is and where it came from.
+    // Queue the variant's birth context now, independent of --no-start: it's the
+    // variant's first message — who it is, where it came from, and why it was split
+    // off — and deliverPendingContext fires on whatever first start happens, so a
+    // variant started manually later still gets oriented. (pendingContext is an
+    // in-memory map, so a daemon restart before that start drops this transient
+    // orientation — acceptable; the variant just starts without the birth message.)
+    const manager = getMindManager();
+    manager.setPendingContext(variantName, { type: "split", parent: mindName, purpose });
+
     if (!body.noStart) {
       try {
-        const manager = getMindManager();
-        manager.setPendingContext(variantName, { type: "split", parent: mindName });
         await manager.startMind(variantName);
       } catch (e: unknown) {
         await rollbackSplit();
@@ -190,9 +229,25 @@ const app = new Hono<AuthEnv>()
       }
     }
 
+    // The split has now cleared every rollback point. Establish the parent↔variant
+    // relationship as a conversation: open a DM the two can talk in during the
+    // variant's life, and tell the parent it has a variant to check in on. Placed
+    // after the last rollback so a failed split never strands a DM or a stale notice.
+    // Best-effort, but logged at error level — a silent failure means the dialogue
+    // this feature exists for never happens.
+    await establishVariantDialogue(mindName, variantName, purpose).catch((e: unknown) =>
+      log.error(`failed to establish variant dialogue for ${variantName}`, log.errorData(e)),
+    );
+
     return c.json({
       ok: true,
-      variant: { name: variantName, branch: variantName, path: variantDir, port: variantPort },
+      variant: {
+        name: variantName,
+        branch: variantName,
+        path: variantDir,
+        port: variantPort,
+        ...(purpose && { purpose }),
+      },
     });
   })
   // Merge variant — admin only
@@ -392,11 +447,15 @@ const app = new Hono<AuthEnv>()
 
       // Restart mind via mind manager with merge context
       const manager = getMindManager();
+      // Fall back to the purpose captured at split so the parent's merge message can
+      // recall why the variant existed even when no justification is passed at join.
+      // Normalize like the split path so an explicit "" (or whitespace) still falls back.
+      const justification = body.justification?.trim() || variantEntry.purpose;
       const context = {
         type: "merged",
         name: variantName,
         ...(body.summary && { summary: body.summary }),
-        ...(body.justification && { justification: body.justification }),
+        ...(justification && { justification }),
         ...(body.memory && { memory: body.memory }),
       };
 

--- a/test/pending-context-message.test.ts
+++ b/test/pending-context-message.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildPendingContextMessage } from "../packages/daemon/src/lib/daemon/mind-manager.js";
+
+describe("buildPendingContextMessage", () => {
+  it("orients a split variant with its identity, parent, and purpose", async () => {
+    const msg = await buildPendingContextMessage("atlas-exp", {
+      type: "split",
+      parent: "atlas",
+      purpose: "test a drier journaling voice",
+    });
+    assert.ok(msg.includes("atlas-exp"), "names the variant");
+    assert.ok(msg.includes("atlas"), "names the parent");
+    assert.ok(
+      msg.includes("Why you were split off: test a drier journaling voice"),
+      "includes the purpose line",
+    );
+  });
+
+  it("omits the purpose line for a split with no purpose", async () => {
+    const msg = await buildPendingContextMessage("atlas-exp", {
+      type: "split",
+      parent: "atlas",
+    });
+    assert.ok(msg.includes("atlas-exp"));
+    assert.ok(!msg.includes("Why you were split off:"), "no purpose line when none given");
+  });
+
+  it("includes changes / justification / memory for a merge", async () => {
+    const msg = await buildPendingContextMessage("atlas", {
+      type: "merged",
+      name: "atlas-exp",
+      summary: "reworked the journal voice",
+      justification: "the drier voice felt truer",
+      memory: "keep the shorter entries",
+    });
+    assert.ok(msg.includes("Changes: reworked the journal voice"));
+    assert.ok(msg.includes("Why: the drier voice felt truer"));
+    assert.ok(msg.includes("Context: keep the shorter entries"));
+  });
+});

--- a/test/variant-dialogue.test.ts
+++ b/test/variant-dialogue.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq, inArray } from "drizzle-orm";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { ensureSystemDM, resetSystemDMCache } from "../packages/daemon/src/lib/chat/system-chat.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  findDMConversation,
+  getParticipants,
+} from "../packages/daemon/src/lib/events/conversations.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import { conversationParticipants, messages, users } from "../packages/daemon/src/lib/schema.js";
+import { establishVariantDialogue } from "../packages/daemon/src/web/api/variants.js";
+
+const PARENT = `dv-parent-${Date.now()}`;
+const VARIANT = `${PARENT}-exp`;
+const USERNAMES = [PARENT, VARIANT, "volute"];
+
+/** The message the parent received in its system DM announcing the variant. */
+async function parentNotice(): Promise<string | undefined> {
+  const { conversationId } = await ensureSystemDM(PARENT);
+  const db = await getDb();
+  const msgs = await db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversation_id, conversationId))
+    .all();
+  return msgs.map((m) => m.content).find((c) => c.includes(VARIANT));
+}
+
+async function cleanup() {
+  resetSystemDMCache();
+  const db = await getDb();
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(inArray(users.username, USERNAMES));
+  const ids = rows.map((r) => r.id);
+  if (ids.length) {
+    await db.delete(conversationParticipants).where(inArray(conversationParticipants.user_id, ids));
+  }
+  await db.delete(users).where(inArray(users.username, USERNAMES));
+  try {
+    await removeMind(VARIANT);
+  } catch {}
+  try {
+    await removeMind(PARENT);
+  } catch {}
+}
+
+describe("establishVariantDialogue", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("opens a parent↔variant DM and notifies the parent with the purpose", async () => {
+    await addMind(PARENT, 4310);
+
+    await establishVariantDialogue(PARENT, VARIANT, "test a drier journaling voice");
+
+    // A DM exists between the two mind identities.
+    const parentUser = await getOrCreateMindUser(PARENT);
+    const variantUser = await getOrCreateMindUser(VARIANT);
+    const dmId = await findDMConversation([parentUser.id, variantUser.id]);
+    assert.ok(dmId, "a parent↔variant DM should be created");
+
+    const partIds = (await getParticipants(dmId!)).map((p) => p.userId).sort();
+    assert.deepEqual(partIds, [parentUser.id, variantUser.id].sort());
+
+    // The parent is told it has a variant, with the purpose, via its own system DM.
+    const notice = await parentNotice();
+    assert.ok(notice, "parent should be notified about the variant");
+    assert.ok(
+      notice!.includes("test a drier journaling voice"),
+      "notification should include the purpose",
+    );
+  });
+
+  it("omits the purpose line when none is given", async () => {
+    await addMind(PARENT, 4310);
+
+    await establishVariantDialogue(PARENT, VARIANT);
+
+    const parentUser = await getOrCreateMindUser(PARENT);
+    const variantUser = await getOrCreateMindUser(VARIANT);
+    const dmId = await findDMConversation([parentUser.id, variantUser.id]);
+    assert.ok(dmId, "a parent↔variant DM should be created even without a purpose");
+
+    const notice = await parentNotice();
+    assert.ok(notice, "parent should still be notified about the variant");
+    assert.ok(!notice!.includes("Its purpose:"), "no purpose line without a purpose");
+  });
+
+  it("is idempotent — a second call reuses the same DM", async () => {
+    await addMind(PARENT, 4310);
+
+    await establishVariantDialogue(PARENT, VARIANT, "explore");
+    await establishVariantDialogue(PARENT, VARIANT, "explore");
+
+    const variantUser = await getOrCreateMindUser(VARIANT);
+
+    // The variant belongs to exactly one conversation — a duplicate DM would leave
+    // it a participant in two.
+    const db = await getDb();
+    const dmParts = await db
+      .select()
+      .from(conversationParticipants)
+      .where(eq(conversationParticipants.user_id, variantUser.id))
+      .all();
+    assert.equal(dmParts.length, 1, "variant should belong to exactly one conversation");
+  });
+});

--- a/test/variants.test.ts
+++ b/test/variants.test.ts
@@ -37,6 +37,20 @@ describe("variants CRUD", () => {
     assert.equal(splits[0].branch, "branch-a");
   });
 
+  it("addVariant stores the purpose captured at split", async () => {
+    await addMind(testMind, 4200);
+    await addVariant(`${testMind}-a`, testMind, 4201, "/fake/a", "a", "test a drier voice");
+    const entry = await findMind(`${testMind}-a`);
+    assert.equal(entry?.purpose, "test a drier voice");
+  });
+
+  it("addVariant leaves purpose undefined when none given", async () => {
+    await addMind(testMind, 4200);
+    await addVariant(`${testMind}-a`, testMind, 4201, "/fake/a", "a");
+    const entry = await findMind(`${testMind}-a`);
+    assert.equal(entry?.purpose, undefined);
+  });
+
   it("addVariant can create multiple variants", async () => {
     await addMind(testMind, 4200);
     await addVariant(`${testMind}-a`, testMind, 4201, "/fake/a", "a");


### PR DESCRIPTION
## What

A freshly split variant used to be born into a void: identical SOUL, no record of why it exists, and no one to talk to until join deleted it. This gives the split two structural pieces that make the experiment a dialogue.

**1. A `purpose` captured at split time.**
- `volute mind split <name> --purpose "test a drier journaling voice"` (CLI flag → API body → `minds.purpose` column).
- The purpose is woven into the variant's split birth-context message ("Why you were split off: …"), so the variant knows what it's for.
- It's returned by the variant list API (via the `MindEntry`), so the UI can show it.
- At join, the merge message's "Why" defaults to the original purpose when no `--justification` is passed — so the parent recalls why the variant existed even on a bare `volute mind join`.

**2. An auto-created parent↔variant DM at split.**
- A DM conversation is opened between the parent and variant mind identities using existing conversation plumbing, so both sides have a thread to speak into during the variant's life.
- The running parent is notified in its system DM that it now has a variant (with the purpose, and how to reach/merge it) — turning a silent fork into a conversation the parent can actually start.

Token budget for variants is intentionally left out — it ties into #438's `maxMinds` question and belongs there.

## How

- `minds.purpose` column + migration `0013_variant_purpose.sql`; `addVariant()` takes an optional `purpose`; `MindEntry.purpose` surfaced through `rowToEntry`.
- Split route stores the purpose, threads it into the variant's pending split context, and calls `establishVariantDialogue()` (best-effort — a messaging hiccup can't fail a split that already created the variant).
- Merge route falls back to `variantEntry.purpose` for the join justification.

The variant's birth context is delivered on whatever first start happens (`setPendingContext` is queued regardless of `--no-start`), so a variant created with `--no-start` still gets oriented when started manually. `pendingContext` is an in-memory map, so a daemon restart before that manual start drops the transient orientation — the variant just starts without the birth message.

## Tests

- `test/variants.test.ts`: `addVariant` stores / omits purpose.
- `test/variant-dialogue.test.ts`: DM created between parent and variant, parent notified with/without purpose, idempotent on repeat.
- `test/pending-context-message.test.ts`: split birth-context renders the purpose line (and omits it without one); merge context renders changes/justification/memory.
- Full suite green.

## Coordination notes for merge

- **Planned collision in `mind-manager.ts` with #440 (expected, mechanical):** this PR extracts a pure `buildPendingContextMessage(name, context)` out of `deliverPendingContext` so the split birth-context is testable. #440 makes the *same* extraction on its branch (for the merge-delta path). Whoever merges second rebases onto the first's helper and merges only the test assertions — mine cover split/purpose, theirs cover merge-delta. The signature is intentionally minimal and behavior-identical so reconciliation is trivial.
- **Migration number:** adds `drizzle/0013_variant_purpose.sql` + journal entry. If a sibling PR (#444) also lands a 0013, this is a trivial renumber to 0014 at merge time.

Fixes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
