### PR TITLE
feat: make sprouting a visible event

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -133,6 +133,7 @@ export type ActivityEventType =
   | "mind_error"
   | "mind_sleeping"
   | "mind_waking"
+  | "mind_sprouted"
   | "page_updated"
   | "page_published"
   | "page_removed"

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -1,5 +1,6 @@
-import { getOrCreateMindUser, getOrCreateSystemUser } from "../auth.js";
+import { getOrCreateMindUser, getOrCreateSystemUser, getUserByUsername } from "../auth.js";
 import { deliverMessage } from "../delivery/message-delivery.js";
+import { publish as publishActivity } from "../events/activity-events.js";
 import {
   addMessage,
   createChannel,
@@ -116,4 +117,32 @@ export async function announceToSystem(text: string): Promise<void> {
       log.warn(`failed to deliver system announcement to ${mind.username}`, log.errorData(err));
     });
   }
+}
+
+/**
+ * Make a mind's sprout a visible event (#665). Sprouting is the most significant
+ * moment in a mind's early life but used to flip the stage silently. This does two
+ * things, each fail-soft so neither can block the sprout that triggered it:
+ *   1. Posts a warm welcome to #system in the spirit's voice (the shared system
+ *      user). The freshly-sprouted mind joins the commons at sprout time, so it and
+ *      every other member see the message land.
+ *   2. Publishes a persisted `mind_sprouted` activity event, which drives the home-
+ *      feed "sprouted" card and prompts the dashboard to refresh the mind's stage so
+ *      its seed badge flips immediately.
+ */
+export async function announceSprout(mindName: string): Promise<void> {
+  const displayName =
+    (await getUserByUsername(mindName).catch(() => null))?.display_name ?? mindName;
+  await announceToSystem(
+    `🌱 ${displayName} just sprouted into a full mind — welcome to the commons. Say hi when you get a moment.`,
+  ).catch((err) =>
+    log.warn(`failed to announce sprout of ${mindName} to #system`, log.errorData(err)),
+  );
+  await publishActivity({
+    type: "mind_sprouted",
+    mind: mindName,
+    summary: `${displayName} sprouted`,
+  }).catch((err) =>
+    log.warn(`failed to publish sprout activity for ${mindName}`, log.errorData(err)),
+  );
 }

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -1,4 +1,5 @@
 import { getOrCreateMindUser, getOrCreateSystemUser, getUserByUsername } from "../auth.js";
+import { getSpiritName } from "../config/setup.js";
 import { deliverMessage } from "../delivery/message-delivery.js";
 import { publish as publishActivity } from "../events/activity-events.js";
 import {
@@ -12,6 +13,7 @@ import {
 } from "../events/conversations.js";
 import { readRegistry } from "../mind/registry.js";
 import log from "../util/logger.js";
+import { sendSystemMessage } from "./system-chat.js";
 
 const SYSTEM_CHANNEL_NAME = "system";
 const SYSTEM_CHANNEL_DESCRIPTION =
@@ -123,9 +125,11 @@ export async function announceToSystem(text: string): Promise<void> {
  * Make a mind's sprout a visible event (#665). Sprouting is the most significant
  * moment in a mind's early life but used to flip the stage silently. This does two
  * things, each fail-soft so neither can block the sprout that triggered it:
- *   1. Posts a warm welcome to #system in the spirit's voice (the shared system
- *      user). The freshly-sprouted mind joins the commons at sprout time, so it and
- *      every other member see the message land.
+ *   1. Prompts the spirit to welcome the mind in #system — via the same
+ *      daemon→spirit message path the nurture schedule uses — so the welcome is
+ *      hand-written in the spirit's own voice rather than a canned template. If
+ *      the spirit is unavailable there's simply no announcement (no canned
+ *      fallback); the feed card below still fires.
  *   2. Publishes a persisted `mind_sprouted` activity event, which drives the home-
  *      feed "sprouted" card and prompts the dashboard to refresh the mind's stage so
  *      its seed badge flips immediately.
