### PR TITLE
feat: exclude memory/journal from variant join merge, narrate the delta

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -113,10 +113,12 @@ function mindPidPath(name: string): string {
 }
 
 /**
- * Build the system message delivered to a mind for a pending context: the merge/split/
- * sprout/upgrade/restart notice plus any changes/justification/memory the caller attached.
- * For a split, the variant's purpose (when set) is appended so it learns why it exists.
- * Pure and exported so the message shape is testable without spawning a mind.
+ * Build the message a mind receives after a lifecycle event (restart, merge,
+ * split, sprout, upgrade). The leading line comes from the prompt registry; the
+ * optional Changes/Why/Context lines, a split's purpose, and a merge's memory
+ * delta are appended from the pending context. Pure and exported so the
+ * stringly-typed context seam — where a mistyped key would silently drop the
+ * variant's purpose or narrated memory — is testable without spawning a mind.
  */
 export async function buildPendingContextMessage(
   name: string,
@@ -138,6 +140,11 @@ export async function buildPendingContextMessage(
   if (context.summary) parts.push(`Changes: ${context.summary}`);
   if (context.justification) parts.push(`Why: ${context.justification}`);
   if (context.memory) parts.push(`Context: ${context.memory}`);
+  if (context.memoryDelta) {
+    parts.push(
+      `\nYour variant's memory & journal (not merged — integrate into your own memory what you want to keep):\n${context.memoryDelta}`,
+    );
+  }
   return parts.join("\n");
 }
 

--- a/packages/daemon/src/lib/mind/variants.ts
+++ b/packages/daemon/src/lib/mind/variants.ts
@@ -1,3 +1,6 @@
+import { gitExec } from "../util/exec.js";
+import log from "../util/logger.js";
+
 const SAFE_BRANCH_RE = /^[a-zA-Z0-9._\-/]+$/;
 
 export function validateBranchName(branch: string): string | null {
@@ -8,4 +11,162 @@ export function validateBranchName(branch: string): string | null {
     return `Invalid branch name: ${branch}. '..' not allowed.`;
   }
   return null;
+}
+
+/**
+ * The mind's living memory — long-term memory and the daily journal — is
+ * accumulated perspective, not code. Two divergent timelines shouldn't be
+ * line-merged by git any more than two people's diaries should be zipped
+ * together, and a conflict here lands in a mind's most identity-critical
+ * files. These paths are excluded from the variant join merge (#440).
+ */
+const MERGE_EXCLUDED_PATHS = ["home/MEMORY.md", "home/memory/journal/"];
+
+/** Cap the narrated delta so a long-running variant's week can't blow up the parent's context. */
+const MAX_DELTA_CHARS = 12000;
+
+/**
+ * Merge a variant branch into the parent worktree, excluding the mind's living
+ * memory (MEMORY.md, memory/journal/) from the textual merge. The parent keeps
+ * its own copy of those files; the variant's delta is returned so it can be
+ * narrated to the parent as context — "here is what your variant learned and
+ * wrote; integrate what you want to keep" — the way memory consolidation
+ * already works (#440).
+ *
+ * Code, skills, and config merge with normal git semantics. A real conflict
+ * there (or a restore that can't fully strip the variant's memory) aborts the
+ * merge and throws {@link VariantMergeError} with the unmerged files, leaving
+ * the parent worktree clean.
+ *
+ * @returns the git diff of the excluded paths across the split, or "" if the
+ *   variant wrote none. Callers thread it into the post-merge context message.
+ */
+export async function mergeVariantExcludingMemory(
+  projectRoot: string,
+  variantBranch: string,
+): Promise<string> {
+  const opts = { cwd: projectRoot };
+
+  // Capture the variant's memory/journal delta before merging. An empty diff is
+  // fine (the variant wrote nothing), but a real git failure would silently lose
+  // the variant's only surviving memory — the branch is deleted right after — so
+  // narrate that honestly to the parent instead of dropping it.
+  let memoryDelta = "";
+  try {
+    const base = (await gitExec(["merge-base", "HEAD", variantBranch], opts)).trim();
+    memoryDelta = (
+      await gitExec(["diff", `${base}..${variantBranch}`, "--", ...MERGE_EXCLUDED_PATHS], opts)
+    ).trim();
+  } catch (err) {
+    log.error(
+      `variant join: failed to compute memory delta for ${variantBranch}`,
+      log.errorData(err),
+    );
+    memoryDelta = `(journal delta unavailable — ${err instanceof Error ? err.message : String(err)})`;
+  }
+  if (memoryDelta.length > MAX_DELTA_CHARS) {
+    memoryDelta = `${memoryDelta.slice(0, MAX_DELTA_CHARS)}\n… (delta truncated)`;
+  }
+
+  // Everything from the merge attempt to the commit is guarded: any failure —
+  // a restore that can't fully strip the variant's memory, or a real code/config
+  // conflict — aborts the merge and throws so the join fails loudly with a clean
+  // worktree, never a contaminated or half-done commit (cleanupVariant deletes
+  // the branch right after, so a bad commit here is unrecoverable).
+  try {
+    // --no-ff --no-commit stages the merge without committing so we can restore
+    // the parent's copy of the excluded paths first. Conflicts (or the
+    // --no-commit stop) are expected; a real code/config conflict resurfaces at
+    // commit time below.
+    await gitExec(["merge", "--no-ff", "--no-commit", variantBranch], opts).catch(() => {});
+
+    // Restore the excluded paths to the parent's committed state: unstage any
+    // variant entries, restore the parent's tracked versions to the worktree
+    // (tolerating paths the parent doesn't track — the variant added them, and
+    // clean removes them), and drop any variant-added files left untracked.
+    await gitExec(["reset", "-q", "HEAD", "--", ...MERGE_EXCLUDED_PATHS], opts);
+    for (const path of MERGE_EXCLUDED_PATHS) {
+      await gitExec(["checkout", "--", path], opts).catch(() => {});
+    }
+    await gitExec(["clean", "-fdq", "--", ...MERGE_EXCLUDED_PATHS], opts);
+    await assertExcludedPathsRestored(opts);
+
+    // Only commit if the merge actually started. A variant with no new commits
+    // leaves "Already up to date" — no MERGE_HEAD, nothing staged — and an
+    // unconditional commit would fail "nothing to commit".
+    if (await mergeInProgress(opts)) {
+      await gitExec(["commit", "--no-edit"], opts);
+    }
+  } catch (err) {
+    const conflicts = await listConflicts(opts);
+    // Restore the parent worktree. If the abort itself fails, the parent is left
+    // mid-merge — surface that so the caller can warn about on-disk conflict
+    // markers the still-running mind might auto-commit.
+    const abortFailed = await gitExec(["merge", "--abort"], opts).then(
+      () => false,
+      () => true,
+    );
+    throw new VariantMergeError(
+      `variant join aborted: ${err instanceof Error ? err.message : String(err)}`,
+      conflicts,
+      abortFailed,
+    );
+  }
+
+  return memoryDelta;
+}
+
+/** Thrown when a variant join is aborted; carries the unmerged files and whether the abort completed. */
+export class VariantMergeError extends Error {
+  constructor(
+    message: string,
+    readonly conflicts: string[],
+    readonly abortFailed: boolean = false,
+  ) {
+    super(message);
+    this.name = "VariantMergeError";
+  }
+}
+
+/** True while a merge is in progress (MERGE_HEAD present) — worktree-safe via rev-parse. */
+async function mergeInProgress(opts: { cwd: string }): Promise<boolean> {
+  return gitExec(["rev-parse", "-q", "--verify", "MERGE_HEAD"], opts).then(
+    () => true,
+    () => false,
+  );
+}
+
+/** List the files left in conflict (unmerged) in the worktree. */
+async function listConflicts(opts: { cwd: string }): Promise<string[]> {
+  try {
+    const out = (await gitExec(["diff", "--name-only", "--diff-filter=U"], opts)).trim();
+    return out ? out.split("\n") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Confirm the excluded paths (index and worktree) match the parent's HEAD after
+ * the restore, so the merge commit can't carry any of the variant's memory or
+ * journal. Throws if a difference or a leftover untracked file remains.
+ */
+async function assertExcludedPathsRestored(opts: { cwd: string }): Promise<void> {
+  await gitExec(["diff", "--cached", "--quiet", "HEAD", "--", ...MERGE_EXCLUDED_PATHS], opts);
+  await gitExec(["diff", "--quiet", "HEAD", "--", ...MERGE_EXCLUDED_PATHS], opts);
+  // `git diff` ignores untracked files, so a variant-added file the clean step
+  // missed (e.g. a new journal day, or a MEMORY.md the parent never tracked)
+  // would slip past the checks above — and the parent's next auto-commit
+  // (`git add -A`) would commit it. Catch it explicitly.
+  const untracked = (
+    await gitExec(
+      ["ls-files", "--others", "--exclude-standard", "--", ...MERGE_EXCLUDED_PATHS],
+      opts,
+    )
+  ).trim();
+  if (untracked) {
+    throw new Error(
+      `untracked memory files remain after restore: ${untracked.replace(/\n/g, ", ")}`,
+    );
+  }
 }

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -84,7 +84,7 @@ import {
 import { isTemplateStale } from "../../lib/mind/template-staleness.js";
 import { applyThinkingLevel, deriveThinkingLevel } from "../../lib/mind/thinking-config.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
-import { validateBranchName } from "../../lib/mind/variants.js";
+import { mergeVariantExcludingMemory, validateBranchName } from "../../lib/mind/variants.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
 import { PLATFORMS } from "../../lib/platforms.js";
 import {
@@ -1543,8 +1543,11 @@ const app = new Hono<AuthEnv>()
             }
           }
 
-          // Merge, cleanup worktree/branch, reinstall
-          await gitExec(["merge", variantEntry.branch], { cwd: projectRoot });
+          // Merge (excluding the mind's living memory/journal — #440), narrate
+          // the memory delta to the parent, then clean up worktree/branch and
+          // reinstall.
+          const memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantEntry.branch);
+          if (memoryDelta && context) context.memoryDelta = memoryDelta;
           await cleanupVariant(mergeVariantName, projectRoot, variantEntry.dir);
           try {
             await npmInstallAsMind(projectRoot, baseName);

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -16,7 +16,11 @@ import {
 } from "../../lib/mind/registry.js";
 import { spawnServer } from "../../lib/mind/spawn-server.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
-import { validateBranchName } from "../../lib/mind/variants.js";
+import {
+  mergeVariantExcludingMemory,
+  VariantMergeError,
+  validateBranchName,
+} from "../../lib/mind/variants.js";
 import { verify } from "../../lib/mind/verify.js";
 import { exec, gitExec } from "../../lib/util/exec.js";
 import { checkHealth } from "../../lib/util/health.js";
@@ -371,40 +375,25 @@ const app = new Hono<AuthEnv>()
         }
       }
 
-      // Merge branch
+      // Merge the variant into the parent, excluding the mind's living memory and
+      // journal — those ride to the parent as `memoryDelta` (#440) instead of
+      // being line-merged. A real code/config conflict (or a failed restore)
+      // aborts the merge and throws VariantMergeError; route it through
+      // failAfterGitWrite so ownership is restored and the conflicts are reported.
+      let memoryDelta = "";
       try {
-        await gitExec(["merge", variantEntry.branch], { cwd: projectRoot });
-      } catch (_e) {
-        // Collect the conflicting files before aborting so the caller/mind knows
-        // what collided.
-        let conflicts: string[] = [];
-        try {
-          const out = (
-            await gitExec(["diff", "--name-only", "--diff-filter=U"], { cwd: projectRoot })
-          ).trim();
-          conflicts = out ? out.split("\n") : [];
-        } catch (err) {
-          log.warn(`failed to list merge conflicts for ${mindName}`, log.errorData(err));
-        }
-        // Restore the parent worktree so the still-running parent mind never
-        // auto-commits conflict markers into SOUL.md/MEMORY.md.
-        let abortFailed = false;
-        try {
-          await gitExec(["merge", "--abort"], { cwd: projectRoot });
-        } catch (err) {
-          abortFailed = true;
-          log.warn(`failed to abort merge for ${mindName}`, log.errorData(err));
-        }
+        memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantEntry.branch);
+      } catch (err) {
+        if (!(err instanceof VariantMergeError)) throw err;
         // Leave the variant intact so the conflict can be resolved in the variant
-        // and the join retried. failAfterGitWrite restores ownership after the
-        // root-run auto-commit/merge/abort git ops above. If the abort itself
-        // failed, the parent is left mid-merge with conflict markers on disk —
-        // say so, since the still-running mind could auto-commit them.
+        // and the join retried. If the abort itself failed, the parent is left
+        // mid-merge with conflict markers on disk — say so, since the still-running
+        // mind could auto-commit them.
         return failAfterGitWrite(
-          abortFailed
+          err.abortFailed
             ? "Merge failed and the abort did not complete — the parent worktree may be left mid-merge with conflict markers; manual cleanup may be needed."
             : "Merge failed. Resolve conflicts in the variant and retry the join.",
-          { conflicts },
+          { conflicts: err.conflicts },
         );
       }
 
