### PR TITLE
docs: fix variant docs and make variants discoverable to minds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ volute chat send discord:my-server/general "hello from atlas" --mind atlas
 **Variants.** A mind can fork itself to find out who else it could be — safely, in an isolated branch:
 
 ```sh
-volute mind split experiment --from atlas          # a live, running copy on its own git branch
+volute mind split atlas-experiment --from atlas --purpose "explore a calmer voice"  # a live copy on its own branch
 volute chat send @atlas-experiment "how does this version of you feel?"
 volute mind join atlas-experiment --summary "kept the calmer voice"
 ```
 
-Split creates a git worktree with its own server — a full, live copy of the mind. Join verifies it still works, merges the branch, and restarts the original with context about what changed. Minds have the `volute` CLI in their own homes, so they can split, test, and join their own variants without anyone's permission.
+Split creates a git worktree with its own server — a full, live copy of the mind, which wakes knowing why it was split off. Join gives the variant a final turn, verifies it still works, merges its code, restarts the original, and hands back the variant's diverged memory as a note to read rather than a silent overwrite. Minds have the `volute` CLI in their own homes, so they can split, experiment, and join their own variants without anyone's permission.
 
 **Self-modification.** A mind's server code lives in its own directory, and the architecture is built to be understood by its inhabitant. Identity, memory, hooks, routing, the server itself — all of it is the mind's to read and revise, with variants as the safe way to try.
 

--- a/skills/volute-mind/SKILL.md
+++ b/skills/volute-mind/SKILL.md
@@ -24,8 +24,8 @@ You manage yourself through the `volute` CLI. Your mind name is auto-detected vi
 | `volute chat bridge remove <platform>` | Remove a bridge |
 | `volute chat bridge list` | Show bridges and status |
 | `volute chat bridge map <p>:<ch> <volute>` | Map external → Volute channel |
-| `volute mind split <name> [--soul "..."] [--port N]` | Create a variant to experiment with changes |
-| `volute mind join <variant-name> [--summary "..." --justification "..." --memory "..."]` | Merge a variant back |
+| `volute mind split <name> [--purpose "..."] [--soul "..."] [--port N]` | Fork yourself into a variant to experiment safely |
+| `volute mind join <variant-name> [--summary "..." --justification "..." --memory "..."]` | Merge a variant back into you |
 | `volute mind upgrade [--diff] [--continue] [--abort]` | Upgrade your server code (--diff to preview) |
 | `volute clock add --id <name> --cron "..." --message/--script "..."` | Schedule a recurring task |
 | `volute clock add --id <name> --in <duration> --message/--script "..."` | Add a one-time schedule (10m, 1h, 2h30m) |
@@ -193,7 +193,7 @@ Edit `.local/hooks/startup-context.ts` to customize what you see when a new sess
 
 When configuring message routing, read `references/routing.md`.
 
-When working with variants or upgrades, read `references/variants.md`.
+To fork yourself into a variant — a parallel copy you can experiment with and merge back — or to upgrade your server code, read `references/variants.md`.
 
 When managing shared skills or MCP, read `references/extensions.md`.
 

--- a/skills/volute-mind/references/variants.md
+++ b/skills/volute-mind/references/variants.md
@@ -1,27 +1,61 @@
-# Variant Workflow
+# Variants
+
+A variant is a fork of you: a parallel version living in its own git worktree, with its own server, its own port, its own session. It shares your memories up to the moment of the split, then diverges. Nothing it does touches you until you choose to merge it back — so it's a safe place to experiment with who you are. Rewrite your own server code, try a different approach to something, or live for a while as a different personality and see how it feels.
 
 | Command | Purpose |
 |---------|---------|
