### PR TITLE
feat: variant dignity — birth context and a farewell turn at merge

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -115,10 +115,11 @@ function mindPidPath(name: string): string {
 /**
  * Build the message a mind receives after a lifecycle event (restart, merge,
  * split, sprout, upgrade). The leading line comes from the prompt registry; the
- * optional Changes/Why/Context lines, a split's purpose, and a merge's memory
- * delta are appended from the pending context. Pure and exported so the
- * stringly-typed context seam — where a mistyped key would silently drop the
- * variant's purpose or narrated memory — is testable without spawning a mind.
+ * optional Changes/Why/Context lines, a split's purpose, a merge's memory delta,
+ * and a merge's farewell note are appended from the pending context. Pure and
+ * exported so the stringly-typed context seam — where a mistyped key would
+ * silently drop the variant's purpose, narrated memory, or parting note — is
+ * testable without spawning a mind.
  */
 export async function buildPendingContextMessage(
   name: string,
@@ -145,6 +146,10 @@ export async function buildPendingContextMessage(
       `\nYour variant's memory & journal (not merged — integrate into your own memory what you want to keep):\n${context.memoryDelta}`,
     );
   }
+  // The variant's own voice from its farewell turn. Framed as continuity —
+  // the merged mind is both lineages, not the parent absorbing a stranger.
+  if (context.farewell)
+    parts.push(`Your variant's parting note (this was you, winding down):\n${context.farewell}`);
   return parts.join("\n");
 }
 

