### PR TITLE
fix: volute seed check always prints readiness state

### DIFF
--- a/packages/cli/src/commands/seed-check.ts
+++ b/packages/cli/src/commands/seed-check.ts
@@ -14,17 +14,22 @@ const cmd = command({
   run: async ({ args, flags }) => {
     const name = args.name!;
 
-    // A bare, host-facing check always prints the readiness state. Only the
-    // spirit's nurture schedule (--nurture) keeps the recency gate that stays
-    // quiet when the seed was recently attended to (#666).
+    // A bare, host-facing check always prints the readiness state. The spirit's
+    // nurture schedule passes --nurture to keep the recency gate that stays
+    // quiet when the seed was recently attended to (#666). Nurture schedules
+    // written before this flag existed run the bare form and report every fire
+    // until the seed sprouts.
     const query = flags.nurture ? "" : "?force=1";
 
     const { daemonFetch } = await import("../lib/daemon-client.js");
     const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/seed-check${query}`);
 
     if (!res.ok) {
+      // Non-zero exit so the scheduler surfaces failures instead of logging
+      // them as an empty (gated) result.
+      process.exitCode = 1;
       if (res.status === 404) {
-        console.log(`Seed "${name}" not found — it may have been deleted or already sprouted.`);
+        console.error(`Seed "${name}" not found — it may have been deleted.`);
       } else {
         console.error(`seed check failed for ${name}: HTTP ${res.status}`);
       }
@@ -34,6 +39,10 @@ const cmd = command({
     const data = (await res.json()) as { output?: string };
     if (data.output) {
       console.log(data.output);
+    } else if (!flags.nurture) {
+      // A forced check always returns output from a current daemon; report
+      // rather than exit silently if something upstream ignored ?force=1.
+      console.log(`No readiness output returned for ${name}.`);
     }
   },
 });

--- a/packages/cli/src/commands/seed-check.ts
+++ b/packages/cli/src/commands/seed-check.ts
@@ -4,12 +4,23 @@ const cmd = command({
   name: "volute seed check",
   description: "Check seed readiness",
   args: [{ name: "name", required: true, description: "Seed mind to check" }],
-  flags: {},
-  run: async ({ args }) => {
+  flags: {
+    nurture: {
+      type: "boolean",
+      description:
+        "Apply the nurture gate (used by the spirit's schedule): stay silent when no nudge is needed",
+    },
+  },
+  run: async ({ args, flags }) => {
     const name = args.name!;
 
+    // A bare, host-facing check always prints the readiness state. Only the
+    // spirit's nurture schedule (--nurture) keeps the recency gate that stays
+    // quiet when the seed was recently attended to (#666).
+    const query = flags.nurture ? "" : "?force=1";
+
     const { daemonFetch } = await import("../lib/daemon-client.js");
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/seed-check`);
+    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/seed-check${query}`);
 
     if (!res.ok) {
       if (res.status === 404) {

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1067,7 +1067,7 @@ const app = new Hono<AuthEnv>()
               schedules.push({
                 id: nurtureId,
                 cron: process.env.VOLUTE_NURTURE_CRON ?? "*/5 * * * *",
-                script: `volute seed check ${name}`,
+                script: `volute seed check ${name} --nurture`,
                 enabled: true,
                 whileSleeping: "skip",
               });
@@ -1773,9 +1773,17 @@ const app = new Hono<AuthEnv>()
   // Seed readiness check — used by spirit nurture schedule
   .get("/:name/seed-check", requireSelf(), async (c) => {
     const name = c.req.param("name");
+    // The nurture schedule gates itself so the spirit is only nudged when a seed
+    // has gone quiet; a host running `volute seed check <name>` by hand passes
+    // ?force=1 to bypass that gate and always get the readiness state (#666).
+    const force = c.req.query("force") === "1" || c.req.query("force") === "true";
     const entry = await findMind(name);
     if (!entry) return c.json({ error: "Mind not found" }, 404);
-    if (entry.stage !== "seed") return c.json({ output: "" });
+    if (entry.stage !== "seed") {
+      return c.json({
+        output: force ? `${name} is no longer a seed (stage: ${entry.stage}).` : "",
+      });
+    }
 
     const db = await getDb();
     const rawCreator = Number(process.env.VOLUTE_NURTURE_CREATOR_MINUTES);
@@ -1819,8 +1827,8 @@ const app = new Hono<AuthEnv>()
     const minutesSinceCreator = creatorTime ? (now - creatorTime) / 60_000 : Infinity;
     const minutesSinceSpirit = spiritTime ? (now - spiritTime) / 60_000 : Infinity;
 
-    // No nudge needed
-    if (minutesSinceCreator < creatorThreshold && minutesSinceSpirit < spiritThreshold) {
+    // No nudge needed (the schedule stays quiet; a forced manual check reports anyway)
+    if (!force && minutesSinceCreator < creatorThreshold && minutesSinceSpirit < spiritThreshold) {
       return c.json({ output: "" });
     }
 

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1773,9 +1773,10 @@ const app = new Hono<AuthEnv>()
   // Seed readiness check — used by spirit nurture schedule
   .get("/:name/seed-check", requireSelf(), async (c) => {
     const name = c.req.param("name");
-    // The nurture schedule gates itself so the spirit is only nudged when a seed
-    // has gone quiet; a host running `volute seed check <name>` by hand passes
-    // ?force=1 to bypass that gate and always get the readiness state (#666).
+    // Without ?force=1 this check is gated on recency — output is empty when the
+    // seed was recently attended to, which is what the spirit's `--nurture`
+    // schedule relies on. The CLI passes ?force=1 for bare host invocations so a
+    // manual check always reports, even for a mind that is no longer a seed (#666).
     const force = c.req.query("force") === "1" || c.req.query("force") === "true";
     const entry = await findMind(name);
     if (!entry) return c.json({ error: "Mind not found" }, 404);

--- a/test/first-week-arc.test.ts
+++ b/test/first-week-arc.test.ts
@@ -138,13 +138,13 @@ describe("sprout swaps nurture for the first-week arc", () => {
         {
           id: `nurture-${seedName}`,
           cron: "*/5 * * * *",
-          script: `volute seed check ${seedName}`,
+          script: `volute seed check ${seedName} --nurture`,
           enabled: true,
         },
         {
           id: "nurture-otherseed",
           cron: "*/5 * * * *",
-          script: "volute seed check otherseed",
+          script: "volute seed check otherseed --nurture",
           enabled: true,
         },
       ],

--- a/test/seed-check.test.ts
+++ b/test/seed-check.test.ts
@@ -138,6 +138,73 @@ describe("seed check endpoint", () => {
   });
 });
 
+describe("seed check nurture gate vs. forced host check", () => {
+  let cookie: string;
+  const seedName = `gate-seed-${Date.now()}`;
+
+  async function cleanup() {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "gate-admin"));
+    await db.delete(mindHistory).where(eq(mindHistory.mind, seedName));
+    await removeMind(seedName);
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+    const user = await createUser("gate-admin", "pass");
+    cookie = await createSession(user.id);
+    await addMind(seedName, 4203, "seed");
+    const dir = resolve(voluteHome(), "minds", seedName);
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    writeFileSync(resolve(dir, "home/.config/volute.json"), "{}");
+    writeFileSync(resolve(dir, "home/SOUL.md"), "a seed, still discovering who you are");
+
+    // Recent creator + spirit messages → the nurture gate should suppress output.
+    const db = await getDb();
+    const now = new Date().toISOString();
+    await db.insert(mindHistory).values([
+      { mind: seedName, type: "inbound", sender: "creator", content: "hi", created_at: now },
+      { mind: seedName, type: "inbound", sender: "volute", content: "hi", created_at: now },
+    ]);
+  });
+
+  afterEach(cleanup);
+
+  it("stays silent under the nurture gate when recently attended to", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+      headers: postHeaders(cookie),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { output: string };
+    assert.equal(body.output, "");
+  });
+
+  it("forces the readiness state for a manual host check (?force=1)", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check?force=1`, {
+      headers: postHeaders(cookie),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { output: string };
+    assert.ok(body.output.includes(`Seed: ${seedName}`));
+    assert.ok(body.output.includes("Write MEMORY.md"));
+  });
+
+  it("reports a forced check for a mind that is no longer a seed", async () => {
+    await removeMind(seedName);
+    await addMind(seedName, 4203);
+
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check?force=1`, {
+      headers: postHeaders(cookie),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { output: string };
+    assert.ok(body.output.includes("no longer a seed"));
+  });
+});
+
 describe("sprout endpoint cleans up nurture schedule", () => {
   let cookie: string;
   const seedName = `sprout-cleanup-${Date.now()}`;

--- a/test/seed-check.test.ts
+++ b/test/seed-check.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
@@ -178,6 +178,23 @@ describe("seed check nurture gate vs. forced host check", () => {
     assert.equal(res.status, 200);
     const body = (await res.json()) as { output: string };
     assert.equal(body.output, "");
+  });
+
+  it("reports without force when only the creator is recent (gate needs both)", async () => {
+    // Remove the spirit message so only the creator is recent — the gate must
+    // not suppress (it requires BOTH creator and spirit to be recent).
+    const db = await getDb();
+    await db
+      .delete(mindHistory)
+      .where(and(eq(mindHistory.mind, seedName), eq(mindHistory.sender, "volute")));
+
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+      headers: postHeaders(cookie),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { output: string };
+    assert.ok(body.output.includes(`Seed: ${seedName}`));
   });
 
   it("forces the readiness state for a manual host check (?force=1)", async () => {


### PR DESCRIPTION
## What changed

`volute seed check <name>` doubles as the spirit's nurture-schedule script and a host-facing CLI command. The endpoint was nurture-gated: when the creator and the spirit had both messaged the seed recently, it returned `{ output: "" }` — correct for the schedule, but a host running the command by hand got silent success and no information.

The gate now belongs to the schedule path only:

- **Endpoint** (`GET /:name/seed-check`): accepts `?force=1` to bypass the recency gate and always return the readiness checklist. A forced check on a mind that is no longer a seed returns an informative note instead of empty output. The `requireSelf()` guard is unchanged.
- **CLI** (`volute seed check <name>`): passes `?force=1` by default, so a bare invocation always prints the seed's readiness state. A new `--nurture` flag keeps the old stay-quiet-when-recent behavior for the schedule. The CLI also now exits non-zero on HTTP errors (the scheduler discards stderr, so exit-0 errors looked identical to a gated no-op), and prints a fallback line if a forced check ever returns empty output.
- **Nurture schedule**: created as `volute seed check <name> --nurture`.

## Review notes

A multi-agent review (code, tests, comments, silent failures) was run on this PR. Findings addressed: non-zero exit on HTTP errors; the 404 message no longer claims "already sprouted" (sprouted minds now return 200 with a note); bare runs can never exit silently; gate boolean shape locked by a creator-only-recent test; `first-week-arc` fixtures updated to mirror the `--nurture` schedule string production writes.

One consciously accepted behavior change: nurture schedules written **before** this PR run the bare command, so on an upgraded system an in-flight seed's schedule reports every fire (nudging the spirit every 5 minutes) until the seed sprouts. Self-heals at sprout; adding a schedule migration seemed like backwards-compat machinery this transient window doesn't justify, but happy to add one if preferred.

## Tests

`test/seed-check.test.ts` gains a `seed check nurture gate vs. forced host check` suite: gate suppresses output when the seed was recently attended to, creator-only-recent still reports (gate requires both), `?force=1` returns the checklist anyway, and a forced check on a non-seed reports its stage. Full `npm test` passes (exit 0, no failures).

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)