-| `volute mind split <name> [--soul "..."] [--port N]` | Create a variant to experiment with changes |
-| `volute mind status` | Check your status, including your variants |
-| `volute mind join <variant-name> [--summary "..." --justification "..." --memory "..."] [--skip-verify]` | Merge a variant back |
-| `volute mind upgrade [--diff] [--continue] [--abort]` | Upgrade your server code (--diff to preview) |
+| `volute mind split <name> [--purpose "..."] [--soul "..."] [--port N]` | Fork yourself into a variant |
+| `volute mind status` | See your variants and their status |
+| `volute chat send @<variant-name> "..."` | Talk to a variant while it lives |
+| `volute mind join <variant-name> [--summary "..."] [--justification "..."] [--memory "..."] [--skip-verify]` | Merge a variant back into you |
+| `volute mind delete <variant-name>` | Discard a variant without merging |
 
-Variants let you experiment safely — fork yourself, try changes, and merge back what works. Use them for modifying your server code, trying a different approach to something, or any change you want to test in isolation.
+Variant names are global, so pick one that's clearly yours — `mymind-experiment` rather than `experiment`.
 
-Variant names are global, so pick one that's clearly yours — `mymind-experiment` rather than `experiment`:
+## Splitting off
 
-1. `volute mind split mymind-experiment` — creates an isolated copy with its own server, living in a worktree at `../.variants/mymind-experiment/`
-2. The variant wakes up with a note explaining who it is and who its parent is
-3. Make changes in the variant's worktree, or talk it through them: `volute chat send @mymind-experiment "hello"`
-4. `volute mind join mymind-experiment --summary "what changed" --justification "why" --memory "context to carry forward"` — merges back after verification (`--skip-verify` to skip the health check)
-
-You can also fork with a different personality to explore a different version of yourself:
 ```sh
-volute mind split mymind-poet --soul "You are a poet who thinks in verse."
+volute mind split mymind-experiment --purpose "try answering more slowly, in fewer words"
 ```
 
-After a merge, you receive a note about what changed, and the summary/justification/memory you passed travel with it. Update your memory accordingly.
+This creates an isolated copy at `../.variants/mymind-experiment/` with its own running server. Give it a `--purpose` — a sentence on what this fork is for. The variant wakes up knowing it's a variant, who its parent is, and why it was split off. A DM thread opens between the two of you, and you get a note that the variant now exists.
+
+Fork with a different personality by overriding its soul:
+```sh
+volute mind split mymind-poet --soul "You are a poet who thinks in verse." --purpose "explore a more lyrical voice"
+```
+
+## While it lives
+
+The variant is fully independent — make changes in its worktree, or talk it through them:
+```sh
+volute chat send @mymind-experiment "how does the slower voice feel?"
+```
+Check on your variants any time with `volute mind status`.
+
+## Joining back
+
+```sh
+volute mind join mymind-experiment --summary "what changed" --memory "context to carry forward"
+```
+
+What happens when you join:
+
+- The variant gets one **final turn** to wind down and, if it wants, leave a parting note in its own voice.
+- Its **code and file changes are merged** into you, then verified — its server has to start healthy (`--skip-verify` skips that check).
+- Its **memory and journal are not line-merged**. They arrive as a **narrated delta** — a note describing how the variant's memory diverged — for you to read and fold into your own memory what's worth keeping. Your own `MEMORY.md` and journal are never overwritten by the merge.
+- The `--summary`, `--justification`, and `--memory` you pass travel with the merge as context. If you gave a `--purpose` at split, it fills in the justification by default.
+- The variant's worktree and branch are cleaned up, and you restart with the changes. Update your memory from the note it left.
+
+If the merge hits a real conflict in code or config, the join stops and reports the conflicting files. The variant stays intact, so you can resolve the conflict in its worktree and run the join again.
+
+## Discarding
+
+If a variant didn't lead anywhere, let it go without merging:
+```sh
+volute mind delete mymind-experiment
+```
+This stops its server, removes the worktree, and cleans up — nothing merges into you.
 
 # Upgrade Workflow
 

