### PR TITLE
fix: Codex OAuth modal renders blank

### DIFF
--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -534,7 +534,7 @@ const app = new Hono<AuthEnv>()
                 instructions: `Enter code: ${info.userCode}`,
               });
           },
-          onSelect: async (_prompt: OAuthSelectPrompt) => undefined,
+          onSelect: selectLoginMethod,
           onPrompt: async (_prompt: OAuthPrompt) => {
             if (promptPromise) {
               const existing = oauthFlows.get(flowId);
@@ -678,6 +678,14 @@ const app = new Hono<AuthEnv>()
       return c.json({ ok: true });
     },
   );
+
+// Some providers (Codex) open their login with a method selector. The web UI has
+// no picker for it, so take the first option — the browser/callback flow, whose
+// manual-code paste path already covers remote daemons. Answering `undefined`
+// cancels the login before it ever produces an auth URL.
+export async function selectLoginMethod(prompt: OAuthSelectPrompt): Promise<string | undefined> {
+  return prompt.options[0]?.id;
+}
 
 // In-memory OAuth flow tracking
 type OAuthFlow = {

--- a/packages/web/src/ui/components/system/AiProviders.svelte
+++ b/packages/web/src/ui/components/system/AiProviders.svelte
@@ -201,15 +201,16 @@ async function handleOAuth(providerId: string) {
   saving = true;
   try {
     const result = await startAiOAuth(providerId);
+    oauthFlowId = result.flowId;
+    oauthNeedsCode = !!result.needsManualCode;
+    oauthInstructions = result.instructions ?? "";
+    oauthPolling = true;
+    // The auth URL may not be ready yet — polling picks it up (and surfaces errors).
     if (result.url) {
       oauthUrl = result.url;
-      oauthFlowId = result.flowId;
-      oauthNeedsCode = !!result.needsManualCode;
-      oauthInstructions = result.instructions ?? "";
-      oauthPolling = true;
       window.open(result.url, "_blank");
-      pollOAuth();
     }
+    pollOAuth();
   } catch (err) {
     error = err instanceof Error ? err.message : "OAuth failed";
     oauthProvider = "";

--- a/packages/web/src/ui/lib/oauth-reauth.svelte.ts
+++ b/packages/web/src/ui/lib/oauth-reauth.svelte.ts
@@ -39,14 +39,15 @@ export async function startReauth(providerId: string, providerName?: string) {
 
   try {
     const result = await startAiOAuth(providerId);
+    oauthReauth.flowId = result.flowId;
+    oauthReauth.needsCode = !!result.needsManualCode;
+    oauthReauth.polling = true;
+    // The auth URL may not be ready yet — polling picks it up (and surfaces errors).
     if (result.url) {
       oauthReauth.url = result.url;
-      oauthReauth.flowId = result.flowId;
-      oauthReauth.needsCode = !!result.needsManualCode;
-      oauthReauth.polling = true;
       window.open(result.url, "_blank");
-      pollReauth();
     }
+    pollReauth();
   } catch (err) {
     oauthReauth.error = err instanceof Error ? err.message : "OAuth failed";
   }

--- a/test/oauth-login-method.test.ts
+++ b/test/oauth-login-method.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import { selectLoginMethod } from "../packages/daemon/src/web/api/system.js";
+
+describe("selectLoginMethod", () => {
+  it("picks the first offered option", async () => {
+    const choice = await selectLoginMethod({
+      message: "Select login method:",
+      options: [
+        { id: "browser", label: "Browser login (default)" },
+        { id: "device_code", label: "Device code login (headless)" },
+      ],
+    });
+    assert.equal(choice, "browser");
+  });
+
+  it("answers the Codex login-method prompt so the flow reaches an auth URL", async () => {
+    // Codex opens its login with a method selector. Answering `undefined` there
+    // cancels the login before onAuth fires, which left the web UI with a blank
+    // OAuth modal (no url, no error). Drive the real provider to prove we get past it.
+    const provider = getOAuthProvider("openai-codex");
+    assert.ok(provider, "openai-codex OAuth provider should be registered");
+
+    let authUrl = "";
+    // Rejecting the manual-code input unwinds the login once we have what we need,
+    // so the flow doesn't sit waiting on the local callback server.
+    const cancelled = new Error("cancelled by test");
+
+    await assert.rejects(
+      provider.login({
+        onAuth: (info) => {
+          authUrl = info.url;
+        },
+        onDeviceCode: () => {},
+        onPrompt: async () => {
+          throw cancelled;
+        },
+        onManualCodeInput: async () => {
+          throw cancelled;
+        },
+        onSelect: selectLoginMethod,
+      }),
+      (err: unknown) => err === cancelled,
+    );
+
+    assert.ok(
+      authUrl.startsWith("https://auth.openai.com/oauth/authorize"),
+      `expected an OpenAI authorize URL, got: ${authUrl || "(none)"}`,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Starting the Codex OAuth flow from the dashboard opened a **modal with an empty body**. The network call to `POST /api/v1/system/ai/oauth/start` came back with only `{"flowId":"…","needsManualCode":true}` — no `url`, no `instructions` — and the dialog then sat there dead, never even surfacing the error.

Two bugs stacked on top of each other:

1. **Daemon (the trigger).** Codex's OAuth provider opens its login by asking which method to use — browser or device code. `system.ts` answered that selector with `onSelect: async () => undefined`, and pi-ai treats an undefined answer as `"Login cancelled"`. The login threw before ever building an authorize URL, so `onAuth` never fired and the flow went straight to `status: "error"`.

2. **Web UI (why it was silent).** `handleOAuth` sets `oauthProvider = providerId`, which opens the modal — but only stored the flow id and started polling inside `if (result.url)`. With no url, nothing polled and every branch of the modal body evaluated false: a blank, dead dialog that couldn't report the "Login cancelled" error sitting on the flow. `oauth-reauth.svelte.ts` (sidebar re-auth) had the identical bug and would hang on "Waiting for authorization…" forever.

## Fix

- Answer the login-method selector with the first option — browser login, whose manual code-paste path already covers remote daemons. Extracted as `selectLoginMethod` so it's testable.
- Always record the flow and start polling; open the browser window only when there's a url. A slow or failing flow now shows its status instead of nothing.

## Testing

`test/oauth-login-method.test.ts` drives the **real** pi-ai Codex provider through `selectLoginMethod` and asserts the flow reaches an `auth.openai.com/oauth/authorize` URL. Both cases fail against the old `undefined` behavior and pass with the fix.

Verified live against a running daemon — `POST /ai/oauth/start` now returns the authorize URL plus instructions and the flow stays `pending`, and the modal works end to end in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)