### PR TITLE
fix: pi minds send GitHub Copilot requests to the wrong backend host

### DIFF
--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -464,29 +464,46 @@ export async function getAvailableModels(): Promise<Model<Api>[]> {
   return result;
 }
 
+/**
+ * Resolve and refresh a provider's stored OAuth credential object (not just the
+ * derived API key). Some providers need more than a bearer token to authenticate
+ * correctly — GitHub Copilot's session tokens are proxy-affinitized, and only the
+ * full OAuth credential shape lets pi-ai derive the matching baseUrl at request
+ * time (a bare API key falls back to the provider's generic default baseUrl,
+ * which the token may not be valid against, producing 421 Misdirected Request).
+ * Returns undefined when the provider has no OAuth credentials configured or
+ * refresh fails.
+ */
+export async function resolveOAuthCredentials(
+  providerId: string,
+): Promise<NonNullable<AiProviderConfig["oauth"]> | undefined> {
+  const ai = getAiConfig();
+  const providerConfig = ai?.providers[providerId];
+  if (!providerConfig?.oauth) return undefined;
+
+  try {
+    const result = await getOAuthApiKey(providerId, { [providerId]: providerConfig.oauth });
+    if (!result) return undefined;
+    // Persist refreshed credentials
+    if (result.newCredentials.access !== providerConfig.oauth.access) {
+      saveProviderConfig(providerId, { ...providerConfig, oauth: result.newCredentials });
+      // Fan the rotated token out to running minds (single refresh authority).
+      fireProviderRefreshHook(providerId);
+    }
+    return result.newCredentials;
+  } catch (err) {
+    aiLog.warn(`OAuth credential resolution failed for ${providerId}`, log.errorData(err));
+    return undefined;
+  }
+}
+
 /** Resolve API key for a provider, checking OAuth → config → env var. */
 export async function resolveApiKey(providerId: string): Promise<string | undefined> {
   const ai = getAiConfig();
   const providerConfig = ai?.providers[providerId];
 
-  if (providerConfig?.oauth) {
-    try {
-      const result = await getOAuthApiKey(providerId, {
-        [providerId]: providerConfig.oauth,
-      });
-      if (result) {
-        // Persist refreshed credentials
-        if (result.newCredentials.access !== providerConfig.oauth.access) {
-          saveProviderConfig(providerId, { ...providerConfig, oauth: result.newCredentials });
-          // Fan the rotated token out to running minds (single refresh authority).
-          fireProviderRefreshHook(providerId);
-        }
-        return result.apiKey;
-      }
-    } catch (err) {
-      aiLog.warn(`OAuth key resolution failed for ${providerId}`, log.errorData(err));
-    }
-  }
+  const oauthCreds = await resolveOAuthCredentials(providerId);
+  if (oauthCreds) return oauthCreds.access;
 
   return resolveProviderKey(providerId, providerConfig?.apiKey);
 }

--- a/packages/daemon/src/lib/daemon/credential-sync.ts
+++ b/packages/daemon/src/lib/daemon/credential-sync.ts
@@ -67,6 +67,34 @@ export async function writePiProviderKey(
   }
 }
 
