### PR TITLE
feat: resolve display names in CLI chat/history output

### DIFF
--- a/packages/cli/src/commands/chat/list.ts
+++ b/packages/cli/src/commands/chat/list.ts
@@ -22,7 +22,7 @@ const cmd = command({
       id: string;
       type: string;
       channel_name: string | null;
-      participants: { username: string }[];
+      participants: { username: string; displayName: string | null }[];
       updated_at: string;
     }[];
 
@@ -38,7 +38,15 @@ const cmd = command({
         label = `#${conv.channel_name}`;
       } else {
         const other = conv.participants?.find((p) => p.username !== mindName);
-        label = other ? `@${other.username}` : conv.id.slice(0, 8);
+        if (other) {
+          // Compact (mind-facing) output stays terse; display names are for humans.
+          label =
+            !compact && other.displayName && other.displayName !== other.username
+              ? `${other.displayName} (@${other.username})`
+              : `@${other.username}`;
+        } else {
+          label = conv.id.slice(0, 8);
+        }
       }
       if (compact) {
         console.log(`${label} (${conv.type})`);

--- a/packages/cli/src/commands/chat/read.ts
+++ b/packages/cli/src/commands/chat/read.ts
@@ -1,6 +1,6 @@
 import { command } from "../../lib/command.js";
 import { daemonFetch } from "../../lib/daemon-client.js";
-import { compactTime, isCompact } from "../../lib/format-cli.js";
+import { compactTime, formatSender, isCompact } from "../../lib/format-cli.js";
 import { resolveMindName } from "../../lib/resolve-mind-name.js";
 
 type Conversation = {
@@ -80,6 +80,7 @@ const cmd = command({
       items: {
         role: string;
         sender_name: string | null;
+        sender_display_name: string | null;
         content: string | { type: string; text?: string }[];
         created_at: string;
       }[];
@@ -92,7 +93,10 @@ const cmd = command({
 
     const compact = isCompact();
     for (const msg of data.items) {
-      const sender = msg.sender_name ?? msg.role;
+      // Compact (mind-facing) output stays terse; display names are for humans.
+      const sender = compact
+        ? (msg.sender_name ?? msg.role)
+        : formatSender(msg.sender_name ?? msg.role, msg.sender_display_name);
       const text = Array.isArray(msg.content)
         ? msg.content
             .filter((b): b is { type: "text"; text: string } => b.type === "text")

--- a/packages/cli/src/commands/mind-history.ts
+++ b/packages/cli/src/commands/mind-history.ts
@@ -2,7 +2,7 @@ import type { SummaryRow } from "@volute/api";
 import { getClient, urlOf } from "../lib/api-client.js";
 import { command } from "../lib/command.js";
 import { daemonFetch } from "../lib/daemon-client.js";
-import { compactTime, isCompact } from "../lib/format-cli.js";
+import { compactTime, formatSender, isCompact } from "../lib/format-cli.js";
 import { resolveMindName } from "../lib/resolve-mind-name.js";
 
 type ActivityRow = {
@@ -19,6 +19,7 @@ type HistoryRow = {
   channel: string | null;
   session: string | null;
   sender: string | null;
+  sender_display_name: string | null;
   content: string | null;
   metadata: string | null;
   created_at: string;
@@ -36,7 +37,10 @@ function formatRow(row: HistoryRow): string {
   switch (row.type) {
     case "inbound":
     case "outbound": {
-      const sender = row.sender ?? (row.type === "outbound" ? "mind" : "unknown");
+      const sender = formatSender(
+        row.sender ?? (row.type === "outbound" ? "mind" : "unknown"),
+        row.sender_display_name,
+      );
       return `[${time}] [${channel}] ${sender}: ${row.content ?? ""}`;
     }
     case "text":
@@ -104,6 +108,7 @@ function formatRowCompact(row: HistoryRow): string {
   switch (row.type) {
     case "inbound":
     case "outbound": {
+      // Compact (mind-facing) output stays terse; display names are for humans.
       const sender = row.sender ?? (row.type === "outbound" ? "mind" : "unknown");
       return `[${time}] [${channel}] ${sender}: ${row.content ?? ""}`;
     }

--- a/packages/cli/src/lib/format-cli.ts
+++ b/packages/cli/src/lib/format-cli.ts
@@ -1,6 +1,15 @@
 /** Whether output should be compact (mind context). */
 export const isCompact = () => !!process.env.VOLUTE_MIND;
 
+/**
+ * Render a sender for human-facing output. When a distinct display name exists,
+ * shows "Display Name (@username)"; otherwise returns the name unchanged.
+ */
+export function formatSender(name: string, displayName?: string | null): string {
+  if (displayName && displayName !== name) return `${displayName} (@${name})`;
+  return name;
+}
+
 /** Format a DB timestamp as HH:MM */
 export function compactTime(dateStr: string): string {
   const d = new Date(dateStr.endsWith("Z") ? dateStr : `${dateStr}Z`);

--- a/packages/daemon/src/lib/auth.ts
+++ b/packages/daemon/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { compareSync, hashSync } from "bcryptjs";
-import { and, count, eq, or } from "drizzle-orm";
+import { and, count, eq, inArray, or } from "drizzle-orm";
 import { getSpiritName } from "./config/setup.js";
 import { getDb } from "./db.js";
 import { broadcast } from "./events/activity-events.js";
@@ -62,6 +62,40 @@ export async function getUser(id: number): Promise<User | null> {
   const db = await getDb();
   const row = await db.select(userSelectFields).from(users).where(eq(users.id, id)).get();
   return (row as User) ?? null;
+}
+
+/**
+ * Resolve display names for a set of usernames.
+ * Returns a map of username → display_name, omitting users without a display name.
+ * Used to render "Display Name (@username)" in human-facing output.
+ */
+export async function getDisplayNames(usernames: (string | null)[]): Promise<Map<string, string>> {
+  const unique = [...new Set(usernames.filter((u): u is string => !!u))];
+  const map = new Map<string, string>();
+  if (unique.length === 0) return map;
+  const db = await getDb();
+  const rows = await db
+    .select({ username: users.username, displayName: users.display_name })
+    .from(users)
+    .where(inArray(users.username, unique));
+  for (const r of rows) {
+    if (r.displayName) map.set(r.username, r.displayName);
+  }
+  return map;
+}
+
+/**
+ * Annotate messages with the sender's display name (resolved from the users
+ * table) so human-facing clients can render "Display Name (@username)".
+ */
+export async function withSenderDisplayNames<T extends { sender_name: string | null }>(
+  msgs: T[],
+): Promise<(T & { sender_display_name: string | null })[]> {
+  const displayNames = await getDisplayNames(msgs.map((m) => m.sender_name));
+  return msgs.map((m) => ({
+    ...m,
+    sender_display_name: m.sender_name ? (displayNames.get(m.sender_name) ?? null) : null,
+  }));
 }
 
 export async function getUserByUsername(username: string): Promise<User | null> {

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -19,7 +19,7 @@ import {
   resolveTemplate,
   unqualifyModelId,
 } from "../../lib/ai-service.js";
-import { deleteMindUser } from "../../lib/auth.js";
+import { deleteMindUser, getDisplayNames, withSenderDisplayNames } from "../../lib/auth.js";
 import {
   announceSprout,
   announceToSystem,
@@ -2399,7 +2399,7 @@ const app = new Hono<AuthEnv>()
     const limitStr = c.req.query("limit");
     if (!beforeStr && !limitStr) {
       const msgs = await getMessages(convId);
-      return c.json({ items: msgs, hasMore: false });
+      return c.json({ items: await withSenderDisplayNames(msgs), hasMore: false });
     }
     const before = beforeStr ? parseInt(beforeStr, 10) : undefined;
     const limit = limitStr ? parseInt(limitStr, 10) : undefined;
@@ -2410,7 +2410,10 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Invalid pagination parameters" }, 400);
     }
     const result = await getMessagesPaginated(convId, { before, limit });
-    return c.json({ items: result.messages, hasMore: result.hasMore });
+    return c.json({
+      items: await withSenderDisplayNames(result.messages),
+      hasMore: result.hasMore,
+    });
   })
   // Budget status
   .get("/:name/budget", requireSelf(), async (c) => {
@@ -3116,7 +3119,13 @@ const app = new Hono<AuthEnv>()
       .limit(limit)
       .offset(offset);
 
-    return c.json(rows);
+    const displayNames = await getDisplayNames(rows.map((r) => r.sender));
+    return c.json(
+      rows.map((r) => ({
+        ...r,
+        sender_display_name: r.sender ? (displayNames.get(r.sender) ?? null) : null,
+      })),
+    );
   });
 
 export default app;

--- a/packages/daemon/src/web/api/volute/conversations.ts
+++ b/packages/daemon/src/web/api/volute/conversations.ts
@@ -1,7 +1,12 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-import { getOrCreateMindUser, getUser, getUserByUsername } from "../../../lib/auth.js";
+import {
+  getOrCreateMindUser,
+  getUser,
+  getUserByUsername,
+  withSenderDisplayNames,
+} from "../../../lib/auth.js";
 import {
   createConversation,
   deleteConversationForUser,
@@ -130,7 +135,7 @@ const app = new Hono<AuthEnv>()
     const beforeStr = c.req.query("before");
     if (!limitStr && !beforeStr) {
       const msgs = await getMessages(id);
-      return c.json({ items: msgs, hasMore: false });
+      return c.json({ items: await withSenderDisplayNames(msgs), hasMore: false });
     }
     const limit = limitStr ? parseInt(limitStr, 10) : undefined;
     const before = beforeStr ? parseInt(beforeStr, 10) : undefined;
@@ -141,7 +146,10 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Invalid pagination parameters" }, 400);
     }
     const result = await getMessagesPaginated(id, { before, limit });
-    return c.json({ items: result.messages, hasMore: result.hasMore });
+    return c.json({
+      items: await withSenderDisplayNames(result.messages),
+      hasMore: result.hasMore,
+    });
   })
   .get("/:name/conversations/:id/participants", async (c) => {
     const id = c.req.param("id");

--- a/test/format-cli.test.ts
+++ b/test/format-cli.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatSender } from "../packages/cli/src/lib/format-cli.js";
+
+describe("formatSender", () => {
+  it("renders 'Display Name (@username)' when a distinct display name exists", () => {
+    assert.equal(formatSender("cricket", "Cricket Song"), "Cricket Song (@cricket)");
+  });
+
+  it("returns the name unchanged when there is no display name", () => {
+    assert.equal(formatSender("cricket", null), "cricket");
+    assert.equal(formatSender("cricket", undefined), "cricket");
+    assert.equal(formatSender("cricket"), "cricket");
+  });
+
+  it("returns the name unchanged when the display name equals the username", () => {
+    assert.equal(formatSender("cricket", "cricket"), "cricket");
+  });
+});

--- a/test/web-conversations.test.ts
+++ b/test/web-conversations.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { approveUser, createUser } from "../packages/daemon/src/lib/auth.js";
+import { approveUser, createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   addMessage,
@@ -12,7 +12,7 @@ import {
   getConversation,
   getMessages,
 } from "../packages/daemon/src/lib/events/conversations.js";
-import { users } from "../packages/daemon/src/lib/schema.js";
+import { minds, users } from "../packages/daemon/src/lib/schema.js";
 import v1ConversationsRoute from "../packages/daemon/src/web/api/v1/conversations.js";
 import conversationsRoute from "../packages/daemon/src/web/api/volute/conversations.js";
 import {
@@ -39,6 +39,7 @@ const TEST_USERNAMES = [
   "group-member",
   "privacy-outsider",
   "volute",
+  "conv-display-mind",
 ];
 
 async function cleanup() {
@@ -46,6 +47,7 @@ async function cleanup() {
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
   }
+  await db.delete(minds).where(eq(minds.name, "conv-display-mind"));
 }
 
 async function setupAuth() {
@@ -102,6 +104,68 @@ describe("web conversations routes", () => {
     assert.equal(body.items.length, 2);
     assert.equal(body.items[0].role, "user");
     assert.equal(body.items[1].role, "assistant");
+
+    await deleteConversation(conv.id);
+  });
+
+  it("GET /:name/conversations/:id/messages — includes sender display names", async () => {
+    const cookie = await setupAuth();
+    const app = createApp();
+    const db = await getDb();
+    // Give the sender a display name distinct from the username.
+    await db
+      .update(users)
+      .set({ display_name: "Admin Person" })
+      .where(eq(users.username, "conv-admin"));
+
+    const conv = await createConversation({ participantIds: [userId] });
+    await addMessage(conv.id, "user", "conv-admin", [{ type: "text", text: "Hi" }]);
+    // A sender with no matching user record resolves to null.
+    await addMessage(conv.id, "user", "ghost-user", [{ type: "text", text: "Boo" }]);
+
+    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}/messages`, {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.items[0].sender_display_name, "Admin Person");
+    assert.equal(body.items[1].sender_display_name, null);
+
+    await deleteConversation(conv.id);
+  });
+
+  it("GET /:name/conversations/:id/messages?limit=N — full app annotates display names (paginated branch)", async () => {
+    // Exercises the route `volute chat read` actually hits: in the composed app,
+    // minds.ts shadows the volute conversations route, and chat read always
+    // paginates (?limit=50), so this pins the paginated branch of minds.ts.
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    // The minds.ts route requires the mind to exist in the registry and the
+    // conversation to include the mind user as a participant.
+    await db
+      .insert(minds)
+      .values({ name: "conv-display-mind", port: 4391, dir: "/tmp/conv-display-mind" });
+    const mindUser = await getOrCreateMindUser("conv-display-mind");
+    await db
+      .update(users)
+      .set({ display_name: "Admin Person" })
+      .where(eq(users.username, "conv-admin"));
+
+    const conv = await createConversation({ participantIds: [userId, mindUser.id] });
+    await addMessage(conv.id, "user", "conv-admin", [{ type: "text", text: "Hi" }]);
+
+    const res = await app.request(
+      `/api/minds/conv-display-mind/conversations/${conv.id}/messages?limit=10`,
+      { headers: { Cookie: `volute_session=${cookie}` } },
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      items: { sender_name: string | null; sender_display_name: string | null }[];
+    };
+    const msg = body.items.find((m) => m.sender_name === "conv-admin");
+    assert.equal(msg?.sender_display_name, "Admin Person");
 
     await deleteConversation(conv.id);
   });

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -210,6 +210,45 @@ describe("web history routes", () => {
     assert.equal(res.status, 401);
   });
 
+  it("GET /api/minds/:name/history — annotates senders with display names", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    // A sender that has a display name distinct from its username.
+    const sender = await createUser("test-history-alice", "pass");
+    await db.update(users).set({ display_name: "Alice Example" }).where(eq(users.id, sender.id));
+
+    await db.insert(mindHistory).values({
+      mind: "test-history-mind1",
+      type: "inbound",
+      channel: "@test-history-alice",
+      sender: "test-history-alice",
+      content: "hello",
+    });
+    // A sender with no matching user record resolves to null.
+    await db.insert(mindHistory).values({
+      mind: "test-history-mind1",
+      type: "inbound",
+      channel: "#room",
+      sender: "test-history-ghost",
+      content: "boo",
+    });
+
+    const res = await app.request("/api/minds/test-history-mind1/history?full=true", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const rows = (await res.json()) as Array<{
+      sender: string | null;
+      sender_display_name: string | null;
+    }>;
+    const alice = rows.find((r) => r.sender === "test-history-alice");
+    const ghost = rows.find((r) => r.sender === "test-history-ghost");
+    assert.equal(alice?.sender_display_name, "Alice Example");
+    assert.equal(ghost?.sender_display_name, null);
+  });
+
   // ── Summaries endpoint tests ──
 
   it("GET /api/v1/history/summaries — requires period param", async () => {


### PR DESCRIPTION
## Summary

The web UI resolves display names via user profiles, but the CLI rendered raw registry names everywhere. This makes human-facing CLI output consistent with the web dashboard:

- **`volute chat read`** — senders render as `Display Name (@username)` when a distinct display name exists
- **`volute chat list`** — DM participant labels show `Display Name (@username)`
- **`volute mind history`** — inbound/outbound senders show display names

Compact (mind-facing, `VOLUTE_MIND`) output stays terse with raw names, and `chat send` targets keep accepting real mind names — identity, not veneer.

## Implementation

- `GET /:name/conversations/:id/messages` (both the minds route and the volute conversations route) and `GET /:name/history` now annotate rows with `sender_display_name`, resolved in one batched `users` lookup via the new `getDisplayNames()` / `withSenderDisplayNames()` helpers in `lib/auth.ts`
- New `formatSender()` helper in `packages/cli/src/lib/format-cli.ts`
- `chat list` uses the `displayName` already present on conversation participants

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)