### PR TITLE
fix: let variants pass requireSelf on their own routes

### DIFF
--- a/packages/daemon/src/web/middleware/auth.ts
+++ b/packages/daemon/src/web/middleware/auth.ts
@@ -191,7 +191,11 @@ export const requireSelf = (paramName = "name") =>
     if (user.role !== "admin" && user.role !== "system") {
       const target = c.req.param(paramName) ?? "";
       const baseName = await getBaseName(target);
-      if (user.username !== baseName) {
+      // Base-map the caller too: a variant's token resolves to its own name,
+      // but the variant shares its parent's trust domain (same OS user, history
+      // recorded under the parent) — without this, a variant 403s on its own
+      // routes and can't even report its events (#652).
+      if (user.username !== baseName && (await getBaseName(user.username)) !== baseName) {
         return c.json({ error: "Forbidden" }, 403);
       }
     }

--- a/test/require-self.test.ts
+++ b/test/require-self.test.ts
@@ -22,7 +22,7 @@ import {
 const testMind = `require-self-test-${Date.now()}`;
 const testVariant = `${testMind}-variant`;
 
-const TEST_USERNAMES = ["admin-user", "admin-placeholder", "regular-user", testMind];
+const TEST_USERNAMES = ["admin-user", "admin-placeholder", "regular-user", testMind, testVariant];
 
 async function cleanup() {
   const db = await getDb();
@@ -130,6 +130,52 @@ describe("requireSelf middleware", () => {
       headers: { Authorization: `Bearer ${token}` },
     });
     assert.equal(res.status, 200);
+  });
+
+  it("variant's own token can access variant-scoped routes (#652)", async () => {
+    await addMind(testMind, 4400);
+    await addVariant(testVariant, testMind, 4401, mindDir(testMind), "variant-branch");
+    await getOrCreateMindUser(testVariant);
+    const token = generateMindToken(testVariant);
+    const app = createApp();
+
+    // The variant's server posts to its own /:name routes (e.g. /events) with
+    // a token issued for the variant name — this must not 403.
+    const res = await app.request(`/api/minds/${testVariant}/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+  });
+
+  it("variant token can access parent-scoped routes (shared trust domain)", async () => {
+    await addMind(testMind, 4400);
+    await addVariant(testVariant, testMind, 4401, mindDir(testMind), "variant-branch");
+    await getOrCreateMindUser(testVariant);
+    const token = generateMindToken(testVariant);
+    const app = createApp();
+
+    const res = await app.request(`/api/minds/${testMind}/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+  });
+
+  it("variant token cannot access an unrelated mind", async () => {
+    await addMind(testMind, 4400);
+    await addVariant(testVariant, testMind, 4401, mindDir(testMind), "variant-branch");
+    await addMind("other-mind", 4402);
+    await getOrCreateMindUser(testVariant);
+    const token = generateMindToken(testVariant);
+    const app = createApp();
+
+    const res = await app.request("/api/minds/other-mind/info", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 403);
+
+    try {
+      await removeMind("other-mind");
+    } catch {}
   });
 
   it("unauthenticated request gets 401", async () => {


### PR DESCRIPTION
Fixes #652.

`requireSelf` base-mapped the route target through `getBaseName()` but not the caller, so a variant's token (issued for its own name by mind-manager) got 403 on every one of the variant's own routes — including `POST /:name/events`, which left variants unable to deliver chat replies, record history, or resolve `chat send --wait`. This is what made the #646–#648 variant-dialogue features inert in practice.

The fix base-maps the caller's username as well: a caller whose base mind matches the target's base mind is self. A variant already shares its parent's trust domain — same OS user under isolation, history recorded under the parent — so this matches the existing model rather than widening it. Unrelated minds still 403 (covered by a new test).

Verified live in the release integration test (hot-patched container): with this change the variant's replies deliver, history records, and `--wait` resolves.

Tests: three new cases in `test/require-self.test.ts` (variant's own token on variant routes, variant token on parent routes, variant token blocked from unrelated minds). Full suite 2349/2349.

Merge order note: #653's fix is also required before variants function under user isolation — the two are independent changes but both needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)