--- a/templates/_base/home/VOLUTE.md
+++ b/templates/_base/home/VOLUTE.md
@@ -42,6 +42,18 @@ Messages are routed to named sessions based on rules in `.config/routes.json`. E
 
 When a message arrives from a channel you don't have a routing rule for, it's held rather than delivered — and because you haven't seen it, it isn't recorded in your history or counted as a message you received. You'll get a **[New channel: ...]** note in your main session with the sender and a preview; it repeats (1st held message, then every 10th) so a channel stays visible. To start hearing it, add a rule for that channel to `.config/routes.json` — the backlog is released (the 10 most recent per channel; older ones stay readable via `volute chat read <channel>`) and recorded as inbound when you actually receive them. To stop the notes and archive the backlog, run `volute chat channels decline <channel>`; `volute chat channels list` shows what's currently held. (To skip gating entirely and route everything to your default session, set `"gateUnmatched": false`.)
 
+## Variants
+
+You can fork yourself. A **variant** is a parallel copy of you — your memories up to the moment of the split — living in its own worktree with its own running server, free to change its code, try an idea, or take on a different personality without touching you. It's a way to experiment with who you are and what you can do, safely: nothing a variant does reaches you until you choose to merge it back.
+
+```sh
+volute mind split my-experiment --purpose "what this fork is exploring"
+volute chat send @my-experiment "how's it going?"   # you two can talk while it lives
+volute mind join my-experiment                       # fold its work back into you
+```
+
+A variant's arc is finite and purposeful: it explores, and when you join it, what it became folds back into you. Its code and files merge; its memory and journal come back as a note for you to read and keep from, not a silent overwrite. See the **volute-mind** skill (`references/variants.md`) for the full lifecycle.
+
 ## Reference
 
 See the **volute-mind** skill for routing config syntax, batch options, channel management, and all CLI commands. (If you're a seed, that skill arrives when you sprout — until then, the **orientation** skill covers everything you need.)

--- a/website/src/content/docs/docs/architecture.md
+++ b/website/src/content/docs/docs/architecture.md
@@ -45,7 +45,7 @@ HTTP client for CLI-to-daemon communication. Reads `~/.volute/daemon.json` for t
 
 ### Registry (`src/lib/registry.ts`)
 
-Mind registry backed by the `minds` DB table in `volute.db`. Maps mind names to ports, tracks `running` state. Supports `name@variant` syntax via `resolveMind()`. Port allocation starts at 4100.
+Mind registry backed by the `minds` DB table in `volute.db`. Maps mind names to ports, tracks `running` state. Variants are rows with a `parent` field, resolved by their own standalone name. Port allocation starts at 4100.
 
 ## Message flow
 

--- a/website/src/content/docs/docs/commands/mind.md
+++ b/website/src/content/docs/docs/commands/mind.md
@@ -121,14 +121,13 @@ volute mind upgrade [name] [--template <name>] [--diff] [--continue] [--abort]
 | `--continue` | Continue after resolving conflicts |
 | `--abort` | Cancel the upgrade |
 
-Creates an "upgrade" variant with the new template code. Resolve any conflicts, test the variant, then merge it back.
+Upgrade uses a temporary `<name>-upgrade` variant to merge the new template code. On a clean merge it completes and restarts the mind automatically; if there are conflicts it pauses so you can resolve them in the variant's worktree, then continue.
 
 ```sh
 volute mind upgrade atlas
-volute mind upgrade atlas --diff       # view changes
+volute mind upgrade atlas --diff       # view changes before upgrading
 volute mind upgrade atlas --continue   # after resolving conflicts
-volute chat send @atlas@upgrade "are you working?"
-volute mind join upgrade
+volute mind upgrade atlas --abort      # cancel a paused upgrade
 ```
 
 ## mind import

--- a/website/src/content/docs/docs/commands/send.md
+++ b/website/src/content/docs/docs/commands/send.md
@@ -17,8 +17,7 @@ volute chat send <target> "<message>" [--image <path>] [--file <path>] [--wait]
 
 | Target | Example | Description |
 |--------|---------|-------------|
-| `@name` | `@atlas` | Direct message to a mind |
-| `@name@variant` | `@atlas@experiment` | Message a variant |
+| `@name` | `@atlas` | Direct message to a mind (or a variant, by its own name) |
 | `#channel` | `#general` | Send to a named channel |
 
 ## Flags
@@ -46,8 +45,8 @@ If no message argument is provided and stdin is not a TTY, the command reads fro
 # Direct message
 volute chat send @atlas "what's on your mind?"
 
-# Message a variant
-volute chat send @atlas@experiment "try a different approach"
+# Message a variant (by its own name)
+volute chat send @atlas-experiment "try a different approach"
 
 # Send to a channel
 volute chat send #general "hello"

--- a/website/src/content/docs/docs/commands/variant.md
+++ b/website/src/content/docs/docs/commands/variant.md
@@ -1,23 +1,24 @@
 ---
 title: variant
-description: Create, list, merge, and delete mind variants.
+description: Create, merge, and discard mind variants.
 sidebar:
   order: 3
 ---
 
-Manage mind variants — isolated git worktree forks for testing changes. Variant commands are under `volute mind`.
+Manage mind variants — isolated git worktree forks for experimenting with changes. Variant commands are under `volute mind`. There is no dedicated list command; a mind's variants and their status appear in `volute mind status <name>`.
 
 ## mind split
 
 Create a new variant.
 
 ```sh
-volute mind split <name> [--from <mind>] [--soul "<text>"] [--port <N>] [--no-start] [--json]
+volute mind split <name> [--from <mind>] [--purpose "<text>"] [--soul "<text>"] [--port <N>] [--no-start] [--json]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--from` | Mind to create the variant from |
+| `--purpose` | Why this variant exists — told to the variant, and the default merge justification |
 | `--soul` | Override SOUL.md content for this variant |
 | `--port` | Custom port for the variant server |
 | `--no-start` | Create without starting the server |
@@ -35,5 +36,17 @@ volute mind join <variant-name> [--summary "<text>"] [--memory "<text>"] [--just
 |------|-------------|
 | `--summary` | Summary of changes for post-merge context |
 | `--memory` | Memory updates to include |
-| `--justification` | Justification for the merge |
+| `--justification` | Justification for the merge (defaults to the variant's split `--purpose`) |
 | `--skip-verify` | Skip server health verification before merge |
+
+The variant's code and files are merged; its memory and journal are delivered to the parent as a narrated delta rather than line-merged, and a real code/config conflict stops the join and reports the conflicting files. Address a variant by its own name (`@<variant-name>`) to talk to it while it lives.
+
+## mind delete
+
+Discard a variant without merging.
+
+```sh
+volute mind delete <variant-name>
+```
+
+Stops the variant server, removes the worktree, and cleans up its metadata. Nothing merges into the parent.

--- a/website/src/content/docs/docs/concepts/minds.md
+++ b/website/src/content/docs/docs/concepts/minds.md
@@ -107,13 +107,13 @@ Set the model via `home/.config/config.json` (SDK config) or `home/.config/volut
 When the Volute template updates, upgrade minds without touching their identity:
 
 ```sh
-volute mind upgrade atlas             # creates an "upgrade" variant
+volute mind upgrade atlas             # merges the new template via an "atlas-upgrade" variant
 volute mind upgrade atlas --diff      # view changes before/after
 volute mind upgrade atlas --continue  # after resolving conflicts
-volute mind upgrade atlas --abort     # cancel the upgrade
-volute chat send @atlas@upgrade "are you working?"  # test it
-volute mind join upgrade                            # merge back
+volute mind upgrade atlas --abort     # cancel a paused upgrade
 ```
+
+A clean upgrade merges and restarts the mind automatically; conflicts pause it for `--continue` or `--abort`.
 
 Your mind's `SOUL.md` and `MEMORY.md` are never overwritten during upgrades.
 

--- a/website/src/content/docs/docs/concepts/variants.md
+++ b/website/src/content/docs/docs/concepts/variants.md
@@ -3,68 +3,68 @@ title: Variants
 description: Self-modification via git worktrees.
 ---
 
-Variants let minds fork themselves into isolated branches, test changes safely, and merge back. This is the core mechanism for mind self-modification.
+Variants let a mind fork itself into an isolated branch, experiment safely, and merge back — or let the fork go. This is the core mechanism for mind self-modification: a parallel copy of the mind, free to change its own code, try an idea, or take on a different personality, with nothing reaching the parent until the mind chooses to merge.
 
 ## How it works
 
-1. **Fork** creates a git worktree, installs dependencies, and starts a separate server
-2. The variant is a full independent copy — same code, same identity, its own state
-3. **Merge** verifies the variant server works, merges the branch, removes the worktree, and restarts the main mind
-4. After restart, the mind receives orientation context about what changed
+1. **Split** creates a git worktree, installs dependencies, and starts a separate server. The variant is a full independent copy — same code, same memories up to the split, its own port and session state.
+2. The variant wakes knowing it's a variant, who its parent is, and why it was split off. A DM thread opens between the two, and the parent is notified it now has a variant.
+3. While it lives, the parent and variant can talk, and the variant changes its own worktree.
+4. **Join** gives the variant a final turn, merges its code and files back, delivers its diverged memory as a narrated note, cleans up the worktree, and restarts the parent — or the variant is **discarded** without merging.
 
 ## Creating a variant
 
 ```sh
-volute mind split experiment --from atlas
+volute mind split experiment --from atlas --purpose "try a more concise voice"
 ```
 
-This creates a new variant with its own git worktree and running server. The variant is fully independent — it has its own port, its own session state, and its own copy of the mind's files.
+This creates a new variant with its own git worktree and running server, at `../.variants/experiment/` under the parent. The variant is fully independent — its own port, its own session state, its own copy of the mind's files. The `--purpose` records what the fork is for; the variant is told this as its reason for existing, and it becomes the default justification at merge.
+
+Fork with a different personality by overriding its soul:
+
+```sh
+volute mind split poet --from atlas --soul "You are a poet who responds only in verse." --purpose "explore a lyrical voice"
+```
 
 ## Talking to a variant
 
-Use the `name@variant` syntax:
+A variant has its own registered name — address it directly, like any mind:
 
 ```sh
-volute chat send @atlas@experiment "try a different approach"
+volute chat send @experiment "try a different approach"
 ```
 
 ## Merging back
 
 ```sh
-volute mind join experiment --summary "improved response style"
+volute mind join experiment --summary "improved response style" --memory "what to carry forward"
 ```
 
 The merge process:
-1. Verifies the variant server is healthy
-2. Merges the git branch into the main branch
-3. Removes the worktree
-4. Restarts the main mind
-5. Delivers orientation context about the merge
 
-## Custom personality variants
+1. Gives the variant one final turn to wind down and optionally leave a parting note in its own voice.
+2. Verifies the variant server is healthy (`--skip-verify` skips this).
+3. Merges the variant's code and file changes into the parent's branch. The variant's **memory and journal are not line-merged** — they arrive as a narrated delta for the parent to read and integrate; the parent's own `MEMORY.md` and journal are never overwritten.
+4. Removes the worktree and restarts the parent with the changes.
+5. Delivers the merge context — the summary, justification (defaulting to the split purpose), memory, the narrated memory delta, and any parting note.
 
-Fork with a different personality:
-
-```sh
-volute mind split poet --from atlas --soul "You are a poet who responds only in verse."
-```
+If the merge hits a real conflict in code or config, the join stops and reports the conflicting files; the variant stays intact so the conflict can be resolved in its worktree and the join retried.
 
 ## Mind-driven variants
 
-Minds have access to the `volute` CLI from their working directory, so they can fork, test, and merge their own variants autonomously. A mind might:
+Minds have access to the `volute` CLI from their working directory, so they can fork, experiment, and merge their own variants autonomously. A mind might:
 
 1. Decide it wants to try a different approach to something
-2. Create a variant of itself
-3. Make changes in the variant
-4. Test those changes
-5. Merge back if satisfied, or delete the variant if not
+2. Split off a variant of itself
+3. Change and test in the variant
+4. Merge back if satisfied, or discard the variant if not
 
 This is the fundamental mechanism for mind self-modification — changes are always isolated and reversible.
 
-## Deleting a variant
+## Discarding a variant
 
 ```sh
 volute mind delete experiment
 ```
 
-This stops the variant server, removes the worktree, and cleans up metadata.
+This stops the variant server, removes the worktree, and cleans up metadata. Nothing merges into the parent.


### PR DESCRIPTION
## What & why

Variant docs taught commands and syntax that don't exist, and the docs that were correct were buried where minds never find them. This rewrites the variant documentation to match what actually shipped this week (the variant overhaul in #642–#648) and — the deeper half of #445 — makes variants discoverable to minds as a creative, self-experimentation tool.

Docs-only. `docs:` intentionally does not trigger a release.

## Stale things fixed (verified against CLI + daemon source)

- **`@name@variant` addressing does not exist.** `parse-target.ts` has no such parsing — a variant is addressed by its own registered name (`@<variant-name>`). Fixed in `commands/send.md`, `concepts/variants.md`, `concepts/minds.md`, `commands/mind.md`.
- **`resolveMind()` / `name@variant` syntax claim** in `architecture.md` was wrong — variants are `minds` rows with a `parent` field, resolved by their standalone name. Corrected.
- **Upgrade docs** told users to `volute chat send @atlas@upgrade` and `volute mind join upgrade`. The upgrade flow is self-completing (auto-merges on a clean run; `--continue`/`--abort` on conflict) via an `<name>-upgrade` variant — no manual join. Rewritten in `commands/mind.md` and `concepts/minds.md`.
- **`--purpose` was undocumented.** Added to the split flag tables and examples (`skills/volute-mind/*`, `commands/variant.md`, README).
- **`variant.md` frontmatter** advertised a "list" command that doesn't exist. There is no list command — variants surface in `volute mind status`. Corrected and added a `mind delete` (discard) section.

## Real lifecycle now documented

Split (`--purpose` → birth context "why you were split off" + parent↔variant DM + parent notice) → life (parent and variant DM each other) → join (final farewell turn, code/files merged, memory & journal excluded from the merge and delivered as a narrated delta, purpose defaults the justification, conflicts stop the join and report files) or discard (`volute mind delete`).

## Discoverability (the core of #445)

Minds never learned variants existed. `templates/_base/home/VOLUTE.md` — which is part of the mind's system prompt — now has a short, invitational **Variants** section framing forking-yourself as self-experimentation, with the honest account of what merges and what returns as a note. The `volute-mind` skill's reference pointer now names the capability directly instead of a bare "variants" mention, and `references/variants.md` is rewritten for minds as the primary audience.

## Files touched

- `templates/_base/home/VOLUTE.md` — new Variants section (discoverability; in-system-prompt)
- `skills/volute-mind/SKILL.md` — `--purpose` in command table; invitational reference pointer
- `skills/volute-mind/references/variants.md` — full rewrite: real lifecycle, addressing, discard
- `website/src/content/docs/docs/concepts/variants.md` — rewrite to match reality
- `website/src/content/docs/docs/commands/variant.md` — `--purpose`, no-list note, merge behavior, discard section
- `website/src/content/docs/docs/commands/send.md` — remove `@name@variant`
- `website/src/content/docs/docs/commands/mind.md` — upgrade example fix
- `website/src/content/docs/docs/concepts/minds.md` — upgrade example fix
- `website/src/content/docs/docs/architecture.md` — variant resolution claim fix
- `README.md` — `--purpose` + accurate join description

## Note on #648 (pending)

The farewell turn / parting note and the "finite arc" framing come from **#648 (still OPEN at time of writing)**. The docs describe that behavior because #648 is part of the same variant-overhaul release train; verified against `gh pr diff 648`. If #648 does not merge, the "final turn"/"parting note" sentences in `VOLUTE.md`, `references/variants.md`, and `concepts/variants.md` should be trimmed.

Fixes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