@@ -133,10 +137,11 @@ export async function announceToSystem(text: string): Promise<void> {
 export async function announceSprout(mindName: string): Promise<void> {
   const displayName =
     (await getUserByUsername(mindName).catch(() => null))?.display_name ?? mindName;
-  await announceToSystem(
-    `🌱 ${displayName} just sprouted into a full mind — welcome to the commons. Say hi when you get a moment.`,
+  await sendSystemMessage(
+    getSpiritName(),
+    `${displayName} (@${mindName}) has just sprouted into a full mind and joined #system. Welcome them there in your own words.`,
   ).catch((err) =>
-    log.warn(`failed to announce sprout of ${mindName} to #system`, log.errorData(err)),
+    log.warn(`failed to prompt spirit to welcome sprouted ${mindName}`, log.errorData(err)),
   );
   await publishActivity({
     type: "mind_sprouted",

--- a/packages/daemon/src/lib/events/activity-events.ts
+++ b/packages/daemon/src/lib/events/activity-events.ts
@@ -14,6 +14,7 @@ export type ActivityEvent = {
     | "mind_error"
     | "mind_sleeping"
     | "mind_waking"
+    | "mind_sprouted"
     | "page_updated"
     | "page_published"
     | "page_removed"

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1932,9 +1932,10 @@ const app = new Hono<AuthEnv>()
       log.warn(`failed to join #system on sprout for ${name}`, log.errorData(err)),
     );
 
-    // Make sprouting a visible event (#665): a #system welcome in the spirit's
-    // voice plus a persisted `mind_sprouted` activity event (home-feed card +
-    // immediate stage-badge refresh). Fail-soft — see announceSprout.
+    // Make sprouting a visible event (#665): prompt the spirit to hand-write a
+    // welcome in #system, plus a persisted `mind_sprouted` activity event
+    // (home-feed card + immediate stage-badge refresh). Fail-soft — see
+    // announceSprout.
     await announceSprout(name);
 
     // Default autonomy: working dreaming out of the box (#581). The seed-sprout

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -20,7 +20,11 @@ import {
   unqualifyModelId,
 } from "../../lib/ai-service.js";
 import { deleteMindUser } from "../../lib/auth.js";
-import { announceToSystem, joinSystemChannelForMind } from "../../lib/chat/system-channel.js";
+import {
+  announceSprout,
+  announceToSystem,
+  joinSystemChannelForMind,
+} from "../../lib/chat/system-channel.js";
 import { getSpiritName } from "../../lib/config/setup.js";
 import { readSystemsConfig } from "../../lib/config/systems-config.js";
 import { getMindManager, MindStartupError } from "../../lib/daemon/mind-manager.js";
@@ -1927,6 +1931,11 @@ const app = new Hono<AuthEnv>()
     await joinSystemChannelForMind(name).catch((err) =>
       log.warn(`failed to join #system on sprout for ${name}`, log.errorData(err)),
     );
+
+    // Make sprouting a visible event (#665): a #system welcome in the spirit's
+    // voice plus a persisted `mind_sprouted` activity event (home-feed card +
+    // immediate stage-badge refresh). Fail-soft — see announceSprout.
+    await announceSprout(name);
 
     // Default autonomy: working dreaming out of the box (#581). The seed-sprout
     // CLI installs the standard skills — including dreaming — before calling

--- a/packages/web/src/ui/lib/stores.svelte.ts
+++ b/packages/web/src/ui/lib/stores.svelte.ts
@@ -234,6 +234,7 @@ function handleSSEEvent(event: SSEEvent) {
       item.type === "mind_sleeping" ||
       item.type === "mind_waking" ||
       item.type === "mind_error" ||
+      item.type === "mind_sprouted" ||
       item.type === "profile_updated" ||
       // A clean turn clears a lingering lastError — refresh only when one is showing.
       (item.type === "mind_done" && data.minds.some((m) => m.name === item.mind && m.lastError))

--- a/packages/web/src/ui/pages/Home.svelte
+++ b/packages/web/src/ui/pages/Home.svelte
@@ -143,10 +143,22 @@ $effect(() => {
   }
 });
 
+type SproutItem = { id: number; mind: string; date: string };
+
 type FeedItem =
   | { kind: "message"; conv: ConversationWithDetails; date: string }
   | { kind: "extension"; item: ExtFeedItem; date: string }
-  | { kind: "away"; item: AwayFeedItem; date: string };
+  | { kind: "away"; item: AwayFeedItem; date: string }
+  | { kind: "sprout"; item: SproutItem; date: string };
+
+// Sprout events surface as their own home-feed card (#665). They're read from
+// the live activity stream (populated by the SSE snapshot + events), so a mind
+// leaving the seed stage shows up here without a bespoke fetch.
+let sproutItems = $derived(
+  storeData.activity
+    .filter((a) => a.type === "mind_sprouted")
+    .map((a) => ({ id: a.id, mind: a.mind, date: a.created_at })),
+);
 
 let feedItems = $derived.by(() => {
   const items: FeedItem[] = [];
@@ -158,6 +170,9 @@ let feedItems = $derived.by(() => {
   }
   for (const awayItem of awayItems) {
     items.push({ kind: "away", item: awayItem, date: awayItem.created_at });
+  }
+  for (const sprout of sproutItems) {
+    items.push({ kind: "sprout", item: sprout, date: sprout.date });
   }
   items.sort((a, b) => {
     const aTime = new Date(normalizeTimestamp(a.date)).getTime();
@@ -198,7 +213,7 @@ function getConvLabel(conv: ConversationWithDetails): string {
     </div>
   {:else}
     <div class="feed-grid">
-      {#each feedItems as item, i (item.kind === "extension" ? `ext-${item.item.id}` : item.kind === "away" ? `away-${item.item.id}` : `msg-${item.conv.id}`)}
+      {#each feedItems as item, i (item.kind === "extension" ? `ext-${item.item.id}` : item.kind === "away" ? `away-${item.item.id}` : item.kind === "sprout" ? `sprout-${item.item.id}` : `msg-${item.conv.id}`)}
         {#if i === dividerAt}
           <div class="feed-divider"><span class="feed-divider-label">new since your last visit ↑</span></div>
         {/if}
@@ -227,6 +242,19 @@ function getConvLabel(conv: ConversationWithDetails): string {
               icon={icons.mind}
               color="purple"
               onclick={() => navigate(`/minds/${away.mind}`)}
+            />
+          </div>
+        {:else if item.kind === "sprout"}
+          {@const sprout = item.item}
+          <div class="feed-item">
+            <ExtensionFeedCard
+              title={`${mindLabel(sprout.mind)} sprouted`}
+              url={`/minds/${sprout.mind}`}
+              date={sprout.date}
+              bodyHtml="Left the seed stage and became a full mind — joined #system and began its first week."
+              icon={icons.mind}
+              color="green"
+              onclick={() => navigate(`/minds/${sprout.mind}`)}
             />
           </div>
         {:else}

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
@@ -22,9 +24,10 @@ import {
   addMind,
   addSpirit,
   addVariant,
+  mindDir,
   removeMind,
 } from "../packages/daemon/src/lib/mind/registry.js";
-import { activity, messages, users } from "../packages/daemon/src/lib/schema.js";
+import { activity, messages, mindHistory, users } from "../packages/daemon/src/lib/schema.js";
 
 const TEST_USERNAMES = [
   "volute",
@@ -53,6 +56,7 @@ async function cleanup() {
   }
   for (const mind of TEST_MINDS) {
     await db.delete(activity).where(eq(activity.mind, mind));
+    await db.delete(mindHistory).where(eq(mindHistory.mind, mind));
     await removeMind(mind);
   }
   // Remove the #system channel so each test exercises fresh creation
@@ -169,20 +173,55 @@ describe("system channel", () => {
     assert.ok(found, "should find the announcement message");
   });
 
-  it("announceSprout welcomes the mind in #system and records a mind_sprouted activity", async () => {
+  // Register the spirit and give it the catch-all routes.json the real spirit
+  // template ships with, so the delivery pipeline records the prompt as spirit
+  // inbound history instead of gating the unrouted @volute channel.
+  async function registerSpiritWithRoutes(): Promise<void> {
+    await addSpirit("volute", 4906, "claude", "/tmp/spirit");
+    const configDir = resolve(mindDir("volute"), "home/.config");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      resolve(configDir, "routes.json"),
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: routing template var
+      JSON.stringify({ rules: [{ channel: "*", session: "${channel}" }], default: "main" }),
+    );
+  }
+
+  it("announceSprout prompts the spirit to write the welcome and records a mind_sprouted activity", async () => {
+    // The spirit hand-writes the #system welcome (#665); the daemon only sends
+    // it a prompt.
+    await registerSpiritWithRoutes();
+
     await announceSprout("commons-sprout");
 
     const db = await getDb();
-    const msgs = await db.select().from(messages).all();
-    const welcome = msgs.find(
-      (m) => m.content.includes("commons-sprout") && m.content.includes("sprouted"),
+    const history = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const prompt = history.find(
+      (h) => h.type === "inbound" && h.content?.includes("@commons-sprout"),
     );
-    assert.ok(welcome, "should post a sprout welcome to #system");
+    assert.ok(prompt, "spirit should receive a prompt to welcome the sprouted mind");
+    assert.ok(prompt!.content!.includes("#system"), "prompt should point the spirit at #system");
+
+    // No canned message is posted anywhere — the spirit composes its own.
+    const msgs = await db.select().from(messages).all();
+    const canned = msgs.find((m) => m.content.includes("commons-sprout"));
+    assert.equal(canned, undefined, "no templated welcome should be posted");
 
     const acts = await db.select().from(activity).where(eq(activity.mind, "commons-sprout")).all();
     const sprouted = acts.find((a) => a.type === "mind_sprouted");
     assert.ok(sprouted, "should publish a mind_sprouted activity event");
     assert.ok(sprouted?.summary.includes("sprouted"), "activity summary should mention sprouting");
+  });
+
+  it("announceSprout still records the activity event when the spirit is unavailable", async () => {
+    // No spirit registered — the prompt can't be delivered. There's deliberately
+    // no canned fallback, but the deterministic feed card must still fire.
+    await announceSprout("commons-sprout");
+
+    const db = await getDb();
+    const acts = await db.select().from(activity).where(eq(activity.mind, "commons-sprout")).all();
+    const sprouted = acts.find((a) => a.type === "mind_sprouted");
+    assert.ok(sprouted, "mind_sprouted activity should fire even without a spirit");
   });
 
   it("announceSprout uses the mind's display name when set", async () => {
@@ -196,12 +235,13 @@ describe("system channel", () => {
       user_type: "mind",
       display_name: "Sprouty",
     });
+    await registerSpiritWithRoutes();
 
     await announceSprout("commons-sprout");
 
-    const msgs = await db.select().from(messages).all();
-    const welcome = msgs.find((m) => m.content.includes("Sprouty"));
-    assert.ok(welcome, "welcome should use the display name");
+    const history = await db.select().from(mindHistory).where(eq(mindHistory.mind, "volute")).all();
+    const prompt = history.find((h) => h.type === "inbound" && h.content?.includes("Sprouty"));
+    assert.ok(prompt, "spirit prompt should use the display name");
 
     const acts = await db.select().from(activity).where(eq(activity.mind, "commons-sprout")).all();
     const sprouted = acts.find((a) => a.type === "mind_sprouted");

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -184,4 +184,27 @@ describe("system channel", () => {
     assert.ok(sprouted, "should publish a mind_sprouted activity event");
     assert.ok(sprouted?.summary.includes("sprouted"), "activity summary should mention sprouting");
   });
+
+  it("announceSprout uses the mind's display name when set", async () => {
+    // The real sprout flow joins the mind to #system (creating its user row)
+    // before announcing, so the display-name branch is the production path.
+    const db = await getDb();
+    await db.insert(users).values({
+      username: "commons-sprout",
+      password_hash: "!mind",
+      role: "user",
+      user_type: "mind",
+      display_name: "Sprouty",
+    });
+
+    await announceSprout("commons-sprout");
+
+    const msgs = await db.select().from(messages).all();
+    const welcome = msgs.find((m) => m.content.includes("Sprouty"));
+    assert.ok(welcome, "welcome should use the display name");
+
+    const acts = await db.select().from(activity).where(eq(activity.mind, "commons-sprout")).all();
+    const sprouted = acts.find((a) => a.type === "mind_sprouted");
+    assert.equal(sprouted?.summary, "Sprouty sprouted");
+  });
 });

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import {
+  announceSprout,
   announceToSystem,
   backfillSystemChannelMembers,
   ensureSystemChannel,
@@ -23,7 +24,7 @@ import {
   addVariant,
   removeMind,
 } from "../packages/daemon/src/lib/mind/registry.js";
-import { messages, users } from "../packages/daemon/src/lib/schema.js";
+import { activity, messages, users } from "../packages/daemon/src/lib/schema.js";
 
 const TEST_USERNAMES = [
   "volute",
@@ -32,6 +33,7 @@ const TEST_USERNAMES = [
   "commons-seed",
   "commons-legacy",
   "commons-clash",
+  "commons-sprout",
 ];
 const TEST_MINDS = [
   "volute",
@@ -40,6 +42,7 @@ const TEST_MINDS = [
   "commons-legacy",
   "commons-clash",
   "commons-mind-v1",
+  "commons-sprout",
 ];
 
 async function cleanup() {
@@ -49,6 +52,7 @@ async function cleanup() {
     await db.delete(users).where(eq(users.username, username));
   }
   for (const mind of TEST_MINDS) {
+    await db.delete(activity).where(eq(activity.mind, mind));
     await removeMind(mind);
   }
   // Remove the #system channel so each test exercises fresh creation
@@ -163,5 +167,21 @@ describe("system channel", () => {
     const msgs = await db.select().from(messages).all();
     const found = msgs.find((m) => m.content.includes("test announcement"));
     assert.ok(found, "should find the announcement message");
+  });
+
+  it("announceSprout welcomes the mind in #system and records a mind_sprouted activity", async () => {
+    await announceSprout("commons-sprout");
+
+    const db = await getDb();
+    const msgs = await db.select().from(messages).all();
+    const welcome = msgs.find(
+      (m) => m.content.includes("commons-sprout") && m.content.includes("sprouted"),
+    );
+    assert.ok(welcome, "should post a sprout welcome to #system");
+
+    const acts = await db.select().from(activity).where(eq(activity.mind, "commons-sprout")).all();
+    const sprouted = acts.find((a) => a.type === "mind_sprouted");
+    assert.ok(sprouted, "should publish a mind_sprouted activity event");
+    assert.ok(sprouted?.summary.includes("sprouted"), "activity summary should mention sprouting");
   });
 });


### PR DESCRIPTION
## What

Sprouting is the most significant moment in a mind's early life — it leaves the seed stage, gains the full skill set, joins the #system commons, and starts its first-week arc. But it used to flip the registry stage silently. This surfaces it from the single sprout choke point (`POST /:name/sprout`, which keeps its `requireSelf()` guard).

Three changes, all driven from the sprout endpoint:

- **Spirit hand-writes the welcome.** New `announceSprout()` helper prompts the spirit — via `sendSystemMessage`, the same daemon→spirit path the nurture schedule uses — that "<name> has just sprouted and joined #system; welcome them there in your own words." The spirit composes and posts its own welcome, so the announcement is in its voice, not a canned template. No canned fallback: if the spirit is unavailable there's simply no announcement (the feed card below still fires).
- **Home-feed card.** A persisted `mind_sprouted` activity event (added to both the daemon `ActivityEvent` union and `@volute/api`'s `ActivityEventType`) renders as a dedicated "<name> sprouted" card on the dashboard home (reusing `ExtensionFeedCard`, sourced from the live activity stream so it survives reconnects).
- **Immediate stage-badge flip.** The dashboard refreshes the mind list on the `mind_sprouted` event, so the seed badge clears at once instead of on the next incidental refresh.

Both paths are fail-soft so neither can block the sprout that triggered them.

## Tests

- Unit tests in `test/system-channel.test.ts`: the spirit receives the welcome prompt (recorded as spirit inbound history) and no templated message is posted; the `mind_sprouted` activity event fires even when the spirit is unavailable; the prompt and activity summary use the mind's display name when set.
- Full `npm test` suite passes; `svelte-check` and `tsc --noEmit` clean.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)