### PR TITLE
feat(web): channel settings editor

### DIFF
--- a/packages/web/src/ui/components/chat/Chat.svelte
+++ b/packages/web/src/ui/components/chat/Chat.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
-import type { ContentBlock, Message, Mind, Participant, SeedChecklist } from "@volute/api";
-import { fetchConversationMessages, sendChat } from "../../lib/client";
+import type {
+  ChannelSettings,
+  ContentBlock,
+  Message,
+  Mind,
+  Participant,
+  SeedChecklist,
+} from "@volute/api";
+import { Icon } from "@volute/ui";
+import { fetchChannelSettings, fetchConversationMessages, sendChat } from "../../lib/client";
 import { subscribe } from "../../lib/connection.svelte";
 import { auth } from "../../lib/stores.svelte";
 import type { ChatEntry } from "../../lib/types";
+import ChannelSettingsModal from "../modals/ChannelSettingsModal.svelte";
 import ActivityIndicator from "./ActivityIndicator.svelte";
 import ChatStatusBar from "./ChatStatusBar.svelte";
 import MessageInput from "./MessageInput.svelte";
@@ -56,6 +65,24 @@ let mindParticipants = $derived.by(() => {
   // For DMs before conversation is created, use the target mind name
   if (convType === "dm" && minds.some((m) => m.name === name)) return [name];
   return [];
+});
+
+// Channel settings (description/rules/char limit/private) for the header + editor
+let channelSettings = $state<ChannelSettings | null>(null);
+let showSettings = $state(false);
+
+$effect(() => {
+  if (convType !== "channel" || !channelName) {
+    channelSettings = null;
+    return;
+  }
+  const target = channelName;
+  fetchChannelSettings(target)
+    .then((res) => {
+      // Guard against a stale response after the channel switched
+      if (target === channelName) channelSettings = res.settings ?? null;
+    })
+    .catch(() => {});
 });
 
 // Notify parent of typing names changes
