### PR TITLE
feat(web): dashboard notice and creation guard when no AI provider is configured

### DIFF
--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -13,6 +13,7 @@ import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { z } from "zod";
 import {
+  isAiConfigured,
   missingCredentialWarning,
   qualifyModelId,
   resolveTemplate,
@@ -893,6 +894,19 @@ const app = new Hono<AuthEnv>()
     if (nameErr) return c.json({ error: nameErr }, 400);
 
     if (await findMind(name)) return c.json({ error: `Mind already exists: ${name}` }, 409);
+
+    // Refuse to create a mind the system can't run. With no AI provider configured
+    // every mind spawns mute (no model to think with), so block creation here rather
+    // than leave an unusable mind behind (#606). Same message as the dashboard banner.
+    if (!isAiConfigured()) {
+      return c.json(
+        {
+          error:
+            "Minds cannot think yet — no AI provider is configured. Add a provider in Settings before creating a mind.",
+        },
+        409,
+      );
+    }
 
     // Cap total minds to protect host resources. Central enforcement here covers
     // `volute mind create`, `volute seed create`, and spirit-driven seeds alike;

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -897,7 +897,7 @@ const app = new Hono<AuthEnv>()
 
     // Refuse to create a mind the system can't run. With no AI provider configured
     // every mind spawns mute (no model to think with), so block creation here rather
-    // than leave an unusable mind behind (#606). Same message as the dashboard banner.
+    // than leave an unusable mind behind (#606). Mirrors the dashboard banner's copy.
     if (!isAiConfigured()) {
       return c.json(
         {

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -21,6 +21,7 @@ import {
   getCustomModels,
   getEnabledModels,
   getUtilityModel,
+  isAiConfigured,
   removeAiConfig,
   removeCustomModel,
   removeProviderConfig,
@@ -101,6 +102,10 @@ const app = new Hono<AuthEnv>()
       system: config?.system ?? null,
       name: globalConfig.name ?? null,
       timezone,
+      // Whether any AI model is available for minds to think with. A providerless
+      // system spawns every mind mute, so the dashboard surfaces a banner (#606).
+      // Boolean only — no provider details or secrets are exposed here.
+      aiConfigured: isAiConfigured(),
     });
   })
   .put("/info", requireAdmin, zValidator("json", z.object({ name: z.string() })), async (c) => {

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -15,6 +15,7 @@ import ChannelBrowserModal from "./components/modals/ChannelBrowserModal.svelte"
 import ContextModal from "./components/modals/ContextModal.svelte";
 import SeedModal from "./components/modals/SeedModal.svelte";
 import UserSettingsModal from "./components/modals/UserSettingsModal.svelte";
+import NoProviderBanner from "./components/system/NoProviderBanner.svelte";
 import PublicFiles from "./components/system/PublicFiles.svelte";
 import SystemLogs from "./components/system/SystemLogs.svelte";
 import UpdateBanner from "./components/system/UpdateBanner.svelte";
@@ -663,6 +664,7 @@ function handleGlobalClick(e: MouseEvent) {
   <div class="shell">
     {#if auth.user.role === "admin"}
       <UpdateBanner />
+      <NoProviderBanner onOpenSettings={() => (activeModal = "systemSettings")} />
     {/if}
     <div class="shell-body">
       <div class="sidebar" class:sidebar-open={layout.sidebarOpen} style:width="{sidebar.width}px">

--- a/packages/web/src/ui/components/system/NoProviderBanner.svelte
+++ b/packages/web/src/ui/components/system/NoProviderBanner.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+// Persistent banner shown to admins when no AI provider is configured. Without a
+// provider every mind spawns mute (no model to think with), so this surfaces the
+// system-level gap and points at Settings to fix it (#606).
+let { onOpenSettings }: { onOpenSettings: () => void } = $props();
+
+let aiConfigured = $state(true);
+
+$effect(() => {
+  let mounted = true;
+
+  async function poll() {
+    try {
+      const res = await fetch("/api/system/info");
+      if (!res.ok) return;
+      const data = await res.json();
+      if (mounted) aiConfigured = data.aiConfigured !== false;
+    } catch (e) {
+      console.debug("[provider] poll failed:", e);
+    }
+  }
+
+  poll();
+  const id = setInterval(poll, 60_000);
+  return () => {
+    mounted = false;
+    clearInterval(id);
+  };
+});
+</script>
+
+{#if !aiConfigured}
+  <div class="banner">
+    <span>Minds cannot think yet — no AI provider is configured.</span>
+    <button class="settings-btn" onclick={onOpenSettings}>add a provider in Settings</button>
+  </div>
+{/if}
+
+<style>
+  .banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 6px 16px;
+    background: var(--red-bg);
+    border-bottom: 1px solid var(--red-border);
+    color: var(--red);
+    font-size: 13px;
+    font-family: inherit;
+    flex-shrink: 0;
+  }
+
+  .settings-btn {
+    background: transparent;
+    color: inherit;
+    border: 1px solid currentColor;
+    border-radius: var(--radius);
+    padding: 2px 10px;
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+</style>

--- a/packages/web/src/ui/components/system/NoProviderBanner.svelte
+++ b/packages/web/src/ui/components/system/NoProviderBanner.svelte
@@ -12,7 +12,10 @@ $effect(() => {
   async function poll() {
     try {
       const res = await fetch("/api/system/info");
-      if (!res.ok) return;
+      if (!res.ok) {
+        console.debug("[provider] poll returned", res.status);
+        return;
+      }
       const data = await res.json();
       if (mounted) aiConfigured = data.aiConfigured !== false;
     } catch (e) {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -88,7 +88,12 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // Ensure setup config exists so CLI commands don't fail with "not set up"
     writeFileSync(
       resolve(voluteSystemDir(), "config.json"),
-      JSON.stringify({ setup: { type: "local", isolation: "none" } }),
+      JSON.stringify({
+        setup: { type: "local", isolation: "none" },
+        // Enable a model so isAiConfigured() is true — mind creation is refused
+        // on a providerless system (#606), and these tests create real minds.
+        ai: { models: ["anthropic:claude-sonnet-4-5"] },
+      }),
     );
 
     // Start daemon

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -169,12 +169,16 @@ describe("web minds routes", () => {
     const { readGlobalConfig, writeGlobalConfig, _resetConfigCache } = await import(
       "../packages/daemon/src/lib/config/setup.js"
     );
+    const { setEnabledModels } = await import("../packages/daemon/src/lib/ai-service.js");
     const existing = `cap-existing-${Date.now()}`;
     const savedConfig = readGlobalConfig();
     await addMind(existing, 4100);
     try {
+      // A provider must be configured for the cap guard to be the one that fires
+      // (a providerless system is refused earlier — see the no-provider test).
+      setEnabledModels(["anthropic:claude-test"]);
       const count = await countCappedMinds();
-      writeGlobalConfig({ ...savedConfig, maxMinds: count });
+      writeGlobalConfig({ ...readGlobalConfig(), maxMinds: count });
 
       const { default: app } = await import("../packages/daemon/src/web/app.js");
       const res = await app.request("http://localhost/api/minds", {
@@ -191,6 +195,48 @@ describe("web minds routes", () => {
       _resetConfigCache();
       await removeMind(existing);
     }
+  });
+
+  it("POST / — 409 with a provider hint when no AI provider is configured", async () => {
+    const cookie = await setupAuth();
+    const { setEnabledModels, isAiConfigured } = await import(
+      "../packages/daemon/src/lib/ai-service.js"
+    );
+    const { readGlobalConfig, writeGlobalConfig, _resetConfigCache } = await import(
+      "../packages/daemon/src/lib/config/setup.js"
+    );
+    const savedConfig = readGlobalConfig();
+    try {
+      // Drop every enabled model so the system reads as providerless.
+      setEnabledModels([]);
+      assert.equal(isAiConfigured(), false);
+
+      const { default: app } = await import("../packages/daemon/src/web/app.js");
+      const res = await app.request("http://localhost/api/minds", {
+        method: "POST",
+        headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
+        body: JSON.stringify({ name: `noprovider-${Date.now()}` }),
+      });
+      assert.equal(res.status, 409);
+      const body = (await res.json()) as { error?: string };
+      assert.match(body.error ?? "", /cannot think/i);
+      assert.match(body.error ?? "", /provider/i);
+      assert.match(body.error ?? "", /Settings/i);
+    } finally {
+      writeGlobalConfig(savedConfig);
+      _resetConfigCache();
+    }
+  });
+
+  it("GET /api/system/info — reports aiConfigured as a boolean", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("http://localhost/api/system/info", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { aiConfigured?: unknown };
+    assert.equal(typeof body.aiConfigured, "boolean");
   });
 
   it("GET/PUT /api/system/max-minds — roundtrips the cap and reports the count", async () => {

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -228,15 +228,35 @@ describe("web minds routes", () => {
     }
   });
 
-  it("GET /api/system/info — reports aiConfigured as a boolean", async () => {
+  it("GET /api/system/info — aiConfigured tracks whether a model is enabled", async () => {
     const cookie = await setupAuth();
+    const { setEnabledModels } = await import("../packages/daemon/src/lib/ai-service.js");
+    const { readGlobalConfig, writeGlobalConfig, _resetConfigCache } = await import(
+      "../packages/daemon/src/lib/config/setup.js"
+    );
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("http://localhost/api/system/info", {
-      headers: { Cookie: `volute_session=${cookie}` },
-    });
-    assert.equal(res.status, 200);
-    const body = (await res.json()) as { aiConfigured?: unknown };
-    assert.equal(typeof body.aiConfigured, "boolean");
+    const savedConfig = readGlobalConfig();
+
+    async function aiConfigured(): Promise<boolean> {
+      const res = await app.request("http://localhost/api/system/info", {
+        headers: { Cookie: `volute_session=${cookie}` },
+      });
+      assert.equal(res.status, 200);
+      return ((await res.json()) as { aiConfigured: boolean }).aiConfigured;
+    }
+
+    try {
+      // The banner keys on this flag, so pin both directions — a constant or
+      // inverted value would silently hide the warning on a providerless system.
+      setEnabledModels([]);
+      assert.equal(await aiConfigured(), false);
+
+      setEnabledModels(["anthropic:claude-test"]);
+      assert.equal(await aiConfigured(), true);
+    } finally {
+      writeGlobalConfig(savedConfig);
+      _resetConfigCache();
+    }
   });
 
   it("GET/PUT /api/system/max-minds — roundtrips the cap and reports the count", async () => {


### PR DESCRIPTION
## What

A system can end up providerless — provider deleted in Settings, OAuth revoked, or legacy config — in which case every mind spawns mute (there's no model to think with). #592 surfaced setup-completion warnings and #602 surfaced per-mind missing-credential notices; this is the missing system-level surface (#606).

When `isAiConfigured()` is false:

- **Dashboard banner.** A persistent admin-only banner (`NoProviderBanner`) reads a new `aiConfigured` boolean from `GET /api/system/info` and shows "Minds cannot think yet — no AI provider is configured" with a button that opens Settings. Polls every 60s (same pattern as `UpdateBanner`), so it clears itself once a provider is added.
- **Creation guard.** `POST /api/minds` refuses mind/seed creation with a `409` and the same operator-actionable message instead of leaving a mute mind behind. Covers `volute mind create`, `volute seed create`, and spirit-driven seeds alike (all route through this endpoint).

## Security

The only new API surface is a boolean `aiConfigured` on the already-existing `GET /api/system/info` — no provider names, keys, or OAuth details are exposed. No route-guard changes; `test/authz-coverage.test.ts` passes.

## Test plan

- New tests in `test/web-minds.test.ts`: the `409` + provider-hint guard when providerless, and `GET /api/system/info` returning `aiConfigured` as a boolean.
- Updated the `maxMinds` cap test to enable a model first (a providerless system is now refused earlier), and credited the e2e daemon config with an enabled model so its real-mind creation still succeeds.
- `npm test`: 2352 passed, 0 failed.
- `tsc --noEmit` clean; `svelte-check`: 0 errors (only a pre-existing SummaryNode warning).

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)