### PR TITLE
fix: chown the whole .mind dir at mind start, not just .mind/tmp

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -264,10 +264,13 @@ export class MindManager {
     mkdirSync(mindTmp, { recursive: true });
 
     // State dir is created by root — chown so the mind user can write to it.
+    // Chown .mind itself, not just .mind/tmp: in a variant worktree .mind is
+    // absent (gitignored), so the recursive mkdir above creates it root-owned
+    // and the variant can't write sessions or its farewell note (#653).
     if (isIsolationEnabled()) {
       try {
         await chownMindDir(mindStateDir, baseName);
-        await chownMindDir(mindTmp, baseName);
+        await chownMindDir(resolve(dir, ".mind"), baseName);
       } catch (err) {
         throw new Error(
           `Cannot start mind ${name}: failed to set ownership on state directory ${mindStateDir}: ${err instanceof Error ? err.message : err}`,


### PR DESCRIPTION
Fixes #653.

In a variant worktree, `.mind/` is gitignored and therefore absent at spawn time. `startMind`'s `mkdirSync(mindTmp, { recursive: true })` runs as root and creates `.mind/` root-owned, and the isolation chown only targeted `.mind/tmp`. The variant process (running as the mind's OS user) could then read `.mind/` but not create anything in it:

- `session-store.save()` EACCES propagates out of `onSessionId` and **kills the stream consumer mid-turn** — every variant turn aborts within seconds
- the farewell turn (#648) can never write `.mind/farewell.md`, so every join eats the full 120s timeout and the parting note is always lost

Regular minds are unaffected (`.mind/` exists with correct ownership from mind create), which is why this never showed up outside variants.

Fix: target `.mind` itself — `chownMindDir` is `chown -R`, so `.mind/tmp` is covered as before.

Verified live in the release integration test: hot-patching this (plus #658) in the isolation container took variants from turns-die-in-seconds to completing the full split → dialogue → farewell → join arc. Coverage lands in the Docker e2e variant-lifecycle phase (PR to follow), which asserts worktree `.mind` ownership and a working variant conversation under isolation — unit-testing this spot would require mocking spawn + isolation wholesale.

Merge order note: pairs with #658; both are required before variants function in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)