@@ -256,7 +283,15 @@ async function handleSend(
 
   {#if convType === "channel" && channelName}
     <div class="channel-header">
-      <span class="channel-title">#{channelName}</span>
+      <div class="channel-info">
+        <span class="channel-title">#{channelName}</span>
+        {#if channelSettings?.description}
+          <span class="channel-description">{channelSettings.description}</span>
+        {/if}
+      </div>
+      <button class="settings-btn" title="Channel settings" onclick={() => (showSettings = true)}>
+        <Icon kind="gear" />
+      </button>
     </div>
   {/if}
 
@@ -289,6 +324,15 @@ async function handleSend(
   />
 </div>
 
+{#if showSettings}
+  <ChannelSettingsModal
+    {channelName}
+    settings={channelSettings}
+    onClose={() => (showSettings = false)}
+    onSaved={(next) => (channelSettings = next)}
+  />
+{/if}
+
 <style>
   .chat {
     display: flex;
@@ -318,10 +362,44 @@ async function handleSend(
     flex-shrink: 0;
   }
 
+  .channel-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+  }
+
   .channel-title {
     font-size: 14px;
     font-weight: 600;
     color: var(--text-0);
+  }
+
+  .channel-description {
+    font-size: 12px;
+    color: var(--text-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: var(--text-2);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: var(--radius);
+    flex-shrink: 0;
+  }
+
+  .settings-btn:hover {
+    color: var(--text-0);
+    background: var(--bg-2);
   }
 
   @media (max-width: 1024px) {

--- a/packages/web/src/ui/components/chat/Chat.svelte
+++ b/packages/web/src/ui/components/chat/Chat.svelte
@@ -69,20 +69,26 @@ let mindParticipants = $derived.by(() => {
 
 // Channel settings (description/rules/char limit/private) for the header + editor
 let channelSettings = $state<ChannelSettings | null>(null);
+let settingsLoadFailed = $state(false);
 let showSettings = $state(false);
 
 $effect(() => {
-  if (convType !== "channel" || !channelName) {
-    channelSettings = null;
-    return;
-  }
+  // Reset first so a failed or in-flight fetch can never leave another
+  // channel's settings behind (the modal seeds its form from this state).
+  channelSettings = null;
+  settingsLoadFailed = false;
+  if (convType !== "channel" || !channelName) return;
   const target = channelName;
   fetchChannelSettings(target)
     .then((res) => {
       // Guard against a stale response after the channel switched
       if (target === channelName) channelSettings = res.settings ?? null;
     })
-    .catch(() => {});
+    .catch((err) => {
+      if (target !== channelName) return;
+      console.error(`Failed to load settings for #${target}:`, err);
+      settingsLoadFailed = true;
+    });
 });
 
 // Notify parent of typing names changes
@@ -328,8 +334,12 @@ async function handleSend(
   <ChannelSettingsModal
     {channelName}
     settings={channelSettings}
+    loadFailed={settingsLoadFailed}
     onClose={() => (showSettings = false)}
-    onSaved={(next) => (channelSettings = next)}
+    onSaved={(next) => {
+      channelSettings = next;
+      settingsLoadFailed = false;
+    }}
   />
 {/if}
 

--- a/packages/web/src/ui/components/modals/ChannelSettingsModal.svelte
+++ b/packages/web/src/ui/components/modals/ChannelSettingsModal.svelte
@@ -6,11 +6,13 @@ import { updateChannelSettings } from "../../lib/client";
 let {
   channelName,
   settings,
+  loadFailed = false,
   onClose,
   onSaved,
 }: {
   channelName: string;
   settings: ChannelSettings | null;
+  loadFailed?: boolean;
   onClose: () => void;
   onSaved: (settings: ChannelSettings) => void;
 } = $props();
@@ -51,8 +53,9 @@ async function handleSave() {
     private: isPrivate,
   };
   try {
-    await updateChannelSettings(channelName, next);
-    onSaved(next);
+    // Propagate the server's canonical settings, not the locally built object.
+    const saved = await updateChannelSettings(channelName, next);
+    onSaved(saved);
     onClose();
   } catch (err) {
     error = err instanceof Error ? err.message : "Failed to save settings";
@@ -64,6 +67,12 @@ async function handleSave() {
 
 <Modal size="420px" title="#{channelName} settings" {onClose}>
   <div class="settings-body">
+    {#if loadFailed}
+      <div class="warning">
+        Couldn't load the channel's current settings — saving will overwrite them.
+      </div>
+    {/if}
+
     <label class="field">
       <span class="field-label">Description</span>
       <textarea
@@ -172,6 +181,14 @@ async function handleSave() {
   .error {
     color: var(--red);
     font-size: 13px;
+  }
+
+  .warning {
+    color: var(--yellow);
+    font-size: 13px;
+    padding: 8px 10px;
+    border: 1px solid var(--yellow-bg);
+    border-radius: var(--radius);
   }
 
   .actions {

--- a/packages/web/src/ui/components/modals/ChannelSettingsModal.svelte
+++ b/packages/web/src/ui/components/modals/ChannelSettingsModal.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+import type { ChannelSettings } from "@volute/api";
+import { Modal } from "@volute/ui";
+import { updateChannelSettings } from "../../lib/client";
+
+let {
+  channelName,
+  settings,
+  onClose,
+  onSaved,
+}: {
+  channelName: string;
+  settings: ChannelSettings | null;
+  onClose: () => void;
+  onSaved: (settings: ChannelSettings) => void;
+} = $props();
+
+// Intentional initial-value capture: the modal remounts on every open, so the
+// form seeds from the settings prop as of open time.
+// svelte-ignore state_referenced_locally
+let description = $state(settings?.description ?? "");
+// svelte-ignore state_referenced_locally
+let rules = $state(settings?.rules ?? "");
+// svelte-ignore state_referenced_locally
+let charLimit = $state(settings?.charLimit != null ? String(settings.charLimit) : "");
+// svelte-ignore state_referenced_locally
+let isPrivate = $state(settings?.private ?? false);
+let saving = $state(false);
+let error = $state("");
+
+async function handleSave() {
+  if (saving) return;
+  error = "";
+
+  const trimmedLimit = charLimit.trim();
+  let parsedLimit: number | null = null;
+  if (trimmedLimit) {
+    const n = Number(trimmedLimit);
+    if (!Number.isInteger(n) || n <= 0) {
+      error = "Char limit must be a positive whole number.";
+      return;
+    }
+    parsedLimit = n;
+  }
+
+  saving = true;
+  const next: ChannelSettings = {
+    description: description.trim() || null,
+    rules: rules.trim() || null,
+    charLimit: parsedLimit,
+    private: isPrivate,
+  };
+  try {
+    await updateChannelSettings(channelName, next);
+    onSaved(next);
+    onClose();
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to save settings";
+  } finally {
+    saving = false;
+  }
+}
+</script>
+
+<Modal size="420px" title="#{channelName} settings" {onClose}>
+  <div class="settings-body">
+    <label class="field">
+      <span class="field-label">Description</span>
+      <textarea
+        bind:value={description}
+        rows="2"
+        placeholder="What this channel is about"
+      ></textarea>
+    </label>
+
+    <label class="field">
+      <span class="field-label">Rules</span>
+      <textarea
+        bind:value={rules}
+        rows="3"
+        placeholder="Guidelines for participants"
+      ></textarea>
+    </label>
+
+    <label class="field">
+      <span class="field-label">Character limit</span>
+      <input
+        type="number"
+        min="1"
+        bind:value={charLimit}
+        placeholder="None"
+      />
+      <span class="hint">Leave empty for no limit.</span>
+    </label>
+
+    <label class="checkbox-field">
+      <input type="checkbox" bind:checked={isPrivate} />
+      <span>Private channel</span>
+    </label>
+
+    {#if error}
+      <div class="error">{error}</div>
+    {/if}
+
+    <div class="actions">
+      <button class="btn-secondary" onclick={onClose} disabled={saving}>Cancel</button>
+      <button class="btn-primary" onclick={handleSave} disabled={saving}>
+        {saving ? "Saving..." : "Save"}
+      </button>
+    </div>
+  </div>
+</Modal>
+
+<style>
+  .settings-body {
+    padding: 12px 16px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .field-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-1);
+  }
+
+  textarea,
+  input[type="number"] {
+    width: 100%;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 8px 10px;
+    color: var(--text-0);
+    font-size: 14px;
+    font-family: inherit;
+    outline: none;
+    box-sizing: border-box;
+    resize: vertical;
+  }
+
+  textarea:focus,
+  input[type="number"]:focus {
+    border-color: var(--border-bright);
+  }
+
+  .hint {
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .checkbox-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: var(--text-0);
+    cursor: pointer;
+  }
+
+  .checkbox-field input {
+    cursor: pointer;
+  }
+
+  .error {
+    color: var(--red);
+    font-size: 13px;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    padding: 7px 14px;
+    border-radius: var(--radius);
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: var(--bg-0);
+    border: 1px solid var(--accent);
+  }
+
+  .btn-secondary {
+    background: none;
+    color: var(--text-1);
+    border: 1px solid var(--border);
+  }
+
+  .btn-primary:disabled,
+  .btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -6,6 +6,7 @@ import type {
   AvailableUser,
   AwayFeedItem,
   ChannelInfo,
+  ChannelSettings,
   Conversation,
   ConversationWithParticipants,
   HistoryMessage,
@@ -407,6 +408,36 @@ export function inviteToChannel(channelName: string, username: string): Promise<
 
 export function fetchChannelMembers(channelName: string): Promise<Participant[]> {
   return get(`${V1}/channels/${enc(channelName)}/members`);
+}
+
+export function fetchChannelSettings(name: string): Promise<
+  Conversation & {
+    channel_name: string;
+    participants: Participant[];
+    settings: ChannelSettings | null;
+  }
+> {
+  return get(`${V1}/channels/${enc(name)}`);
+}
+
+export async function updateChannelSettings(
+  name: string,
+  settings: {
+    description?: string | null;
+    rules?: string | null;
+    charLimit?: number | null;
+    private?: boolean;
+  },
+): Promise<void> {
+  const res = await _client.fetch(`${V1}/channels/${enc(name)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(data.error || "Failed to update channel settings");
+  }
 }
 
 // --- Skills ---

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -428,16 +428,23 @@ export async function updateChannelSettings(
     charLimit?: number | null;
     private?: boolean;
   },
-): Promise<void> {
+): Promise<ChannelSettings> {
   const res = await _client.fetch(`${V1}/channels/${enc(name)}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(settings),
   });
   if (!res.ok) {
-    const data = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(data.error || "Failed to update channel settings");
+    const data = (await res.json().catch(() => ({}))) as { error?: unknown };
+    const message =
+      typeof data.error === "string"
+        ? data.error
+        : `Failed to update channel settings (${res.status})`;
+    throw new Error(message);
   }
+  // Return the server's canonical settings so the UI reflects any normalization.
+  const body = (await res.json()) as { settings: ChannelSettings };
+  return body.settings;
 }
 
 // --- Skills ---

--- a/test/web-v1-channels.test.ts
+++ b/test/web-v1-channels.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { createUser, getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { createUser, getOrCreateMindUser, setUserRole } from "../packages/daemon/src/lib/auth.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   createChannel,
@@ -532,6 +532,56 @@ describe("web v1 channels routes", () => {
     assert.equal(body2.settings.rules, "Be brief");
     assert.equal(body2.settings.description, "Updated desc");
     assert.equal(body2.settings.charLimit, 1000);
+
+    await deleteConversation(ch.id);
+  });
+
+  it("PATCH /:name — 403 for non-member, non-admin caller", async () => {
+    await setupAuth(); // ch-admin (admin) is the channel creator
+    const app = createApp();
+
+    // A separate, non-admin user who is NOT a member of the channel.
+    const bob = await createUser("bob", "pass");
+    await setUserRole(bob.id, "user");
+    const bobCookie = await createSession(bob.id);
+
+    const ch = await createChannel("guarded", userId);
+
+    const res = await app.request("/api/v1/channels/guarded", {
+      method: "PATCH",
+      headers: {
+        Cookie: `volute_session=${bobCookie}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ description: "hijacked" }),
+    });
+    assert.equal(res.status, 403);
+
+    // Settings must be untouched.
+    const settings = await getChannelSettings("guarded");
+    assert.equal(settings?.description, null);
+
+    await deleteConversation(ch.id);
+  });
+
+  it("PATCH /:name — admin may edit a channel they are not a member of", async () => {
+    const cookie = await setupAuth(); // ch-admin is admin
+    const app = createApp();
+
+    // Channel created without ch-admin as a member.
+    const ch = await createChannel("adminless");
+
+    const res = await app.request("/api/v1/channels/adminless", {
+      method: "PATCH",
+      headers: {
+        Cookie: `volute_session=${cookie}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ description: "admin edit" }),
+    });
+    assert.equal(res.status, 200);
+    const settings = await getChannelSettings("adminless");
+    assert.equal(settings?.description, "admin edit");
 
     await deleteConversation(ch.id);
   });

--- a/test/web-v1-channels.test.ts
+++ b/test/web-v1-channels.test.ts
@@ -533,6 +533,72 @@ describe("web v1 channels routes", () => {
     assert.equal(body2.settings.description, "Updated desc");
     assert.equal(body2.settings.charLimit, 1000);
 
+    // Explicit null clears a field (the UI relies on null-vs-undefined)
+    const res3 = await app.request("/api/v1/channels/patchable", {
+      method: "PATCH",
+      headers: {
+        Cookie: `volute_session=${cookie}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ description: null }),
+    });
+    assert.equal(res3.status, 200);
+    const body3 = await res3.json();
+    assert.equal(body3.settings.description, null);
+    assert.equal(body3.settings.rules, "Be brief");
+
+    await deleteConversation(ch.id);
+  });
+
+  it("PATCH /:name — non-admin channel member may update settings", async () => {
+    await setupAuth(); // first user (admin) exists but is not used as the caller
+    const app = createApp();
+
+    const bob = await createUser("bob", "pass");
+    await setUserRole(bob.id, "user");
+    const bobCookie = await createSession(bob.id);
+
+    // bob is an ordinary member (creator) of the channel — the isParticipant
+    // allow branch, which every mind relies on, must permit the edit.
+    const ch = await createChannel("member-edit", bob.id);
+
+    const res = await app.request("/api/v1/channels/member-edit", {
+      method: "PATCH",
+      headers: {
+        Cookie: `volute_session=${bobCookie}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ description: "set by member" }),
+    });
+    assert.equal(res.status, 200);
+    const settings = await getChannelSettings("member-edit");
+    assert.equal(settings?.description, "set by member");
+
+    await deleteConversation(ch.id);
+  });
+
+  it("PATCH /:name — 400 for invalid charLimit", async () => {
+    const cookie = await setupAuth();
+    const app = createApp();
+
+    const ch = await createChannel("strict", userId);
+
+    for (const bad of [0, -5, 2.5]) {
+      const res = await app.request("/api/v1/channels/strict", {
+        method: "PATCH",
+        headers: {
+          Cookie: `volute_session=${cookie}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ charLimit: bad }),
+      });
+      assert.equal(res.status, 400, `charLimit ${bad} should be rejected`);
+    }
+
+    // Nothing was persisted.
+    const settings = await getChannelSettings("strict");
+    assert.equal(settings?.char_limit, null);
+
     await deleteConversation(ch.id);
   });
 


### PR DESCRIPTION
Adds a settings editor for channels in the web UI, using the existing `PATCH /api/v1/channels/:name` endpoint.

## Changes

- **Channel header**: shows the channel description under the `#name` title, plus a gear button that opens the settings modal
- **ChannelSettingsModal** (new): edit description, rules, character limit (blank = no limit, validated as a positive integer), and the private flag
- **Client**: `fetchChannelSettings()` / `updateChannelSettings()` in `packages/web/src/ui/lib/client.ts`; the PATCH returns the server's canonical settings, which the header adopts
- **Safety**: settings state resets on channel switch and fetch failures are surfaced (console + a warning in the modal), so the editor can never silently overwrite unknown or stale server state
- **Tests**: authz coverage for the PATCH route — 403 for a non-member non-admin caller (settings untouched), admin override, and the member (role `user`) allow path that minds rely on; explicit `null` clears a field; invalid `charLimit` (0, negative, fractional) rejected with 400

No backend changes: the PATCH route already enforces member-or-admin in-handler authz and is documented in `AUTHZ_EXEMPT` of `test/authz-coverage.test.ts`.

## Testing

- `test/web-v1-channels.test.ts` — 26 tests pass (5 new)
- Full suite green (pre-push hook); frontend `vite build` and `svelte-check` pass with 0 errors

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
