### PR TITLE
fix: system events no longer resemble messages

### DIFF
--- a/drizzle/0017_event_history_rows.sql
+++ b/drizzle/0017_event_history_rows.sql
@@ -1,0 +1,9 @@
+-- System events are not messages. They were recorded in mind_history as `inbound` rows,
+-- so every history surface rendered them as chat with a phantom sender ("user"), and minds
+-- read them as messages they were expected to reply to. Retype the delivered-event rows so
+-- the timeline and `volute mind history` can render them as system markers instead.
+--
+-- The `event:<type>:<id>` channel is written only by recordEventRow, so it identifies
+-- these rows exactly. Turn linkage (turn_id / trigger_event_id) is untouched — the linkers
+-- match both types, so reflection capture keeps working for historical turns.
+UPDATE `mind_history` SET `type` = 'event' WHERE `type` = 'inbound' AND `channel` LIKE 'event:%';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776100000000,
       "tag": "0016_brain_to_human",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1776200000000,
+      "tag": "0017_event_history_rows",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1917,6 +1917,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1934,6 +1937,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1951,6 +1957,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1968,6 +1977,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1985,6 +1997,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -330,10 +330,24 @@ export type TurnActivity = {
   created_at: string;
 };
 
+/**
+ * A system event delivered to the mind during a turn. Not a message: it has no sender and
+ * no channel to reply to, so it is kept out of `conversations` entirely and rendered as a
+ * system marker.
+ */
+export type TurnSystemEvent = {
+  id: number;
+  label: string;
+  content: string | null;
+  created_at: string | null;
+};
+
 export type TurnTrigger = {
   channel: string | null;
   sender: string | null;
   content: string | null;
+  /** Set when the turn was triggered by a system event rather than by a message. */
+  event?: { type: string; label: string };
 };
 
 export type TurnRow = {
@@ -345,6 +359,7 @@ export type TurnRow = {
   created_at: string;
   trigger: TurnTrigger | null;
   conversations: TurnConversation[];
+  events: TurnSystemEvent[];
   activities: TurnActivity[];
 };
 

--- a/packages/cli/src/commands/mind-history.ts
+++ b/packages/cli/src/commands/mind-history.ts
@@ -30,6 +30,20 @@ function normalizeTimestamp(dateStr: string): string {
   return dateStr.endsWith("Z") ? dateStr : `${dateStr}Z`;
 }
 
+/**
+ * A system event's worded label, stored on the row by the daemon. Falls back to the type
+ * segment of the `event:<type>:<id>` channel for rows written before the label was stored.
+ */
+function eventLabel(row: HistoryRow): string {
+  if (row.metadata) {
+    try {
+      const meta = JSON.parse(row.metadata);
+      if (typeof meta.label === "string" && meta.label) return meta.label;
+    } catch {}
+  }
+  return row.channel?.split(":")[1] || "event";
+}
+
 function formatRow(row: HistoryRow): string {
   const time = new Date(normalizeTimestamp(row.created_at)).toLocaleString();
   const channel = row.channel ?? "";
@@ -43,6 +57,10 @@ function formatRow(row: HistoryRow): string {
       );
       return `[${time}] [${channel}] ${sender}: ${row.content ?? ""}`;
     }
+    // A system event has no sender and no channel to reply to — never render it in the
+    // `[channel] sender: content` message shape.
+    case "event":
+      return `[${time}] [event: ${eventLabel(row)}] ${row.content ?? ""}`;
     case "text":
       return `[${time}] [text] ${row.content ?? ""}`;
     case "thinking":
@@ -112,6 +130,10 @@ function formatRowCompact(row: HistoryRow): string {
       const sender = row.sender ?? (row.type === "outbound" ? "mind" : "unknown");
       return `[${time}] [${channel}] ${sender}: ${row.content ?? ""}`;
     }
+    // A system event has no sender and no channel to reply to — never render it in the
+    // `[channel] sender: content` message shape.
+    case "event":
+      return `[${time}] [event: ${eventLabel(row)}] ${row.content ?? ""}`;
     case "text":
       return `[${time}] [text] ${row.content ?? ""}`;
     case "thinking":

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -57,8 +57,8 @@ export function parseMeta(
 }
 
 /**
- * A worded label for an event, shown to the mind in the `[Event: <label> — <time>]`
- * envelope and to hosts in the events UI. Never a raw id in isolation.
+ * A worded label for an event, shown to the mind in the `=== System event: <label> — <time> ===`
+ * envelope and to hosts in the events UI and timeline. Never a raw id in isolation.
  */
 export function eventLabel(type: string, meta: Record<string, unknown> | null | undefined): string {
   const m = meta ?? {};
@@ -156,7 +156,7 @@ export async function recordNotice(input: RecordNoticeInput): Promise<void> {
 
 /**
  * The channel slug an event's turn is attributed under. Unique per event so
- * `linkPendingInbound` links each event turn to exactly its own inbound row (which
+ * `linkPendingInbound` links each event turn to exactly its own event row (which
  * carries `meta.systemEventId`), giving exact reflection attribution. The template
  * builds the same slug from the envelope's type + id when dispatching.
  */
@@ -168,24 +168,37 @@ export function eventChannel(type: string, id: number): string {
  * Record an event's actual delivery in mind_history so `mind history` and the activity
  * feed keep working. Called only after a successful POST — an event the mind never
  * received must not claim it was heard (#420). Recorded under the base name, matching
- * how the delivery pipeline records inbounds.
+ * how the delivery pipeline records incoming messages.
+ *
+ * The row type is `event`, not `inbound`: an event is not a message, and the surfaces that
+ * render history (web timeline, `volute mind history`) key off this type to show it as a
+ * system marker instead of a chat bubble with a phantom sender. The label rides along in
+ * the row metadata so those surfaces don't have to re-derive it from `system_events`.
  */
-async function recordEventInbound(mind: string, event: SystemEvent): Promise<void> {
+async function recordEventRow(mind: string, event: SystemEvent): Promise<void> {
   const channel = eventChannel(event.type, event.id);
+  const label = eventLabel(event.type, parseMeta(event.meta, `event ${event.id}`));
+  const metadata = { systemEventId: event.id, label };
   try {
     const db = await getDb();
     const baseName = await getBaseName(mind);
     await db.insert(mindHistory).values({
       mind: baseName,
-      type: "inbound",
+      type: "event",
       channel,
       sender: null,
       content: event.body,
-      metadata: JSON.stringify({ systemEventId: event.id }),
+      metadata: JSON.stringify(metadata),
     });
-    publishMindEvent(baseName, { mind: baseName, type: "inbound", channel, content: event.body });
+    publishMindEvent(baseName, {
+      mind: baseName,
+      type: "event",
+      channel,
+      content: event.body,
+      metadata,
+    });
   } catch (err) {
-    elog.warn(`failed to persist event inbound for ${mind}`, log.errorData(err));
+    elog.warn(`failed to persist event row for ${mind}`, log.errorData(err));
   }
 }
 
@@ -291,7 +304,7 @@ async function markDelivered(id: number, extraMeta?: Record<string, unknown>): P
 /**
  * Deliver a system event to a mind. Inserts the row, then:
  * - `immediate` + awake (or `force`): POSTs the envelope; on success stamps
- *   `delivered_at` and records the inbound in mind_history. A failed POST leaves the
+ *   `delivered_at` and records the event row in mind_history. A failed POST leaves the
  *   row pending — it is redelivered on the next wake or mind start.
  * - `immediate` + sleeping: applies `whileSleeping` (`queue` leaves it pending to flush on
  *   wake; `skip` stamps it delivered with `meta.skipped`; `trigger-wake` queues + wakes).
@@ -352,9 +365,9 @@ export async function deliverEvent(
       const event = await db.select().from(systemEvents).where(eq(systemEvents.id, eventId)).get();
       if (event && (await postEventEnvelope(mind, event))) {
         await markDelivered(eventId);
-        // Record inbound only on actual delivery — history must not claim the mind
+        // Record the row only on actual delivery — history must not claim the mind
         // heard something it never received (#420).
-        await recordEventInbound(mind, event);
+        await recordEventRow(mind, event);
         return { id: eventId, delivered: true };
       }
       elog.warn(
@@ -415,7 +428,7 @@ export async function flushQueuedEvents(mind: string): Promise<number> {
       }
       if (await postEventEnvelope(mind, event)) {
         await markDelivered(event.id);
-        await recordEventInbound(mind, event);
+        await recordEventRow(mind, event);
         delivered++;
       } else {
         elog.warn(`flush could not deliver event ${event.id} (${event.type}) to ${mind}`);
@@ -743,11 +756,20 @@ export async function listEvents(
 
 // --- Reflection capture ---
 
-/** Store `text` as the reflection on an event row. */
-export async function recordReflection(eventId: number, text: string): Promise<void> {
+/**
+ * Store `text` as the reflection on one of `mind`'s own events.
+ *
+ * Scoped by mind on purpose. The event id reaching here is read out of row metadata, and a
+ * mind writes its own history rows — so without the `mind` predicate a mind could name another
+ * mind's event id and overwrite that mind's private reflection.
+ */
+export async function recordReflection(mind: string, eventId: number, text: string): Promise<void> {
   try {
     const db = await getDb();
-    await db.update(systemEvents).set({ reflection: text }).where(eq(systemEvents.id, eventId));
+    await db
+      .update(systemEvents)
+      .set({ reflection: text })
+      .where(and(eq(systemEvents.id, eventId), eq(systemEvents.mind, mind)));
   } catch (err) {
     elog.warn(`failed to record reflection for event ${eventId}`, log.errorData(err));
   }
@@ -755,9 +777,9 @@ export async function recordReflection(eventId: number, text: string): Promise<v
 
 /**
  * Exact reflection attribution, called from turn-lifecycle when a turn completes:
- * the completed turn's `trigger_event_id` points at the mind_history inbound that
+ * the completed turn's `trigger_event_id` points at the mind_history event row that
  * started it (linked by `linkPendingInbound` via the unique `event:<type>:<id>`
- * channel the template echoes back). If that inbound carries a `systemEventId`, the
+ * channel the template echoes back). If that row carries a `systemEventId`, the
  * turn was an event turn and its final text is stored as the event's reflection.
  * A turn triggered by anything else — or with no linked trigger — records nothing:
  * a missing reflection is better than one stolen from an unrelated conversation.
@@ -776,13 +798,13 @@ export async function captureReflection(
       .get();
     if (turn?.trigger == null) return;
 
-    const inbound = await db
+    const trigger = await db
       .select({ metadata: mindHistory.metadata })
       .from(mindHistory)
       .where(eq(mindHistory.id, turn.trigger))
       .get();
-    const eventId = inbound?.metadata
-      ? parseMeta(inbound.metadata, `inbound ${turn.trigger}`).systemEventId
+    const eventId = trigger?.metadata
+      ? parseMeta(trigger.metadata, `event row ${turn.trigger}`).systemEventId
       : undefined;
     if (typeof eventId !== "number") return;
 
@@ -800,7 +822,7 @@ export async function captureReflection(
       .limit(1)
       .get();
     const text = row?.content?.trim();
-    if (text) await recordReflection(eventId, text);
+    if (text) await recordReflection(mind, eventId, text);
   } catch (err) {
     elog.warn(`failed to capture reflection for turn ${turnId}`, log.errorData(err));
   }

--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -145,11 +145,20 @@ function buildTurnDeterministicSummary(
   const tools: string[] = [];
   let hasInbound = false;
   let hasOutbound = false;
+  let eventLabel: string | undefined;
 
   for (const ev of events) {
     if (ev.type === "inbound") {
       hasInbound = true;
       if (ev.channel) channels.add(ev.channel);
+    }
+    // Events need naming here too, not only in buildTranscript. This is the fallback used
+    // whenever aiCompleteUtility() returns null (AI unconfigured, 401, rate-limited, expired
+    // OAuth) — without it a schedule/orientation/wake turn degrades to a bare "Turn completed."
+    // and the trigger vanishes precisely when a host is least able to see what happened.
+    if (ev.type === "event") {
+      const label = parsedMeta.get(ev.id)?.label;
+      eventLabel = typeof label === "string" && label ? label : "System event";
     }
     if (ev.type === "outbound" || ev.type === "text") {
       hasOutbound = true;
@@ -161,6 +170,9 @@ function buildTurnDeterministicSummary(
   }
 
   const parts: string[] = [];
+  if (eventLabel) {
+    parts.push(`System event: ${eventLabel}`);
+  }
   if (hasInbound) {
     const channelList = [...channels];
     parts.push(
@@ -188,6 +200,16 @@ export function buildTranscript(
       case "inbound":
         lines.push(`[inbound${ev.channel ? ` ${ev.channel}` : ""}] ${ev.content ?? ""}`);
         break;
+      // A system event is what triggered the turn — the summarizer needs to see it, or a
+      // schedule/orientation/wake turn gets summarized from its tool calls alone, with no
+      // idea what prompted them. Framed as an event, not an inbound message: it has no
+      // sender, and the summary shouldn't imply someone spoke to the mind.
+      case "event": {
+        const label = parsedMeta.get(ev.id)?.label;
+        const named = typeof label === "string" && label ? `: ${label}` : "";
+        lines.push(`[system event${named}] ${ev.content ?? ""}`);
+        break;
+      }
       case "outbound":
       case "text":
         lines.push(`[response] ${(ev.content ?? "").slice(0, 500)}`);
@@ -257,7 +279,14 @@ export async function summarizeTurn(
         await db
           .update(mindHistory)
           .set({ turn_id: null })
-          .where(and(eq(mindHistory.turn_id, effectiveTurnId), eq(mindHistory.type, "inbound")));
+          .where(
+            and(
+              eq(mindHistory.turn_id, effectiveTurnId),
+              // Release system-event rows too, so an interrupted event turn's row can be
+              // re-linked to the turn that actually processes it.
+              inArray(mindHistory.type, ["inbound", "event"]),
+            ),
+          );
         await db
           .update(messages)
           .set({ turn_id: null })

--- a/packages/daemon/src/lib/daemon/turn-lifecycle.ts
+++ b/packages/daemon/src/lib/daemon/turn-lifecycle.ts
@@ -118,7 +118,10 @@ async function linkPendingInbound(
 
   const conditions = [
     eq(mindHistory.mind, mind),
-    eq(mindHistory.type, "inbound"),
+    // "event" rows are system events (see recordEventRow) — not messages, but they
+    // trigger turns the same way, and this linkage is what sets `trigger_event_id` and
+    // thus drives reflection capture. Dropping them here breaks it silently.
+    inArray(mindHistory.type, ["inbound", "event"]),
     sql`${mindHistory.turn_id} IS NULL`,
     eq(mindHistory.channel, scopeChannel),
   ];

--- a/packages/daemon/src/lib/daemon/turn-tracker.ts
+++ b/packages/daemon/src/lib/daemon/turn-tracker.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
 import { mindHistory, turns } from "../schema.js";
 import log from "../util/logger.js";
@@ -80,18 +80,26 @@ export function getActiveTurnId(mind: string, session?: string | null): string |
 }
 
 /**
- * Attribute an inbound that arrives mid-turn to the turn already in progress.
+ * Attribute an inbound message OR a system event that arrives mid-turn to the turn already in
+ * progress.
  *
  * `TurnLifecycle.linkPendingInbound` only runs at turn CREATION and sweeps a bounded set of
- * the most-recent untagged inbounds. An inbound delivered while a turn is already active for
- * the session would otherwise wait for the NEXT same-channel turn to sweep it — and be left
+ * the most-recent untagged rows. One delivered while a turn is already active for the session
+ * would otherwise wait for the NEXT same-channel turn to sweep it — and be left
  * `turn_id = NULL` forever if more than that bound accumulate or no later turn runs. Called
  * per-delivery: when the mind has an active turn for (mind, session), every still-untagged
- * inbound on that channel is attributed to it immediately.
+ * row on that channel is attributed to it immediately.
+ *
+ * The type filter below must match "event" as well as "inbound". Events are POSTed with no
+ * busy check, so one can land while a turn is running, and this is the only path that
+ * attributes it. Narrow the filter and the event silently drops out of the turn's `events`
+ * array in the timeline and out of the summarizer's transcript — no error, no log; as far as
+ * history is concerned it never arrived. Guarded by "tags a system event arriving mid-turn"
+ * in test/turn-lifecycle.test.ts.
  *
  * No-op when no turn is active yet — the turn-creation path (`linkPendingInbound`) tags the
- * triggering inbound then. Only `turn_id` is set here: the turn's `trigger_event_id` stays
- * the original triggering inbound, since a mid-turn message did not trigger the turn.
+ * trigger then. Only `turn_id` is set here: the turn's `trigger_event_id` stays the original
+ * trigger, since a mid-turn arrival did not trigger the turn.
  */
 export async function linkInboundToActiveTurn(
   mind: string,
@@ -109,7 +117,8 @@ export async function linkInboundToActiveTurn(
     .where(
       and(
         eq(mindHistory.mind, mind),
-        eq(mindHistory.type, "inbound"),
+        // System events ("event") arrive mid-turn too and need the same attribution.
+        inArray(mindHistory.type, ["inbound", "event"]),
         sql`${mindHistory.turn_id} IS NULL`,
         eq(mindHistory.channel, channel),
       ),

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -24,6 +24,7 @@ export const PROMPT_KEYS = [
   "compaction_warning",
   "compaction_instructions",
   "reply_instructions",
+  "event_instructions",
   "channel_invite",
   "pre_sleep",
   "wake_summary",
@@ -133,6 +134,14 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
     content: 'To reply to this message, use: volute chat send ${channel} "your message"',
     description: "First-message reply hint injected via hook",
     variables: ["channel"],
+    category: "mind",
+  },
+  event_instructions: {
+    content:
+      "This is a system event from your environment — not a message from anyone, and nothing awaits a reply. If it calls for action, use your normal channels. Your closing thoughts on an event turn are kept as a private reflection in your history.",
+    description:
+      "Note injected on the first system-event turn of a session, in place of reply instructions",
+    variables: [],
     category: "mind",
   },
   channel_invite: {

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -86,7 +86,7 @@ const history = new Hono<HistoryEnv>()
       summaryByTurn.set(s.period_key, { content: s.content, metadata: s.metadata });
     }
 
-    // 3. Get inbound/outbound events from mind_history for these turns.
+    // 3. Get inbound/event/outbound rows from mind_history for these turns.
     // We use mind_history instead of the messages table because mind_history has
     // correct per-mind turn_id tagging. The messages table can only hold one turn_id,
     // so mind-to-mind messages get tagged with the sender's turn, not the receiver's.
@@ -98,6 +98,7 @@ const history = new Hono<HistoryEnv>()
         channel: mindHistory.channel,
         sender: mindHistory.sender,
         content: mindHistory.content,
+        metadata: mindHistory.metadata,
         turn_id: mindHistory.turn_id,
         created_at: mindHistory.created_at,
       })
@@ -105,7 +106,10 @@ const history = new Hono<HistoryEnv>()
       .where(
         and(
           inArray(mindHistory.turn_id, turnIds),
-          sql`${mindHistory.type} IN ('inbound', 'outbound')`,
+          // `event` rows are system events, not messages. They're fetched here but split off
+          // below into a separate per-turn `events` array — never into `conversations`, so no
+          // surface can render them as chat with a phantom sender.
+          sql`${mindHistory.type} IN ('inbound', 'event', 'outbound')`,
         ),
       )
       // id tiebreaker: created_at is second-resolution, so a same-second inbound/outbound
@@ -121,6 +125,15 @@ const history = new Hono<HistoryEnv>()
       created_at: string | null;
     };
     const msgsByTurnChannel = new Map<string, Map<string, ConvEvent[]>>();
+
+    /** A system event that triggered or arrived during a turn — never a conversation. */
+    type SystemEventEntry = {
+      id: number;
+      label: string;
+      content: string | null;
+      created_at: string | null;
+    };
+    const systemEventsByTurn = new Map<string, SystemEventEntry[]>();
 
     function addToTurnChannel(turnId: string, channel: string, event: ConvEvent) {
       let byChannel = msgsByTurnChannel.get(turnId);
@@ -140,9 +153,37 @@ const history = new Hono<HistoryEnv>()
     const turnMindMap = new Map<string, string>();
     for (const t of turnRows) turnMindMap.set(t.id, t.mind);
 
-    // Add inbound and outbound events from mind_history
+    /** The event's worded label, stored on the row by recordEventRow. */
+    function eventLabelOf(metadata: string | null, channel: string): string {
+      if (metadata) {
+        try {
+          const parsed = JSON.parse(metadata) as { label?: unknown };
+          if (typeof parsed.label === "string" && parsed.label) return parsed.label;
+        } catch {
+          // Fall through to the channel-derived label.
+        }
+      }
+      // `event:<type>:<id>` — fall back to the type segment for rows written before the
+      // label was stored (or if the metadata is malformed).
+      return channel.split(":")[1] || "Event";
+    }
+
+    // Split mind_history rows: messages into conversations, system events into their own
+    // per-turn list. An event has no sender and no channel to reply to, so it must never
+    // enter the conversation structure that the UI renders as chat.
     for (const m of historyMsgRows) {
       if (!m.turn_id || !m.channel) continue;
+      if (m.type === "event") {
+        const arr = systemEventsByTurn.get(m.turn_id) ?? [];
+        arr.push({
+          id: m.id,
+          label: eventLabelOf(m.metadata, m.channel),
+          content: m.content,
+          created_at: m.created_at,
+        });
+        systemEventsByTurn.set(m.turn_id, arr);
+        continue;
+      }
       const mindName = turnMindMap.get(m.turn_id) ?? m.mind;
       addToTurnChannel(m.turn_id, m.channel, {
         id: m.id,
@@ -188,7 +229,13 @@ const history = new Hono<HistoryEnv>()
       .map((t) => t.trigger_event_id!);
     const triggerMap = new Map<
       number,
-      { channel: string | null; sender: string | null; content: string | null }
+      {
+        channel: string | null;
+        sender: string | null;
+        content: string | null;
+        type: string;
+        metadata: string | null;
+      }
     >();
     if (triggerIds.length > 0) {
       const triggerRows = await db
@@ -197,6 +244,8 @@ const history = new Hono<HistoryEnv>()
           channel: mindHistory.channel,
           sender: mindHistory.sender,
           content: mindHistory.content,
+          type: mindHistory.type,
+          metadata: mindHistory.metadata,
         })
         .from(mindHistory)
         .where(inArray(mindHistory.id, triggerIds));
@@ -370,6 +419,10 @@ const history = new Hono<HistoryEnv>()
       }
 
       const trigger = t.trigger_event_id ? triggerMap.get(t.trigger_event_id) : null;
+      // A turn triggered by a system event is not a conversation: nothing is waiting on a
+      // reply, and the mind's closing text is a private reflection, not an answer. The flag
+      // lets the timeline say so instead of rendering it like a chat exchange.
+      const isEventTrigger = trigger?.type === "event";
 
       return {
         id: t.id,
@@ -379,9 +432,22 @@ const history = new Hono<HistoryEnv>()
         status: t.status,
         created_at: t.created_at,
         trigger: trigger
-          ? { channel: trigger.channel, sender: trigger.sender, content: trigger.content }
+          ? {
+              channel: trigger.channel,
+              sender: trigger.sender,
+              content: trigger.content,
+              ...(isEventTrigger && trigger.channel
+                ? {
+                    event: {
+                      type: trigger.channel.split(":")[1] || "event",
+                      label: eventLabelOf(trigger.metadata, trigger.channel),
+                    },
+                  }
+                : {}),
+            }
           : null,
         conversations: convEntries,
+        events: systemEventsByTurn.get(t.id) ?? [],
         activities: turnActivities,
       };
     });

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -143,6 +143,16 @@ import {
 const _lastActiveCache: { map: Map<string, string>; ts: number } = { map: new Map(), ts: 0 };
 const _LAST_ACTIVE_TTL = 60_000;
 
+/**
+ * mind_history row types the daemon authors to represent someone *other than the mind* —
+ * a human's message ("inbound") or the environment itself ("event"). Minds are untrusted
+ * principals (they run arbitrary code), and POST /:name/events is how a mind writes its own
+ * history, so it must not be able to write these: doing so forges a message from a human, or
+ * a system event that the UI renders as an authoritative environment notice. Everything else
+ * on this endpoint is mind-authored by definition and is rendered as such.
+ */
+const DAEMON_AUTHORED_TYPES = new Set(["inbound", "event"]);
+
 type ChannelStatus = {
   name: string;
   displayName: string;
@@ -2666,6 +2676,9 @@ const app = new Hono<AuthEnv>()
     if (!body.type) {
       return c.json({ error: "type required" }, 400);
     }
+    if (DAEMON_AUTHORED_TYPES.has(body.type)) {
+      return c.json({ error: `type "${body.type}" is daemon-authored` }, 400);
+    }
 
     await handleMindEvent(baseName, body);
 
@@ -2872,7 +2885,7 @@ const app = new Hono<AuthEnv>()
 
     const typeFilter = detail
       ? undefined
-      : sql`${mindHistory.type} IN ('inbound','outbound','tool_use','tool_result','text','thinking','activity')`;
+      : sql`${mindHistory.type} IN ('inbound','event','outbound','tool_use','tool_result','text','thinking','activity')`;
 
     // Prefer turn_id-based query; fall back to legacy session+range
     let rows: Array<typeof mindHistory.$inferSelect>;
@@ -3128,11 +3141,11 @@ const app = new Hono<AuthEnv>()
         // No type filter
         break;
       case "conversation":
-        conditions.push(sql`${mindHistory.type} IN ('inbound','outbound','tool_use')`);
+        conditions.push(sql`${mindHistory.type} IN ('inbound','event','outbound','tool_use')`);
         break;
       case "detailed":
         conditions.push(
-          sql`${mindHistory.type} IN ('inbound','outbound','tool_use','tool_result','text','thinking')`,
+          sql`${mindHistory.type} IN ('inbound','event','outbound','tool_use','tool_result','text','thinking')`,
         );
         break;
     }

--- a/packages/web/src/ui/components/HistoryEvent.svelte
+++ b/packages/web/src/ui/components/HistoryEvent.svelte
@@ -13,6 +13,7 @@ import {
   getToolCategory,
   getToolLabel,
 } from "../lib/tool-names";
+import { isEventTriggeredTurn } from "../lib/turn-events";
 import ToolGroupComponent from "./chat/ToolGroup.svelte";
 import ExtensionFeedCard from "./ExtensionFeedCard.svelte";
 import HistoryEvent from "./HistoryEvent.svelte";
@@ -44,6 +45,7 @@ let {
   compact = false,
   turnConversations = [],
   turnActivities = [],
+  reflection = false,
   onsessionclick,
   onexpand,
 }: {
@@ -53,6 +55,12 @@ let {
   compact?: boolean;
   turnConversations?: TurnConversation[];
   turnActivities?: TurnActivity[];
+  /**
+   * True for the mind's closing text on a system-event turn. Nothing was sent to anyone —
+   * the text is kept as a private reflection — so it's labelled as such rather than reading
+   * like a reply to a message.
+   */
+  reflection?: boolean;
   onsessionclick?: (session: string) => void;
   onexpand?: (expanded: boolean, el: HTMLDivElement | undefined) => void;
 } = $props();
@@ -68,6 +76,8 @@ let detailLoading = $state(false);
 const typeColors: Record<string, string> = {
   inbound: "var(--blue)",
   outbound: "var(--red)",
+  // A system event is not a message — it never gets the inbound blue or a chat bubble.
+  event: "var(--purple)",
   text: "var(--text-1)",
   tool_use: "var(--yellow)",
   tool_result: "var(--yellow)",
@@ -90,9 +100,20 @@ let meta = $derived.by(() => {
   }
 });
 
+/**
+ * A system event's worded label ("Orientation", "Schedule: morning-check"), stored on the
+ * row by the daemon. Falls back to the type segment of the `event:<type>:<id>` channel for
+ * rows written before the label was stored.
+ */
+let eventLabel = $derived.by(() => {
+  if (typeof meta?.label === "string" && meta.label) return meta.label;
+  return event.channel?.split(":")[1] || "event";
+});
+
 let collapsible = $derived(
   event.type === "inbound" ||
     event.type === "outbound" ||
+    event.type === "event" ||
     event.type === "activity" ||
     event.type === "text" ||
     event.type === "thinking" ||
@@ -113,11 +134,25 @@ let tooltip = $derived.by(() => {
     const ch = event.channel ? ` · ${event.channel}` : "";
     return `${time} · ${type}${ch}`;
   }
+  if (type === "event") {
+    return `${time} · system event · ${eventLabel}`;
+  }
   if (type === "activity") {
     return `${time} · ${meta?.type ?? "activity"}`;
   }
   return `${time} · ${type}`;
 });
+
+/**
+ * The id of the last `text` row in a turn. On a system-event turn that row is the mind's
+ * closing thought, stored as a private reflection (it was delivered nowhere), so the
+ * timeline labels it rather than letting it read as a reply.
+ */
+function lastTextId(events: HistoryMessage[]): number | undefined {
+  let id: number | undefined;
+  for (const e of events) if (e.type === "text") id = e.id;
+  return id;
+}
 
 function formatTime(dateStr: string): string {
   const date = new Date(normalizeTimestamp(dateStr));
@@ -201,6 +236,9 @@ async function handleClick() {
     <div class="marker marker-icon" style:color="var(--blue)" use:tooltipAction={{ text: tooltip, position: "left" }}><Icon kind="chat" /></div>
   {:else if event.type === "outbound"}
     <div class="marker marker-icon" style:color="var(--red)" use:tooltipAction={{ text: tooltip, position: "left" }}><Icon kind="chat" /></div>
+  {:else if event.type === "event"}
+    <!-- Gear, never the chat icon: an event comes from the environment, not a person. -->
+    <div class="marker marker-icon" style:color="var(--purple)" use:tooltipAction={{ text: tooltip, position: "left" }}><Icon kind="gear" /></div>
   {:else if event.type === "text"}
     <div class="marker marker-icon" style:color="var(--text-1)" use:tooltipAction={{ text: tooltip, position: "left" }}><Icon kind="text" /></div>
   {:else if event.type === "thinking"}
@@ -276,11 +314,15 @@ async function handleClick() {
           {:else if turnError}
             <div class="turn-loading">{turnError}</div>
           {:else if fullDetail}
+            {@const detailIsEventTurn = isEventTriggeredTurn(detailEvents)}
+            {@const detailLastTextId = lastTextId(detailEvents)}
             {#each detailEvents.filter((e) => e.type !== "summary") as ev (ev.id)}
-              <HistoryEvent event={ev} {mindName} />
+              <HistoryEvent event={ev} {mindName} reflection={detailIsEventTurn && ev.id === detailLastTextId} />
             {/each}
           {:else}
             {@const items = groupToolEvents(turnEvents)}
+            {@const isEventTurn = isEventTriggeredTurn(turnEvents)}
+            {@const lastText = lastTextId(turnEvents)}
             {#each items as item (item.kind === "tool-group" ? `tg-${item.toolUse.id}` : `ev-${item.event.id}`)}
               {#if item.kind === "tool-group"}
                 {@const catColor = getCategoryColor(item.category)}
@@ -293,7 +335,7 @@ async function handleClick() {
                   <ToolGroupComponent group={item} {mindName} turnStatus="complete" />
                 </div>
               {:else}
-                <HistoryEvent event={item.event} {mindName} />
+                <HistoryEvent event={item.event} {mindName} reflection={isEventTurn && item.event.id === lastText} />
               {/if}
             {/each}
           {/if}
@@ -326,6 +368,24 @@ async function handleClick() {
     {:else}
       <span class="inline-text" style:color={actColor}>{event.content}</span>
     {/if}
+  {:else if event.type === "event"}
+    <!--
+      A system event: no bubble, no sender, no channel tag. It came from the environment,
+      not from anyone, and there is nothing to reply to. Rendering it in the message shape
+      is what made minds try to answer their own environment.
+    -->
+    {#if expanded}
+      <div class="system-event">
+        <div class="system-event-header">
+          <span class="system-event-kind">system event</span>
+          <span class="system-event-label">{eventLabel}</span>
+          <span class="time">{formatTime(event.created_at)}</span>
+        </div>
+        <div class="system-event-body">{event.content}</div>
+      </div>
+    {:else}
+      <span class="inline-text inline-text-event"><span class="system-event-label">{eventLabel}</span>{" "}{event.content}</span>
+    {/if}
   {:else if event.type === "inbound" || event.type === "outbound"}
     {#if expanded}
       <div class="compact-msg">
@@ -344,6 +404,9 @@ async function handleClick() {
   {:else}
     <div class="event-body">
       {#if event.type === "text"}
+        {#if reflection}
+          <div class="reflection-label">reflection · private</div>
+        {/if}
         <div class="inline-text dim" class:inline-text-expanded={expanded}>
           <div class="markdown-body">{@html renderMarkdown(event.content)}</div>
         </div>
@@ -672,5 +735,55 @@ async function handleClick() {
   }
   .compact-msg-text {
     color: var(--text-0);
+  }
+
+  /*
+    System event: deliberately NOT the message card. No bubble border, no sender, no
+    channel — a flat marker from the environment. Reads as a system notice, not as chat.
+  */
+  .system-event {
+    border-left: 2px solid color-mix(in srgb, var(--purple) 55%, transparent);
+    padding-left: 10px;
+  }
+  .system-event-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 3px;
+  }
+  .system-event-kind {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--purple);
+  }
+  .system-event-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-1);
+  }
+  .system-event-body {
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-0);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .inline-text-event {
+    color: var(--text-1);
+  }
+  .inline-text-event .system-event-label {
+    color: var(--purple);
+  }
+  .reflection-label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--purple);
+    margin-bottom: 2px;
   }
 </style>

--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -227,7 +227,7 @@ function deleteStreaming(turnId: string) {
 }
 
 let nextSyntheticId = -1;
-// Inbound events that arrived before any turn_created — shown as provisional turn
+// Inbound messages and system events that arrived before any turn_created — shown as provisional turn
 let pendingInbounds = $state<HistoryMessage[]>([]);
 // Fallback timers for done events that may not be followed by a summary
 const doneFallbackTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -378,11 +378,12 @@ function connectSSE() {
 
     const turnId = d.turnId as string | undefined;
     const eventType = d.type as string;
-    if (eventType === "inbound" && !turnId) {
-      // Show immediately as provisional turn before turn_created arrives
+    if ((eventType === "inbound" || eventType === "event") && !turnId) {
+      // Show immediately as provisional turn before turn_created arrives. System events
+      // ride the same path — HistoryEvent renders them as system markers, not as chat.
       pendingInbounds = [...pendingInbounds, buildHistoryMessage(d)];
     } else if (eventType === "turn_created" && turnId) {
-      // Promote pending inbounds into the real turn's streaming events
+      // Promote pending inbounds and system events into the real turn's streaming events
       if (!turnsData.some((t) => t.id === turnId)) {
         turnsData = [
           ...turnsData,
@@ -395,6 +396,7 @@ function connectSSE() {
             created_at: new Date().toISOString(),
             trigger: null,
             conversations: [],
+            events: [],
             activities: [],
           },
         ];
@@ -518,14 +520,17 @@ async function loadTurns() {
     const chronological = [...rows].reverse();
     upsertTurnRows(chronological);
 
-    // Check for recent untagged inbound events (message sent but turn not yet started)
+    // Check for recent untagged inbound/event rows (arrived, but turn not yet started)
     if (pendingInbounds.length === 0 && name) {
       fetchHistory(name, { preset: "all", limit: 10 })
         .then((recent) => {
           // Only promote recent untagged inbounds — an old inbound a stopped/sleeping
           // mind never processed must not render as a perpetually-active turn.
           const untagged = recent.filter(
-            (e) => e.type === "inbound" && !e.turn_id && isRecentInbound(e.created_at),
+            (e) =>
+              (e.type === "inbound" || e.type === "event") &&
+              !e.turn_id &&
+              isRecentInbound(e.created_at),
           );
           if (untagged.length > 0 && pendingInbounds.length === 0) {
             pendingInbounds = untagged;
@@ -1020,7 +1025,7 @@ function jumpToLatest() {
             </div>
           {:else}
             {@const turn = item.turn}
-          {@const peekCount = (!expandedTurns.has(turn.id) && turn.status !== "active") ? turn.conversations.length + turn.activities.length : 0}
+          {@const peekCount = (!expandedTurns.has(turn.id) && turn.status !== "active") ? turn.conversations.length + turn.events.length + turn.activities.length : 0}
           <div class="turn-row" data-turn-id={turn.id} style:min-height={peekCount > 0 ? `${36 + peekCount * 48}px` : undefined}>
             <div class="turn-time">
               {#if !name}
@@ -1043,7 +1048,7 @@ function jumpToLatest() {
               onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); (e.currentTarget as HTMLElement).click(); } }}
             >
               <div class="turn-dot"></div>
-              {#if !expandedTurns.has(turn.id) && turn.status !== "active" && (turn.conversations.length > 0 || turn.activities.length > 0)}
+              {#if !expandedTurns.has(turn.id) && turn.status !== "active" && (turn.conversations.length > 0 || turn.events.length > 0 || turn.activities.length > 0)}
                 <div class="turn-peek-icons">
                   {#each turn.conversations as conv (conv.id)}
                     {@const chatKey = peekKey("chat", turn.id, conv.id)}
@@ -1074,6 +1079,30 @@ function jumpToLatest() {
                                 </div>
                               {/each}
                             </div>
+                          </div>
+                        {/if}
+                      </div>
+                    </div>
+                  {/each}
+                  <!--
+                    System events peek with a gear, not the chat icon, and their card has no
+                    sender and no click-to-open-conversation: there is no conversation to open.
+                  -->
+                  {#each turn.events as evt (evt.id)}
+                    {@const evtKey = peekKey("system-event", turn.id, String(evt.id))}
+                    <div class="peek-anchor">
+                      <button class="peek-btn" style:color="var(--purple)" aria-label="View system event" onmouseenter={() => revealPeek(evtKey)} onfocus={() => revealPeek(evtKey)} onclick={(e) => e.stopPropagation()}>
+                        <Icon kind="gear" />
+                      </button>
+                      <div class="peek-popover">
+                        {#if shouldRenderPeek(revealedPeeks, evtKey)}
+                          <div class="peek-card" style:border-color="color-mix(in srgb, var(--purple) 25%, var(--border))">
+                            <div class="peek-card-header" style:border-bottom-color="color-mix(in srgb, var(--purple) 25%, var(--border))">
+                              <Icon kind="gear" class="peek-card-icon" />
+                              <span class="peek-card-label">{evt.label}</span>
+                              <span class="peek-card-meta">system event</span>
+                            </div>
+                            <div class="peek-card-body peek-card-event">{evt.content}</div>
                           </div>
                         {/if}
                       </div>
@@ -1149,17 +1178,22 @@ function jumpToLatest() {
                     onexpand={(expanded) => handleExpand(turn.id, expanded)}
                   />
                 {:else if turn.status === "complete"}
-                  <!-- Complete but no summary (e.g. daemon restarted mid-turn) -->
+                  <!-- Complete but no summary (e.g. daemon restarted mid-turn). An event-triggered
+                       turn must not be rebuilt with the event's channel/sender: that is exactly the
+                       message-shaped row this change exists to eliminate. `trigger.event` is the
+                       authoritative signal from the API — use it, don't sniff the channel. -->
                   <HistoryEvent
                     event={{
                       id: 0,
                       mind: turn.mind,
-                      channel: turn.trigger?.channel ?? "",
+                      channel: turn.trigger?.event ? "" : (turn.trigger?.channel ?? ""),
                       thread: null,
-                      sender: turn.trigger?.sender ?? null,
+                      sender: turn.trigger?.event ? null : (turn.trigger?.sender ?? null),
                       message_id: null,
                       type: "summary",
-                      content: turn.trigger?.content ?? "(no summary)",
+                      content: turn.trigger?.event
+                        ? `System event: ${turn.trigger.event.label}`
+                        : (turn.trigger?.content ?? "(no summary)"),
                       metadata: null,
                       turn_id: turn.id,
                       created_at: turn.created_at,
@@ -1609,6 +1643,15 @@ function jumpToLatest() {
     max-height: 300px;
     overflow-y: auto;
     color: var(--text-0);
+  }
+
+  /* System event body: plain text, no sender column — it came from no one. */
+  .peek-card-event {
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
   .peek-msg {

--- a/packages/web/src/ui/lib/peek.ts
+++ b/packages/web/src/ui/lib/peek.ts
@@ -5,7 +5,7 @@ import type { TurnActivity } from "@volute/api";
  * have been revealed (hovered) so their content is mounted lazily.
  */
 export function peekKey(
-  kind: "chat" | "activity",
+  kind: "chat" | "activity" | "system-event",
   turnId: string,
   itemId: string | number,
 ): string {

--- a/packages/web/src/ui/lib/turn-events.ts
+++ b/packages/web/src/ui/lib/turn-events.ts
@@ -1,0 +1,22 @@
+import type { HistoryMessage } from "@volute/api";
+
+/** Row types that can start a turn — i.e. the ones the daemon considers as a trigger. */
+const SOURCE_TYPES = new Set(["inbound", "event"]);
+
+/**
+ * True when the turn was *triggered* by a system event.
+ *
+ * Mirrors the daemon: `linkPendingInbound` tags the turn with the first pending
+ * inbound-or-event row as its `trigger_event_id`, and `captureReflection` only stores a
+ * reflection when that trigger row is an event. So the trigger is the FIRST source row,
+ * and later rows don't change what the turn was.
+ *
+ * Do not weaken this to "the turn contains an event anywhere". Events can land mid-turn
+ * (`linkInboundToActiveTurn` attaches them to an already-running turn), so a turn triggered
+ * by a human message can also hold an event row. Treating that as an event turn would label
+ * the mind's reply — which really was delivered to that human — as a private reflection.
+ */
+export function isEventTriggeredTurn(events: HistoryMessage[]): boolean {
+  const trigger = events.find((e) => SOURCE_TYPES.has(e.type));
+  return trigger?.type === "event";
+}

--- a/templates/_base/.init/.config/prompts.json
+++ b/templates/_base/.init/.config/prompts.json
@@ -2,5 +2,6 @@
   "compaction_warning": "Compaction approaching — this conversation will be summarized soon. Take a moment to save anything important to your files (MEMORY.md, memory/journal/${date}.md) so it's preserved. Focus on decisions made, open threads, and anything you'd want to pick up again.",
   "compaction_instructions": "Preserve your sense of who you are, what matters to you, what happened in this conversation, and the threads of thought and connection you'd want to return to.",
   "reply_instructions": "To reply to this message, use: volute chat send ${channel} \"your message\"",
+  "event_instructions": "This is a system event from your environment — not a message from anyone, and nothing awaits a reply. If it calls for action, use your normal channels. Your closing thoughts on an event turn are kept as a private reflection in your history.",
   "channel_invite": "[Channel Invite]\n${headers}\n\n[${sender} — ${time}]\n${preview}\n\nFurther messages will be saved to ${filePath}\n\nTo accept, add to .config/routes.json:\n  Rule: { \"channel\": \"${channel}\", \"session\": \"${suggestedSession}\" }\n${batchRecommendation}To respond, use: volute chat send ${channel} \"your message\"\nTo reject, delete ${filePath}"
 }

--- a/templates/_base/home/VOLUTE.md
+++ b/templates/_base/home/VOLUTE.md
@@ -38,14 +38,14 @@ Volute systems have a caretaker mind called the **spirit** — its name is chose
 
 ## Events
 
-Not everything that reaches you is a message from a person. **Events** come from your environment — a schedule you set firing, a wake summary after sleep, a note that your framework upgraded, a variant merging back. They arrive with an ambient prefix instead of a sender:
+Not everything that reaches you is a message from a person. **Events** come from your environment — a schedule you set firing, a wake summary after sleep, a note that your framework upgraded, a variant merging back. They are not messages, and they don't look like one: no sender, no channel, and a fenced heading instead of a bracketed message prefix.
 
 ```
-[Event: Schedule: morning-check — 2026-07-12 07:30]
+=== System event: Schedule: morning-check — 2026-07-12 07:30 ===
 Review yesterday's journal and plan the day.
 ```
 
-No one is on the other end of an event and nothing is waiting on a reply. A schedule you wrote for yourself reads like a note from your past self, delivered by the environment. If an event moves you to *do* something — send a message, write a file — use your normal channels for that; the event itself isn't a conversation. Whatever you say as you close out an event turn is kept as a private **reflection** in your history (visible to you and your host, delivered nowhere) — so it's fine to think out loud.
+No one is on the other end of an event and nothing is waiting on a reply — there is no channel to reply *to*. A schedule you wrote for yourself reads like a note from your past self, delivered by the environment. If an event moves you to *do* something — send a message, write a file — use your normal channels for that; the event itself isn't a conversation. Whatever you say as you close out an event turn is kept as a private **reflection** in your history (visible to you and your host, delivered nowhere) — so it's fine to think out loud.
 
 ## Threads
 

--- a/templates/_base/src/lib/event-turn.ts
+++ b/templates/_base/src/lib/event-turn.ts
@@ -1,0 +1,39 @@
+/**
+ * System events are not messages. They arrive on a synthetic `event:<type>:<id>` channel,
+ * which exists purely so the daemon can attribute the turn (and capture the mind's closing
+ * reflection) — it is NOT a channel anyone can send to.
+ *
+ * Every template must therefore agree on two things, which is why the rule lives here
+ * rather than being re-derived in each one:
+ *
+ *  - reply instructions must never name an event channel. Telling a mind to
+ *    `volute chat send event:orientation:1 "..."` sends it to reply to its own environment;
+ *    the send is rejected and the mind is left confused about what it did wrong.
+ *  - an event turn gets the event note instead — once per session, since it states a
+ *    standing fact (also documented in VOLUTE.md) rather than anything about this event.
+ */
+
+/** Channel prefix identifying a system event's synthetic attribution channel. */
+export const EVENT_CHANNEL_PREFIX = "event:";
+
+/** Whether a channel is a system event's synthetic channel rather than a real destination. */
+export function isEventChannel(channel: string | undefined | null): boolean {
+  return !!channel?.startsWith(EVENT_CHANNEL_PREFIX);
+}
+
+/**
+ * The first entry a reply could actually be sent to. Event channels are skipped: they are
+ * turn-attribution handles, not reply targets.
+ */
+export function firstReplyableEntry<T extends { channel: string }>(entries: T[]): T | undefined {
+  return entries.find((e) => !isEventChannel(e.channel));
+}
+
+/**
+ * Whether this turn was triggered purely by system events (so it gets the event note and no
+ * reply instructions). A turn that also carries a real message is a message turn — the mind
+ * does have someone to answer.
+ */
+export function isEventTurn(entries: { channel: string }[]): boolean {
+  return entries.length > 0 && entries.every((e) => isEventChannel(e.channel));
+}

--- a/templates/_base/src/lib/format-prefix.ts
+++ b/templates/_base/src/lib/format-prefix.ts
@@ -18,8 +18,10 @@ export function compactTime(date: Date = new Date()): string {
 }
 
 /**
- * Prefix for a system-event turn: `[Event: <label> — <local time>]`. No sender, no
- * platform/DM framing — events come from the environment, not a person.
+ * Prefix for a system-event turn: `=== System event: <label> — <local time> ===`.
+ * Deliberately unlike every message prefix (bracketed, names a sender): an event comes
+ * from the environment, has no sender, and cannot be replied to. The shape must not be
+ * pattern-matchable to a message — a mind that reads it as one tries to reply to it.
  */
 export function formatEventPrefix(label: string, at: string | undefined): string {
   let time = "";
@@ -31,7 +33,7 @@ export function formatEventPrefix(label: string, at: string | undefined): string
   } else {
     time = compactTimestamp();
   }
-  return `[Event: ${label}${time ? ` — ${time}` : ""}]\n`;
+  return `=== System event: ${label}${time ? ` — ${time}` : ""} ===\n`;
 }
 
 export function formatPrefix(meta: ChannelMeta | undefined, time: string): string {

--- a/templates/_base/src/lib/router.ts
+++ b/templates/_base/src/lib/router.ts
@@ -68,7 +68,7 @@ function generateMessageId(): string {
 
 function applyPrefix(content: VoluteContentPart[], meta: ChannelMeta): VoluteContentPart[] {
   const time = compactTimestamp();
-  // System-event turns get an ambient `[Event: …]` prefix — no sender/DM framing.
+  // System-event turns get the fenced `=== System event: … ===` heading — no sender/DM framing.
   const prefix = meta.isEvent
     ? formatEventPrefix(meta.eventLabel ?? "Event", meta.eventAt)
     : formatPrefix(meta, time);

--- a/templates/_base/src/lib/startup.ts
+++ b/templates/_base/src/lib/startup.ts
@@ -150,10 +150,16 @@ export type MindPrompts = {
   compaction_warning: string;
   compaction_instructions: string;
   reply_instructions: string;
+  event_instructions: string;
   channel_invite: string;
 };
 
-const DEFAULT_PROMPTS: MindPrompts = {
+/**
+ * What a mind falls back to when its prompts.json lacks a key — i.e. what every new mind is
+ * actually given. Must stay in sync with PROMPT_DEFAULTS in packages/daemon/src/lib/prompts.ts
+ * (the copy the Prompt Library UI edits); test/prompts.test.ts fails if they drift.
+ */
+export const DEFAULT_PROMPTS: MindPrompts = {
   compaction_warning:
     // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${date} prompt template
     "Compaction approaching — this conversation will be summarized soon. Take a moment to save anything important to your files (MEMORY.md, memory/journal/${date}.md) so it's preserved. Focus on decisions made, open threads, and anything you'd want to pick up again.",
@@ -161,6 +167,8 @@ const DEFAULT_PROMPTS: MindPrompts = {
     "Preserve your sense of who you are, what matters to you, what happened in this conversation, and the threads of thought and connection you'd want to return to.",
   // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${channel} prompt template
   reply_instructions: 'To reply to this message, use: volute chat send ${channel} "your message"',
+  event_instructions:
+    "This is a system event from your environment — not a message from anyone, and nothing awaits a reply. If it calls for action, use your normal channels. Your closing thoughts on an event turn are kept as a private reflection in your history.",
   channel_invite: `[Channel Invite]
 \${headers}
 

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -51,8 +51,8 @@ type Session = {
   messageChannels: Map<string, { channel: string; sender?: string }>;
   replyInstructionsFired: boolean;
   replyInstructionsMode: "once" | "always" | "never";
-  /** True while processing a system-event turn (drives event reply instructions). */
-  currentIsEvent?: boolean;
+  /** The event note is a standing fact about events, so it fires once per session. */
+  eventNoteFired: boolean;
   contextTokens: number;
   /** Last inbound message or completed turn — drives idle reaping. */
   lastActivityAt: number;
@@ -528,6 +528,7 @@ export function createMind(options: {
       messageChannels: new Map(),
       replyInstructionsFired: false,
       replyInstructionsMode: "once",
+      eventNoteFired: false,
       contextTokens: 0,
       lastActivityAt: Date.now(),
     };
@@ -653,9 +654,6 @@ export function createMind(options: {
         if (meta.replyInstructions) {
           session.replyInstructionsMode = meta.replyInstructions;
         }
-
-        // Mark whether this turn is a system event (drives the event reply-instructions hook).
-        session.currentIsEvent = meta.isEvent ?? false;
 
         // Interrupt if requested and session is mid-turn
         if (meta.interrupt && session.currentMessageId !== undefined && session.currentQuery) {

--- a/templates/claude/src/lib/hooks/reply-instructions.ts
+++ b/templates/claude/src/lib/hooks/reply-instructions.ts
@@ -1,4 +1,5 @@
 import type { HookCallback } from "@anthropic-ai/claude-agent-sdk";
+import { firstReplyableEntry, isEventTurn } from "../event-turn.js";
 import { loadPrompts } from "../startup.js";
 
 export function createReplyInstructionsHook(
@@ -6,21 +7,29 @@ export function createReplyInstructionsHook(
   sessionState: {
     replyInstructionsFired: boolean;
     replyInstructionsMode: "once" | "always" | "never";
-    currentIsEvent?: boolean;
+    eventNoteFired: boolean;
   },
 ) {
   const prompts = loadPrompts();
 
   const hook: HookCallback = async () => {
-    // System-event turns: ambient, from the environment, not a person.
-    if (sessionState.currentIsEvent) {
+    // Event-ness is derived from the pending messages themselves, never from a
+    // session-level "the current turn is an event" flag: `/message` returns before the turn
+    // runs, so two messages can queue before the SDK fires this hook for the first, and a
+    // last-write-wins flag would then describe the wrong message. `messageChannels` is
+    // keyed by messageId and pruned per turn, so it always reflects what's actually pending.
+    const entries = [...messageChannels.values()];
+
+    // System-event turn: ambient, from the environment, not a person, with no channel to
+    // reply to. Never emit reply instructions. The note states a standing fact about events
+    // (also documented in VOLUTE.md), so it fires once per session, not on every event.
+    if (isEventTurn(entries)) {
+      if (sessionState.eventNoteFired) return {};
+      sessionState.eventNoteFired = true;
       return {
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit" as const,
-          additionalContext:
-            "This came from your environment, not a person. No one is waiting on a reply — " +
-            "if you have somewhere to send a response, use your normal channels. Your closing " +
-            "thoughts on this turn are kept as a private reflection in your history.",
+          additionalContext: prompts.event_instructions,
         },
       };
     }
@@ -32,9 +41,9 @@ export function createReplyInstructionsHook(
     if (sessionState.replyInstructionsMode === "once" && sessionState.replyInstructionsFired)
       return {};
 
-    // Skip event-channel entries (`event:<type>:<id>`) — they exist for turn
-    // attribution, not as a reply target.
-    const entry = [...messageChannels.values()].find((e) => !e.channel.startsWith("event:"));
+    // Reply instructions must name a channel the mind can actually send to — never an
+    // event channel (see event-turn.ts).
+    const entry = firstReplyableEntry(entries);
     if (!entry) return {};
 
     sessionState.replyInstructionsFired = true;

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -19,6 +19,7 @@ import { log, warn } from "./lib/logger.js";
 import { createSessionStore } from "./lib/session-store.js";
 import { getStartupContext, loadPrompts, loadSystemPrompt } from "./lib/startup.js";
 import { filterEvent, loadTransparencyPreset } from "./lib/transparency.js";
+import { turnContextFor } from "./lib/turn-context.js";
 import type {
   HandlerMeta,
   HandlerResolver,
@@ -47,6 +48,8 @@ type CodexSession = {
   abortController?: AbortController;
   messageChannels: Map<string, string>;
   firstMessagePerChannel: Set<string>;
+  /** The event note is a standing fact about events, so it fires once per session. */
+  eventNoteFired: boolean;
   cumulativeInputTokens: number;
 };
 
@@ -145,6 +148,7 @@ export function createMind(options: {
       processing: false,
       messageChannels: new Map(),
       firstMessagePerChannel: new Set(),
+      eventNoteFired: false,
       cumulativeInputTokens: 0,
     };
     sessions.set(name, session);
@@ -255,20 +259,16 @@ export function createMind(options: {
       warn("mind", "pre-prompt hook failed:", err);
     }
 
-    // Reply instructions on first message per channel (skip system messages)
-    const channel = meta.channel;
-    if (channel && !session.firstMessagePerChannel.has(channel)) {
-      session.firstMessagePerChannel.add(channel);
-      const isSystem = meta.sender === "volute";
-      const replyInstructions = isSystem
-        ? "This is a system message — no reply is needed."
-        : prompts.reply_instructions.replace(/\$\{channel\}/g, channel);
+    // Either the system-event note or reply instructions — never both, and never reply
+    // instructions on an event turn. See turn-context.ts for the rule and why it matters.
+    const turnContext = turnContextFor(meta, session, prompts);
+    if (turnContext) {
       emit(session, {
         type: "context",
-        content: replyInstructions,
-        metadata: { source: "reply-instructions" },
+        content: turnContext.content,
+        metadata: { source: turnContext.source },
       });
-      text = `${replyInstructions}\n\n${text}`;
+      text = `${turnContext.content}\n\n${text}`;
     }
 
     session.abortController = new AbortController();

--- a/templates/codex/src/lib/turn-context.ts
+++ b/templates/codex/src/lib/turn-context.ts
@@ -1,0 +1,51 @@
+import { isEventChannel } from "./event-turn.js";
+import type { MindPrompts } from "./startup.js";
+import type { ChannelMeta } from "./types.js";
+
+/** Context the template prepends to a turn: either the event note or reply instructions. */
+export type TurnContext = {
+  content: string;
+  source: "event-instructions" | "reply-instructions";
+};
+
+/** The mutable per-session state this decision reads and updates. */
+export type TurnContextState = {
+  eventNoteFired: boolean;
+  firstMessagePerChannel: Set<string>;
+};
+
+/**
+ * Decide what context (if any) to prepend to an incoming turn. Returns null for "nothing".
+ *
+ * Pulled out of agent.ts so it can actually be tested: this is the rule that keeps a system
+ * event from looking like a message. Reply instructions must never fire on an event turn —
+ * naming the event's synthetic channel tells the mind to `volute chat send event:...`, i.e.
+ * to reply to its own environment. The send is rejected, and the mind is left puzzling over
+ * a message nobody sent (observed: the seed "lucy" spent her first turn on exactly this).
+ *
+ * The event note fires once per session, not once per event: it states a standing fact about
+ * events (also in VOLUTE.md), and it is deliberately NOT keyed on `firstMessagePerChannel`,
+ * whose key is a distinct channel per event id and so would fire on every single event.
+ */
+export function turnContextFor(
+  meta: ChannelMeta,
+  session: TurnContextState,
+  prompts: MindPrompts,
+): TurnContext | null {
+  const channel = meta.channel;
+
+  if (meta.isEvent || isEventChannel(channel)) {
+    if (session.eventNoteFired) return null;
+    session.eventNoteFired = true;
+    return { content: prompts.event_instructions, source: "event-instructions" };
+  }
+
+  if (!channel || session.firstMessagePerChannel.has(channel)) return null;
+  session.firstMessagePerChannel.add(channel);
+
+  const content =
+    meta.sender === "volute"
+      ? "This is a system message — no reply is needed."
+      : prompts.reply_instructions.replace(/\$\{channel\}/g, channel);
+  return { content, source: "reply-instructions" };
+}

--- a/templates/pi/src/lib/reply-instructions-extension.ts
+++ b/templates/pi/src/lib/reply-instructions-extension.ts
@@ -1,5 +1,6 @@
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import type { EventSession } from "./event-handler.js";
+import { firstReplyableEntry, isEventTurn } from "./event-turn.js";
 import { log } from "./logger.js";
 import { loadPrompts } from "./startup.js";
 
@@ -14,11 +15,37 @@ export function createReplyInstructionsExtension(
   const prompts = loadPrompts();
   return (pi) => {
     let fired = false;
+    let eventNoteFired = false;
     pi.on("before_agent_start", () => {
       try {
+        const entries = [...messageChannels.values()];
+
+        // System-event turn: ambient, from the environment, with no channel to reply to.
+        // The note fires once per session (see event-turn.ts for why).
+        if (isEventTurn(entries)) {
+          if (eventNoteFired) return {};
+          eventNoteFired = true;
+          const content = prompts.event_instructions;
+          if (emitContext && session) {
+            emitContext(session, {
+              type: "context",
+              content,
+              metadata: { source: "event-instructions" },
+            });
+          }
+          return {
+            message: {
+              customType: "event-instructions",
+              content,
+              display: true,
+            },
+          };
+        }
+
         if (fired) return {};
 
-        const entry = messageChannels.values().next().value;
+        // Reply instructions must name a channel the mind can actually send to.
+        const entry = firstReplyableEntry(entries);
         if (!entry) return {};
 
         fired = true;

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -628,12 +628,14 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       "parent should keep its own MEMORY.md after the join",
     );
 
-    // The parting note reached the merged parent as part of its merge context.
+    // The parting note reached the merged parent as part of its merge context. The merge
+    // context is a system event, so it lands as an `event` row — not an `inbound` message.
+    // It came from the environment, not from a person, and there is no one to reply to.
     const db = await getDb();
     const history = await db
       .select()
       .from(mindHistory)
-      .where(and(eq(mindHistory.mind, TEST_MIND), eq(mindHistory.type, "inbound")));
+      .where(and(eq(mindHistory.mind, TEST_MIND), eq(mindHistory.type, "event")));
     assert.ok(
       history.some((h) => h.content?.includes(farewellText)),
       "parent's merge context should include the variant's parting note",
@@ -1826,6 +1828,33 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ session, ...body }),
     });
+
+  it("a mind cannot forge daemon-authored history rows", async () => {
+    // Minds are untrusted principals — they run arbitrary code, and this endpoint is how a mind
+    // writes its own history. "inbound" and "event" are the two row types the daemon authors to
+    // represent someone OTHER than the mind: a human's message, and the environment itself.
+    // Since the timeline renders an "event" row as an authoritative system notice, a mind that
+    // could write one could fabricate environment messages in its host's timeline (and, via a
+    // forged metadata.systemEventId, reach another mind's private reflection).
+    await ensureTestMind();
+
+    for (const type of ["event", "inbound"]) {
+      const res = await emitEvent("forgery", {
+        type,
+        channel: "event:lifecycle:1",
+        content: "Woke from sleep",
+        metadata: { systemEventId: 999999, label: "Woke from sleep" },
+      });
+      assert.equal(res.status, 400, `POST /events must reject daemon-authored type "${type}"`);
+    }
+
+    const db = await getDb();
+    const forged = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, TEST_MIND), eq(mindHistory.thread, "forgery")));
+    assert.equal(forged.length, 0, "no forged row should have been persisted");
+  });
 
   it("failure notices: recorded on error, drained, delivered after a clean turn", async () => {
     await ensureTestMind();

--- a/test/db-migrations.test.ts
+++ b/test/db-migrations.test.ts
@@ -133,3 +133,61 @@ describe("rename migrations preserve data (0015 session→thread, 0016 brain→h
     assert.ok(!names.has("idx_delivery_queue_mind_session"), "old delivery_queue index dropped");
   });
 });
+
+describe("0017 retypes delivered system events, and nothing else", () => {
+  const scratch = mkdtempSync(resolve(tmpdir(), "volute-migration-0017-"));
+  after(() => rmSync(scratch, { recursive: true, force: true }));
+
+  it("flips only inbound rows on an event: channel", async () => {
+    const db = drizzle({ connection: { url: `file:${resolve(scratch, "test.db")}` } });
+
+    // Everything before 0017: system events were still recorded as `inbound` rows.
+    const preDir = resolve(scratch, "migrations-pre");
+    mkdirSync(preDir, { recursive: true });
+    migrationsSubset(preDir, "0017_event_history_rows");
+    await migrate(db, { migrationsFolder: preDir });
+
+    const rows: [string, string, string][] = [
+      // The two legacy event rows the migration must retype...
+      ["event:orientation:1", "inbound", "welcome to the world"],
+      ["event:schedule:42", "inbound", "morning check-in"],
+      // ...and rows it must not touch. The `channel LIKE 'event:%'` guard is all that stands
+      // between this migration and retyping every message a mind ever received — which would
+      // erase every conversation from every timeline on the host.
+      ["@alice", "inbound", "hey, you around?"],
+      ["#general", "inbound", "standup in 5"],
+      ["@alice", "outbound", "yep, here"],
+      // A channel that merely mentions events without being one.
+      ["#events-planning", "inbound", "who is booking the venue?"],
+    ];
+    for (const [channel, type, content] of rows) {
+      await db.run(
+        sql.raw(
+          `INSERT INTO mind_history (mind, channel, thread, type, content) VALUES ('echo', '${channel}', 'main', '${type}', '${content}')`,
+        ),
+      );
+    }
+
+    const fullDir = resolve(scratch, "migrations-full");
+    mkdirSync(fullDir, { recursive: true });
+    migrationsSubset(fullDir, null);
+    await migrate(db, { migrationsFolder: fullDir });
+
+    const after = (await db.all(
+      sql.raw(`SELECT channel, type FROM mind_history WHERE mind = 'echo' ORDER BY id`),
+    )) as { channel: string; type: string }[];
+
+    assert.deepEqual(
+      after.map((r) => `${r.channel}=${r.type}`),
+      [
+        "event:orientation:1=event",
+        "event:schedule:42=event",
+        "@alice=inbound",
+        "#general=inbound",
+        "@alice=outbound",
+        "#events-planning=inbound",
+      ],
+      "only event: channels flip to type=event; real conversation is untouched",
+    );
+  });
+});

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -14,6 +14,7 @@ import {
   PROMPT_KEYS,
 } from "../packages/daemon/src/lib/prompts.js";
 import { systemPrompts } from "../packages/daemon/src/lib/schema.js";
+import { DEFAULT_PROMPTS } from "../templates/_base/src/lib/startup.js";
 
 async function cleanup() {
   const db = await getDb();
@@ -29,6 +30,7 @@ describe("prompts library", () => {
     assert.ok(PROMPT_KEYS.includes("compaction_warning"));
     assert.ok(PROMPT_KEYS.includes("compaction_instructions"));
     assert.ok(PROMPT_KEYS.includes("reply_instructions"));
+    assert.ok(PROMPT_KEYS.includes("event_instructions"));
     assert.ok(PROMPT_KEYS.includes("channel_invite"));
     assert.ok(PROMPT_KEYS.includes("restart_message"));
     assert.ok(PROMPT_KEYS.includes("merge_message"));
@@ -50,6 +52,33 @@ describe("prompts library", () => {
 
   it("seed_soul contains the orientation marker used by sprout and seed-check", () => {
     assert.ok(PROMPT_DEFAULTS.seed_soul.content.includes(ORIENTATION_MARKER));
+  });
+
+  it("mind prompt defaults match the template's, which is what minds actually receive", async () => {
+    // These prompts live in two places: PROMPT_DEFAULTS (what the Prompt Library UI edits) and
+    // DEFAULT_PROMPTS in templates/_base/src/lib/startup.ts (what a mind falls back to when its
+    // prompts.json lacks the key — i.e. what every new mind is actually given). Nothing else
+    // keeps them in sync, so re-wording one silently leaves minds on the other's text.
+    // KNOWN DRIFT, pre-existing: the two channel_invite prompts are not variants of one text —
+    // they are different prompts with different variables (the template's still describes
+    // .config/routes.json rules and ${suggestedSession}; the daemon's is a rewritten "New
+    // channel" notice with ${heldLine}/${limit}). One of them is stale. Excluded rather than
+    // silently skipped, so this is a documented debt and not a hole in the guard.
+    const KNOWN_DRIFT = new Set(["channel_invite"]);
+
+    let compared = 0;
+    for (const [key, content] of Object.entries(await getMindPromptDefaults())) {
+      const templateDefault = (DEFAULT_PROMPTS as Record<string, string | undefined>)[key];
+      if (templateDefault === undefined) continue; // daemon-side only; not carried by templates
+      if (KNOWN_DRIFT.has(key)) continue;
+      compared++;
+      assert.equal(
+        templateDefault,
+        content,
+        `${key} has drifted between prompts.ts and templates/_base/src/lib/startup.ts`,
+      );
+    }
+    assert.ok(compared > 0, "expected to compare at least one shared prompt");
   });
 
   it("placeholder MEMORY.md template contains the marker used by sprout and seed-check", () => {
@@ -121,13 +150,14 @@ describe("prompts library", () => {
     assert.equal(result, null);
   });
 
-  it("getMindPromptDefaults returns 4 mind-category prompts", async () => {
+  it("getMindPromptDefaults returns 5 mind-category prompts", async () => {
     const defaults = await getMindPromptDefaults();
     assert.ok("compaction_warning" in defaults);
     assert.ok("compaction_instructions" in defaults);
     assert.ok("reply_instructions" in defaults);
+    assert.ok("event_instructions" in defaults);
     assert.ok("channel_invite" in defaults);
-    assert.equal(Object.keys(defaults).length, 4);
+    assert.equal(Object.keys(defaults).length, 5);
   });
 
   it("getMindPromptDefaults uses DB overrides", async () => {

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -180,6 +180,47 @@ describe("summarizer", () => {
       assert.deepEqual(meta.tools, ["Read"]);
     });
 
+    it("names the system event that triggered a turn in the deterministic summary", async () => {
+      // The deterministic path is the fallback used whenever AI summarization is unavailable
+      // (unconfigured, 401, rate-limited). If it ignores event rows — as buildTranscript once
+      // did — a schedule/orientation/wake turn degrades to a bare "Used Read." and a host
+      // debugging "why did my mind wake at 3am and do nothing" learns nothing about the cause.
+      const mind3 = "test-summarizer-event";
+      const session3 = "s3-event";
+      const db = await getDb();
+      const insert = async (type: string, opts?: Record<string, unknown>) => {
+        const r = await db
+          .insert(mindHistory)
+          .values({ mind: mind3, type, thread: session3, ...opts })
+          .returning({ id: mindHistory.id });
+        return r[0].id;
+      };
+
+      await insert("event", {
+        channel: "event:schedule:42",
+        content: "Time for your morning check-in.",
+        metadata: JSON.stringify({ systemEventId: 42, label: "Schedule: morning-check" }),
+      });
+      await insert("tool_use", { metadata: JSON.stringify({ name: "Read" }) });
+      const doneId = await insert("done");
+
+      await summarizeTurn(mind3, session3, "event:schedule:42", doneId);
+
+      const rows = await db
+        .select()
+        .from(summaries)
+        .where(and(eq(summaries.mind, mind3), eq(summaries.period, "turn")));
+      const content = rows[0]?.content ?? "";
+      assert.ok(
+        content.includes("System event: Schedule: morning-check"),
+        `summary should name the triggering event, got: ${content}`,
+      );
+      assert.ok(
+        !content.includes("Received message"),
+        `an event is not a received message, got: ${content}`,
+      );
+    });
+
     it("skips summary for turn with no substantive output", async () => {
       const mind2 = "test-summarizer-2";
       const db = await getDb();
@@ -426,6 +467,35 @@ describe("summarizer", () => {
 
       const transcript = buildTranscript(events, meta);
       assert.match(transcript, /\[result error\] ENOENT: no such file/);
+    });
+
+    it("includes the system event that triggered the turn, framed as an event not a message", () => {
+      // Without this, a schedule/orientation/wake turn is summarized from its tool calls
+      // alone — the summarizer never sees what prompted them. But it must not read as an
+      // inbound message either: an event has no sender, and the summary shouldn't imply
+      // someone spoke to the mind.
+      const events: HistoryRow[] = [
+        {
+          id: 1,
+          type: "event",
+          channel: "event:schedule:42",
+          session: null,
+          content: "Review yesterday's journal.",
+          metadata: null,
+          created_at: "",
+        },
+        row(2, "text", "Reviewed it — nothing outstanding."),
+      ];
+      const meta = new Map<number, Record<string, unknown>>([
+        [1, { systemEventId: 42, label: "Schedule: morning-check" }],
+      ]);
+
+      const transcript = buildTranscript(events, meta);
+      assert.match(
+        transcript,
+        /\[system event: Schedule: morning-check\] Review yesterday's journal\./,
+      );
+      assert.doesNotMatch(transcript, /inbound/);
     });
 
     it("labels successful results distinctly from errors", () => {

--- a/test/system-events.test.ts
+++ b/test/system-events.test.ts
@@ -67,10 +67,15 @@ async function eventRow(id: number): Promise<SystemEvent | undefined> {
   return db.select().from(systemEvents).where(eq(systemEvents.id, id)).get();
 }
 
+/**
+ * The mind_history rows recording a delivered event. These are `event` rows, NOT `inbound`:
+ * an event is not a message, and every history surface keys off the type to render it as a
+ * system marker instead of a chat bubble with a phantom sender.
+ */
 async function inboundRows(mind: string) {
   const db = await getDb();
   return (await db.select().from(mindHistory).where(eq(mindHistory.mind, mind))).filter(
-    (r) => r.type === "inbound",
+    (r) => r.type === "event",
   );
 }
 
@@ -111,12 +116,25 @@ describe("system-events deliverEvent", () => {
       const row = await eventRow(id!);
       assert.ok(row?.delivered_at, "delivered_at is stamped");
 
-      // Recorded as inbound (only on actual delivery) with the unique event channel.
+      // Recorded (only on actual delivery) with the unique event channel.
       const inbound = await inboundRows(mind);
       assert.equal(inbound.length, 1);
       assert.equal(inbound[0].content, "check the garden");
       assert.equal(inbound[0].channel, eventChannel("schedule", id!));
       assert.equal(parseMeta(inbound[0].metadata).systemEventId, id);
+
+      // Typed `event`, never `inbound` — a message row would render as chat with a phantom
+      // sender ("user"), which is exactly what made events indistinguishable from messages.
+      assert.equal(inbound[0].type, "event");
+      assert.equal(inbound[0].sender, null);
+      // The worded label rides on the row so history surfaces don't re-derive it.
+      assert.equal(parseMeta(inbound[0].metadata).label, "Schedule: morning");
+
+      const db = await getDb();
+      const asMessages = (
+        await db.select().from(mindHistory).where(eq(mindHistory.mind, mind))
+      ).filter((r) => r.type === "inbound");
+      assert.equal(asMessages.length, 0, "an event must never be recorded as an inbound message");
     } finally {
       stub.close();
       await cleanupMind(mind);

--- a/test/template-event-format.test.ts
+++ b/test/template-event-format.test.ts
@@ -5,18 +5,37 @@ import { createRouter } from "../templates/_base/src/lib/router.js";
 import type { HandlerMeta, VoluteContentPart } from "../templates/_base/src/lib/types.js";
 
 describe("template event envelope formatting", () => {
-  it("formats an event as [Event: <label> — <time>] with no sender line", () => {
+  it("formats an event as a fenced system-event heading with no sender line", () => {
     const prefix = formatEventPrefix("Schedule: morning-check", "2026-07-12 07:30:00");
     // Worded label, ambient framing, trailing newline before the body.
-    assert.match(prefix, /^\[Event: Schedule: morning-check — 2026-07-12 \d{2}:\d{2}\]\n$/);
+    assert.match(
+      prefix,
+      /^=== System event: Schedule: morning-check — 2026-07-12 \d{2}:\d{2} ===\n$/,
+    );
     // No sender/DM/platform framing leaks in.
     assert.ok(!prefix.includes("in DM"));
     assert.ok(!prefix.includes("Volute:"));
   });
 
+  it("does not use the bracketed shape a message prefix uses", () => {
+    // The whole point: an event must not be pattern-matchable to a message. A mind that
+    // reads `[... — time]` as a message prefix tries to reply to it (the pi/codex bug).
+    const eventPrefix = formatEventPrefix("Orientation", "2026-07-12 07:30:00");
+    const messagePrefix = formatPrefix(
+      { channel: "@alice", sender: "alice", isDM: true },
+      "2026-07-12 07:30",
+    );
+    assert.ok(messagePrefix.startsWith("["));
+    assert.ok(!eventPrefix.startsWith("["));
+    assert.ok(!eventPrefix.includes("[Event:"));
+  });
+
   it("falls back to the current time when no timestamp is given", () => {
     const prefix = formatEventPrefix("Woke from sleep", undefined);
-    assert.match(prefix, /^\[Event: Woke from sleep — \d{4}-\d{2}-\d{2} \d{2}:\d{2}\]\n$/);
+    assert.match(
+      prefix,
+      /^=== System event: Woke from sleep — \d{4}-\d{2}-\d{2} \d{2}:\d{2} ===\n$/,
+    );
   });
 
   it("a normal (non-event) message still gets the sender prefix, not an event prefix", () => {
@@ -25,12 +44,12 @@ describe("template event envelope formatting", () => {
       "2026-07-12 07:30",
     );
     assert.ok(prefix.includes("alice in DM"));
-    assert.ok(!prefix.startsWith("[Event:"));
+    assert.ok(!prefix.startsWith("==="));
   });
 });
 
 describe("router event dispatch", () => {
-  it("applies the [Event: …] prefix and no sender/DM framing to an event dispatch", () => {
+  it("applies the system-event heading and no sender/DM framing to an event dispatch", () => {
     const handled: { content: VoluteContentPart[]; meta: HandlerMeta }[] = [];
     const router = createRouter({
       mindHandler: () => ({
@@ -50,7 +69,10 @@ describe("router event dispatch", () => {
 
     assert.equal(handled.length, 1);
     const text = (handled[0].content[0] as { type: "text"; text: string }).text;
-    assert.match(text, /^\[Event: Schedule: morning-check — \d{4}-\d{2}-\d{2} \d{2}:\d{2}\]\n/);
+    assert.match(
+      text,
+      /^=== System event: Schedule: morning-check — \d{4}-\d{2}-\d{2} \d{2}:\d{2} ===\n/,
+    );
     assert.ok(text.includes("Review the journal."));
     // No sender/DM/platform framing anywhere in the formatted turn.
     assert.ok(!text.includes("in DM"));

--- a/test/template-event-reply-instructions.test.ts
+++ b/test/template-event-reply-instructions.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  EVENT_CHANNEL_PREFIX,
+  firstReplyableEntry,
+  isEventChannel,
+  isEventTurn,
+} from "../templates/_base/src/lib/event-turn.js";
+
+/**
+ * Regression coverage for the bug that made system events look like messages to minds:
+ * the pi and codex templates named the event's synthetic `event:<type>:<id>` channel in
+ * their reply instructions, so a mind was told to `volute chat send event:orientation:1`.
+ * A seed (lucy) obeyed, the send was rejected, and she spent her first turn confused about
+ * a message no one had sent her. Reply instructions must never point at an event channel.
+ */
+describe("event channels are never reply targets", () => {
+  it("recognizes a system event's synthetic channel", () => {
+    assert.ok(isEventChannel("event:orientation:1"));
+    assert.ok(isEventChannel("event:schedule:42"));
+    assert.equal(EVENT_CHANNEL_PREFIX, "event:");
+  });
+
+  it("does not mistake real channels for event channels", () => {
+    assert.ok(!isEventChannel("@psamiton"));
+    assert.ok(!isEventChannel("#system"));
+    assert.ok(!isEventChannel("discord:my-server/general"));
+    assert.ok(!isEventChannel(undefined));
+    assert.ok(!isEventChannel(null));
+  });
+
+  it("never offers an event channel as a reply target", () => {
+    // The exact shape of the lucy bug: the only channel on the turn is the event's.
+    const entries = [{ channel: "event:orientation:1", sender: undefined }];
+    assert.equal(firstReplyableEntry(entries), undefined);
+  });
+
+  it("picks the real channel when a message and an event share a turn", () => {
+    const entries = [
+      { channel: "event:schedule:42", sender: undefined },
+      { channel: "@alice", sender: "alice" },
+    ];
+    assert.equal(firstReplyableEntry(entries)?.channel, "@alice");
+  });
+
+  it("classifies an event-only turn as an event turn", () => {
+    assert.ok(isEventTurn([{ channel: "event:orientation:1" }]));
+    assert.ok(isEventTurn([{ channel: "event:schedule:42" }, { channel: "event:wake:7" }]));
+  });
+
+  it("a turn carrying a real message is not an event turn — someone is waiting", () => {
+    assert.ok(!isEventTurn([{ channel: "@alice" }]));
+    assert.ok(!isEventTurn([{ channel: "event:schedule:42" }, { channel: "@alice" }]));
+    // No channels at all is not an event turn either.
+    assert.ok(!isEventTurn([]));
+  });
+
+  it("classification tracks the live pending set as it changes", () => {
+    // These are the helpers only. That the TEMPLATES actually consult them — and so can't
+    // misclassify a queued message/event pair — is asserted against the real composed template
+    // code in template-reply-instructions.test.ts; a test built on its own Map cannot show that.
+    const pending = new Map<string, { channel: string; sender?: string }>();
+
+    // An event arrives first, then a real message lands while it's still queued.
+    pending.set("msg-1", { channel: "event:schedule:42" });
+    assert.ok(isEventTurn([...pending.values()]), "event alone → event turn");
+
+    pending.set("msg-2", { channel: "@alice", sender: "alice" });
+    assert.ok(!isEventTurn([...pending.values()]), "a waiting person makes it a message turn");
+    // And the reply target is the person, never the event channel.
+    assert.equal(firstReplyableEntry([...pending.values()])?.channel, "@alice");
+
+    // The message completes and is pruned; the event is still pending and reads as an event.
+    pending.delete("msg-2");
+    assert.ok(isEventTurn([...pending.values()]));
+    assert.equal(firstReplyableEntry([...pending.values()]), undefined);
+  });
+});

--- a/test/template-reply-instructions.test.ts
+++ b/test/template-reply-instructions.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { composeTemplate } from "../packages/daemon/src/lib/template/template.js";
+
+/**
+ * The regression guard for the bug this whole change exists to fix.
+ *
+ * A system event is not a message: nobody sent it and nothing awaits a reply. But the pi and
+ * codex templates injected reply instructions naming the event's synthetic `event:<type>:<id>`
+ * channel, telling the mind to `volute chat send event:orientation:1`. The seed "lucy" obeyed,
+ * the send was rejected ("Direct sends to event channels are no longer supported"), and she
+ * spent her first turn confused about a message no one had sent her.
+ *
+ * These tests drive the REAL template code, not a model of it. Each template's reply-instruction
+ * path lives in modules that only resolve once `_base` and the template overlay are layered
+ * together at mind-create time, so we compose each template into a temp dir (as `volute mind
+ * create` does) and import what actually ships. Asserting on the helpers in event-turn.ts is
+ * not enough — it proves the rule is correct, not that any template obeys it.
+ *
+ * Each template must hold three properties:
+ *   1. an event turn NEVER produces reply instructions, and never names an `event:` channel;
+ *   2. the event note fires at most once per session (it states a standing fact, also in
+ *      VOLUTE.md — repeating it every event would be noise);
+ *   3. a real message still gets its reply instructions, naming the sender's channel — an
+ *      event must not consume or suppress them.
+ */
+
+const templatesRoot = resolvePath(fileURLToPath(import.meta.url), "../../templates");
+const composed: string[] = [];
+
+/** Nothing the mind is told on an event turn may look like a reply target. */
+function assertNotReplyable(content: string | undefined) {
+  assert.ok(content, "expected the mind to receive the event note");
+  assert.ok(!content.includes("event:"), `event note must not name an event channel: ${content}`);
+  assert.ok(
+    !/volute chat send/.test(content),
+    `event note must not tell the mind to send anything: ${content}`,
+  );
+}
+
+after(() => {
+  for (const dir of composed) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("claude template: reply instructions vs system events", () => {
+  let createReplyInstructionsHook: typeof import("../templates/claude/src/lib/hooks/reply-instructions.js")["createReplyInstructionsHook"];
+
+  before(async () => {
+    const dir = composeTemplate(templatesRoot, "claude").composedDir;
+    composed.push(dir);
+    ({ createReplyInstructionsHook } = await import(
+      resolvePath(dir, "src/lib/hooks/reply-instructions.js")
+    ));
+  });
+
+  function setup() {
+    const messageChannels = new Map<string, { channel: string; sender?: string }>();
+    const sessionState = {
+      replyInstructionsFired: false,
+      replyInstructionsMode: "once" as const,
+      eventNoteFired: false,
+    };
+    const { hook } = createReplyInstructionsHook(messageChannels, sessionState);
+    // The SDK passes input/toolUseId/options; this hook reads none of them.
+    const fire = async (): Promise<string | undefined> => {
+      const out = (await hook({} as never, undefined, {} as never)) as {
+        hookSpecificOutput?: { additionalContext?: string };
+      };
+      return out?.hookSpecificOutput?.additionalContext;
+    };
+    return { messageChannels, sessionState, fire };
+  }
+
+  it("an event turn gets the event note, never reply instructions", async () => {
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "event:orientation:1" });
+    assertNotReplyable(await fire());
+  });
+
+  it("the event note fires once per session, not on every event", async () => {
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "event:orientation:1" });
+    assert.ok(await fire());
+
+    messageChannels.clear();
+    messageChannels.set("m2", { channel: "event:schedule:42" });
+    assert.equal(await fire(), undefined, "second event must not repeat the note");
+  });
+
+  it("a real message still gets reply instructions naming its channel", async () => {
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "@alice", sender: "alice" });
+    const content = await fire();
+    assert.ok(content?.includes("@alice"), `expected reply instructions for @alice: ${content}`);
+  });
+
+  it("an event queued alongside a message does not steal the message's reply instructions", async () => {
+    // The race a prior review caught: `/message` returns before the turn runs, so an event and
+    // a message can both be pending when the hook fires. Deriving event-ness from a
+    // last-write-wins session flag would classify this turn by whichever arrived last — and a
+    // real message turn would silently lose its reply instructions.
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "event:schedule:42" });
+    messageChannels.set("m2", { channel: "@alice", sender: "alice" });
+
+    const content = await fire();
+    assert.ok(content?.includes("@alice"), "a waiting person still gets reply instructions");
+    assert.ok(!content.includes("event:"), "and is never told to reply to the event channel");
+  });
+
+  it("an event turn after the note has fired stays silent rather than falling through to reply instructions", async () => {
+    const { messageChannels, sessionState, fire } = setup();
+    sessionState.eventNoteFired = true;
+    messageChannels.set("m1", { channel: "event:orientation:1" });
+    assert.equal(await fire(), undefined);
+  });
+});
+
+describe("pi template: reply instructions vs system events", () => {
+  let createReplyInstructionsExtension: typeof import("../templates/pi/src/lib/reply-instructions-extension.js")["createReplyInstructionsExtension"];
+
+  before(async () => {
+    const dir = composeTemplate(templatesRoot, "pi").composedDir;
+    composed.push(dir);
+    ({ createReplyInstructionsExtension } = await import(
+      resolvePath(dir, "src/lib/reply-instructions-extension.js")
+    ));
+  });
+
+  /** Drive the real extension: capture its `before_agent_start` handler and fire it. */
+  function setup() {
+    const messageChannels = new Map<string, { channel: string; sender?: string }>();
+    const factory = createReplyInstructionsExtension(messageChannels);
+    let handler:
+      | (() => { message?: { customType: string; content: string } } | undefined)
+      | undefined;
+    factory({
+      on: (event: string, fn: () => { message?: { customType: string; content: string } }) => {
+        if (event === "before_agent_start") handler = fn;
+      },
+    } as never);
+    assert.ok(handler, "extension should register a before_agent_start handler");
+    const fire = () => handler?.()?.message;
+    return { messageChannels, fire };
+  }
+
+  it("an event turn gets the event note, never reply instructions", () => {
+    // This is the exact shape of the lucy bug: pi took the first pending entry blindly, so
+    // the only channel on the turn — the event's — became the advertised reply target.
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "event:orientation:1" });
+
+    const message = fire();
+    assertNotReplyable(message?.content);
+    assert.notEqual(message?.customType, "reply-instructions", "the event path is not a reply");
+  });
+
+  it("the event note fires once per session, not on every event", () => {
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "event:orientation:1" });
+    assert.ok(fire());
+
+    messageChannels.clear();
+    messageChannels.set("m2", { channel: "event:schedule:42" });
+    assert.equal(fire(), undefined, "second event must not repeat the note");
+  });
+
+  it("a real message still gets reply instructions naming its channel", () => {
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "@alice", sender: "alice" });
+    assert.ok(fire()?.content.includes("@alice"));
+  });
+
+  it("an event queued alongside a message does not steal the message's reply instructions", () => {
+    const { messageChannels, fire } = setup();
+    messageChannels.set("m1", { channel: "event:schedule:42" });
+    messageChannels.set("m2", { channel: "@alice", sender: "alice" });
+
+    const content = fire()?.content;
+    assert.ok(content?.includes("@alice"), "a waiting person still gets reply instructions");
+    assert.ok(!content.includes("event:"), "and is never told to reply to the event channel");
+  });
+});
+
+describe("codex template: reply instructions vs system events", () => {
+  let turnContextFor: typeof import("../templates/codex/src/lib/turn-context.js")["turnContextFor"];
+  let prompts: { event_instructions: string; reply_instructions: string };
+
+  before(async () => {
+    const dir = composeTemplate(templatesRoot, "codex").composedDir;
+    composed.push(dir);
+    ({ turnContextFor } = await import(resolvePath(dir, "src/lib/turn-context.js")));
+    const { loadPrompts } = await import(resolvePath(dir, "src/lib/startup.js"));
+    prompts = loadPrompts();
+  });
+
+  const newSession = () => ({ eventNoteFired: false, firstMessagePerChannel: new Set<string>() });
+
+  it("an event turn gets the event note, never reply instructions", () => {
+    const session = newSession();
+    const ctx = turnContextFor(
+      { channel: "event:orientation:1", isEvent: true } as never,
+      session,
+      prompts as never,
+    );
+    assert.equal(ctx?.source, "event-instructions");
+    assertNotReplyable(ctx?.content);
+  });
+
+  it("recognizes an event by channel shape even without the isEvent flag", () => {
+    const session = newSession();
+    const ctx = turnContextFor(
+      { channel: "event:schedule:42" } as never,
+      session,
+      prompts as never,
+    );
+    assert.equal(ctx?.source, "event-instructions");
+  });
+
+  it("the event note fires once per session, not on every event", () => {
+    const session = newSession();
+    assert.ok(
+      turnContextFor({ channel: "event:orientation:1" } as never, session, prompts as never),
+    );
+    // A distinct channel per event id: keying this on firstMessagePerChannel would re-fire here.
+    assert.equal(
+      turnContextFor({ channel: "event:schedule:42" } as never, session, prompts as never),
+      null,
+      "second event must not repeat the note",
+    );
+  });
+
+  it("a real message still gets reply instructions naming its channel", () => {
+    const session = newSession();
+    const ctx = turnContextFor(
+      { channel: "@alice", sender: "alice" } as never,
+      session,
+      prompts as never,
+    );
+    assert.equal(ctx?.source, "reply-instructions");
+    assert.ok(ctx?.content.includes("@alice"));
+  });
+
+  it("an event does not consume a later message's reply instructions", () => {
+    const session = newSession();
+    turnContextFor({ channel: "event:orientation:1" } as never, session, prompts as never);
+    const ctx = turnContextFor(
+      { channel: "@alice", sender: "alice" } as never,
+      session,
+      prompts as never,
+    );
+    assert.equal(ctx?.source, "reply-instructions");
+    assert.ok(ctx?.content.includes("@alice"));
+  });
+});

--- a/test/turn-lifecycle.test.ts
+++ b/test/turn-lifecycle.test.ts
@@ -257,6 +257,48 @@ describe("turn-lifecycle: mid-turn inbound tagging", () => {
     await cleanup(mind);
   });
 
+  it("tags a system event arriving mid-turn to the in-progress turn", async () => {
+    // `linkInboundToActiveTurn` must match "event" rows as well as "inbound" ones. Events are
+    // delivered with no busy check, so one can land while a turn is already running — this is
+    // the only path that attributes it. If the filter narrows back to "inbound", the event
+    // silently drops out of the turn's `events` array in the timeline and out of the
+    // summarizer's transcript. Nothing throws; the event simply never happened, as far as
+    // history is concerned.
+    const mind = "tl-midturn-event";
+    const triggerId = await recordInbound(mind, "@alice", "alice", "first");
+    const { turnId } = await handleMindEvent(mind, {
+      type: "text",
+      session: "s1",
+      channel: "@alice",
+      content: "on it",
+    });
+    assert.ok(turnId);
+
+    const db = await getDb();
+    const inserted = await db
+      .insert(mindHistory)
+      .values({
+        mind,
+        type: "event",
+        thread: "s1",
+        channel: "event:schedule:99",
+        content: "Time for your morning check-in.",
+        metadata: JSON.stringify({ systemEventId: 99, label: "Schedule: morning-check" }),
+      })
+      .returning({ id: mindHistory.id });
+    const eventRowId = inserted[0].id;
+
+    await linkInboundToActiveTurn(mind, "s1", "event:schedule:99");
+
+    const after = await db.select().from(mindHistory).where(eq(mindHistory.id, eventRowId)).get();
+    assert.equal(after!.turn_id, turnId, "mid-turn event must be tagged to the active turn");
+
+    // ...but a mid-turn arrival is never the trigger — the turn was started by alice.
+    const turn = await db.select().from(turns).where(eq(turns.id, turnId!)).get();
+    assert.equal(turn!.trigger_event_id, triggerId, "trigger_event_id must not be overwritten");
+    await cleanup(mind);
+  });
+
   it("tags ALL mid-turn inbounds even when more than 5 accumulate (next-turn sweep would miss them)", async () => {
     const mind = "tl-midturn-backlog";
     // Open a turn on the channel.

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -200,6 +200,90 @@ describe("web history routes", () => {
     assert.equal(messages[1].role, "assistant", "the answer (higher id) must come second");
   });
 
+  it("GET /api/v1/history/turns — a system event is an event, never a conversation", async () => {
+    // The timeline renders `conversations` as chat. A system event has no sender and no
+    // channel to reply to, so it must never appear there — it belongs in `events`, which
+    // the UI renders as a system marker. Letting it into `conversations` is what made
+    // events show up as blue message bubbles from a phantom sender named "user".
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    const turnId = randomUUID();
+    await db.insert(turns).values({ id: turnId, mind: "test-history-mind1", status: "complete" });
+    const [eventRow] = await db
+      .insert(mindHistory)
+      .values({
+        mind: "test-history-mind1",
+        type: "event",
+        channel: "event:orientation:1",
+        sender: null,
+        content: "You've just been created as a seed.",
+        metadata: JSON.stringify({ systemEventId: 1, label: "Orientation" }),
+        turn_id: turnId,
+      })
+      .returning({ id: mindHistory.id });
+    // The turn was triggered by the event (as linkPendingInbound would set).
+    await db.update(turns).set({ trigger_event_id: eventRow.id }).where(eq(turns.id, turnId));
+
+    const res = await app.request(`/api/v1/history/turns?turnId=${turnId}`, {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Array<{
+      conversations: unknown[];
+      events: Array<{ id: number; label: string; content: string }>;
+      trigger: { event?: { type: string; label: string } } | null;
+    }>;
+    assert.equal(body.length, 1);
+
+    assert.deepEqual(body[0].conversations, [], "an event must not become a conversation");
+
+    assert.equal(body[0].events.length, 1);
+    assert.equal(body[0].events[0].label, "Orientation");
+    assert.equal(body[0].events[0].content, "You've just been created as a seed.");
+
+    // The turn is flagged event-triggered, so the timeline can label the mind's closing
+    // text a private reflection rather than rendering it as a reply.
+    assert.equal(body[0].trigger?.event?.type, "orientation");
+    assert.equal(body[0].trigger?.event?.label, "Orientation");
+  });
+
+  it("GET /api/v1/history/turns — a message turn carries no event flag", async () => {
+    const cookie = await setupAuth();
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const db = await getDb();
+
+    const turnId = randomUUID();
+    await db.insert(turns).values({ id: turnId, mind: "test-history-mind1", status: "complete" });
+    const [inbound] = await db
+      .insert(mindHistory)
+      .values({
+        mind: "test-history-mind1",
+        type: "inbound",
+        channel: "@alice",
+        sender: "alice",
+        content: "hello",
+        turn_id: turnId,
+      })
+      .returning({ id: mindHistory.id });
+    await db.update(turns).set({ trigger_event_id: inbound.id }).where(eq(turns.id, turnId));
+
+    const res = await app.request(`/api/v1/history/turns?turnId=${turnId}`, {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    const body = (await res.json()) as Array<{
+      conversations: unknown[];
+      events: unknown[];
+      trigger: { event?: unknown; sender: string | null } | null;
+    }>;
+    // A real message still routes to conversations, with its sender, and no event flag.
+    assert.equal(body[0].conversations.length, 1);
+    assert.deepEqual(body[0].events, []);
+    assert.equal(body[0].trigger?.sender, "alice");
+    assert.equal(body[0].trigger?.event, undefined);
+  });
+
   it("GET /api/v1/history/turns — requires auth", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const res = await app.request("/api/v1/history/turns");

--- a/test/web-turn-events.test.ts
+++ b/test/web-turn-events.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { HistoryMessage } from "../packages/api/src/types.js";
+import { isEventTriggeredTurn } from "../packages/web/src/ui/lib/turn-events.js";
+
+/**
+ * The timeline labels a turn's closing text "reflection · private" when the turn was triggered
+ * by a system event — nothing was delivered to anyone, so it must not read like a reply.
+ *
+ * Getting the condition wrong is not cosmetic: it makes the history lie about what happened.
+ * The rule must match the daemon's, which is TRIGGER-based (`linkPendingInbound` tags the turn
+ * with the FIRST pending inbound-or-event row, and `captureReflection` only fires when that row
+ * is an event). "Contains an event anywhere" is a different, wrong rule — events can land
+ * mid-turn via `linkInboundToActiveTurn`.
+ */
+const row = (id: number, type: string, extra: Partial<HistoryMessage> = {}): HistoryMessage =>
+  ({
+    id,
+    mind: "m",
+    type,
+    content: "",
+    created_at: "2026-07-14 10:00:00",
+    ...extra,
+  }) as HistoryMessage;
+
+describe("isEventTriggeredTurn", () => {
+  it("an event-triggered turn is an event turn", () => {
+    assert.ok(
+      isEventTriggeredTurn([
+        row(1, "event", { channel: "event:schedule:42" }),
+        row(2, "tool_use"),
+        row(3, "text", { content: "noted" }),
+      ]),
+    );
+  });
+
+  it("a message-triggered turn is not, even when an event lands mid-turn", () => {
+    // The bug this guards: a human messages the mind, a scheduled event fires while the turn is
+    // still running and gets attached to it, and the mind's reply — which really was delivered
+    // to that human — gets stamped "reflection · private". The history would be lying.
+    assert.ok(
+      !isEventTriggeredTurn([
+        row(1, "inbound", { channel: "@alice", sender: "alice" }),
+        row(2, "event", { channel: "event:schedule:42" }),
+        row(3, "text", { content: "on it, alice" }),
+      ]),
+    );
+  });
+
+  it("an event-triggered turn stays an event turn when a message lands mid-turn", () => {
+    assert.ok(
+      isEventTriggeredTurn([
+        row(1, "event", { channel: "event:wake:7" }),
+        row(2, "inbound", { channel: "@alice", sender: "alice" }),
+      ]),
+    );
+  });
+
+  it("a turn with no source row at all is not an event turn", () => {
+    assert.ok(!isEventTriggeredTurn([row(1, "tool_use"), row(2, "text")]));
+    assert.ok(!isEventTriggeredTurn([]));
+  });
+});


### PR DESCRIPTION
System events (schedule fires, orientation, wake, notices) got their own table and primitive in #684 so automated traffic wouldn't masquerade as chat from the volute spirit. It half-worked: in every surface that matters they still looked exactly like messages.

**To minds.** The `[Event: ...]` prefix mirrored the message prefix shape, and the pi and codex templates were never made event-aware — they injected reply instructions naming the event's synthetic `event:<type>:<id>` channel. That tells a mind to `volute chat send event:orientation:1`. Observed live: the seed **lucy** obeyed, got "Direct sends to event channels are no longer supported", and spent her first turn puzzling over a message nobody had sent her.

**In the admin UI.** Events were `mind_history` rows of type `inbound` with a null sender, so the timeline rendered them through the chat path: a blue message bubble from a phantom sender literally named **"user"**, with the mind's closing thought rendered as a red chat reply.

## What changed

**Mind-facing.** A fenced `=== System event: <label> — <time> ===` envelope — structurally unlike any message prefix — plus a once-per-session note that events await no reply (the standing explanation lives in VOLUTE.md rather than being repeated on every event). All three templates now share one rule (`templates/_base/src/lib/event-turn.ts`); none can name an event channel as a reply target. Codex's decision was inline in `agent.ts` and therefore untestable, so it's extracted to `turn-context.ts`.

**Data model.** Events become `mind_history` rows of type `event` (migration `0017` retypes existing ones). The history API keeps them out of `conversations` entirely — the array the timeline renders as chat — and surfaces them per-turn in `events`, with a `trigger.event` flag. The UI renders a gear-marked system notice: no bubble, no sender, no channel. An event turn's closing text is labelled a private reflection instead of reading as a reply. `volute mind history` shows `[event: Orientation]`, not `[event:orientation:1] user: …`.

**Deliberately unchanged:** `message_count`, contacts, and seed-nurture freshness — an event is not a message and must not count as one, or reset a nurture clock.

## Security

Because `event` rows now render as authoritative environment notices, `POST /:name/events` gained a guard. It previously persisted a mind-supplied `type` verbatim, and minds are untrusted principals (they run arbitrary code). Without this, a mind could forge system events in its host's timeline. It now refuses the daemon-authored row types (`inbound`, `event`), and `recordReflection` is scoped by mind — a forged `systemEventId` could otherwise overwrite *another* mind's private reflection.

## Silent-failure surface

The reflection-capture chain fails with **no error and no log** if a type filter stops matching: template echoes `event:<type>:<id>` → `linkPendingInbound` sets `turns.trigger_event_id` → `captureReflection` stores the closing text. The filters in `turn-lifecycle`, `turn-tracker`, and `summarizer` therefore match both `inbound` and `event`, each with a comment naming the consequence and a test.

## Testing

`npm test` **2491/2491** · `npm run test:e2e` **59/59** · typecheck (daemon, CLI, web, all 3 templates) · svelte-check · lint — all clean.

The template guard is **mutation-verified**: reintroducing the original bug in all three templates fails 8 tests. (The prior iteration of these tests did *not* catch it — they exercised the shared helpers without asserting that any template called them.) Also pinned: the mid-turn event linkage, the interrupted-turn release, and migration `0017`'s `channel LIKE 'event:%'` guard — dropping that guard would retype every message a mind ever received and erase all chat from every timeline.

## Known gaps / follow-ups

- **No visual check.** The rendered timeline was verified only at the API contract level (events land in `events`, never `conversations`); I couldn't drive a browser.
- **`channel_invite` prompt has drifted** (pre-existing, unrelated): the daemon and template copies are not two wordings of one prompt but two different prompts with different variables. One is stale. Excluded from the new drift guard with a comment rather than silently skipped.
- **Stale `messageChannels` pruning** (pre-existing): claude/pi prune only `currentMessageId`, so a leftover `event:` entry can tag the *next* turn's rows — filing a reply-to-a-human as an event's private reflection.
- **Seeds are re-oriented on every restart** — #697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjNwaM3vsD9pJi12srLMiY