### PR TITLE
feat(web): render human messages as markdown in chat

### DIFF
--- a/packages/web/src/ui/components/chat/MessageEntry.svelte
+++ b/packages/web/src/ui/components/chat/MessageEntry.svelte
@@ -154,7 +154,7 @@ function buildAssistantItems(
     {#if role === "user"}
       {#each blocks as block}
         {#if block.type === "text"}
-          <div class="user-text">{block.text}</div>
+          <div class="markdown-body">{@html renderMarkdown(block.text)}</div>
         {:else if block.type === "image"}
           {@const imgSrc = `data:${block.media_type};base64,${block.data}`}
           <button type="button" class="chat-image-btn" onclick={() => (lightboxSrc = imgSrc)}>
@@ -242,11 +242,6 @@ function buildAssistantItems(
     min-width: 0;
     font-family: var(--mono);
     font-size: 14px;
-  }
-
-  .user-text {
-    color: var(--text-0);
-    white-space: pre-wrap;
   }
 
   .chat-image-btn {


### PR DESCRIPTION
## What changed

Human chat messages in the web dashboard previously rendered as plain text (`white-space: pre-wrap`), so code blocks, links, bold, and lists appeared as raw markdown source. Mind (assistant) messages already rendered as markdown.

This change renders user text blocks through the same DOMPurify-backed `renderMarkdown` path (`markdown-body` class) as assistant text blocks in `MessageEntry.svelte`, and removes the now-unused `.user-text` plain-text branch/CSS.

- Sanitization goes through `@volute/ui`'s `renderMarkdown` (DOMPurify-backed) — safe for untrusted authors in shared channels.
- Visual distinction (sender color/label) is unchanged; only text rendering changed.
- The renderer already uses `breaks: true`, so single newlines still break lines — short multi-line messages don't collapse into a paragraph.
- The optimistic-send path in `Chat.svelte` builds the same `{ type: "text", text }` blocks, so it renders identically.

## Testing

- `npm run build:web` passes.
- Full `npm test` passes (the pre-push hook ran it; an earlier run had 7 `SQLITE_FULL` failures caused by a transient low-disk condition on the machine, all in DB test setup — unrelated to this frontend-only change; they pass with disk space restored).

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)