### PR TITLE
fix: daemon fails to start in sandbox mode with sandbox-runtime 0.0.56

### DIFF
--- a/packages/daemon/src/lib/mind/sandbox.ts
+++ b/packages/daemon/src/lib/mind/sandbox.ts
@@ -94,18 +94,21 @@ export async function initSandbox(): Promise<void> {
       }
     }
 
-    // Omit network config so the sandbox doesn't set up a proxy. All minds
-    // need direct API access and the proxy breaks clients that don't respect
-    // HTTP_PROXY (e.g. the claude subprocess spawned by the Agent SDK).
-    // Without network.allowedDomains, wrapWithSandbox generates a seatbelt
-    // profile with `(allow network*)` — unrestricted network while filesystem
-    // restrictions still apply.
+    // Leave network.allowedDomains/deniedDomains unset so the sandbox doesn't set
+    // up a proxy. All minds need direct API access and the proxy breaks clients
+    // that don't respect HTTP_PROXY (e.g. the claude subprocess spawned by the
+    // Agent SDK). Without network.allowedDomains, wrapWithSandbox generates a
+    // seatbelt profile with `(allow network*)` — unrestricted network while
+    // filesystem restrictions still apply. `network` itself must still be present:
+    // SandboxManager.initialize() reads `runtimeConfig.network.parentProxy` directly
+    // (added in sandbox-runtime 0.0.56) and throws a TypeError if `network` is missing.
     const config = {
       filesystem: {
         denyRead: [],
         allowWrite: [],
         denyWrite: [],
       },
+      network: {},
       ...(ripgrepConfig ? { ripgrep: ripgrepConfig } : {}),
     } as unknown as SandboxRuntimeConfig;
     await SandboxManager.initialize(config);


### PR DESCRIPTION
## Summary
- `initSandbox()` built a sandbox config that deliberately omitted `network` (to keep minds on unrestricted network and avoid a proxy that breaks clients ignoring `HTTP_PROXY`).
- The `@anthropic-ai/sandbox-runtime` dependency was bumped 0.0.46 → 0.0.56 a while back; that version's `SandboxManager.initialize()` unconditionally reads `runtimeConfig.network.parentProxy`, so a missing `network` key throws `TypeError: Cannot read properties of undefined (reading 'parentProxy')`.
- Since `initSandbox()` wraps any init failure as `SandboxUnavailableError` and fails closed, this broke daemon startup entirely for any install with `isolation: "sandbox"` (the default for local installs) — `volute setup` and `volute up` would silently fail with exit code 1 and nothing in `daemon.log` (the crash happens before the log redirect is wired up).
- Fix: add `network: {}` to the config, satisfying the runtime while leaving `allowedDomains`/`deniedDomains` unset (preserves the existing unrestricted-network behavior).

## Test plan
- [x] `npm test` — all 2450 tests pass (pre-push hook)
- [x] Reproduced the crash directly: `node dist/daemon.js --foreground` printed `SandboxUnavailableError: ... TypeError: Cannot read properties of undefined (reading 'parentProxy')`
- [x] After the fix, rebuilt and confirmed the daemon starts and serves `/api/health`
- [x] Ran `volute setup` end-to-end — completes and reaches "Open http://127.0.0.1:1618 to continue setup."