### PR TITLE
docs: correct variant discard — CLI delete doesn't remove the worktree

### DIFF
--- a/skills/volute-mind/references/variants.md
+++ b/skills/volute-mind/references/variants.md
@@ -55,7 +55,7 @@ If a variant didn't lead anywhere, let it go without merging:
 ```sh
 volute mind delete mymind-experiment
 ```
-This stops its server, removes the worktree, and cleans up — nothing merges into you.
+This removes the variant from the registry and discards its work — nothing merges into you.
 
 # Upgrade Workflow
 

--- a/skills/volute-mind/references/variants.md
+++ b/skills/volute-mind/references/variants.md
@@ -55,7 +55,7 @@ If a variant didn't lead anywhere, let it go without merging:
 ```sh
 volute mind delete mymind-experiment
 ```
-This removes the variant from the registry and discards its work — nothing merges into you.
+This removes the variant from the registry — nothing merges into you. Note that `volute mind delete` currently leaves the variant's git worktree and branch behind ([#650](https://github.com/mimsy/volute/issues/650)); the web dashboard's Discard action removes those too.
 
 # Upgrade Workflow
 

--- a/website/src/content/docs/docs/commands/variant.md
+++ b/website/src/content/docs/docs/commands/variant.md
@@ -49,4 +49,4 @@ Discard a variant without merging.
 volute mind delete <variant-name>
 ```
 
-Stops the variant server, removes the worktree, and cleans up its metadata. Nothing merges into the parent.
+Removes the variant from the registry and discards its work. Nothing merges into the parent.

--- a/website/src/content/docs/docs/commands/variant.md
+++ b/website/src/content/docs/docs/commands/variant.md
@@ -49,4 +49,4 @@ Discard a variant without merging.
 volute mind delete <variant-name>
 ```
 
-Removes the variant from the registry and discards its work. Nothing merges into the parent.
+Removes the variant from the registry; nothing merges into the parent. Note that this CLI path currently leaves the variant's git worktree and branch behind ([#650](https://github.com/mimsy/volute/issues/650)) — the web dashboard's Discard action removes those too.

--- a/website/src/content/docs/docs/concepts/variants.md
+++ b/website/src/content/docs/docs/concepts/variants.md
@@ -67,4 +67,4 @@ This is the fundamental mechanism for mind self-modification — changes are alw
 volute mind delete experiment
 ```
 
-This removes the variant from the registry and discards its work. Nothing merges into the parent. (The clean-up path that also removes the worktree runs from the web dashboard's discard action and the daemon's variant endpoint.)
+This removes the variant from the registry; nothing merges into the parent. Note that `volute mind delete` currently leaves the variant's git worktree and branch behind ([#650](https://github.com/mimsy/volute/issues/650)); the web dashboard's Discard action (and the daemon's variant endpoint) removes those too.

--- a/website/src/content/docs/docs/concepts/variants.md
+++ b/website/src/content/docs/docs/concepts/variants.md
@@ -67,4 +67,4 @@ This is the fundamental mechanism for mind self-modification — changes are alw
 volute mind delete experiment
 ```
 
-This stops the variant server, removes the worktree, and cleans up metadata. Nothing merges into the parent.
+This removes the variant from the registry and discards its work. Nothing merges into the parent. (The clean-up path that also removes the worktree runs from the web dashboard's discard action and the daemon's variant endpoint.)


### PR DESCRIPTION
Follow-up to #649 (which merged before this accuracy fix could land on its branch).

An accuracy review of #649 caught one false claim: `volute mind delete <variant>` does **not** remove the variant's git worktree. Triage confirmed this is a product gap, tracked as **#650**.

The CLI `volute mind delete` hits the general `DELETE /api/minds/:name` handler, not the variant endpoint. For a variant, `dir = mindDir(variant)` resolves to `<mindsDir>/<variant>` (not the worktree at `<parent>/.variants/<variant>`), and `findVariants(variant)` is empty, so `cleanupVariant` never runs. It drops the registry row, but the worktree/branch are left behind (even `--force` targets the wrong path). Only the variant endpoint `DELETE /:name/variants/:variant` — used by the web dashboard's Discard action — removes the worktree.

This PR documents current reality (not aspirational behavior) in the three docs that made the false claim, each now citing #650:
- `skills/volute-mind/references/variants.md`
- `website/src/content/docs/docs/commands/variant.md`
- `website/src/content/docs/docs/concepts/variants.md`

Docs-only, no code changes. Relates to #445; documents #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)