### PR TITLE
fix: sandboxed minds can't run their shell or the volute CLI

### DIFF
--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -64,6 +64,18 @@ type DaemonConfig = {
 // This module is CLI-only (imported by src/commands/). process.exit() is intentional —
 // CLI commands should terminate immediately with a clear error when the daemon is unreachable.
 function readDaemonConfig(): DaemonConfig {
+  // A mind runs the CLI inside its sandbox, which denies the whole host home —
+  // daemon.json included. It doesn't need the file: the daemon that spawned it
+  // passes the same connection details in its env, as it does for the mind server.
+  const mindPort = process.env.VOLUTE_MIND_TOKEN && process.env.VOLUTE_DAEMON_PORT;
+  if (mindPort) {
+    return {
+      port: Number(mindPort),
+      hostname: process.env.VOLUTE_DAEMON_HOSTNAME || "127.0.0.1",
+      token: process.env.VOLUTE_MIND_TOKEN,
+    };
+  }
+
   const configPath = resolve(voluteSystemDir(), "daemon.json");
   if (!existsSync(configPath)) {
     // If a system service is installed, the issue is likely VOLUTE_HOME not being set

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -11,6 +11,7 @@ import {
   findMind,
   mindDir,
   mindTmpDir,
+  mindTmpEnv,
   setMindRunning,
   stateDir,
   voluteSystemDir,
@@ -317,7 +318,7 @@ export class MindManager {
       // hook then skips its "This system is named X" line rather than asserting
       // a fabricated one.
       VOLUTE_SYSTEM_NAME: readGlobalConfig().name,
-      TMPDIR: mindTmp,
+      ...mindTmpEnv(dir),
       PATH: `${mindLocalBin}:${currentPath}`,
       // Strip CLAUDECODE so the Agent SDK can spawn Claude Code subprocesses
       CLAUDECODE: undefined,

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -2,7 +2,14 @@ import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { deliverEvent } from "../chat/system-events.js";
 import { loadMergedEnv } from "../config/env.js";
-import { findMind, mindDir, mindTmpDir, stateDir, voluteSystemDir } from "../mind/registry.js";
+import {
+  findMind,
+  mindDir,
+  mindTmpDir,
+  mindTmpEnv,
+  stateDir,
+  voluteSystemDir,
+} from "../mind/registry.js";
 import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
 import { readVoluteConfig, type Schedule, writeVoluteConfig } from "../mind/volute-config.js";
 import { exec } from "../util/exec.js";
@@ -295,7 +302,7 @@ export class Scheduler {
       VOLUTE_MIND_DIR: dir,
       VOLUTE_MIND_PORT: entry ? String(entry.port) : undefined,
       VOLUTE_MIND_TOKEN: token,
-      TMPDIR: mindTmpDir(dir),
+      ...mindTmpEnv(dir),
       PATH: `${mindLocalBin}:${currentPath}`,
     };
   }

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -387,6 +387,15 @@ export function stateDir(name: string): string {
  * the sandbox's allowRead/allowWrite and, under user isolation, chowned to the
  * mind). Used as the mind's TMPDIR so minds never share a writable /tmp.
  */
+export function mindTmpEnv(dir: string): { TMPDIR: string; CLAUDE_CODE_TMPDIR: string } {
+  const tmp = mindTmpDir(dir);
+  // Claude Code ignores TMPDIR for its Bash scratch dir, building it as
+  // `${CLAUDE_CODE_TMPDIR ?? "/tmp"}/claude-<uid>` instead. Left unset it lands in
+  // the real /tmp, outside the sandbox's allowWrite set, and every Bash call fails
+  // with EPERM before the command runs.
+  return { TMPDIR: tmp, CLAUDE_CODE_TMPDIR: tmp };
+}
+
 export function mindTmpDir(dir: string): string {
   return resolve(dir, ".mind", "tmp");
 }

--- a/packages/daemon/src/lib/mind/sandbox.ts
+++ b/packages/daemon/src/lib/mind/sandbox.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import { readGlobalConfig } from "../config/setup.js";
 import log from "../util/logger.js";
@@ -138,6 +140,44 @@ export async function initSandbox(): Promise<void> {
 }
 
 /**
+ * Locate every path a sandboxed mind must be able to read to execute the `volute`
+ * CLI: the bin shim on PATH, the node install prefix, and the package root the
+ * shim resolves to.
+ *
+ * All three are needed. npm installs the shim as a symlink into
+ * `<prefix>/lib/node_modules/volute`, which under `npm link` is itself a symlink
+ * elsewhere. Seatbelt checks every hop it resolves, so a denied intermediate link
+ * fails the whole lookup — and the CLI bundle then loads sibling chunks and
+ * node_modules from the package root.
+ *
+ * Skips any `.local/bin` dir — that holds the mind's own wrapper, which re-scans
+ * PATH for the real CLI and reports "volute: command not found" if it finds none.
+ */
+export function voluteCliPaths(env: NodeJS.ProcessEnv = process.env): string[] {
+  for (const dir of (env.PATH ?? "").split(":")) {
+    if (!dir || dir.endsWith("/.local/bin")) continue;
+    const shim = resolve(dir, "volute");
+    if (!existsSync(shim)) continue;
+
+    const paths = [shim, resolve(dirname(process.execPath), "..")];
+    let target: string;
+    try {
+      target = realpathSync(shim);
+    } catch {
+      return paths;
+    }
+    for (let dir = dirname(target); dir !== dirname(dir); dir = dirname(dir)) {
+      if (existsSync(resolve(dir, "package.json"))) {
+        paths.push(dir);
+        break;
+      }
+    }
+    return paths;
+  }
+  return [];
+}
+
+/**
  * Build deny/allow read lists for a mind's sandbox.
  * Strategy: deny the user's entire home directory, then re-allow just the mind's
  * own directory via allowRead. This is much more restrictive than cherry-picking
@@ -151,7 +191,10 @@ export async function buildSandboxReadConfig(
   const userHome = process.env.HOME || "";
 
   const denyRead: string[] = [];
-  const allowRead: string[] = [mindDir];
+  // The sandbox runtime already exempts the node binary itself, but not the
+  // volute CLI. When it lives under $HOME (nvm, npm --prefix=~) the blanket
+  // denyRead below hides it, and a mind loses its only way to act or speak.
+  const allowRead: string[] = [mindDir, ...voluteCliPaths()];
 
   // Block user's entire home directory — covers .ssh, .aws, .gnupg, .config,
   // other projects, other minds, volute system state, etc.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,10 @@ const ungatedCommands = new Set([
   "service",
   undefined,
 ]);
-if (!ungatedCommands.has(command)) {
+// A mind only exists because a set-up daemon spawned it, so the gate has nothing
+// to tell it — and its sandbox denies the host config the check reads anyway.
+const isMind = !!process.env.VOLUTE_MIND_TOKEN;
+if (!isMind && !ungatedCommands.has(command)) {
   const { setupStatus, setupUrl } = await import("@volute/daemon/lib/config/setup.js");
   const status = setupStatus();
   if (status !== "complete") {

--- a/test/daemon-client.test.ts
+++ b/test/daemon-client.test.ts
@@ -4,7 +4,11 @@ import { createServer, type Server } from "node:http";
 import { resolve } from "node:path";
 import { after, afterEach, before, describe, it } from "node:test";
 import { Agent } from "undici";
-import { daemonDispatcher, resolveWebUrl } from "../packages/cli/src/lib/daemon-client.js";
+import {
+  daemonDispatcher,
+  resolveDaemonUrl,
+  resolveWebUrl,
+} from "../packages/cli/src/lib/daemon-client.js";
 
 // A server that waits before sending any response headers, simulating a
 // long-running daemon operation (e.g. upgrade running `npm install`).
@@ -85,5 +89,26 @@ describe("resolveWebUrl", () => {
   it("prefers VOLUTE_DAEMON_URL when set", () => {
     process.env.VOLUTE_DAEMON_URL = "https://remote.example:8443";
     assert.equal(resolveWebUrl(), "https://remote.example:8443");
+  });
+});
+
+describe("resolveDaemonUrl in a mind", () => {
+  const origToken = process.env.VOLUTE_MIND_TOKEN;
+  const origPort = process.env.VOLUTE_DAEMON_PORT;
+
+  afterEach(() => {
+    if (origToken === undefined) delete process.env.VOLUTE_MIND_TOKEN;
+    else process.env.VOLUTE_MIND_TOKEN = origToken;
+    if (origPort === undefined) delete process.env.VOLUTE_DAEMON_PORT;
+    else process.env.VOLUTE_DAEMON_PORT = origPort;
+  });
+
+  // A mind's sandbox denies the host home, so daemon.json is unreadable — without
+  // the env fallback every CLI call it makes dies with "Volute is not running".
+  it("uses the env the daemon passed instead of reading daemon.json", () => {
+    rmSync(resolve(process.env.VOLUTE_HOME!, "system", "daemon.json"), { force: true });
+    process.env.VOLUTE_MIND_TOKEN = "mind-token";
+    process.env.VOLUTE_DAEMON_PORT = "1618";
+    assert.equal(resolveDaemonUrl(), "http://127.0.0.1:1618");
   });
 });

--- a/test/mind-tmp-env.test.ts
+++ b/test/mind-tmp-env.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mindTmpDir, mindTmpEnv } from "../packages/daemon/src/lib/mind/registry.js";
+
+describe("mindTmpEnv", () => {
+  it("points TMPDIR at the mind's own tmp dir", () => {
+    const env = mindTmpEnv("/minds/alice");
+    assert.equal(env.TMPDIR, mindTmpDir("/minds/alice"));
+  });
+
+  // Claude Code builds its Bash scratch dir as `${CLAUDE_CODE_TMPDIR ?? "/tmp"}/claude-<uid>`
+  // and ignores TMPDIR. Left unset, it mkdirs under the real /tmp, which is outside the
+  // mind's sandbox allowWrite set — every Bash tool call then dies with EPERM.
+  it("points CLAUDE_CODE_TMPDIR at the mind's own tmp dir so the sandbox allows it", () => {
+    const env = mindTmpEnv("/minds/alice");
+    assert.equal(env.CLAUDE_CODE_TMPDIR, mindTmpDir("/minds/alice"));
+  });
+});

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
 import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
@@ -89,6 +98,41 @@ describe("buildSandboxReadConfig", () => {
   it("allows the mind's own directory", async () => {
     const { allowRead } = await buildSandboxReadConfig("alice", "/tmp/minds/alice");
     assert.ok(allowRead.includes("/tmp/minds/alice"), "should allow mind's own dir");
+  });
+
+  // A mind acts and speaks only through the volute CLI. Installed under $HOME
+  // (nvm, npm --prefix=~) it falls under the blanket home denyRead, and the mind
+  // is left mute — so the CLI's own paths must be re-allowed.
+  it("allows the volute CLI even when it lives under the denied home dir", async () => {
+    const home = mkdtempSync(resolve(tmpdir(), "volute-cli-"));
+    const binDir = resolve(home, ".nvm/bin");
+    const pkgDir = resolve(home, ".nvm/lib/node_modules/volute");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(resolve(pkgDir, "dist"), { recursive: true });
+    writeFileSync(resolve(pkgDir, "package.json"), "{}");
+    writeFileSync(resolve(pkgDir, "dist/cli.js"), "");
+    symlinkSync(resolve(pkgDir, "dist/cli.js"), resolve(binDir, "volute"));
+
+    const origPath = process.env.PATH;
+    process.env.HOME = home;
+    process.env.PATH = `${home}/.local/bin:${binDir}`;
+    try {
+      const { denyRead, allowRead } = await buildSandboxReadConfig("alice", "/tmp/minds/alice");
+      assert.ok(denyRead.includes(home), "home is still denied");
+      assert.ok(allowRead.includes(resolve(binDir, "volute")), "CLI shim must be readable");
+      // The bundle loads sibling chunks and node_modules, so the file alone won't run.
+      assert.ok(allowRead.includes(realpathSync(pkgDir)), "CLI package root must be readable");
+      // Seatbelt resolves every symlink hop; npm's shim points through the node
+      // prefix's lib/node_modules, so a denied hop there fails the whole lookup.
+      assert.ok(
+        allowRead.includes(resolve(dirname(process.execPath), "..")),
+        "node install prefix must be readable (npm's symlink hop lives under it)",
+      );
+    } finally {
+      if (origPath === undefined) delete process.env.PATH;
+      else process.env.PATH = origPath;
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it("mind inside home dir is allowed via allowRead", async () => {


### PR DESCRIPTION
A mind on a local (sandbox-isolation) install is currently unable to act at all. Three independent denials, each fatal on its own. Found while investigating a freshly set-up local system whose spirit could not speak — her first and only message was *"(waiting on a broken tool — will retry shortly)"*.

## 1. Every Bash call fails with EPERM

Claude Agent SDK 0.3.207 (pulled in by #694) bundles a newer Claude Code that builds its Bash scratch dir as `${CLAUDE_CODE_TMPDIR ?? "/tmp"}/claude-<uid>/<cwd-slug>`. It ignores `TMPDIR`, which is what we were setting — so the first `mkdir` lands outside the sandbox's `allowWrite` set and every Bash tool call dies before the command runs:

```
EPERM: operation not permitted, mkdir '/private/tmp/claude-501/-Users-...-spirit-home'
```

Fix: set `CLAUDE_CODE_TMPDIR` to the mind's own tmp dir, which is already allowed for writes. Applies to every sandboxed claude-template mind, not just the spirit.

## 2. The `volute` CLI is invisible to the mind

The sandbox denies the whole host home, which hides the CLI whenever it's installed under `$HOME` (nvm, `npm --prefix=~`). The mind's `.local/bin/volute` wrapper scans PATH, can't stat anything, and reports its own `volute: command not found` — leaving the mind with no way to speak or act.

Fix: re-allow the CLI's paths — the bin shim, the node install prefix, and the resolved package root. All three are needed: seatbelt resolves every symlink hop, and npm's shim links through `<prefix>/lib/node_modules/volute`, which under `npm link` is itself a symlink elsewhere. A denied intermediate hop fails the whole lookup.

Installs with node outside `$HOME` (e.g. homebrew) were unaffected, which is likely why this went unnoticed.

## 3. The CLI still refuses to run

Its setup gate reads `config.json` and its daemon client reads `daemon.json` — both under the denied home, so the mind got `Volute is not set up` / `Volute is not running`.

A mind needs neither: it only exists because a set-up daemon spawned it, and that daemon already passes the connection details in env — the same contract the mind server's own client already uses. Skip the gate and read the daemon's address from env when running as a mind. No widening of the sandbox.

## Verification

Tests: 2458 pass, plus regression tests for each fix.

Verified end-to-end against a real sandboxed mind, not just tests:
- `echo hello-from-bash` → `hello-from-bash` (scratch dir now lands under `.mind/tmp/claude-<uid>/`)
- `volute mind list` → `suzy: running`, authenticated as her own mind token

🤖 Generated with [Claude Code](https://claude.com/claude-code)