### PR TITLE
fix: match only this spawn's output when detecting the detached server port

### DIFF
--- a/packages/daemon/src/lib/mind/spawn-server.ts
+++ b/packages/daemon/src/lib/mind/spawn-server.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { closeSync, mkdirSync, openSync, readFileSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { isIsolationEnabled, wrapForIsolation } from "./isolation.js";
 import { mindTmpDir } from "./registry.js";
@@ -88,6 +88,13 @@ function spawnDetached(
   const logsDir = logDir ?? resolve(cwd, ".mind", "logs");
   mkdirSync(logsDir, { recursive: true });
   const logPath = resolve(logsDir, "mind.log");
+  // The log persists across spawns (append mode), so only match output written
+  // by THIS spawn: an earlier attempt's "listening on :PORT" line would
+  // otherwise be matched first and the (long-dead) stale port returned (#654).
+  let startOffset = 0;
+  try {
+    startOffset = statSync(logPath).size;
+  } catch {}
   const logFd = openSync(logPath, "a");
 
   const child = spawn(cmd, args, {
@@ -112,7 +119,8 @@ function spawnDetached(
 
     const interval = setInterval(() => {
       try {
-        const content = readFileSync(logPath, "utf-8");
+        // Byte offset, so slice the raw buffer before decoding.
+        const content = readFileSync(logPath).subarray(startOffset).toString("utf-8");
         const match = content.match(/listening on :(\d+)/);
         if (match) {
           finish({ child, actualPort: parseInt(match[1], 10) });

--- a/test/spawn-server.test.ts
+++ b/test/spawn-server.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
 import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
@@ -51,6 +52,43 @@ describe("spawnServer verification wrapping", () => {
     // spawned, so the attached spawn resolves null rather than throwing.
     const result = await spawnServer("/tmp/nonexistent-spawn-dir", 0);
     assert.equal(result, null);
+  });
+
+  it("detached spawn ignores stale 'listening on' lines from earlier attempts (#654)", async () => {
+    // The verify path appends every attempt's output to the same
+    // .mind/logs/mind.log; matching the first "listening on :PORT" in the file
+    // returned a previous (dead) server's port, failing every re-verify.
+    const dir = mkdtempSync(join(tmpdir(), "spawn-detached-"));
+    try {
+      mkdirSync(join(dir, "src"), { recursive: true });
+      writeFileSync(
+        join(dir, "src", "server.ts"),
+        'console.log("listening on :43219");\nsetTimeout(() => {}, 15000);\n',
+      );
+      // `node --import tsx` resolves tsx from the spawn cwd
+      symlinkSync(resolve(process.cwd(), "node_modules"), join(dir, "node_modules"), "dir");
+      // Seed the log with a prior attempt's line
+      mkdirSync(join(dir, ".mind", "logs"), { recursive: true });
+      writeFileSync(join(dir, ".mind", "logs", "mind.log"), "listening on :1\n");
+
+      const result = await spawnServer(dir, 0, { detached: true });
+      try {
+        assert.ok(result, "spawn should succeed");
+        assert.equal(result.actualPort, 43219);
+      } finally {
+        if (result?.child.pid) {
+          try {
+            process.kill(-result.child.pid, "SIGKILL");
+          } catch {
+            try {
+              process.kill(result.child.pid, "SIGKILL");
+            } catch {}
+          }
+        }
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("skips sandbox wrap for codex-template minds", async () => {


### PR DESCRIPTION
Fixes #654.

`spawnDetached` appends every attempt's output to the same `.mind/logs/mind.log` and matched the **first** `listening on :PORT` in the whole file. The first join verification of a variant seeds the log; every later verification matches that first attempt's (SIGTERM'd) port, health-checks a dead server, and fails with "Verification failed. Fix issues or use skipVerify to proceed." — permanently, which is how the verify guardrail trains everyone to bypass it. Observed exactly this pattern in the release integration test: first join verified fine, every retry failed at the health check with the variant demonstrably healthy.

Fix: record the log's byte size before spawning and match only content appended after that offset (raw-buffer slice so multibyte content can't misalign the byte offset).

Test: new case in `test/spawn-server.test.ts` does a real detached spawn against a log pre-seeded with a stale `listening on :1` line and asserts the fresh server's port is returned — fails on main (returns 1), passes with the fix. Full suite 2347/2347.

Part of the variant-train fixes with #658/#659; the Docker e2e variant-lifecycle phase (PR to follow) seeds a stale log before join to exercise this end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)