### PR TITLE
fix(cli): correct guidance when VOLUTE_HOME is unset on system installs

### DIFF
--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { Agent } from "undici";
+import { detectSystemInstallHint } from "./system-install.js";
 
 // Long-running daemon operations (upgrade, create, import) run `npm install`
 // synchronously before responding, which can exceed undici's default 5-minute
@@ -66,10 +67,9 @@ function readDaemonConfig(): DaemonConfig {
   const configPath = resolve(voluteSystemDir(), "daemon.json");
   if (!existsSync(configPath)) {
     // If a system service is installed, the issue is likely VOLUTE_HOME not being set
-    if (existsSync("/etc/systemd/system/volute.service") && !process.env.VOLUTE_HOME) {
-      console.error("Volute is running as a system service but VOLUTE_HOME is not set.");
-      console.error("Re-run setup to update the CLI wrapper: sudo volute service install --system");
-      console.error("Then start a new shell or run: source /etc/profile.d/volute.sh");
+    const hint = detectSystemInstallHint();
+    if (hint) {
+      console.error(hint);
     } else {
       console.error("Volute is not running. Start with: volute up");
     }

--- a/packages/cli/src/lib/system-install.ts
+++ b/packages/cli/src/lib/system-install.ts
@@ -1,0 +1,43 @@
+import { existsSync } from "node:fs";
+
+// System-service install markers (must match service-mode.ts). A system install
+// exports VOLUTE_HOME=/var/lib/volute from /etc/profile.d/volute.sh, but that's
+// only sourced by login shells — ssh one-liners, cron, scripts, and CI don't get
+// it, so the CLI falls back to ~/.volute and looks unconfigured.
+const SYSTEM_SYSTEMD_SERVICE = "/etc/systemd/system/volute.service";
+const SYSTEM_LAUNCHD_PLIST = "/Library/LaunchDaemons/com.volute.daemon.plist";
+const SYSTEM_DATA_DIR = "/var/lib/volute";
+
+type SystemInstallFacts = {
+  hasSystemd?: boolean;
+  hasLaunchd?: boolean;
+  voluteHomeSet?: boolean;
+};
+
+/**
+ * When a system service is installed but VOLUTE_HOME is unset, the CLI is looking
+ * at ~/.volute instead of the system install. Returns guidance to fix that, or
+ * null when there's no system install / VOLUTE_HOME is already set. Facts default
+ * to the real environment; tests inject them to exercise the decision table.
+ */
+export function detectSystemInstallHint({
+  hasSystemd = existsSync(SYSTEM_SYSTEMD_SERVICE),
+  hasLaunchd = existsSync(SYSTEM_LAUNCHD_PLIST),
+  voluteHomeSet = Boolean(process.env.VOLUTE_HOME),
+}: SystemInstallFacts = {}): string | null {
+  if (voluteHomeSet) return null;
+  if (!hasSystemd && !hasLaunchd) return null;
+
+  const lines = [
+    "Volute is installed as a system service, but VOLUTE_HOME is not set in this shell.",
+    `The CLI is defaulting to ~/.volute and can't see the system install at ${SYSTEM_DATA_DIR}.`,
+    `Set it for this session:  export VOLUTE_HOME=${SYSTEM_DATA_DIR}`,
+  ];
+  if (hasSystemd) {
+    lines.push("Login shells load this automatically via /etc/profile.d/volute.sh;");
+    lines.push(
+      "non-login shells (ssh one-liners, cron, scripts) don't — run: source /etc/profile.d/volute.sh",
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,8 +49,14 @@ if (!ungatedCommands.has(command)) {
       console.error(`Open ${setupUrl()} in your browser to complete it.`);
       console.error("(If the daemon isn't running, start it with `volute up` first.)");
     } else {
-      console.error("Volute is not set up. Run `volute setup` to get started.");
-      console.error("It starts the daemon and opens a browser wizard to finish configuration.");
+      const { detectSystemInstallHint } = await import("@volute/cli/lib/system-install.js");
+      const hint = detectSystemInstallHint();
+      if (hint) {
+        console.error(hint);
+      } else {
+        console.error("Volute is not set up. Run `volute setup` to get started.");
+        console.error("It starts the daemon and opens a browser wizard to finish configuration.");
+      }
     }
     process.exit(1);
   }

--- a/test/system-install.test.ts
+++ b/test/system-install.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { detectSystemInstallHint } from "../packages/cli/src/lib/system-install.js";
+
+describe("detectSystemInstallHint", () => {
+  const originalHome = process.env.VOLUTE_HOME;
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.VOLUTE_HOME;
+    else process.env.VOLUTE_HOME = originalHome;
+  });
+
+  it("returns the hint when a systemd service is installed and VOLUTE_HOME is unset", () => {
+    const hint = detectSystemInstallHint({
+      hasSystemd: true,
+      hasLaunchd: false,
+      voluteHomeSet: false,
+    });
+    assert.ok(hint);
+    assert.match(hint, /VOLUTE_HOME is not set/);
+    assert.match(hint, /export VOLUTE_HOME=\/var\/lib\/volute/);
+    // systemd installs get the profile.d guidance
+    assert.match(hint, /source \/etc\/profile\.d\/volute\.sh/);
+  });
+
+  it("returns the hint for a macOS LaunchDaemon without profile.d guidance", () => {
+    const hint = detectSystemInstallHint({
+      hasSystemd: false,
+      hasLaunchd: true,
+      voluteHomeSet: false,
+    });
+    assert.ok(hint);
+    assert.match(hint, /export VOLUTE_HOME=\/var\/lib\/volute/);
+    // no systemd → no profile.d line
+    assert.doesNotMatch(hint, /profile\.d/);
+  });
+
+  it("returns null when no system service is installed", () => {
+    assert.equal(
+      detectSystemInstallHint({ hasSystemd: false, hasLaunchd: false, voluteHomeSet: false }),
+      null,
+    );
+  });
+
+  it("returns null when VOLUTE_HOME is already set, even with a service present", () => {
+    assert.equal(
+      detectSystemInstallHint({ hasSystemd: true, hasLaunchd: true, voluteHomeSet: true }),
+      null,
+    );
+  });
+
+  it("reads process.env.VOLUTE_HOME by default", () => {
+    process.env.VOLUTE_HOME = "/var/lib/volute";
+    assert.equal(detectSystemInstallHint({ hasSystemd: true, hasLaunchd: false }), null);
+  });
+});


### PR DESCRIPTION
## What & why

On a system install (daemon running fine as a service), any gated CLI command run without `VOLUTE_HOME` in the environment failed with the misleading `Volute is not set up. Run \`volute setup\` first.` Following that suggestion would start configuring a second per-user install. This bit every non-login-shell context (ssh one-liners, cron, scripts, CI) because `/etc/profile.d/volute.sh` — which exports `VOLUTE_HOME=/var/lib/volute` — is only sourced by login shells.

Root cause: the setup gate in `src/cli.ts` calls `setupStatus()`/`isSetupComplete()`, which reads `voluteHome()/system/config.json`, and `voluteHome()` falls back to `~/.volute` when `VOLUTE_HOME` is unset. `readDaemonConfig()` already detected this one layer down, but gated commands never got that far.

## Changes

- New shared helper `detectSystemInstallHint()` in `packages/cli/src/lib/system-install.ts`. Returns actionable guidance (set `VOLUTE_HOME=/var/lib/volute`, plus the `source /etc/profile.d/volute.sh` hint on systemd installs) when a system service is installed (systemd unit **or** macOS LaunchDaemon) and `VOLUTE_HOME` is unset; otherwise `null`. Facts are injectable so the decision table is unit-testable.
- `src/cli.ts` setup gate: on "not set up", checks the helper first and prints the correct guidance when applicable.
- `readDaemonConfig()` in `daemon-client.ts`: now uses the same helper (removing duplicated, systemd-only message text and adding macOS coverage).
- Unit tests covering the decision table (service present/absent × `VOLUTE_HOME` set/unset, plus systemd-vs-launchd message variation).

## Tests

`npm test` — 2355 passing, 0 failing.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)