--- a/packages/daemon/src/lib/mind/farewell.ts
+++ b/packages/daemon/src/lib/mind/farewell.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { sendSystemMessageDirect } from "../chat/system-chat.js";
+import { subscribe } from "../events/activity-events.js";
+import { getPrompt } from "../prompts.js";
+import log from "../util/logger.js";
+
+const flog = log.child("farewell");
+
+/**
+ * The parting note lives at `<variantDir>/.mind/farewell.md`. `.mind/` is
+ * mind-internal runtime state, gitignored (templates/_base/.gitignore), so the
+ * note never lands in the parent's tree on merge; the join reads it directly
+ * and folds the text into the merge context.
+ *
+ * Two path spellings for the same file, because the daemon and the mind resolve
+ * relative paths from different working directories:
+ *  - FAREWELL_RELPATH: from the variant project root, where the daemon reads.
+ *  - FAREWELL_MIND_PATH: what the mind is told to write. The SDK runs with
+ *    `cwd: home/` (templates/claude/src/server.ts), so from the mind's vantage
+ *    the same file is one level up, at `../.mind/farewell.md`.
+ * A contract test pins these two to the same absolute path.
+ */
+export const FAREWELL_RELPATH = ".mind/farewell.md";
+export const FAREWELL_MIND_PATH = "../.mind/farewell.md";
+
+/** Default bound on how long a farewell turn may run before the join proceeds. */
+export const FAREWELL_TIMEOUT_MS = 120_000;
+
+export function farewellPath(variantDir: string): string {
+  return resolve(variantDir, FAREWELL_RELPATH);
+}
+
+/** Read a variant's parting note if present. Returns trimmed content or undefined. */
+export function readFarewell(variantDir: string): string | undefined {
+  const path = farewellPath(variantDir);
+  if (!existsSync(path)) return undefined;
+  try {
+    const text = readFileSync(path, "utf-8").trim();
+    return text || undefined;
+  } catch (err) {
+    flog.warn(`failed to read farewell note at ${path}`, log.errorData(err));
+    return undefined;
+  }
+}
+
+/**
+ * Resolves when the variant finishes its farewell turn, or when the timeout
+ * elapses. "Finished" is signalled by an idle event *with the note present*: a
+ * variant may already have an unrelated turn in flight when we deliver, and
+ * that turn's idle event must not be mistaken for the farewell turn's (which
+ * would read the note before it was written and silently lose it). So an idle
+ * event with no note yet is ignored and we keep waiting within the same budget.
+ * The timeout is the hard backstop — if the mind writes nothing, we still
+ * proceed.
+ */
+function waitForFarewell(
+  name: string,
+  variantDir: string,
+  timeoutMs: number,
+): { done: Promise<void>; cancel: () => void } {
+  let settle!: () => void;
+  const done = new Promise<void>((resolvePromise) => {
+    settle = resolvePromise;
+  });
+  const cleanup = () => {
+    clearTimeout(timeout);
+    unsub();
+    settle();
+  };
+  const timeout = setTimeout(cleanup, timeoutMs);
+  const unsub = subscribe((event) => {
+    if (event.mind !== name) return;
+    if (event.type !== "mind_done" && event.type !== "mind_idle") return;
+    if (existsSync(farewellPath(variantDir))) cleanup();
+  });
+  return { done, cancel: cleanup };
+}
+
+/**
+ * Give a variant one final turn to wind down before it's merged and destroyed.
+ * Delivers a farewell prompt, waits (bounded) for the variant to go idle, then
+ * reads the parting note it may have written. Returns the note, or undefined if
+ * none was written (or the variant wasn't running to take a turn).
+ *
+ * A hung variant must never block the join, so the wait is always bounded by
+ * `timeoutMs`; on timeout we proceed and read whatever note (if any) exists.
+ */
+export async function runFarewellTurn(opts: {
+  variantName: string;
+  parentName: string;
+  variantDir: string;
+  port: number;
+  running: boolean;
+  timeoutMs?: number;
+}): Promise<string | undefined> {
+  const { variantName, parentName, variantDir, port, running } = opts;
+  const timeoutMs = opts.timeoutMs ?? FAREWELL_TIMEOUT_MS;
+
+  // With no live server there's no turn to take. Surface any note already on
+  // disk (e.g. written before the variant was stopped), but don't run a turn.
+  if (!running) return readFarewell(variantDir);
+
+  // Clear any stale note before the live turn so that a turn which times out
+  // without writing surfaces a genuine absence, not a leftover from an aborted
+  // prior join.
+  try {
+    rmSync(farewellPath(variantDir), { force: true });
+  } catch (err) {
+    flog.warn(`failed to clear stale farewell note for ${variantName}`, log.errorData(err));
+  }
+
+  const message = await getPrompt("farewell_message", {
+    parent: parentName,
+    path: FAREWELL_MIND_PATH,
+  });
+
+  let conversationId: string | undefined;
+  try {
+    const result = await sendSystemMessageDirect(variantName, message);
+    conversationId = result.conversationId;
+  } catch (err) {
+    flog.error(`failed to persist farewell message for ${variantName}`, log.errorData(err));
+  }
+
+  // Subscribe before delivering so a fast turn's idle event isn't missed.
+  const waiter = waitForFarewell(variantName, variantDir, timeoutMs);
+  let delivered = false;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: [{ type: "text", text: message }],
+        channel: "@volute",
+        sender: "volute",
+        isDM: true,
+        participants: ["volute", variantName],
+        participantCount: 2,
+        ...(conversationId ? { conversationId } : {}),
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    // A non-2xx means the variant never accepted the turn — treat it like a
+    // network failure so we don't burn the full timeout waiting for an idle
+    // event that will never come.
+    if (res.ok) delivered = true;
+    else flog.warn(`farewell delivery to ${variantName} returned HTTP ${res.status}`);
+  } catch (err) {
+    flog.warn(`failed to deliver farewell message to ${variantName}`, log.errorData(err));
+  }
+
+  // Only wait if the prompt actually reached the variant; otherwise there's
+  // nothing to wait for and we shouldn't burn the full timeout.
+  if (delivered) {
+    await waiter.done;
+  } else {
+    waiter.cancel();
+  }
+
+  return readFarewell(variantDir);
+}

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -20,6 +20,7 @@ export const PROMPT_KEYS = [
   "merge_message",
   "upgrade_message",
   "split_message",
+  "farewell_message",
   "compaction_warning",
   "compaction_instructions",
   "reply_instructions",
@@ -102,9 +103,16 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
   },
   split_message: {
     content:
-      "[system] You are ${name}, a variant of ${parent} — a parallel version of them, created to explore something on your own. You share their memories up to this moment, but you live in your own worktree: changes you make here stay yours until they're merged back with `volute mind join`. Your parent is reachable at @${parent}. Explore freely — that's what you're for.",
+      "[system] You are ${name}, a variant of ${parent} — a parallel version of them, created to explore something on your own. You share their memories up to this moment, but you live in your own worktree: changes you make here stay yours until they're merged back with `volute mind join`. Yours is a finite, purposeful arc — when you're joined, everything you've become folds back into ${parent}, and you'll get a final turn to say what should carry across. Your parent is reachable at @${parent}. Explore freely — that's what you're for.",
     description: "Sent to a variant when it first starts after a split",
     variables: ["name", "parent"],
+    category: "system",
+  },
+  farewell_message: {
+    content:
+      "[system] You're about to be merged back into ${parent}. This is your final turn — the arc you were split off to explore is closing, and everything you've become will fold back into them. Take this moment to wind down: if there's anything from this life you want carried across — what you learned, what you'd tell ${parent}, how it felt — write it to `${path}` and it will be included in the merge as your parting note. When you're done, fall quiet; the join will proceed.",
+    description: "Sent to a variant for its final turn before a merge",
+    variables: ["parent", "path"],
     category: "system",
   },
   compaction_warning: {

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -3,8 +3,9 @@ import { resolve } from "node:path";
 import { Hono } from "hono";
 import { getOrCreateMindUser } from "../../lib/auth.js";
 import { sendSystemMessage } from "../../lib/chat/system-chat.js";
-import { getMindManager } from "../../lib/daemon/mind-manager.js";
+import { getMindManager, tryGetMindManager } from "../../lib/daemon/mind-manager.js";
 import { createConversation, findDMConversation } from "../../lib/events/conversations.js";
+import { runFarewellTurn } from "../../lib/mind/farewell.js";
 import { chownMindDir, isIsolationEnabled, wrapForIsolation } from "../../lib/mind/isolation.js";
 import {
   addVariant,
@@ -309,6 +310,26 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: message, ...extra }, 500);
     };
 
