### PR TITLE
fix(web): allow wake triggers off in Mind Defaults

### DIFF
--- a/packages/web/src/ui/components/system/MindDefaults.svelte
+++ b/packages/web/src/ui/components/system/MindDefaults.svelte
@@ -131,8 +131,8 @@ async function save() {
           : undefined,
         wakeTriggers: sleepEnabled
           ? {
-              mentions: wakeOnMentions || undefined,
-              dms: wakeOnDms || undefined,
+              mentions: wakeOnMentions,
+              dms: wakeOnDms,
               channels: splitList(wakeChannels),
               senders: splitList(wakeSenders),
             }


### PR DESCRIPTION
## What changed

The system-level Mind Defaults form saved wake triggers as `mentions: wakeOnMentions || undefined` / `dms: wakeOnDms || undefined`. Unchecking a toggle therefore persisted `undefined`, which `resolveWakeTriggers()` resolves back to the default (`true`) — so an operator could not set wake-triggers-off as the system default. (Noted in #452's fix, PR #473; the per-mind Rhythms form already persists explicit booleans.)

This persists explicit `false` when unchecked, matching `MindSettingsRhythms.svelte`. The other `|| undefined` fields in the form are strings/arrays where empty→undefined is the intended behavior, so they are unchanged.

Defaults resolution (`resolveWakeTriggers` honoring explicit `false`) is already covered by `test/volute-config.test.ts`.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)