### PR TITLE
fix: stop versioning SDK runtime state in mind repos

### DIFF
--- a/templates/_base/.gitignore
+++ b/templates/_base/.gitignore
@@ -24,14 +24,21 @@ home/*
 !home/.config/
 !home/.config/**
 
-# Skills (template-specific directories)
+# Skills (template-specific directories). Un-ignoring the agent dir alone would
+# track ALL its contents (`home/*` only matches one level), so re-ignore its
+# children and whitelist just skills + settings — SDK runtime state (session
+# transcripts, backups, .last-cleanup) must never be versioned: it bloats the
+# repo and conflicts on variant merges (#656).
 !home/.claude/
+home/.claude/*
 !home/.claude/skills/
 !home/.claude/skills/**
 !home/.claude/settings.json
 !home/.pi/
+home/.pi/*
 !home/.pi/skills/
 !home/.pi/skills/**
 !home/.agents/
+home/.agents/*
 !home/.agents/skills/
 !home/.agents/skills/**


### PR DESCRIPTION
Part of #656 (the tracked-runtime-noise half; the data-loss half — auto-commit claiming files it failed to add, new `home/` files dying with the variant worktree — stays open).

The template `.gitignore` whitelists `home/.claude/` intending skills + settings, but `home/*` only matches one level deep — un-ignoring the directory tracked **everything** under it. In practice: SDK session transcripts (`projects/*.jsonl`), 600+ line `.claude.json.backup.*` files, and `.last-cleanup` were committed by auto-commit, merged into parents on variant joins, and — when both parent and variant had run turns — **conflicted on `.last-cleanup` and aborted the join**. The new Docker e2e variant phase hit exactly that on its first validation run.

Fix: re-ignore the agent dirs' children (`home/.claude/*`, same for `.pi`/`.agents`) and whitelist what the block always intended — `skills/` and `settings.json`. Verified semantics in a scratch repo: skills + settings stage, transcripts/backups/`.last-cleanup` are ignored.

Only affects newly created minds (a `.gitignore` change doesn't untrack existing files in existing mind repos).

Suite 2346/2346. The Docker e2e variant-lifecycle phase (next PR) depends on this to pass its join step reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)