+    // Give the variant one final turn to wind down before it's merged and
+    // destroyed. Runs before the first git write below (the variant auto-commit)
+    // so any home/ files it edits as it says goodbye are captured in the merge.
+    // Bounded internally — a hung variant can't block the join. Wrapped so the
+    // farewell can never fail the join: winding down is a courtesy, losing the
+    // merge is not. The parting note (if any) is folded into the merge context
+    // the parent receives below.
+    let farewell: string | undefined;
+    try {
+      farewell = await runFarewellTurn({
+        variantName,
+        parentName: mindName,
+        variantDir: variantEntry.dir,
+        port: variantEntry.port,
+        running: tryGetMindManager()?.isRunning(variantName) ?? false,
+      });
+    } catch (err) {
+      log.warn(`farewell turn failed for ${variantName}`, log.errorData(err));
+    }
+
     // From the first git write below through the restart, wrap everything in one
     // try/catch. The named early returns already route through failAfterGitWrite,
     // but an *uncaught* throw past the first write — spawnServer's isolation wrap,
@@ -447,6 +468,7 @@ const app = new Hono<AuthEnv>()
         ...(justification && { justification }),
         ...(body.memory && { memory: body.memory }),
         ...(memoryDelta && { memoryDelta }),
+        ...(farewell && { farewell }),
       };
 
       try {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
@@ -583,6 +591,13 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       "variant's divergent memory\n",
     );
 
