### PR TITLE
feat: seed-progress card in the seed's chat view

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -29,6 +29,17 @@ export type Mind = {
   description?: string;
   avatar?: string;
   mindType?: "mind" | "spirit";
+  /** Sprout-checklist state — present only for seed-stage minds. */
+  seedChecklist?: SeedChecklist;
+};
+
+/** The seed → sprout checklist, as surfaced in a seed's status payload. */
+export type SeedChecklist = {
+  soulWritten: boolean;
+  memoryWritten: boolean;
+  displayNameSet: boolean;
+  avatarSet: boolean;
+  imagegenEnabled: boolean;
 };
 
 export type MindLastError = {

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -81,6 +81,7 @@ import {
   stateDir,
   validateMindName,
 } from "../../lib/mind/registry.js";
+import { evaluateSeedChecklist } from "../../lib/mind/seed-readiness.js";
 import { isTemplateStale } from "../../lib/mind/template-staleness.js";
 import { applyThinkingLevel, deriveThinkingLevel } from "../../lib/mind/thinking-config.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
@@ -140,7 +141,12 @@ type ChannelStatus = {
   status: "connected" | "disconnected";
 };
 
-async function getMindStatus(name: string, port: number, registryRunning?: boolean) {
+async function getMindStatus(
+  name: string,
+  port: number,
+  registryRunning?: boolean,
+  seed?: { stage?: string | null; dir?: string | null },
+) {
   const manager = getMindManager();
   let status: "running" | "stopped" | "starting" | "sleeping" = "stopped";
   let wakeAt: string | null = null;
@@ -185,6 +191,13 @@ async function getMindStatus(name: string, port: number, registryRunning?: boole
   // automatically once the notice drains on the next clean turn.
   const lastError = await latestFailureNotice(name);
 
+  // Seed minds surface their sprout checklist so the host watching the seed's
+  // chat can see how close it is (#664). Derived from the same predicates as the
+  // sprout gate and the spirit's nurture check — nothing secret, so it rides in
+  // the public status payload alongside displayName/avatar.
+  const seedChecklist =
+    seed?.stage === "seed" ? evaluateSeedChecklist(seed.dir ?? mindDir(name)) : undefined;
+
   return {
     status,
     wakeAt,
@@ -193,6 +206,7 @@ async function getMindStatus(name: string, port: number, registryRunning?: boole
     displayName: config?.profile?.displayName,
     description: config?.profile?.description,
     avatar: config?.profile?.avatar,
+    seedChecklist,
   };
 }
 
@@ -233,6 +247,7 @@ export function toPublicMind(
     displayName: status.displayName,
     description: status.description,
     avatar: status.avatar,
+    seedChecklist: status.seedChecklist,
     hasPages: extras.hasPages,
     lastActiveAt: extras.lastActiveAt ?? null,
   };
@@ -1342,7 +1357,10 @@ const app = new Hono<AuthEnv>()
     const privileged = isPrivileged(c);
     const minds = await Promise.all(
       entries.map(async (entry) => {
-        const mindStatus = await getMindStatus(entry.name, entry.port, entry.running);
+        const mindStatus = await getMindStatus(entry.name, entry.port, entry.running, {
+          stage: entry.stage,
+          dir: entry.dir,
+        });
         const hasPages = existsSync(resolve(mindDir(entry.name), "home", "pages"));
         const lastActiveAt = lastActiveMap.get(entry.name) ?? null;
         if (!privileged) return toPublicMind(entry, mindStatus, { hasPages, lastActiveAt });
@@ -1366,7 +1384,10 @@ const app = new Hono<AuthEnv>()
     const dir = entry.dir ?? mindDir(entry.parent ?? name);
     if (!existsSync(dir)) return c.json({ error: "Mind directory missing" }, 404);
 
-    const mindStatus = await getMindStatus(name, entry.port);
+    const mindStatus = await getMindStatus(name, entry.port, undefined, {
+      stage: entry.stage,
+      dir: entry.dir,
+    });
     const hasPages = existsSync(resolve(mindDir(name), "home", "pages"));
 
     // Non-privileged callers (minds, non-admin users) get profile-level fields

--- a/packages/web/src/ui/components/chat/Chat.svelte
+++ b/packages/web/src/ui/components/chat/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ContentBlock, Message, Mind, Participant } from "@volute/api";
+import type { ContentBlock, Message, Mind, Participant, SeedChecklist } from "@volute/api";
 import { fetchConversationMessages, sendChat } from "../../lib/client";
 import { subscribe } from "../../lib/connection.svelte";
 import { auth } from "../../lib/stores.svelte";
@@ -8,6 +8,7 @@ import ActivityIndicator from "./ActivityIndicator.svelte";
 import ChatStatusBar from "./ChatStatusBar.svelte";
 import MessageInput from "./MessageInput.svelte";
 import MessageList from "./MessageList.svelte";
+import SeedProgressCard from "./SeedProgressCard.svelte";
 
 let {
   name,
@@ -15,6 +16,7 @@ let {
   conversationId,
   onConversationId,
   stage,
+  seedChecklist,
   convType = "dm",
   channelName = "",
   minds = [],
@@ -27,6 +29,7 @@ let {
   conversationId: string | null;
   onConversationId: (id: string) => void;
   stage?: "seed" | "sprouted";
+  seedChecklist?: SeedChecklist;
   convType?: string;
   channelName?: string;
   minds?: Mind[];
@@ -244,7 +247,11 @@ async function handleSend(
 
 <div class="chat">
   {#if stage === "seed"}
-    <div class="orientation-bar">orientation</div>
+    {#if seedChecklist}
+      <SeedProgressCard checklist={seedChecklist} />
+    {:else}
+      <div class="orientation-bar">orientation</div>
+    {/if}
   {/if}
 
   {#if convType === "channel" && channelName}

--- a/packages/web/src/ui/components/chat/SeedProgressCard.svelte
+++ b/packages/web/src/ui/components/chat/SeedProgressCard.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+import type { SeedChecklist } from "@volute/api";
+
+let { checklist }: { checklist: SeedChecklist } = $props();
+
+// Avatar is only part of the sprout gate when image generation is enabled.
+let items = $derived([
+  { label: "SOUL.md written", done: checklist.soulWritten },
+  { label: "MEMORY.md written", done: checklist.memoryWritten },
+  { label: "Display name set", done: checklist.displayNameSet },
+  ...(checklist.imagegenEnabled ? [{ label: "Avatar set", done: checklist.avatarSet }] : []),
+]);
+
+let doneCount = $derived(items.filter((i) => i.done).length);
+let ready = $derived(doneCount === items.length);
+</script>
+
+<div class="seed-progress" class:ready>
+  <div class="header">
+    <span class="title">Orientation</span>
+    <span class="count">{doneCount}/{items.length}</span>
+  </div>
+  <ul class="checklist">
+    {#each items as item (item.label)}
+      <li class:done={item.done}>
+        <span class="mark" aria-hidden="true">{item.done ? "✓" : "○"}</span>
+        <span class="label">{item.label}</span>
+      </li>
+    {/each}
+  </ul>
+  <p class="hint">
+    {#if ready}
+      Ready to sprout — the seed can run <code>volute seed sprout</code>.
+    {:else}
+      Steps the seed completes before it can sprout into a full mind.
+    {/if}
+  </p>
+</div>
+
+<style>
+  .seed-progress {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--yellow-bg);
+    background: var(--yellow-bg);
+    flex-shrink: 0;
+  }
+
+  .seed-progress.ready {
+    border-bottom-color: var(--green-bg, var(--border));
+    background: var(--green-bg, var(--yellow-bg));
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .title {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--yellow);
+  }
+
+  .seed-progress.ready .title {
+    color: var(--green, var(--yellow));
+  }
+
+  .count {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-2);
+  }
+
+  .checklist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+  }
+
+  .checklist li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text-2);
+  }
+
+  .checklist li.done {
+    color: var(--text-0);
+  }
+
+  .mark {
+    width: 14px;
+    text-align: center;
+    color: var(--text-3, var(--text-2));
+  }
+
+  .checklist li.done .mark {
+    color: var(--green, var(--yellow));
+  }
+
+  .hint {
+    margin: 8px 0 0;
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .hint code {
+    font-size: 11px;
+    background: var(--bg-2, rgba(0, 0, 0, 0.1));
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+</style>

--- a/packages/web/src/ui/pages/MindPage.svelte
+++ b/packages/web/src/ui/pages/MindPage.svelte
@@ -72,6 +72,7 @@ function handleIframeNav(e: Event) {
         conversationId={conversationId ?? null}
         onConversationId={onConversationId ?? (() => {})}
         stage={mind.stage}
+        seedChecklist={mind.seedChecklist}
         minds={minds ?? data.minds}
         participants={currentConv?.participants ?? []}
         {onOpenMind}

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -415,6 +415,100 @@ describe("web minds routes", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("GET /:name — surfaces the sprout checklist for seed minds (#664)", async () => {
+    const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const { addMind, mindDir, removeMind } = await import(
+      "../packages/daemon/src/lib/mind/registry.js"
+    );
+    const { initMindManager, tryGetMindManager } = await import(
+      "../packages/daemon/src/lib/daemon/mind-manager.js"
+    );
+    if (!tryGetMindManager()) initMindManager();
+
+    const name = `web-seed-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    // SOUL written (no orientation marker), MEMORY still unwritten (empty),
+    // display name set — a partially-oriented seed.
+    writeFileSync(resolve(dir, "home/SOUL.md"), "# Me\nA real identity.");
+    writeFileSync(resolve(dir, "home/MEMORY.md"), "   \n");
+    writeFileSync(
+      resolve(dir, "home/.config/volute.json"),
+      JSON.stringify({ profile: { displayName: "Sprout" } }),
+    );
+    await addMind(name, 4197, "seed", "claude");
+
+    try {
+      const cookie = await setupAuth();
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request(`/api/minds/${name}`, {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as {
+        seedChecklist?: {
+          soulWritten: boolean;
+          memoryWritten: boolean;
+          displayNameSet: boolean;
+          avatarSet: boolean;
+        };
+      };
+      assert.ok(body.seedChecklist, "seed minds expose seedChecklist");
+      assert.equal(body.seedChecklist.soulWritten, true);
+      assert.equal(body.seedChecklist.memoryWritten, false);
+      assert.equal(body.seedChecklist.displayNameSet, true);
+      assert.equal(body.seedChecklist.avatarSet, false);
+
+      // Non-privileged callers get the checklist too — it's derived from
+      // already-public profile fields, nothing secret.
+      const user2 = await createUser("regular-user2", "pass");
+      await approveUser(user2.id);
+      const cookie2 = await createSession(user2.id);
+      const res2 = await app.request(`/api/minds/${name}`, {
+        headers: { Cookie: `volute_session=${cookie2}` },
+      });
+      const body2 = (await res2.json()) as { seedChecklist?: { soulWritten: boolean } };
+      assert.ok(body2.seedChecklist, "non-privileged callers also see the checklist");
+      assert.equal(body2.seedChecklist.soulWritten, true);
+      await deleteSession(cookie2);
+    } finally {
+      await removeMind(name);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("GET /:name — omits the sprout checklist for sprouted minds (#664)", async () => {
+    const { mkdirSync, rmSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const { addMind, mindDir, removeMind } = await import(
+      "../packages/daemon/src/lib/mind/registry.js"
+    );
+    const { initMindManager, tryGetMindManager } = await import(
+      "../packages/daemon/src/lib/daemon/mind-manager.js"
+    );
+    if (!tryGetMindManager()) initMindManager();
+
+    const name = `web-sprouted-${Date.now()}`;
+    const dir = resolve(mindDir(name));
+    mkdirSync(dir, { recursive: true });
+    await addMind(name, 4196, "sprouted", "claude");
+
+    try {
+      const cookie = await setupAuth();
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request(`/api/minds/${name}`, {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { seedChecklist?: unknown };
+      assert.equal(body.seedChecklist, undefined);
+    } finally {
+      await removeMind(name);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("toPublicMind", () => {

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -473,6 +473,21 @@ describe("web minds routes", () => {
       assert.ok(body2.seedChecklist, "non-privileged callers also see the checklist");
       assert.equal(body2.seedChecklist.soulWritten, true);
       await deleteSession(cookie2);
+
+      // The dashboard renders the card from the list route (data.minds), a
+      // separate call site from GET /:name — assert the checklist rides it too.
+      const listRes = await app.request("/api/minds", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(listRes.status, 200);
+      const list = (await listRes.json()) as Array<{
+        name: string;
+        seedChecklist?: { soulWritten: boolean; displayNameSet: boolean };
+      }>;
+      const listed = list.find((m) => m.name === name);
+      assert.ok(listed?.seedChecklist, "list route carries the seed checklist");
+      assert.equal(listed.seedChecklist.soulWritten, true);
+      assert.equal(listed.seedChecklist.displayNameSet, true);
     } finally {
       await removeMind(name);
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Renders a **seed-progress card** in a seed's chat view showing its sprout checklist, so the host watching the seed in the dashboard can see how close it is to sprouting at a glance — instead of only the bare `orientation` label.

The card lists each step and its state:
- SOUL.md written
- MEMORY.md written
- Display name set
- Avatar set (only shown when image generation is enabled)

When all steps are done, it flips to a "Ready to sprout" state.

## How

- **API**: fold the checklist into the existing mind status payload for `stage: "seed"` minds. `getMindStatus()` now calls the shared `evaluateSeedChecklist()` (the same predicates as the sprout gate and the spirit's nurture check) and returns `seedChecklist`. No new web route is added, so the authz surface is unchanged; the field rides in the existing `GET /api/minds` / `GET /api/minds/:name` responses (public projection included — it's derived from already-public profile fields, nothing secret).
- **Types**: new `SeedChecklist` type on `@volute/api`, added to `Mind`.
- **Frontend**: new `SeedProgressCard.svelte`, rendered in `Chat.svelte` in place of the plain orientation bar when a seed's checklist is present (falls back to the old bar otherwise).

## Tests

- Added API-side tests in `test/web-minds.test.ts`: seed minds surface `seedChecklist` (privileged and non-privileged callers), sprouted minds omit it.
- Existing `evaluateSeedChecklist` unit tests already cover the predicate logic.
- Full `npm test` green (the checklist logic is unchanged and shared).

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)