@@ -457,6 +446,7 @@ const app = new Hono<AuthEnv>()
         ...(body.summary && { summary: body.summary }),
         ...(justification && { justification }),
         ...(body.memory && { memory: body.memory }),
+        ...(memoryDelta && { memoryDelta }),
       };
 
       try {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -574,6 +574,15 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       'export const marker = "e2e";\n',
     );
 
+    // Both minds diverge their living memory. On a plain merge these conflict;
+    // the join must instead keep the parent's copy and narrate the variant's
+    // (#440). The endpoint auto-commits both worktrees before merging.
+    writeFileSync(resolve(parentDir, "home", "MEMORY.md"), "parent's own memory\n");
+    writeFileSync(
+      resolve(created.variant.path, "home", "MEMORY.md"),
+      "variant's divergent memory\n",
+    );
+
     // Join: merge the variant back. skipVerify avoids booting a verification server.
     const mergeRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-var/merge`, {
       method: "POST",
@@ -589,6 +598,14 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(
       existsSync(resolve(parentDir, "src", "e2e-merge-marker.ts")),
       "merged file should exist in the parent src/",
+    );
+
+    // The parent kept its own MEMORY.md; the variant's divergent memory was not
+    // spliced in (it rides along as narrated context instead).
+    assert.equal(
+      readFileSync(resolve(parentDir, "home", "MEMORY.md"), "utf-8"),
+      "parent's own memory\n",
+      "parent should keep its own MEMORY.md after the join",
     );
 
     // The variant is cleaned up: gone from registry and disk.
@@ -627,13 +644,16 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       );
     };
 
-    // Conflicting edits to the same tracked file in both parent and variant.
-    const conflictFile = "home/MEMORY.md";
-    gitCommit(parentDir, conflictFile, "parent version of memory\n", "parent conflict edit");
+    // Conflicting edits to the same tracked, non-excluded file in both parent and
+    // variant. SOUL.md is identity but not memory/journal, so #440 does NOT
+    // exclude it — a real conflict here must still surface (unlike MEMORY.md,
+    // which now merges cleanly and is covered by the happy-path test above).
+    const conflictFile = "home/SOUL.md";
+    gitCommit(parentDir, conflictFile, "parent version of soul\n", "parent conflict edit");
     gitCommit(
       created.variant.path,
       conflictFile,
-      "variant version of memory\n",
+      "variant version of soul\n",
       "variant conflict edit",
     );
 
@@ -670,8 +690,8 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // The failed join must not leave root-owned files in the parent dir. Under
     // real user isolation the merge git ops (run as the daemon) would otherwise
-    // orphan home/MEMORY.md as root:root, locking the parent mind out of its own
-    // identity files. (This harness runs the daemon as the test user, so this is
+    // orphan the parent's identity files as root:root, locking the parent mind
+    // out of its own home dir. (This harness runs the daemon as the test user, so this is
     // a regression tripwire; the ownership-restore path itself is unit-tested in
     // variant-join-isolation.test.ts.)
     if (process.getuid && process.getuid() !== 0) {

--- a/test/pending-context-message.test.ts
+++ b/test/pending-context-message.test.ts
@@ -38,4 +38,27 @@ describe("buildPendingContextMessage", () => {
     assert.ok(msg.includes("Why: the drier voice felt truer"));
     assert.ok(msg.includes("Context: keep the shorter entries"));
   });
+
+  it("delivers the variant's memory delta to the parent on merge", async () => {
+    const delta = "diff --git a/home/MEMORY.md b/home/MEMORY.md\n+ variant learned to whistle";
+    const content = await buildPendingContextMessage("parent", {
+      type: "merged",
+      name: "variant",
+      summary: "did some work",
+      memoryDelta: delta,
+    });
+
+    // The stringly-typed context seam must actually carry the delta through.
+    assert.ok(content.includes(delta), `expected delta in delivered message:\n${content}`);
+    assert.match(content, /not merged/);
+    assert.match(content, /Changes: did some work/);
+  });
+
+  it("omits the delta section when there is no delta", async () => {
+    const content = await buildPendingContextMessage("parent", {
+      type: "merged",
+      name: "variant",
+    });
+    assert.doesNotMatch(content, /not merged/);
+  });
 });

--- a/test/variant-merge.test.ts
+++ b/test/variant-merge.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  mergeVariantExcludingMemory,
+  VariantMergeError,
+} from "../packages/daemon/src/lib/mind/variants.js";
+import { gitExec } from "../packages/daemon/src/lib/util/exec.js";
+
+const repo = resolve("/tmp", `variant-merge-test-${process.pid}`);
+
+async function git(...args: string[]): Promise<string> {
+  return gitExec(args, { cwd: repo });
+}
+
+function write(rel: string, content: string) {
+  const path = resolve(repo, rel);
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+}
+
+async function commitAll(message: string) {
+  await git("add", "-A");
+  await git("commit", "-m", message);
+}
+
+describe("mergeVariantExcludingMemory", () => {
+  beforeEach(async () => {
+    rmSync(repo, { recursive: true, force: true });
+    mkdirSync(repo, { recursive: true });
+    await git("init", "-b", "main");
+    await git("config", "user.name", "test");
+    await git("config", "user.email", "test@example.com");
+
+    write("home/MEMORY.md", "# Memory\n\n- parent baseline fact\n");
+    write("home/memory/journal/2026-07-01.md", "Day one, shared baseline.\n");
+    write("src/server.ts", "export const value = 1;\n");
+    await commitAll("initial");
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("merges code but excludes divergent memory/journal without conflicting", async () => {
+    // Variant diverges: rewrites MEMORY.md, appends to the shared journal day,
+    // adds a new journal day, and edits code.
+    await git("checkout", "-b", "variant");
+    write("home/MEMORY.md", "# Memory\n\n- variant learned something new\n");
+    write("home/memory/journal/2026-07-01.md", "Day one, shared baseline.\nVariant's evening.\n");
+    write("home/memory/journal/2026-07-02.md", "Day two, variant only.\n");
+    write("src/feature.ts", "export const feature = true;\n");
+    await commitAll("variant work");
+
+    // Parent diverges the SAME memory/journal files (would conflict on a plain
+    // merge) plus an unrelated, cleanly-mergeable code change.
+    await git("checkout", "main");
+    write("home/MEMORY.md", "# Memory\n\n- parent learned a different thing\n");
+    write("home/memory/journal/2026-07-01.md", "Day one, shared baseline.\nParent's evening.\n");
+    write("src/server.ts", "export const value = 2;\n");
+    await commitAll("parent work");
+
+    const delta = await mergeVariantExcludingMemory(repo, "variant");
+
+    // The merge committed cleanly — no conflict markers, no merge in progress.
+    assert.ok(!existsSync(resolve(repo, ".git/MERGE_HEAD")), "merge should be committed");
+    const status = (await git("status", "--porcelain")).trim();
+    assert.equal(status, "", "worktree should be clean after merge");
+
+    // Parent's living memory is preserved verbatim; the variant's is not spliced.
+    const memory = readFileSync(resolve(repo, "home/MEMORY.md"), "utf-8");
+    assert.match(memory, /parent learned a different thing/);
+    assert.doesNotMatch(memory, /variant learned something new/);
+
+    const journalDay1 = readFileSync(resolve(repo, "home/memory/journal/2026-07-01.md"), "utf-8");
+    assert.match(journalDay1, /Parent's evening/);
+    assert.doesNotMatch(journalDay1, /Variant's evening/);
+
+    // The variant's new journal day is NOT added to the parent's tree.
+    assert.ok(
+      !existsSync(resolve(repo, "home/memory/journal/2026-07-02.md")),
+      "variant-only journal day should not be merged in",
+    );
+
+    // Code merges with normal git semantics: both edits land.
+    assert.match(readFileSync(resolve(repo, "src/server.ts"), "utf-8"), /value = 2/);
+    assert.ok(existsSync(resolve(repo, "src/feature.ts")), "variant code should merge in");
+
+    // The delta reaches the caller and carries the variant's memory + journal.
+    assert.match(delta, /variant learned something new/);
+    assert.match(delta, /Variant's evening/);
+    assert.match(delta, /Day two, variant only/);
+    // ...but not the merged code.
+    assert.doesNotMatch(delta, /feature = true/);
+  });
+
+  it("returns an empty delta when the variant wrote no memory or journal", async () => {
+    await git("checkout", "-b", "variant");
+    write("src/feature.ts", "export const feature = true;\n");
+    await commitAll("variant code only");
+    await git("checkout", "main");
+
+    const delta = await mergeVariantExcludingMemory(repo, "variant");
+
+    assert.equal(delta, "");
+    assert.ok(existsSync(resolve(repo, "src/feature.ts")), "variant code should merge in");
+    assert.ok(!existsSync(resolve(repo, ".git/MERGE_HEAD")), "merge should be committed");
+  });
+
+  it("aborts cleanly on a real code conflict and reports the conflicting files", async () => {
+    await git("checkout", "-b", "variant");
+    write("src/server.ts", "export const value = 99;\n");
+    await commitAll("variant code");
+
+    await git("checkout", "main");
+    write("src/server.ts", "export const value = 2;\n");
+    await commitAll("parent code");
+
+    // A genuine code conflict must reject with the conflicting files, not swallow
+    // into a bogus clean commit.
+    await assert.rejects(mergeVariantExcludingMemory(repo, "variant"), (err: unknown) => {
+      assert.ok(err instanceof VariantMergeError);
+      assert.deepEqual(err.conflicts, ["src/server.ts"]);
+      return true;
+    });
+
+    // The parent is left clean: no merge in progress, no stray changes, and no
+    // merge commit landed.
+    assert.ok(!existsSync(resolve(repo, ".git/MERGE_HEAD")), "merge should be aborted");
+    assert.equal((await git("status", "--porcelain")).trim(), "", "worktree should be clean");
+    const log = (await git("log", "--oneline")).trim().split("\n");
+    assert.equal(log.length, 2, "no merge commit should have landed");
+  });
+
+  it("does not throw when the variant has no new commits (no-op join)", async () => {
+    // Branch the variant but never commit past the branch point.
+    await git("branch", "variant");
+
+    const delta = await mergeVariantExcludingMemory(repo, "variant");
+
+    assert.equal(delta, "");
+    assert.ok(!existsSync(resolve(repo, ".git/MERGE_HEAD")), "no merge should be in progress");
+    assert.equal((await git("status", "--porcelain")).trim(), "", "worktree should be clean");
+  });
+
+  it("keeps the parent's journal when the variant deleted a day", async () => {
+    await git("checkout", "-b", "variant");
+    rmSync(resolve(repo, "home/memory/journal/2026-07-01.md"));
+    write("src/feature.ts", "export const feature = true;\n");
+    await commitAll("variant deletes a journal day");
+    await git("checkout", "main");
+
+    await mergeVariantExcludingMemory(repo, "variant");
+
+    // The parent keeps the day the variant deleted; code still merges.
+    assert.ok(
+      existsSync(resolve(repo, "home/memory/journal/2026-07-01.md")),
+      "parent's journal day should survive the variant's deletion",
+    );
+    assert.ok(existsSync(resolve(repo, "src/feature.ts")), "variant code should merge in");
+  });
+
+  it("merges cleanly when the variant added a MEMORY.md the parent never tracked", async () => {
+    // Parent drops MEMORY.md entirely.
+    await git("rm", "-q", "home/MEMORY.md");
+    await commitAll("parent drops memory");
+
+    // Variant re-introduces it and does some code work.
+    await git("checkout", "-b", "variant");
+    write("home/MEMORY.md", "# Memory\n\n- variant reinvented memory\n");
+    write("src/feature.ts", "export const feature = true;\n");
+    await commitAll("variant re-adds memory");
+    await git("checkout", "main");
+
+    // Must merge successfully (not abort): the variant-added file is dropped, not
+    // left untracked to be swept up by the parent's next auto-commit.
+    await mergeVariantExcludingMemory(repo, "variant");
+
+    assert.ok(
+      !existsSync(resolve(repo, "home/MEMORY.md")),
+      "variant-added MEMORY.md the parent never tracked must not be merged in",
+    );
+    assert.equal((await git("status", "--porcelain")).trim(), "", "no untracked file left behind");
+    assert.ok(existsSync(resolve(repo, "src/feature.ts")), "variant code should merge in");
+  });
+
+  it("caps an oversized delta", async () => {
+    await git("checkout", "-b", "variant");
+    write("home/MEMORY.md", `# Memory\n\n${"variant fact line\n".repeat(2000)}`);
+    await commitAll("variant floods memory");
+    await git("checkout", "main");
+
+    const delta = await mergeVariantExcludingMemory(repo, "variant");
+
+    assert.ok(delta.length < 13000, "delta should be capped near MAX_DELTA_CHARS");
+    assert.match(delta, /delta truncated/);
+    // The flood is still kept out of the parent's own memory.
+    assert.doesNotMatch(
+      readFileSync(resolve(repo, "home/MEMORY.md"), "utf-8"),
+      /variant fact line/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Variant join was a plain `git merge` of everything tracked — including `home/MEMORY.md` and `home/memory/journal/`. Both parent and variant are living minds that write memory and journal continuously, so the longer a variant runs, the more likely join is to conflict — and the conflict lands in the mind's most identity-critical files. Memory is accumulated *perspective*, not code; two divergent timelines shouldn't be line-merged by git any more than two people's diaries should be zipped together.

## How

`mergeVariantExcludingMemory()` (in `mind/variants.ts`) merges code/skills/config with normal git semantics but keeps the **parent's** copy of `MEMORY.md` and `memory/journal/`:

- Captures the variant's delta across the split (`git diff <base>..<variant>`) *before* merging, capped at 12k chars. A real git failure is logged and surfaced honestly to the parent (`(journal delta unavailable — …)`) rather than dropped.
- Merges with `--no-ff --no-commit`, restores the excluded paths to the parent's committed state (unstage, per-path checkout, clean), and **verifies** index + worktree + untracked state all match the parent's HEAD before committing.
- Returns the delta; both call sites thread it into the post-merge context, and `mind-manager` delivers it as its own section: *"Your variant's memory & journal (not merged — integrate into your own memory what you want to keep)"*.

**Guarded failure:** if the restore can't fully strip the variant's memory, or a real code/config conflict remains at commit, the merge is aborted (`git merge --abort`) and `VariantMergeError` is thrown carrying the unmerged files — the parent worktree is left clean, never a contaminated or half-done commit (the branch is deleted right after). A no-op join (variant with no new commits) no longer throws.

## Where the delta goes

Wired into **both** join paths:
- `volute mind join` → `POST /:name/variants/:variant/merge` (the primary CLI path): delta rides in the existing `type: "merged"` restart context; conflicts are reported to the caller as before.
- The mind-initiated merge restart (`context.type === "merge"` in `minds.ts`): delta rides in the `type: "merge"` context.

## Scope decisions

- Excludes **both** `MEMORY.md` and `memory/journal/` per the issue's decided proposal. `SOUL.md` and other identity files are **not** excluded — they still merge/conflict normally.
- No backwards-compat shims.

## Tests

- `test/variant-merge.test.ts` (7 cases): divergent memory+journal+code join merges cleanly excluding memory/journal; empty delta; **real code conflict aborts clean and reports conflicts**; **no-op join doesn't throw**; **variant-deleted journal day is preserved from the parent**; **variant-added MEMORY.md the parent never tracked merges cleanly (dropped, not left untracked)**; oversized delta is capped.
- `test/pending-context-message.test.ts`: the delta actually lands in the delivered message (guards the stringly-typed context seam).
- `test/daemon-e2e.test.ts`: the happy-path join now also diverges MEMORY.md in both minds and asserts the parent keeps its own; the conflict test uses `SOUL.md` (a non-excluded file) to keep asserting 500 + conflicts + clean abort.

Full unit suite green except one pre-existing unrelated failure (`mail-poller.test.ts`, broken by #636 on main — fixed separately).

## Coordination

This PR extracts `buildPendingContextMessage()` from `mind-manager.ts`'s `deliverPendingContext` (behavior-identical, pure move) so the context-delivery seam is unit-testable. Sibling PR #447 independently extracts the same function to test its split-purpose branch. Whichever lands second should rebase onto the first's extraction and merge the two test files' assertions — the extraction is mechanical and behavior-identical, so reconciliation is trivial.

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