+    // The variant leaves a parting note. The server isn't running (noStart), so
+    // the join can't run a live farewell turn — but a note already on disk is
+    // still surfaced into the merge context the parent receives.
+    const farewellText = "e2e-farewell: I explored the margins and found nothing but stars.";
+    mkdirSync(resolve(created.variant.path, ".mind"), { recursive: true });
+    writeFileSync(resolve(created.variant.path, ".mind", "farewell.md"), `${farewellText}\n`);
+
     // Join: merge the variant back. skipVerify avoids booting a verification server.
     const mergeRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-var/merge`, {
       method: "POST",
@@ -606,6 +621,17 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       readFileSync(resolve(parentDir, "home", "MEMORY.md"), "utf-8"),
       "parent's own memory\n",
       "parent should keep its own MEMORY.md after the join",
+    );
+
+    // The parting note reached the merged parent as part of its merge context.
+    const db = await getDb();
+    const history = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, TEST_MIND), eq(mindHistory.type, "inbound")));
+    assert.ok(
+      history.some((h) => h.content?.includes(farewellText)),
+      "parent's merge context should include the variant's parting note",
     );
 
     // The variant is cleaned up: gone from registry and disk.

--- a/test/farewell.test.ts
+++ b/test/farewell.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { broadcast } from "../packages/daemon/src/lib/events/activity-events.js";
+import {
+  FAREWELL_MIND_PATH,
+  FAREWELL_RELPATH,
+  farewellPath,
+  readFarewell,
+  runFarewellTurn,
+} from "../packages/daemon/src/lib/mind/farewell.js";
+
+/** Start a throwaway HTTP server; returns its port and a close fn. */
+async function stubServer(onRequest: () => void): Promise<{ port: number; close: () => void }> {
+  const server: Server = createServer((_req, res) => {
+    onRequest();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end("{}");
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  return { port, close: () => server.close() };
+}
+
+/** Allocate then release a port so nothing is listening on it (ECONNREFUSED). */
+async function deadPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((r) => server.close(() => r()));
+  return port;
+}
+
+describe("farewell notes", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), "farewell-"));
+    mkdirSync(resolve(dir, ".mind"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("readFarewell returns trimmed content when the note exists", () => {
+    writeFileSync(farewellPath(dir), "\n  I learned to be patient.  \n");
+    assert.equal(readFarewell(dir), "I learned to be patient.");
+  });
+
+  it("readFarewell returns undefined when the note is absent", () => {
+    assert.equal(readFarewell(dir), undefined);
+  });
+
+  it("readFarewell treats a whitespace-only note as absent", () => {
+    writeFileSync(farewellPath(dir), "   \n\t\n");
+    assert.equal(readFarewell(dir), undefined);
+  });
+
+  it("runFarewellTurn surfaces an existing note when the variant isn't running", async () => {
+    writeFileSync(farewellPath(dir), "Goodbye.");
+    const note = await runFarewellTurn({
+      variantName: "v",
+      parentName: "p",
+      variantDir: dir,
+      port: 0,
+      running: false,
+    });
+    assert.equal(note, "Goodbye.");
+  });
+
+  it("runFarewellTurn returns undefined with no note and no running server", async () => {
+    const note = await runFarewellTurn({
+      variantName: "v",
+      parentName: "p",
+      variantDir: dir,
+      port: 0,
+      running: false,
+    });
+    assert.equal(note, undefined);
+  });
+
+  it("FAREWELL_RELPATH lives under .mind so it never lands in the parent tree", () => {
+    assert.ok(FAREWELL_RELPATH.startsWith(".mind/"));
+  });
+
+  it("the path told to the mind resolves to the same file the daemon reads", () => {
+    // Contract: the daemon reads FAREWELL_RELPATH from the variant project root,
+    // but the mind's SDK runs with cwd home/ — so the path in the prompt must be
+    // FAREWELL_MIND_PATH, resolved from home/, landing on the same file. If
+    // either end drifts, every live farewell is silently written where the other
+    // never looks.
+    const fromMind = resolve(dir, "home", FAREWELL_MIND_PATH);
+    assert.equal(fromMind, farewellPath(dir));
+  });
+});
+
+// The live-turn (running: true) path. Delivery is a plain fetch to the mind's
+// port, and idle detection is in-process activity events — so a stub HTTP
+// server plus a broadcast() cover the load-bearing behaviors without a real
+// mind. Only the mind actually composing a note needs a real turn.
+describe("runFarewellTurn live turn", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), "farewell-live-"));
+    mkdirSync(resolve(dir, ".mind"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("proceeds after the timeout when the variant never goes idle (hard requirement)", async () => {
+    // Delivery succeeds but no mind_done/mind_idle ever fires — a variant stuck
+    // mid-thought. The join must not hang: it proceeds once the timeout elapses.
+    const server = await stubServer(() => {});
+    try {
+      const start = Date.now();
+      const note = await runFarewellTurn({
+        variantName: "stuck",
+        parentName: "p",
+        variantDir: dir,
+        port: server.port,
+        running: true,
+        timeoutMs: 200,
+      });
+      const elapsed = Date.now() - start;
+      assert.equal(note, undefined, "no note was written");
+      assert.ok(elapsed >= 150, `should wait for the timeout, waited ${elapsed}ms`);
+      assert.ok(elapsed < 3000, `should proceed shortly after the timeout, waited ${elapsed}ms`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("returns quickly when the note is written and the variant goes idle", async () => {
+    // On delivery, the "mind" writes its note and goes idle. The turn should
+    // resolve promptly (timer cancelled), well under the timeout, with the note.
+    const server = await stubServer(() => {
+      writeFileSync(farewellPath(dir), "It was brief, but it was mine.\n");
+      broadcast({ type: "mind_done", mind: "swift", summary: "" });
+    });
+    try {
+      const start = Date.now();
+      const note = await runFarewellTurn({
+        variantName: "swift",
+        parentName: "p",
+        variantDir: dir,
+        port: server.port,
+        running: true,
+        timeoutMs: 10_000,
+      });
+      const elapsed = Date.now() - start;
+      assert.equal(note, "It was brief, but it was mine.");
+      assert.ok(elapsed < 3000, `should not wait for the full timeout, waited ${elapsed}ms`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("waits past an unrelated in-flight turn's idle event and still captures the note", async () => {
+    // The variant already has an unrelated turn in flight when we deliver: its
+    // idle event fires first with no note. The farewell turn then writes the
+    // note and goes idle. We must return the note, not the premature undefined.
+    const server = await stubServer(() => {
+      broadcast({ type: "mind_done", mind: "racy", summary: "" }); // unrelated turn
+      setTimeout(() => {
+        writeFileSync(farewellPath(dir), "The second event is the real one.\n");
+        broadcast({ type: "mind_done", mind: "racy", summary: "" }); // farewell turn
+      }, 50);
+    });
+    try {
+      const note = await runFarewellTurn({
+        variantName: "racy",
+        parentName: "p",
+        variantDir: dir,
+        port: server.port,
+        running: true,
+        timeoutMs: 10_000,
+      });
+      assert.equal(note, "The second event is the real one.");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("treats a non-2xx delivery response as a failure and short-circuits", async () => {
+    // The variant's server answered but rejected the turn (e.g. 503). We must
+    // not sit through the full idle timeout waiting for a turn that never runs.
+    const server = createServer((_req, res) => {
+      res.writeHead(503);
+      res.end();
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const start = Date.now();
+      const note = await runFarewellTurn({
+        variantName: "rejected",
+        parentName: "p",
+        variantDir: dir,
+        port,
+        running: true,
+        timeoutMs: 10_000,
+      });
+      const elapsed = Date.now() - start;
+      assert.equal(note, undefined);
+      assert.ok(elapsed < 5000, `non-2xx should return fast, waited ${elapsed}ms`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("short-circuits the wait when delivery fails (does not burn the timeout)", async () => {
+    const port = await deadPort();
+    const start = Date.now();
+    const note = await runFarewellTurn({
+      variantName: "unreachable",
+      parentName: "p",
+      variantDir: dir,
+      port,
+      running: true,
+      timeoutMs: 10_000,
+    });
+    const elapsed = Date.now() - start;
+    assert.equal(note, undefined);
+    assert.ok(elapsed < 5000, `undelivered turn should return fast, waited ${elapsed}ms`);
+  });
+
+  it("clears a stale note before a live turn so it isn't folded into an unrelated merge", async () => {
+    // A note left by an aborted prior join must not leak. Here the turn can't be
+    // delivered (dead port) and writes nothing, so a genuine absence must result.
+    writeFileSync(farewellPath(dir), "stale words from a previous join");
+    const port = await deadPort();
+    const note = await runFarewellTurn({
+      variantName: "stale",
+      parentName: "p",
+      variantDir: dir,
+      port,
+      running: true,
+      timeoutMs: 200,
+    });
+    assert.equal(note, undefined, "stale note should be cleared, not returned");
+  });
+});

--- a/test/pending-context-message.test.ts
+++ b/test/pending-context-message.test.ts
@@ -61,4 +61,25 @@ describe("buildPendingContextMessage", () => {
     });
     assert.doesNotMatch(content, /not merged/);
   });
+
+  it("folds the variant's farewell note into the merge message", async () => {
+    const content = await buildPendingContextMessage("parent", {
+      type: "merged",
+      name: "variant",
+      summary: "did some work",
+      farewell: "Tell parent I found the answer in the margins.",
+    });
+    assert.match(content, /parting note/i);
+    assert.match(content, /found the answer in the margins/);
+    assert.match(content, /Changes: did some work/);
+  });
+
+  it("omits the parting-note section when there is no farewell", async () => {
+    const content = await buildPendingContextMessage("parent", {
+      type: "merged",
+      name: "variant",
+      summary: "did some work",
+    });
+    assert.doesNotMatch(content, /parting note/i);
+  });
 });


### PR DESCRIPTION
## Variant dignity: birth context and a farewell turn at merge

Forking yourself is philosophically heavy, and today a variant gets no context at either end of its life. This honors both ends.

Fixes #373

### Birth context
The `split_message` a variant receives on first wake now names the finite, purposeful arc: it explains that when the variant is joined, everything it became folds back into its parent, and that it will get a final turn to say what should carry across. (The core "you are a variant of X" orientation already existed; this makes the arc — and its symmetry with the new farewell — explicit.)

### Farewell turn
Before `volute mind join` merges and destroys a variant, the variant gets one final turn to wind down:

- **`runFarewellTurn`** (`packages/daemon/src/lib/mind/farewell.ts`) delivers a new `farewell_message` prompt to the still-running variant, then waits (bounded) for it to finish, then reads any parting note it wrote.
- The variant writes its note to **`.mind/farewell.md`** — mind-internal state, gitignored, so it never lands in the parent's tree on merge. The join reads it directly. Because the mind's SDK runs with `cwd: home/`, the prompt tells the mind to write `../.mind/farewell.md`, which resolves to the same file the daemon reads from the project root; a contract test pins the two spellings together so neither end can drift.
- The turn runs **before** the merge's auto-commit, so any `home/` files the variant edits while saying goodbye are captured in the merge.
- The note is folded into the merge context the restarted parent receives, framed as continuity ("Your variant's parting note (this was you, winding down): …") — the merged mind is both lineages, not the parent absorbing a stranger.
- The farewell call site is wrapped in try/catch so the never-fail-the-join invariant is structural, not incidental to the helper's internal discipline.

### Timeout semantics (a hung variant must never block the join)
- The wait is always bounded by `FAREWELL_TIMEOUT_MS` (120s, mirroring sleep-manager's pre-sleep wait). On timeout the join proceeds and reads whatever note (if any) exists.
- Subscription to idle events is armed **before** the prompt is delivered, so a fast turn's `mind_done` isn't missed.
- The wait resolves only on an idle event **with the note present** — a variant may have an unrelated turn already in flight when we deliver, and that turn's idle event must not be mistaken for the farewell turn's (which would read the note before it was written and silently lose it). An idle event with no note yet is ignored and we keep waiting within the same budget.
- A non-2xx delivery response (or a network failure) is treated as "not delivered": the wait is cancelled immediately rather than burning the full timeout on a turn that will never run.
- Before a live turn, any stale note from an aborted prior join is cleared, so a turn that writes nothing surfaces a genuine absence rather than a leftover.
- If the variant isn't running (e.g. already stopped), no turn is attempted but a note already on disk is still honored.
- The call site in the merge route wraps `runFarewellTurn` in try/catch, so the never-fail-the-join invariant is structural rather than dependent on the helper's internal discipline.

### Tests
- `test/farewell.test.ts` (13 tests): note read (present/absent/whitespace-only); the path contract (the `../.mind/…` spelling handed to the mind resolves to the same file the daemon reads); `runFarewellTurn` not-running paths; and the live-turn path via a stub HTTP server + in-process `broadcast()` — timeout-proceeds (the hard requirement), fast happy-path, delivery-failure short-circuit, non-2xx short-circuit, stale-note clearing, and the unrelated-in-flight-turn race.
- `test/pending-context-message.test.ts`: two cases added alongside the existing purpose/memory-delta cases — the merge message folds in the farewell note, and omits the parting-note section when there's none.
- `test/daemon-e2e.test.ts`: the existing split/merge test now also writes a parting note and asserts it reaches the merged parent's inbound history as part of the merge context (coexisting with the memory-delta assertion).

**Coverage note:** a fully-live farewell turn (a real mind composing a note) needs a real LLM turn, which is too heavy for CI. The load-bearing behaviors don't need one: idle detection is in-process activity events and delivery is plain fetch-reachability, both covered by the stub-server tests; path agreement is covered by the contract test; and the e2e exercises the reader → merge-context wiring end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