+/**
+ * Set a provider's oauth entry in a pi mind's auth.json, preserving any other
+ * providers already present. Unlike writePiProviderKey, this stores the full
+ * credential (access/refresh/expires + provider-specific extras) so pi-ai's own
+ * OAuth resolution runs inside the mind — some providers (GitHub Copilot) derive
+ * a per-credential baseUrl from this shape that a flattened api_key loses,
+ * causing requests to hit the wrong backend. It also lets the mind refresh its
+ * own token from the stored refresh grant instead of relying solely on the
+ * daemon's refresh fan-out.
+ */
+export async function writePiProviderOAuth(
+  piAgentDir: string,
+  baseName: string,
+  provider: string,
+  oauth: Record<string, unknown>,
+): Promise<void> {
+  mkdirSync(piAgentDir, { recursive: true });
+  const authPath = resolve(piAgentDir, "auth.json");
+  const authData: Record<string, unknown> = existsSync(authPath)
+    ? JSON.parse(readFileSync(authPath, "utf-8"))
+    : {};
+  authData[provider] = { type: "oauth", ...oauth };
+  writeFileSync(authPath, JSON.stringify(authData, null, 2), { mode: 0o600 });
+  if (isIsolationEnabled()) {
+    await chownMindDir(piAgentDir, baseName);
+  }
+}
+
 type MindLookup = {
   name: string;
   template?: string;

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -2,7 +2,7 @@ import { type ChildProcess, execFile, type SpawnOptions, spawn } from "node:chil
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
-import { getAiConfig, resolveApiKey } from "../ai-service.js";
+import { getAiConfig, resolveApiKey, resolveOAuthCredentials } from "../ai-service.js";
 import { deliverEvent, recordNotice } from "../chat/system-events.js";
 import { loadMergedEnv } from "../config/env.js";
 import { getSystemName, readGlobalConfig } from "../config/setup.js";
@@ -21,7 +21,11 @@ import { checkHealth } from "../util/health.js";
 import { clearJsonMap, loadJsonMap, saveJsonMap } from "../util/json-state.js";
 import log from "../util/logger.js";
 import { RotatingLog } from "../util/rotating-log.js";
-import { writeClaudeCredentials, writePiProviderKey } from "./credential-sync.js";
+import {
+  writeClaudeCredentials,
+  writePiProviderKey,
+  writePiProviderOAuth,
+} from "./credential-sync.js";
 import { generateMindToken, revokeMindToken } from "./mind-tokens.js";
 import { RestartTracker } from "./restart-tracker.js";
 import { clearMind as clearTurnState, summarizeOrphanedTurns } from "./turn-tracker.js";
@@ -328,35 +332,48 @@ export class MindManager {
           const modelStr = config.model as string | undefined;
           if (modelStr?.includes(":")) {
             const provider = modelStr.split(":")[0];
-            const apiKey = await resolveApiKey(provider);
-            if (apiKey) {
-              // Write API key to pi-coding-agent auth storage so the mind can use it.
-              // The pi template watches auth.json and reloads, so the daemon can
-              // push a refreshed OAuth token here without restarting the mind.
-              const piAgentDir = resolve(dir, ".mind", "pi-agent");
-              await writePiProviderKey(piAgentDir, baseName, provider, apiKey);
+            const piAgentDir = resolve(dir, ".mind", "pi-agent");
+            const oauthCreds = await resolveOAuthCredentials(provider);
+            if (oauthCreds) {
+              // Store the full OAuth credential (not just the derived key) so
+              // pi-ai's own OAuth resolution runs inside the mind — some
+              // providers (GitHub Copilot) derive a per-credential baseUrl from
+              // this shape that a flattened api_key loses, misdirecting
+              // requests to the wrong backend (421 Misdirected Request). It
+              // also lets the mind refresh its own token from the stored
+              // refresh grant.
+              await writePiProviderOAuth(piAgentDir, baseName, provider, oauthCreds);
               env.PI_CODING_AGENT_DIR = piAgentDir;
-
-              // Also set provider-specific env var as fallback — the sandbox may
-              // block proper-lockfile from reading auth.json, so the env var
-              // ensures getEnvApiKey() in pi-ai still resolves the key.
-              const providerEnvVars: Record<string, string> = {
-                openrouter: "OPENROUTER_API_KEY",
-                openai: "OPENAI_API_KEY",
-                anthropic: "ANTHROPIC_API_KEY",
-                google: "GEMINI_API_KEY",
-                groq: "GROQ_API_KEY",
-                cerebras: "CEREBRAS_API_KEY",
-                xai: "XAI_API_KEY",
-                mistral: "MISTRAL_API_KEY",
-                zai: "ZAI_API_KEY",
-              };
-              const providerEnv = providerEnvVars[provider];
-              if (providerEnv) env[providerEnv] = apiKey;
             } else {
-              mlog.warn(
-                `no API key found for provider "${provider}" — mind ${name} may fail to start`,
-              );
+              const apiKey = await resolveApiKey(provider);
+              if (apiKey) {
+                // Write API key to pi-coding-agent auth storage so the mind can use it.
+                // The pi template watches auth.json and reloads, so the daemon can
+                // push a refreshed key here without restarting the mind.
+                await writePiProviderKey(piAgentDir, baseName, provider, apiKey);
+                env.PI_CODING_AGENT_DIR = piAgentDir;
+
+                // Also set provider-specific env var as fallback — the sandbox may
+                // block proper-lockfile from reading auth.json, so the env var
+                // ensures getEnvApiKey() in pi-ai still resolves the key.
+                const providerEnvVars: Record<string, string> = {
+                  openrouter: "OPENROUTER_API_KEY",
+                  openai: "OPENAI_API_KEY",
+                  anthropic: "ANTHROPIC_API_KEY",
+                  google: "GEMINI_API_KEY",
+                  groq: "GROQ_API_KEY",
+                  cerebras: "CEREBRAS_API_KEY",
+                  xai: "XAI_API_KEY",
+                  mistral: "MISTRAL_API_KEY",
+                  zai: "ZAI_API_KEY",
+                };
+                const providerEnv = providerEnvVars[provider];
+                if (providerEnv) env[providerEnv] = apiKey;
+              } else {
+                mlog.warn(
+                  `no API key found for provider "${provider}" — mind ${name} may fail to start`,
+                );
+              }
             }
           }
         }

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -83,9 +83,17 @@ export function createMind(options: {
 
   // Shared setup (created once)
   const modelStr = options.model || process.env.PI_MODEL || "anthropic:claude-sonnet-4-20250514";
-  const model = resolveModel(modelStr);
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage);
+  // Prefer the registry's model: for OAuth providers with a per-credential baseUrl
+  // (e.g. GitHub Copilot, whose token is pinned to an individual/business/enterprise
+  // proxy host) it has already run the provider's modifyModels() patch. The static
+  // catalog lookup in resolveModel() has no way to apply that and would send every
+  // request to the wrong host, which the provider's API rejects (421 Misdirected
+  // Request for Copilot). Fall back to resolveModel() for ids the registry doesn't
+  // carry (e.g. an admin-registered custom id not yet in the built-in catalog).
+  const [modelProvider, ...modelRest] = modelStr.split(":");
+  const model = modelRegistry.find(modelProvider, modelRest.join(":")) ?? resolveModel(modelStr);
 
   // The daemon centrally refreshes the system OAuth token and rewrites auth.json
   // with the fresh token. Watch the file and reload so a running mind adopts the

--- a/test/ai-service.test.ts
+++ b/test/ai-service.test.ts
@@ -15,6 +15,7 @@ import {
   removeAiConfig,
   removeCustomModel,
   removeProviderConfig,
+  resolveOAuthCredentials,
   saveProviderConfig,
   setEnabledModels,
   setUtilityModel,
@@ -64,6 +65,26 @@ describe("ai-service config", () => {
     saveProviderConfig("anthropic", { apiKey: "sk-test" });
     removeProviderConfig("anthropic");
     assert.equal(getAiConfig(), null);
+  });
+});
+
+describe("resolveOAuthCredentials", () => {
+  it("returns undefined when the provider has no stored oauth", async () => {
+    removeAiConfig();
+    saveProviderConfig("github-copilot", { apiKey: "static-key" });
+    assert.equal(await resolveOAuthCredentials("github-copilot"), undefined);
+  });
+
+  it("returns the stored credential unchanged when it isn't expired (no refresh/network call)", async () => {
+    removeAiConfig();
+    const oauth = {
+      access: "copilot-session-token",
+      refresh: "gh-oauth-refresh",
+      expires: 4102444800000, // year 2100 — never expired during a test run
+    };
+    saveProviderConfig("github-copilot", { oauth });
+    const result = await resolveOAuthCredentials("github-copilot");
+    assert.deepEqual(result, oauth);
   });
 });
 

--- a/test/credential-sync.test.ts
+++ b/test/credential-sync.test.ts
@@ -7,6 +7,7 @@ import {
   syncProviderToMinds,
   writeClaudeCredentials,
   writePiProviderKey,
+  writePiProviderOAuth,
 } from "../packages/daemon/src/lib/daemon/credential-sync.js";
 
 function tmpRoot(label: string): string {
@@ -66,6 +67,38 @@ describe("writePiProviderKey", () => {
     await writePiProviderKey(piAgentDir, "mymind", "anthropic", OAUTH.access);
     const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
     assert.deepEqual(auth, { anthropic: { type: "api_key", key: OAUTH.access } });
+  });
+});
+
+describe("writePiProviderOAuth", () => {
+  it("stores the full oauth credential, preserving other providers", async () => {
+    const dir = tmpRoot("pi-oauth");
+    const piAgentDir = resolve(dir, ".mind", "pi-agent");
+    mkdirSync(piAgentDir, { recursive: true });
+    writeFileSync(
+      resolve(piAgentDir, "auth.json"),
+      JSON.stringify({ openai: { type: "api_key", key: "openai-key" } }),
+    );
+
+    const copilotOauth = {
+      ...OAUTH,
+      availableModelIds: ["claude-sonnet-4.6"],
+    };
+    await writePiProviderOAuth(piAgentDir, "mymind", "github-copilot", copilotOauth);
+
+    const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
+    assert.deepEqual(auth, {
+      openai: { type: "api_key", key: "openai-key" },
+      "github-copilot": { type: "oauth", ...copilotOauth },
+    });
+  });
+
+  it("creates auth.json when none exists", async () => {
+    const dir = tmpRoot("pi-oauth-fresh");
+    const piAgentDir = resolve(dir, ".mind", "pi-agent");
+    await writePiProviderOAuth(piAgentDir, "mymind", "github-copilot", OAUTH);
+    const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
+    assert.deepEqual(auth, { "github-copilot": { type: "oauth", ...OAUTH } });
   });
 });
 


### PR DESCRIPTION
## Summary

Any pi-template mind (including the spirit, when only GitHub Copilot is configured) fails every turn with `421 Misdirected Request` from Copilot's API. Two bugs combine to cause this:

1. **Wrong credential shape.** The daemon flattens OAuth-backed provider credentials into a bare `{ type: "api_key", key }` entry in the mind's `pi-agent/auth.json` (`writePiProviderKey` in `credential-sync.ts`, called from `mind-manager.ts`). GitHub Copilot's session token is proxy-affinitized — it's only valid against the specific host embedded in the token itself (`proxy-ep=...` → `api.individual|business|enterprise.githubcopilot.com`). Only `pi-ai`'s OAuth-credential resolution path (`resolveStoredOAuth` → `oauth.toAuth()`) derives that per-token base URL; the flattened `api_key` path always falls back to the provider's static default host, which won't match a business/enterprise token.
   - Added `resolveOAuthCredentials()` in `ai-service.ts` (extracted from `resolveApiKey`) to get the refreshed OAuth credential object, not just the derived key.
   - Added `writePiProviderOAuth()` in `credential-sync.ts` to store the full `{ type: "oauth", ... }` shape.
   - `mind-manager.ts`'s pi credential injection now prefers this path when the provider has OAuth configured, falling back to the existing `api_key` flow otherwise (unaffected for providers with only a static key).

2. **Even with the right credential stored, the pi template ignored it.** `templates/pi/src/agent.ts`'s `createMind()` resolved its model via `resolveModel()` — a static built-in-catalog lookup with no way to apply a provider's credential-derived `baseUrl` patch (that patch only runs inside `ModelRegistry`, via `oauthProvider.modifyModels()`, gated on the stored credential being `type: "oauth"`). So the model actually used for every completion call kept the provider's default base URL regardless of what got fixed in (1).
   - `createMind()` now prefers `modelRegistry.find(provider, modelId)` (which already has the patched `baseUrl`), falling back to `resolveModel()` for ids the registry doesn't carry (e.g. an admin-registered custom id).

## Test plan
- [x] `npm test` — 2454 tests pass
- [x] `npm run typecheck:templates` — claude/pi/codex templates all pass
- [x] Reproduced live against a real spirit mind on GitHub Copilot (business plan): every turn failed with `421 Misdirected Request` before the fix (confirmed via direct API calls that the default `api.individual.githubcopilot.com` host rejects the token, while the token's own derived `api.business.githubcopilot.com` host + correct Copilot headers return 200)
- [x] After applying both parts of the fix and restarting, sent a real chat turn — the mind replied successfully with no error
- [x] Added unit tests: `writePiProviderOAuth` (credential-sync.test.ts), `resolveOAuthCredentials` (ai-service.test.ts)