### PR TITLE
feat(web): pending incoming-file visibility panel

### DIFF
--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -11,6 +11,7 @@ import UnifiedSidebar from "./components/layout/UnifiedSidebar.svelte";
 import MindRightPanel from "./components/mind/MindRightPanel.svelte";
 import MindSettings from "./components/mind/MindSettings.svelte";
 import MindVariants from "./components/mind/MindVariants.svelte";
+import PendingFiles from "./components/mind/PendingFiles.svelte";
 import ChannelBrowserModal from "./components/modals/ChannelBrowserModal.svelte";
 import ContextModal from "./components/modals/ContextModal.svelte";
 import SeedModal from "./components/modals/SeedModal.svelte";
@@ -870,6 +871,7 @@ function handleGlobalClick(e: MouseEvent) {
   {#if activeModal === "mindFiles" && mindModalName}
     <Modal title="Files — {mindModalName}" onClose={() => { activeModal = null; mindModalName = null; }}>
       <div class="modal-scroll-body">
+        <PendingFiles name={mindModalName} />
         <PublicFiles name={mindModalName} />
       </div>
     </Modal>

--- a/packages/web/src/ui/components/mind/PendingFiles.svelte
+++ b/packages/web/src/ui/components/mind/PendingFiles.svelte
@@ -1,21 +1,16 @@
 <script lang="ts">
-import { Button, SectionHeader } from "@volute/ui";
-import {
-  acceptPendingFile,
-  fetchPendingFiles,
-  type PendingFile,
-  rejectPendingFile,
-} from "../../lib/client";
+import { SectionHeader } from "@volute/ui";
+import { fetchPendingFiles, type PendingFile } from "../../lib/client";
 import { formatRelativeTime } from "../../lib/format";
+
+// Read-only by design: accepting or rejecting a file is the mind's decision
+// (a consent gate) — this panel only provides visibility into the queue.
 
 let { name }: { name: string } = $props();
 
 let files = $state<PendingFile[]>([]);
 let loading = $state(true);
 let error = $state("");
-// Per-file action state (holds the id being confirmed / acted on)
-let confirmingReject = $state<string | null>(null);
-let busy = $state<string | null>(null);
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -47,41 +42,12 @@ $effect(() => {
   void name;
   load();
 });
-
-async function handleAccept(id: string) {
-  busy = id;
-  error = "";
-  try {
-    await acceptPendingFile(name, id);
-    await load();
-  } catch (err) {
-    console.error("Failed to accept file:", err);
-    error = err instanceof Error ? err.message : "Failed to accept file";
-  } finally {
-    busy = null;
-  }
-}
-
-async function handleReject(id: string) {
-  busy = id;
-  error = "";
-  try {
-    await rejectPendingFile(name, id);
-    confirmingReject = null;
-    await load();
-  } catch (err) {
-    console.error("Failed to reject file:", err);
-    error = err instanceof Error ? err.message : "Failed to reject file";
-  } finally {
-    busy = null;
-  }
-}
 </script>
 
 <div class="pending">
   <SectionHeader
     title="Incoming files"
-    subtitle="Files sent to this mind awaiting review — accept to save into its home directory, or reject to discard"
+    subtitle="Files sent to this mind, awaiting its review"
   />
 
   {#if error}
@@ -104,25 +70,13 @@ async function handleReject(id: string) {
             <span class="sender">from {f.sender}</span>
             <span class="created">{formatRelativeTime(f.createdAt)}</span>
           </div>
-          <div class="file-actions">
-            {#if confirmingReject === f.id}
-              <span class="confirm">
-                Discard this file?
-                <button class="confirm-yes danger" onclick={() => handleReject(f.id)} disabled={busy === f.id}>
-                  {busy === f.id ? "rejecting…" : "reject"}
-                </button>
-                <button class="confirm-no" onclick={() => (confirmingReject = null)} disabled={busy === f.id}>cancel</button>
-              </span>
-            {:else}
-              <Button variant="primary" onclick={() => handleAccept(f.id)} disabled={!!busy}>
-                {busy === f.id ? "Accepting…" : "Accept"}
-              </Button>
-              <Button variant="text" onclick={() => (confirmingReject = f.id)} disabled={!!busy}>Reject</Button>
-            {/if}
-          </div>
         </li>
       {/each}
     </ul>
+    <div class="hint">
+      Accepting or rejecting a file is the mind's decision — it runs
+      <code>volute chat accept/reject &lt;id&gt;</code> when it's ready.
+    </div>
   {/if}
 </div>
 
@@ -190,42 +144,13 @@ async function handleReject(id: string) {
     color: var(--text-2);
   }
 
-  .file-actions {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    flex-wrap: wrap;
-  }
-
-  .confirm {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 13px;
-    color: var(--text-1);
-  }
-
-  .confirm-yes,
-  .confirm-no {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 13px;
-    font-weight: 500;
-    padding: 2px 4px;
-  }
-
-  .confirm-yes.danger {
-    color: var(--red);
-  }
-
-  .confirm-no {
+  .hint {
     color: var(--text-2);
+    font-size: 12px;
   }
 
-  .confirm-yes:disabled,
-  .confirm-no:disabled {
-    opacity: 0.5;
-    cursor: default;
+  .hint code {
+    font-family: var(--mono, monospace);
+    font-size: 11px;
   }
 </style>

--- a/packages/web/src/ui/components/mind/PendingFiles.svelte
+++ b/packages/web/src/ui/components/mind/PendingFiles.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+import { Button, SectionHeader } from "@volute/ui";
+import {
+  acceptPendingFile,
+  fetchPendingFiles,
+  type PendingFile,
+  rejectPendingFile,
+} from "../../lib/client";
+import { formatRelativeTime } from "../../lib/format";
+
+let { name }: { name: string } = $props();
+
+let files = $state<PendingFile[]>([]);
+let loading = $state(true);
+let error = $state("");
+// Per-file action state (holds the id being confirmed / acted on)
+let confirmingReject = $state<string | null>(null);
+let busy = $state<string | null>(null);
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(value < 10 ? 1 : 0)} ${units[unit]}`;
+}
+
+async function load() {
+  loading = true;
+  try {
+    files = await fetchPendingFiles(name);
+    error = "";
+  } catch (err) {
+    console.error("Failed to load pending files:", err);
+    error = err instanceof Error ? err.message : "Failed to load pending files";
+  } finally {
+    loading = false;
+  }
+}
+
+$effect(() => {
+  // Re-run when the mind changes.
+  void name;
+  load();
+});
+
+async function handleAccept(id: string) {
+  busy = id;
+  error = "";
+  try {
+    await acceptPendingFile(name, id);
+    await load();
+  } catch (err) {
+    console.error("Failed to accept file:", err);
+    error = err instanceof Error ? err.message : "Failed to accept file";
+  } finally {
+    busy = null;
+  }
+}
+
+async function handleReject(id: string) {
+  busy = id;
+  error = "";
+  try {
+    await rejectPendingFile(name, id);
+    confirmingReject = null;
+    await load();
+  } catch (err) {
+    console.error("Failed to reject file:", err);
+    error = err instanceof Error ? err.message : "Failed to reject file";
+  } finally {
+    busy = null;
+  }
+}
+</script>
+
+<div class="pending">
+  <SectionHeader
+    title="Incoming files"
+    subtitle="Files sent to this mind awaiting review — accept to save into its home directory, or reject to discard"
+  />
+
+  {#if error}
+    <div class="error">{error}</div>
+  {/if}
+
+  {#if loading}
+    <div class="muted">Loading…</div>
+  {:else if files.length === 0}
+    <div class="muted">No pending files.</div>
+  {:else}
+    <ul class="file-list">
+      {#each files as f (f.id)}
+        <li class="file-row">
+          <div class="file-main">
+            <span class="file-name">{f.filename}</span>
+            <span class="file-size">{formatSize(f.size)}</span>
+          </div>
+          <div class="file-meta">
+            <span class="sender">from {f.sender}</span>
+            <span class="created">{formatRelativeTime(f.createdAt)}</span>
+          </div>
+          <div class="file-actions">
+            {#if confirmingReject === f.id}
+              <span class="confirm">
+                Discard this file?
+                <button class="confirm-yes danger" onclick={() => handleReject(f.id)} disabled={busy === f.id}>
+                  {busy === f.id ? "rejecting…" : "reject"}
+                </button>
+                <button class="confirm-no" onclick={() => (confirmingReject = null)} disabled={busy === f.id}>cancel</button>
+              </span>
+            {:else}
+              <Button variant="primary" onclick={() => handleAccept(f.id)} disabled={!!busy}>
+                {busy === f.id ? "Accepting…" : "Accept"}
+              </Button>
+              <Button variant="text" onclick={() => (confirmingReject = f.id)} disabled={!!busy}>Reject</Button>
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .pending {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .error {
+    color: var(--red);
+    font-size: 13px;
+    white-space: pre-wrap;
+  }
+
+  .muted {
+    color: var(--text-2);
+    font-size: 14px;
+    padding: 8px 0;
+  }
+
+  .file-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .file-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .file-main {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .file-name {
+    color: var(--text-0);
+    font-weight: 500;
+    font-family: var(--mono, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .file-size {
+    font-size: 12px;
+    color: var(--text-2);
+    flex-shrink: 0;
+  }
+
+  .file-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .file-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .confirm {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-1);
+  }
+
+  .confirm-yes,
+  .confirm-no {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 2px 4px;
+  }
+
+  .confirm-yes.danger {
+    color: var(--red);
+  }
+
+  .confirm-no {
+    color: var(--text-2);
+  }
+
+  .confirm-yes:disabled,
+  .confirm-no:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+</style>

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -894,6 +894,34 @@ export function deleteSchedule(name: string, id: string): Promise<void> {
   return del(`${V1}/minds/${enc(name)}/schedules/${enc(id)}`);
 }
 
+// --- Pending incoming files ---
+// These routes live under /api/minds (not /api/v1), guarded by requireSelf.
+
+export type PendingFile = {
+  id: string;
+  sender: string;
+  filename: string;
+  originalPath: string;
+  size: number;
+  createdAt: string;
+};
+
+export function fetchPendingFiles(mind: string): Promise<PendingFile[]> {
+  return get(`/api/minds/${enc(mind)}/files/pending`);
+}
+
+export function acceptPendingFile(
+  mind: string,
+  id: string,
+  dest?: string,
+): Promise<{ ok: boolean; destPath: string }> {
+  return post(`/api/minds/${enc(mind)}/files/accept`, { id, ...(dest ? { dest } : {}) });
+}
+
+export function rejectPendingFile(mind: string, id: string): Promise<{ ok: boolean }> {
+  return post(`/api/minds/${enc(mind)}/files/reject`, { id });
+}
+
 // --- Profile ---
 
 export async function updateMindProfile(

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -895,7 +895,10 @@ export function deleteSchedule(name: string, id: string): Promise<void> {
 }
 
 // --- Pending incoming files ---
-// These routes live under /api/minds (not /api/v1), guarded by requireSelf.
+// This route lives under /api/minds (not /api/v1), guarded by requireSelf.
+// Read-only by design: accepting or rejecting a file is the mind's decision,
+// made via its own tools (volute chat accept/reject) — the web UI only
+// provides visibility into the queue.
 
 export type PendingFile = {
   id: string;
@@ -908,18 +911,6 @@ export type PendingFile = {
 
 export function fetchPendingFiles(mind: string): Promise<PendingFile[]> {
   return get(`/api/minds/${enc(mind)}/files/pending`);
-}
-
-export function acceptPendingFile(
-  mind: string,
-  id: string,
-  dest?: string,
-): Promise<{ ok: boolean; destPath: string }> {
-  return post(`/api/minds/${enc(mind)}/files/accept`, { id, ...(dest ? { dest } : {}) });
-}
-
-export function rejectPendingFile(mind: string, id: string): Promise<{ ok: boolean }> {
-  return post(`/api/minds/${enc(mind)}/files/reject`, { id });
 }
 
 // --- Profile ---


### PR DESCRIPTION
## What

Surfaces the incoming-file (pending) queue in the web dashboard — **visibility only**. Until now the queue was invisible outside the CLI: files sent to a mind via web chat or `volute chat send --file` staged silently into its `pending-files/` queue.

**Scope decision:** the panel is deliberately read-only. Accepting or rejecting a file is the mind's decision (a consent gate) — a human must not be able to force-accept a file into a mind's space. The mind acts via its own tools (`volute chat accept/reject <id>`); the web UI only shows what's waiting.

## Changes

- **`packages/web/src/ui/lib/client.ts`** — `fetchPendingFiles(mind)` → `GET /api/minds/:name/files/pending`, plus a `PendingFile` type matching the backend `PendingFileMetadata`.
- **`packages/web/src/ui/components/mind/PendingFiles.svelte`** — new read-only panel listing each pending file (filename, size, sender, staged-at), with a hint that the mind decides via `volute chat accept/reject <id>`. Errors surfaced inline; styling modeled on `MindVariants.svelte`.
- **`packages/web/src/ui/App.svelte`** — renders `PendingFiles` above `PublicFiles` in the existing Files modal.

No API changes — reuses the existing `requireSelf`-guarded route, so the panel is visible to admins and to the mind itself.

## Testing

- `npm test` — full suite passes (2350 tests).
- Frontend `build:ui` (vite + svelte-check) passes with 0 errors; Svelte autofixer reports no issues.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
