### PR TITLE
feat: image generation via OpenAI Codex and xAI Grok subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -267,6 +267,13 @@ export async function startDaemon(opts: {
   const delivery = initDeliveryManager();
   const manager = initMindManager();
   manager.loadCrashAttempts();
+
+  // Register the xAI (Grok) OAuth provider before any minds start, so a running
+  // xai-model mind can resolve its subscription OAuth credentials at boot. (Also
+  // powers Grok Imagine image generation via the provider OAuth UI.)
+  const { registerXaiOAuthProvider } = await import("./lib/oauth/xai.js");
+  registerXaiOAuthProvider();
+
   const bridgeManager = initBridgeManager();
   const scheduler = initScheduler();
   scheduler.start();
@@ -420,11 +427,6 @@ export async function startDaemon(opts: {
       listRunning: () => getMindManager().getRunningMinds(),
     }).catch((err) => log.warn("credential sync to minds failed", log.errorData(err)));
   });
-
-  // Register the xAI (Grok) OAuth provider so subscription login flows through
-  // the existing provider OAuth UI (used for Grok Imagine image generation).
-  const { registerXaiOAuthProvider } = await import("./lib/oauth/xai.js");
-  registerXaiOAuthProvider();
 
   // Start periodic API key cache refresh for mind provider keys
   startApiKeyRefresh();

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -421,6 +421,11 @@ export async function startDaemon(opts: {
     }).catch((err) => log.warn("credential sync to minds failed", log.errorData(err)));
   });
 
+  // Register the xAI (Grok) OAuth provider so subscription login flows through
+  // the existing provider OAuth UI (used for Grok Imagine image generation).
+  const { registerXaiOAuthProvider } = await import("./lib/oauth/xai.js");
+  registerXaiOAuthProvider();
+
   // Start periodic API key cache refresh for mind provider keys
   startApiKeyRefresh();
 

--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -52,11 +52,9 @@ export type ServiceProviderConfig = { apiKey?: string };
  * (ChatGPT plan without the hosted image tool; xAI tier not allowlisted).
  * Non-secret — lives in config.json, keyed by provider id.
  */
-export type ImagegenEntitlement = {
-  state: "entitled" | "not_entitled";
-  reason?: string;
-  checkedAt: number;
-};
+export type ImagegenEntitlement =
+  | { state: "entitled"; checkedAt: number }
+  | { state: "not_entitled"; reason: string; checkedAt: number };
 
 export type ImagegenConfig = {
   enabled?: boolean;

--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -46,11 +46,25 @@ export type AiConfig = {
 /** Shared across daemon services (imagegen, future TTS, etc.) */
 export type ServiceProviderConfig = { apiKey?: string };
 
+/**
+ * Whether a provider's credential is actually allowed to generate images.
+ * Distinct from "configured": a plan can be authenticated yet not entitled
+ * (ChatGPT plan without the hosted image tool; xAI tier not allowlisted).
+ * Non-secret — lives in config.json, keyed by provider id.
+ */
+export type ImagegenEntitlement = {
+  state: "entitled" | "not_entitled";
+  reason?: string;
+  checkedAt: number;
+};
+
 export type ImagegenConfig = {
   enabled?: boolean;
   providers?: Record<string, ServiceProviderConfig>;
   models?: string[];
   defaultModel?: string;
+  /** Per-provider entitlement cache (sibling of providers → stays in config.json). */
+  entitlements?: Record<string, ImagegenEntitlement>;
 };
 
 export type BackupSettings = {

--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -368,14 +368,28 @@ export function getSystemName(): string {
   return readGlobalConfig().name ?? "this system";
 }
 
+/**
+ * AI providers that double as image providers (chat/image unification): a
+ * subscription configured for chat also enables image generation. Kept in sync
+ * with the `aiProviderId` links in services/imagegen.ts — duplicated here only
+ * to avoid a setup.ts → imagegen.ts import cycle.
+ */
+const IMAGEGEN_AI_PROVIDERS = ["openai-codex", "xai"];
+
 export function isImagegenEnabled(): boolean {
   const config = readGlobalConfig();
   const ig = config.imagegen;
-  if (!ig) return false;
   // Legacy: explicit toggle
-  if (ig.enabled === true) return true;
-  // New: enabled if any provider is configured
-  if (ig.providers && Object.keys(ig.providers).length > 0) return true;
+  if (ig?.enabled === true) return true;
+  // Enabled if any imagegen provider has a key configured
+  if (ig?.providers && Object.keys(ig.providers).length > 0) return true;
+  // Or if a subscription AI provider (codex/xai) is configured for chat, since
+  // it is auto-added as an image provider.
+  const aiProviders = config.ai?.providers;
+  for (const id of IMAGEGEN_AI_PROVIDERS) {
+    const p = aiProviders?.[id];
+    if (p?.oauth || p?.apiKey) return true;
+  }
   return false;
 }
 

--- a/packages/daemon/src/lib/daemon/credential-sync.ts
+++ b/packages/daemon/src/lib/daemon/credential-sync.ts
@@ -131,9 +131,11 @@ function piUsesProvider(piAgentDir: string, provider: string): boolean {
  * refreshing the rotating grant independently (which invalidated each other).
  */
 export async function syncProviderToMinds(provider: string, deps: SyncDeps = {}): Promise<void> {
-  if (provider !== "anthropic") return;
+  // anthropic (claude + pi minds) and xai (pi minds only — its OAuth provider is
+  // daemon-registered, so minds consume the rotated token as an api_key).
+  if (provider !== "anthropic" && provider !== "xai") return;
 
-  const getOauth = deps.getOauth ?? (() => getAiConfig()?.providers.anthropic?.oauth);
+  const getOauth = deps.getOauth ?? (() => getAiConfig()?.providers[provider]?.oauth);
   const oauth = getOauth();
   if (!oauth?.access) return;
 
@@ -148,13 +150,13 @@ export async function syncProviderToMinds(provider: string, deps: SyncDeps = {})
       const baseName = entry.parent ?? name;
       const template = entry.template;
 
-      if (template === "claude" || !template) {
-        await writeClaudeCredentials(resolve(dir, "home"), baseName, oauth);
-      } else if (template === "pi") {
+      if (template === "pi") {
         const piAgentDir = resolve(dir, ".mind", "pi-agent");
-        if (piUsesProvider(piAgentDir, "anthropic")) {
-          await writePiProviderKey(piAgentDir, baseName, "anthropic", oauth.access);
+        if (piUsesProvider(piAgentDir, provider)) {
+          await writePiProviderKey(piAgentDir, baseName, provider, oauth.access);
         }
+      } else if (provider === "anthropic" && (template === "claude" || !template)) {
+        await writeClaudeCredentials(resolve(dir, "home"), baseName, oauth);
       }
     } catch (err) {
       slog.warn(`failed to sync ${provider} credentials to mind ${name}`, log.errorData(err));

--- a/packages/daemon/src/lib/daemon/credential-sync.ts
+++ b/packages/daemon/src/lib/daemon/credential-sync.ts
@@ -159,7 +159,9 @@ export async function syncProviderToMinds(provider: string, deps: SyncDeps = {})
         await writeClaudeCredentials(resolve(dir, "home"), baseName, oauth);
       }
     } catch (err) {
-      slog.warn(`failed to sync ${provider} credentials to mind ${name}`, log.errorData(err));
+      // A desync leaves this mind on a stale token → its next model call auth-fails
+      // until the next successful sync. Log at error so it's not buried as noise.
+      slog.error(`failed to sync ${provider} credentials to mind ${name}`, log.errorData(err));
     }
   }
 }

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -35,6 +35,12 @@ const mlog = log.child("minds");
 
 const execFileAsync = promisify(execFile);
 
+// OAuth providers registered only in the daemon's pi-ai (not pi-ai built-ins),
+// so a mind's own pi-ai can't turn their stored OAuth blob into a key. For these
+// the daemon writes the resolved access token as an api_key instead. Keep in sync
+// with the daemon-only OAuth providers registered in daemon.ts (e.g. xai).
+const DAEMON_ONLY_OAUTH = new Set(["xai"]);
+
 // Benign system env vars a mind's node/tsx process needs to run. Everything else
 // from the daemon environment (ambient AWS_*/GITHUB_TOKEN/etc.) is withheld.
 const MIND_ENV_ALLOWLIST = [
@@ -335,7 +341,7 @@ export class MindManager {
             const provider = modelStr.split(":")[0];
             const piAgentDir = resolve(dir, ".mind", "pi-agent");
             const oauthCreds = await resolveOAuthCredentials(provider);
-            if (oauthCreds) {
+            if (oauthCreds && !DAEMON_ONLY_OAUTH.has(provider)) {
               // Store the full OAuth credential (not just the derived key) so
               // pi-ai's own OAuth resolution runs inside the mind — some
               // providers (GitHub Copilot) derive a per-credential baseUrl from
@@ -346,7 +352,11 @@ export class MindManager {
               await writePiProviderOAuth(piAgentDir, baseName, provider, oauthCreds);
               env.PI_CODING_AGENT_DIR = piAgentDir;
             } else {
-              const apiKey = await resolveApiKey(provider);
+              // DAEMON_ONLY_OAUTH providers (xai) are registered only in the
+              // daemon's pi-ai, so the mind can't resolve their OAuth blob — hand
+              // it the already-resolved access token as an api_key (works directly
+              // as the provider's bearer; the daemon stays the refresh authority).
+              const apiKey = oauthCreds?.access ?? (await resolveApiKey(provider));
               if (apiKey) {
                 // Write API key to pi-coding-agent auth storage so the mind can use it.
                 // The pi template watches auth.json and reloads, so the daemon can

--- a/packages/daemon/src/lib/mind/isolation.ts
+++ b/packages/daemon/src/lib/mind/isolation.ts
@@ -266,3 +266,23 @@ export async function chownMindDir(dir: string, name: string): Promise<void> {
     throw new Error(`Failed to chmod ${dir}${stderr ? `: ${stderr}` : ""}`);
   }
 }
+
+/**
+ * Set ownership of a single file the daemon wrote into a mind's dir to that
+ * mind's system user. Targeted counterpart to chownMindDir — used when the
+ * daemon drops one file (e.g. a generated image) into home/ and must hand it to
+ * the mind without re-chowning the whole tree. No-op when isolation is off.
+ */
+export async function chownMindFile(filePath: string, name: string): Promise<void> {
+  if (!isIsolationEnabled()) return;
+  const user = mindUserName(name);
+  const group = process.platform === "darwin" ? "volute" : user;
+  try {
+    await exec("chown", [`${user}:${group}`, filePath]);
+  } catch (err) {
+    const stderr = String((err as { stderr?: string })?.stderr ?? "").trim();
+    throw new Error(
+      `Failed to chown ${filePath} to ${user}:${group}${stderr ? `: ${stderr}` : ""}`,
+    );
+  }
+}

--- a/packages/daemon/src/lib/oauth/xai.ts
+++ b/packages/daemon/src/lib/oauth/xai.ts
@@ -1,0 +1,169 @@
+/**
+ * xAI (Grok) OAuth provider — lets a SuperGrok / X Premium subscriber log in
+ * and use their subscription programmatically (no metered API key). Registered
+ * into pi-ai's OAuth registry so it flows through Volute's existing provider
+ * OAuth UI with no new frontend.
+ *
+ * We reuse the first-party Grok CLI OAuth client, as every third-party tool in
+ * the ecosystem does (OpenClaw, Hermes, and xAI's own blessed OpenCode
+ * integration) — xAI offers no bring-your-own-client registration, and its auth
+ * server rejects this client from non-allowlisted flows. The consent screen may
+ * read "Grok Build" because of the shared client. We prefer the device-code
+ * flow: the Volute daemon often runs headless/remote, where a loopback callback
+ * can't reach the admin's browser but a "visit URL, enter code" flow can.
+ */
+
+import {
+  type OAuthCredentials,
+  type OAuthLoginCallbacks,
+  type OAuthProviderInterface,
+  pollOAuthDeviceCodeFlow,
+  registerOAuthProvider,
+} from "@earendil-works/pi-ai/oauth";
+
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_ISSUER = "https://auth.x.ai";
+const XAI_DISCOVERY_URL = `${XAI_ISSUER}/.well-known/openid-configuration`;
+// Fallbacks if discovery is unavailable (these are xAI's documented endpoints).
+const FALLBACK_DEVICE_ENDPOINT = `${XAI_ISSUER}/oauth2/device/code`;
+const FALLBACK_TOKEN_ENDPOINT = `${XAI_ISSUER}/oauth2/token`;
+
+type Endpoints = { deviceEndpoint: string; tokenEndpoint: string };
+
+/** Only accept endpoints served by xAI's auth host — never a redirected origin. */
+function validateXaiUrl(url: string): string {
+  const u = new URL(url);
+  if (u.hostname !== "auth.x.ai" || u.protocol !== "https:") {
+    throw new Error(`Refusing non-xAI OAuth endpoint: ${url}`);
+  }
+  return u.toString();
+}
+
+async function discoverEndpoints(signal?: AbortSignal): Promise<Endpoints> {
+  try {
+    const res = await fetch(XAI_DISCOVERY_URL, { signal });
+    if (res.ok) {
+      const doc = (await res.json()) as {
+        device_authorization_endpoint?: string;
+        token_endpoint?: string;
+      };
+      if (doc.device_authorization_endpoint && doc.token_endpoint) {
+        return {
+          deviceEndpoint: validateXaiUrl(doc.device_authorization_endpoint),
+          tokenEndpoint: validateXaiUrl(doc.token_endpoint),
+        };
+      }
+    }
+  } catch {
+    // fall through to documented defaults
+  }
+  return { deviceEndpoint: FALLBACK_DEVICE_ENDPOINT, tokenEndpoint: FALLBACK_TOKEN_ENDPOINT };
+}
+
+function credentialsFromTokenResponse(raw: unknown): OAuthCredentials {
+  const json = (raw ?? {}) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+  if (!json.access_token || typeof json.expires_in !== "number") {
+    throw new Error("xAI token response missing access_token/expires_in");
+  }
+  return {
+    access: json.access_token,
+    // A refresh grant may omit refresh_token; the caller merges the old one.
+    refresh: json.refresh_token ?? "",
+    expires: Date.now() + json.expires_in * 1000,
+  };
+}
+
+async function login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+  const { deviceEndpoint, tokenEndpoint } = await discoverEndpoints(callbacks.signal);
+
+  const deviceRes = await fetch(deviceEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ client_id: XAI_OAUTH_CLIENT_ID, scope: XAI_OAUTH_SCOPE }),
+    signal: callbacks.signal,
+  });
+  if (!deviceRes.ok) {
+    throw new Error(`xAI device authorization failed: HTTP ${deviceRes.status}`);
+  }
+  const device = (await deviceRes.json()) as {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    verification_uri_complete?: string;
+    interval?: number;
+    expires_in?: number;
+  };
+
+  callbacks.onDeviceCode({
+    userCode: device.user_code,
+    verificationUri: device.verification_uri_complete ?? device.verification_uri,
+    intervalSeconds: device.interval,
+    expiresInSeconds: device.expires_in,
+  });
+
+  return pollOAuthDeviceCodeFlow<OAuthCredentials>({
+    intervalSeconds: device.interval,
+    expiresInSeconds: device.expires_in,
+    signal: callbacks.signal,
+    poll: async () => {
+      const res = await fetch(tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code: device.device_code,
+          client_id: XAI_OAUTH_CLIENT_ID,
+        }),
+        signal: callbacks.signal,
+      });
+      if (res.ok) {
+        return { status: "complete", value: credentialsFromTokenResponse(await res.json()) };
+      }
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (body.error === "authorization_pending") return { status: "pending" };
+      if (body.error === "slow_down") return { status: "slow_down" };
+      return { status: "failed", message: body.error ?? `HTTP ${res.status}` };
+    },
+  });
+}
+
+async function refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+  const { tokenEndpoint } = await discoverEndpoints();
+  const res = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: credentials.refresh,
+      client_id: XAI_OAUTH_CLIENT_ID,
+    }),
+  });
+  if (!res.ok) throw new Error(`xAI token refresh failed: HTTP ${res.status}`);
+  const next = credentialsFromTokenResponse(await res.json());
+  // xAI may not re-issue a refresh token; keep the existing one.
+  if (!next.refresh) next.refresh = credentials.refresh;
+  return next;
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+  id: "xai",
+  name: "xAI (Grok)",
+  usesCallbackServer: false,
+  login,
+  refreshToken,
+  getApiKey: (credentials) => credentials.access,
+};
+
+let registered = false;
+
+/** Register the xAI OAuth provider into pi-ai's registry (idempotent). */
+export function registerXaiOAuthProvider(): void {
+  if (registered) return;
+  registerOAuthProvider(xaiOAuthProvider);
+  registered = true;
+}

--- a/packages/daemon/src/lib/oauth/xai.ts
+++ b/packages/daemon/src/lib/oauth/xai.ts
@@ -32,7 +32,7 @@ const FALLBACK_TOKEN_ENDPOINT = `${XAI_ISSUER}/oauth2/token`;
 type Endpoints = { deviceEndpoint: string; tokenEndpoint: string };
 
 /** Only accept endpoints served by xAI's auth host — never a redirected origin. */
-function validateXaiUrl(url: string): string {
+export function validateXaiUrl(url: string): string {
   const u = new URL(url);
   if (u.hostname !== "auth.x.ai" || u.protocol !== "https:") {
     throw new Error(`Refusing non-xAI OAuth endpoint: ${url}`);

--- a/packages/daemon/src/lib/services/imagegen-codex.ts
+++ b/packages/daemon/src/lib/services/imagegen-codex.ts
@@ -16,8 +16,9 @@ const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 const HOST_MODEL = "gpt-5.4-mini";
 
 /**
- * Exact 400 body the backend returns when the account's plan is not entitled to
- * the hosted image tool. Callers (entitlement) match on this precise string.
+ * Substring the backend includes in its 400 error body when the account's plan
+ * isn't entitled to the hosted image tool. Callers match it with `.includes()`
+ * — it's a fragment of a larger JSON error body, not the whole body.
  */
 export const CODEX_NOT_ENTITLED_SENTINEL =
   "Tool choice 'image_generation' not found in 'tools' parameter.";
@@ -90,14 +91,22 @@ export function buildCodexRequest(imageModel: string, prompt: string): unknown {
 /**
  * Parse the Codex SSE stream and return the final image bytes. The image never
  * appears in the terminal `response.completed` payload (its output array is
- * empty); the bytes arrive in `image_generation_call.partial_image` /
- * `output_item.done` events, so we keep the longest base64 blob seen.
+ * empty); the bytes stream across the partial-image / output-item events, so we
+ * keep the longest base64 blob seen. We require the terminal `response.completed`
+ * event before returning: because `partial_images: 1` sends a low-res preview
+ * first, a stream that closes cleanly *before* completion (server timeout,
+ * truncated final frame) would otherwise silently yield the blurry partial as if
+ * it were the finished image.
  */
-export async function parseCodexImageStream(body: ReadableStream<Uint8Array>): Promise<Buffer> {
+export async function parseCodexImageStream(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): Promise<Buffer> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buf = "";
   let best = "";
+  let completed = false;
 
   const consumeLine = (line: string) => {
     if (!line.startsWith("data:")) return;
@@ -109,6 +118,7 @@ export async function parseCodexImageStream(body: ReadableStream<Uint8Array>): P
     } catch {
       return;
     }
+    if (evt.type === "response.completed") completed = true;
     const candidate =
       (evt.partial_image_b64 as string | undefined) ??
       (evt.result as string | undefined) ??
@@ -118,6 +128,7 @@ export async function parseCodexImageStream(body: ReadableStream<Uint8Array>): P
   };
 
   for (;;) {
+    if (signal?.aborted) throw new Error("Codex stream aborted");
     const { value, done } = await reader.read();
     if (done) break;
     buf += decoder.decode(value, { stream: true });
@@ -128,6 +139,9 @@ export async function parseCodexImageStream(body: ReadableStream<Uint8Array>): P
   }
   consumeLine(buf);
 
+  if (!completed) {
+    throw new Error("Codex stream closed before completion — only a partial image was received");
+  }
   if (!best) throw new Error("Codex stream produced no image");
   return Buffer.from(best, "base64");
 }
@@ -136,11 +150,13 @@ export async function codexGenerate(
   model: string,
   prompt: string,
   cred: Credential,
+  signal?: AbortSignal,
 ): Promise<Buffer> {
   const res = await fetch(CODEX_RESPONSES_URL, {
     method: "POST",
     headers: codexHeaders(cred.token),
     body: JSON.stringify(buildCodexRequest(model, prompt)),
+    signal,
   });
 
   if (res.status === 400) {
@@ -153,14 +169,16 @@ export async function codexGenerate(
     throw new Error(`Codex image generation failed (${res.status}): ${errBody.slice(0, 200)}`);
   }
 
-  return parseCodexImageStream(res.body);
+  return parseCodexImageStream(res.body, signal);
 }
 
 /**
  * Cheaply probe whether the account is entitled to the hosted image tool: force
- * the tool, then abort the stream the instant it's accepted (the
- * `image_generation_call.in_progress` event) — so we learn entitlement without
- * paying for a full image. A 400 with the sentinel means not entitled.
+ * the tool, then abort the stream the instant the tool starts (any
+ * `image_generation_call` event) — so we learn entitlement without paying for a
+ * full image. A 400 with the sentinel means not entitled. We key on the tool
+ * *starting* rather than a specific sub-event so a marker rename can't
+ * false-negative an entitled account.
  */
 export async function probeCodexEntitlement(
   cred: Credential,
@@ -197,7 +215,7 @@ export async function probeCodexEntitlement(
       const { value, done } = await reader.read();
       if (done) break;
       buf += decoder.decode(value, { stream: true });
-      if (buf.includes("response.image_generation_call.in_progress")) {
+      if (buf.includes("image_generation_call")) {
         controller.abort();
         return "entitled";
       }

--- a/packages/daemon/src/lib/services/imagegen-codex.ts
+++ b/packages/daemon/src/lib/services/imagegen-codex.ts
@@ -156,6 +156,60 @@ export async function codexGenerate(
   return parseCodexImageStream(res.body);
 }
 
+/**
+ * Cheaply probe whether the account is entitled to the hosted image tool: force
+ * the tool, then abort the stream the instant it's accepted (the
+ * `image_generation_call.in_progress` event) — so we learn entitlement without
+ * paying for a full image. A 400 with the sentinel means not entitled.
+ */
+export async function probeCodexEntitlement(
+  cred: Credential,
+): Promise<"entitled" | "not_entitled"> {
+  const controller = new AbortController();
+  let res: Response;
+  try {
+    res = await fetch(CODEX_RESPONSES_URL, {
+      method: "POST",
+      headers: codexHeaders(cred.token),
+      body: JSON.stringify(buildCodexRequest("gpt-image-2", "entitlement probe")),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") return "entitled";
+    throw err;
+  }
+
+  if (res.status === 400) {
+    const body = await res.text().catch(() => "");
+    if (body.includes(CODEX_NOT_ENTITLED_SENTINEL)) return "not_entitled";
+    throw new Error(`Codex entitlement probe failed (400): ${body.slice(0, 200)}`);
+  }
+  if (!res.ok || !res.body) {
+    throw new Error(`Codex entitlement probe failed (${res.status})`);
+  }
+
+  // Stream until the tool is accepted, then abort — the account is entitled.
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      if (buf.includes("response.image_generation_call.in_progress")) {
+        controller.abort();
+        return "entitled";
+      }
+    }
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") return "entitled";
+    throw err;
+  }
+  // Stream ended without the tool starting — treat as not entitled.
+  return "not_entitled";
+}
+
 // Codex exposes a single hosted image model; return it statically so it can be
 // enabled in the model-selection UI like any other.
 export async function codexSearch(_query: string, _cred: Credential): Promise<ModelSearchResult[]> {

--- a/packages/daemon/src/lib/services/imagegen-codex.ts
+++ b/packages/daemon/src/lib/services/imagegen-codex.ts
@@ -1,0 +1,170 @@
+/**
+ * OpenAI Codex image provider — generates images through a ChatGPT subscription
+ * (no metered API key) by driving the Codex Responses backend's hosted
+ * `image_generation` tool. This is the same mechanism OpenClaw and Hermes use.
+ *
+ * The credential is a Codex OAuth access token (resolved by the imagegen
+ * service from the `openai-codex` AI provider). The account id is read from the
+ * token's own JWT claim, so nothing extra needs storing.
+ */
+
+import type { Credential, ModelSearchResult } from "./imagegen.js";
+
+const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+// Host chat model: cheap, only needs to carry the hosted image tool. Its text
+// output is discarded — the image comes from the tool, not the model.
+const HOST_MODEL = "gpt-5.4-mini";
+
+/**
+ * Exact 400 body the backend returns when the account's plan is not entitled to
+ * the hosted image tool. Callers (entitlement) match on this precise string.
+ */
+export const CODEX_NOT_ENTITLED_SENTINEL =
+  "Tool choice 'image_generation' not found in 'tools' parameter.";
+
+/** Raised when the plan can't use the hosted image tool (vs. a transient error). */
+export class CodexNotEntitledError extends Error {
+  constructor() {
+    super(CODEX_NOT_ENTITLED_SENTINEL);
+    this.name = "CodexNotEntitledError";
+  }
+}
+
+/** Extract the chatgpt-account-id from a Codex OAuth access token's JWT claims. */
+export function accountIdFromToken(token: string): string | undefined {
+  const parts = token.split(".");
+  if (parts.length !== 3) return undefined;
+  try {
+    const claims = JSON.parse(Buffer.from(parts[1], "base64url").toString()) as Record<
+      string,
+      unknown
+    >;
+    const auth = claims["https://api.openai.com/auth"] as
+      | { chatgpt_account_id?: string }
+      | undefined;
+    return auth?.chatgpt_account_id;
+  } catch {
+    return undefined;
+  }
+}
+
+function codexHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "OpenAI-Beta": "responses=experimental",
+    originator: "codex_cli_rs",
+    session_id: crypto.randomUUID(),
+  };
+  const accountId = accountIdFromToken(token);
+  if (accountId) headers["chatgpt-account-id"] = accountId;
+  return headers;
+}
+
+/**
+ * Build the Responses request that forces the hosted image tool.
+ * `imageModel` is the image model id (e.g. "gpt-image-2").
+ */
+export function buildCodexRequest(imageModel: string, prompt: string): unknown {
+  return {
+    model: HOST_MODEL,
+    instructions:
+      "Use the image_generation tool immediately to render the request. Never ask questions.",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: prompt }] }],
+    tools: [
+      {
+        type: "image_generation",
+        model: imageModel,
+        size: "1024x1024",
+        quality: "auto",
+        output_format: "png",
+        partial_images: 1,
+      },
+    ],
+    tool_choice: { type: "image_generation" },
+    stream: true,
+    store: false,
+  };
+}
+
+/**
+ * Parse the Codex SSE stream and return the final image bytes. The image never
+ * appears in the terminal `response.completed` payload (its output array is
+ * empty); the bytes arrive in `image_generation_call.partial_image` /
+ * `output_item.done` events, so we keep the longest base64 blob seen.
+ */
+export async function parseCodexImageStream(body: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let best = "";
+
+  const consumeLine = (line: string) => {
+    if (!line.startsWith("data:")) return;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") return;
+    let evt: Record<string, unknown>;
+    try {
+      evt = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    const candidate =
+      (evt.partial_image_b64 as string | undefined) ??
+      (evt.result as string | undefined) ??
+      (evt.item as { result?: string } | undefined)?.result ??
+      undefined;
+    if (candidate && candidate.length > best.length) best = candidate;
+  };
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    for (let nl = buf.indexOf("\n"); nl !== -1; nl = buf.indexOf("\n")) {
+      consumeLine(buf.slice(0, nl));
+      buf = buf.slice(nl + 1);
+    }
+  }
+  consumeLine(buf);
+
+  if (!best) throw new Error("Codex stream produced no image");
+  return Buffer.from(best, "base64");
+}
+
+export async function codexGenerate(
+  model: string,
+  prompt: string,
+  cred: Credential,
+): Promise<Buffer> {
+  const res = await fetch(CODEX_RESPONSES_URL, {
+    method: "POST",
+    headers: codexHeaders(cred.token),
+    body: JSON.stringify(buildCodexRequest(model, prompt)),
+  });
+
+  if (res.status === 400) {
+    const errBody = await res.text().catch(() => "");
+    if (errBody.includes(CODEX_NOT_ENTITLED_SENTINEL)) throw new CodexNotEntitledError();
+    throw new Error(`Codex image generation failed (400): ${errBody.slice(0, 200)}`);
+  }
+  if (!res.ok || !res.body) {
+    const errBody = await res.text().catch(() => `HTTP ${res.status}`);
+    throw new Error(`Codex image generation failed (${res.status}): ${errBody.slice(0, 200)}`);
+  }
+
+  return parseCodexImageStream(res.body);
+}
+
+// Codex exposes a single hosted image model; return it statically so it can be
+// enabled in the model-selection UI like any other.
+export async function codexSearch(_query: string, _cred: Credential): Promise<ModelSearchResult[]> {
+  return [
+    {
+      id: "openai-codex:gpt-image-2",
+      name: "gpt-image-2 (ChatGPT subscription)",
+      description: "OpenAI's image model via a ChatGPT/Codex subscription — no API key required.",
+      owner: "openai",
+    },
+  ];
+}

--- a/packages/daemon/src/lib/services/imagegen-jobs.ts
+++ b/packages/daemon/src/lib/services/imagegen-jobs.ts
@@ -1,0 +1,172 @@
+/**
+ * Async image-generation jobs. Generation can take minutes (e.g. gpt-image-2),
+ * so the mind's `imagegen generate` no longer blocks on it: the daemon runs the
+ * job in the background, the skill foregrounds it briefly (long-poll), and on
+ * completion the daemon writes the file and wakes the mind with a system event.
+ *
+ * Jobs live in memory only (like the session/oauth-flow maps) — they do not
+ * survive a daemon restart. A `status` check for a lost job 404s, and the skill
+ * tells the mind to re-run.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { deliverEvent } from "../chat/system-events.js";
+import { chownMindFile } from "../mind/isolation.js";
+import { resolveMindDir } from "../mind/registry.js";
+import log from "../util/logger.js";
+import { safeResolveWithinBase } from "../util/paths.js";
+import { generateImage } from "./imagegen.js";
+
+const jobLog = log.child("imagegen-jobs");
+
+/** Most jobs a single mind may have generating at once. */
+const MAX_INFLIGHT_PER_MIND = 4;
+/** How long a settled job stays queryable via `status` before cleanup. */
+const DONE_TTL_MS = 10 * 60 * 1000;
+
+export type JobStatus = "running" | "done" | "error";
+
+/** Public view of a job (what the API returns). */
+export type ImagegenJob = {
+  id: string;
+  mind: string;
+  status: JobStatus;
+  /** Absolute path of the written image (status "done"). */
+  path?: string;
+  /** Failure message (status "error"). */
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+};
+
+type JobRecord = ImagegenJob & {
+  /** Resolves when the job leaves "running" (drives the long-poll). */
+  settled: Promise<void>;
+  resolveSettled: () => void;
+};
+
+const jobs = new Map<string, JobRecord>();
+
+function publicView(r: JobRecord): ImagegenJob {
+  return {
+    id: r.id,
+    mind: r.mind,
+    status: r.status,
+    path: r.path,
+    error: r.error,
+    createdAt: r.createdAt,
+    completedAt: r.completedAt,
+  };
+}
+
+function countInflight(mind: string): number {
+  let n = 0;
+  for (const r of jobs.values()) if (r.mind === mind && r.status === "running") n++;
+  return n;
+}
+
+function settle(record: JobRecord, patch: Partial<JobRecord>): void {
+  Object.assign(record, patch, { completedAt: Date.now() });
+  record.resolveSettled();
+  // Keep the settled job briefly for status checks, then drop it. unref so a
+  // pending timer never keeps the daemon alive.
+  setTimeout(() => jobs.delete(record.id), DONE_TTL_MS).unref?.();
+}
+
+async function runJob(record: JobRecord, model: string, prompt: string, filename: string) {
+  try {
+    const buf = await generateImage(model, prompt);
+
+    const home = `${await resolveMindDir(record.mind)}/home`;
+    const target = safeResolveWithinBase(home, `images/${filename}.png`);
+    if (!target) throw new Error(`Invalid image filename: ${filename}`);
+
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, buf);
+    await chownMindFile(target, record.mind);
+
+    settle(record, { status: "done", path: target });
+
+    // Wake the mind with the finished image (queues if it's asleep).
+    await deliverEvent(record.mind, {
+      type: "imagegen",
+      body: `image ready: ${target}`,
+      delivery: "immediate",
+      whileSleeping: "queue",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    jobLog.error(`job ${record.id} failed`, log.errorData(err));
+    settle(record, { status: "error", error: message });
+  }
+}
+
+/**
+ * Start a background generation job. Throws if the mind is already at its
+ * in-flight cap. Returns the job id immediately; generation proceeds async.
+ */
+export function createImagegenJob(
+  mind: string,
+  model: string,
+  prompt: string,
+  filename: string,
+): string {
+  if (countInflight(mind) >= MAX_INFLIGHT_PER_MIND) {
+    throw new Error(
+      `Too many image generations in progress (max ${MAX_INFLIGHT_PER_MIND}). Wait for one to finish.`,
+    );
+  }
+  const id = crypto.randomUUID();
+  let resolveSettled!: () => void;
+  const settled = new Promise<void>((r) => {
+    resolveSettled = r;
+  });
+  const record: JobRecord = {
+    id,
+    mind,
+    status: "running",
+    createdAt: Date.now(),
+    settled,
+    resolveSettled,
+  };
+  jobs.set(id, record);
+  void runJob(record, model, prompt, filename);
+  return id;
+}
+
+/** Fetch a job, enforcing that it belongs to the requesting mind. */
+export function getImagegenJob(mind: string, id: string): ImagegenJob | undefined {
+  const record = jobs.get(id);
+  if (!record || record.mind !== mind) return undefined;
+  return publicView(record);
+}
+
+/**
+ * Wait up to `timeoutMs` for a job to finish, then return its current state
+ * (still "running" on timeout). Returns undefined if the job is unknown or not
+ * owned by the mind.
+ */
+export async function waitForImagegenJob(
+  mind: string,
+  id: string,
+  timeoutMs: number,
+): Promise<ImagegenJob | undefined> {
+  const record = jobs.get(id);
+  if (!record || record.mind !== mind) return undefined;
+  if (record.status === "running" && timeoutMs > 0) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((r) => {
+      timer = setTimeout(r, timeoutMs);
+      timer.unref?.();
+    });
+    await Promise.race([record.settled, timeout]);
+    if (timer) clearTimeout(timer);
+  }
+  return publicView(record);
+}
+
+/** Test seam: drop all jobs. */
+export function _resetImagegenJobs(): void {
+  jobs.clear();
+}

--- a/packages/daemon/src/lib/services/imagegen-jobs.ts
+++ b/packages/daemon/src/lib/services/imagegen-jobs.ts
@@ -44,6 +44,14 @@ type JobRecord = ImagegenJob & {
   /** Resolves when the job leaves "running" (drives the long-poll). */
   settled: Promise<void>;
   resolveSettled: () => void;
+  /**
+   * Set once a foreground long-poll times out with the job still running — i.e.
+   * the job outlived the caller's wait and dropped to the background. Only then
+   * does completion fire an "image ready" event; a job that finishes within the
+   * foreground wait is already reported to the caller via `saved:`, so a second
+   * async notification would just confuse the mind with a duplicate.
+   */
+  notifyOnDone: boolean;
 };
 
 const jobs = new Map<string, JobRecord>();
@@ -74,9 +82,23 @@ function settle(record: JobRecord, patch: Partial<JobRecord>): void {
   setTimeout(() => jobs.delete(record.id), DONE_TTL_MS).unref?.();
 }
 
-async function runJob(record: JobRecord, model: string, prompt: string, filename: string) {
+/** Injectable side effects (defaults hit the real provider/event bus; tests override). */
+export type JobDeps = {
+  generate?: (model: string, prompt: string) => Promise<Buffer>;
+  deliver?: typeof deliverEvent;
+};
+
+async function runJob(
+  record: JobRecord,
+  model: string,
+  prompt: string,
+  filename: string,
+  deps: JobDeps,
+) {
+  const generate = deps.generate ?? generateImage;
+  const deliver = deps.deliver ?? deliverEvent;
   try {
-    const buf = await generateImage(model, prompt);
+    const buf = await generate(model, prompt);
 
     const home = `${await resolveMindDir(record.mind)}/home`;
     const target = safeResolveWithinBase(home, `images/${filename}.png`);
@@ -88,13 +110,17 @@ async function runJob(record: JobRecord, model: string, prompt: string, filename
 
     settle(record, { status: "done", path: target });
 
-    // Wake the mind with the finished image (queues if it's asleep).
-    await deliverEvent(record.mind, {
-      type: "imagegen",
-      body: `image ready: ${target}`,
-      delivery: "immediate",
-      whileSleeping: "queue",
-    });
+    // Only wake the mind if the job outlived the foreground wait (dropped to
+    // background). A job that finished within the wait already returned `saved:`
+    // to the caller, so a completion event here would be a confusing duplicate.
+    if (record.notifyOnDone) {
+      await deliver(record.mind, {
+        type: "imagegen",
+        body: `image ready: ${target}`,
+        delivery: "immediate",
+        whileSleeping: "queue",
+      });
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     jobLog.error(`job ${record.id} failed`, log.errorData(err));
@@ -111,6 +137,7 @@ export function createImagegenJob(
   model: string,
   prompt: string,
   filename: string,
+  deps: JobDeps = {},
 ): string {
   if (countInflight(mind) >= MAX_INFLIGHT_PER_MIND) {
     throw new Error(
@@ -129,9 +156,10 @@ export function createImagegenJob(
     createdAt: Date.now(),
     settled,
     resolveSettled,
+    notifyOnDone: false,
   };
   jobs.set(id, record);
-  void runJob(record, model, prompt, filename);
+  void runJob(record, model, prompt, filename, deps);
   return id;
 }
 
@@ -162,6 +190,9 @@ export async function waitForImagegenJob(
     });
     await Promise.race([record.settled, timeout]);
     if (timer) clearTimeout(timer);
+    // Still running after the wait → the job is going to the background, so its
+    // eventual completion should notify the mind (see JobRecord.notifyOnDone).
+    if (record.status === "running") record.notifyOnDone = true;
   }
   return publicView(record);
 }

--- a/packages/daemon/src/lib/services/imagegen-jobs.ts
+++ b/packages/daemon/src/lib/services/imagegen-jobs.ts
@@ -24,23 +24,54 @@ const jobLog = log.child("imagegen-jobs");
 const MAX_INFLIGHT_PER_MIND = 4;
 /** How long a settled job stays queryable via `status` before cleanup. */
 const DONE_TTL_MS = 10 * 60 * 1000;
+/**
+ * Hard ceiling on a single generation. Without it a hung provider connection
+ * (e.g. a Codex SSE stream that never closes) would leave the job "running"
+ * forever, never freeing its inflight slot or arming TTL cleanup — after
+ * MAX_INFLIGHT_PER_MIND hangs the mind could not generate until a daemon restart.
+ */
+const GENERATION_TIMEOUT_MS = 3 * 60 * 1000;
 
 export type JobStatus = "running" | "done" | "error";
 
-/** Public view of a job (what the API returns). */
-export type ImagegenJob = {
+/**
+ * Public view of a job (what the API returns). A discriminated union so the
+ * status↔payload invariant is compile-time: a `done` job always has `path`, an
+ * `error` job always has `error`, and consumers can't read `job.path` without
+ * first narrowing to `status: "done"`.
+ */
+export type ImagegenJob =
+  | { status: "running"; id: string; mind: string; createdAt: number }
+  | {
+      status: "done";
+      id: string;
+      mind: string;
+      createdAt: number;
+      completedAt: number;
+      path: string;
+    }
+  | {
+      status: "error";
+      id: string;
+      mind: string;
+      createdAt: number;
+      completedAt: number;
+      error: string;
+    };
+
+/**
+ * Internal record — kept flat and mutable (the union above would fight the
+ * in-place `Object.assign` in `settle`). `publicView` is the single place that
+ * projects it into the tight union, enforcing the invariant at that boundary.
+ */
+type JobRecord = {
   id: string;
   mind: string;
   status: JobStatus;
-  /** Absolute path of the written image (status "done"). */
   path?: string;
-  /** Failure message (status "error"). */
   error?: string;
   createdAt: number;
   completedAt?: number;
-};
-
-type JobRecord = ImagegenJob & {
   /** Resolves when the job leaves "running" (drives the long-poll). */
   settled: Promise<void>;
   resolveSettled: () => void;
@@ -57,15 +88,20 @@ type JobRecord = ImagegenJob & {
 const jobs = new Map<string, JobRecord>();
 
 function publicView(r: JobRecord): ImagegenJob {
-  return {
-    id: r.id,
-    mind: r.mind,
-    status: r.status,
-    path: r.path,
-    error: r.error,
-    createdAt: r.createdAt,
-    completedAt: r.completedAt,
-  };
+  const base = { id: r.id, mind: r.mind, createdAt: r.createdAt };
+  if (r.status === "done") {
+    if (!r.path) throw new Error(`job ${r.id} is done but has no path`);
+    return { ...base, status: "done", completedAt: r.completedAt ?? r.createdAt, path: r.path };
+  }
+  if (r.status === "error") {
+    return {
+      ...base,
+      status: "error",
+      completedAt: r.completedAt ?? r.createdAt,
+      error: r.error ?? "unknown error",
+    };
+  }
+  return { ...base, status: "running" };
 }
 
 function countInflight(mind: string): number {
@@ -84,9 +120,24 @@ function settle(record: JobRecord, patch: Partial<JobRecord>): void {
 
 /** Injectable side effects (defaults hit the real provider/event bus; tests override). */
 export type JobDeps = {
-  generate?: (model: string, prompt: string) => Promise<Buffer>;
+  generate?: (model: string, prompt: string, signal?: AbortSignal) => Promise<Buffer>;
   deliver?: typeof deliverEvent;
 };
+
+/** Deliver a job event to the mind, logging (never throwing) if it doesn't land. */
+async function notify(deliver: typeof deliverEvent, mind: string, body: string): Promise<void> {
+  try {
+    const { delivered } = await deliver(mind, {
+      type: "imagegen",
+      body,
+      delivery: "immediate",
+      whileSleeping: "queue",
+    });
+    if (!delivered) jobLog.warn(`imagegen event not delivered to ${mind}: ${body}`);
+  } catch (err) {
+    jobLog.warn(`failed to deliver imagegen event to ${mind}`, log.errorData(err));
+  }
+}
 
 async function runJob(
   record: JobRecord,
@@ -97,8 +148,13 @@ async function runJob(
 ) {
   const generate = deps.generate ?? generateImage;
   const deliver = deps.deliver ?? deliverEvent;
+  // Abort a generation that outruns the ceiling so a hung provider connection
+  // can't pin the job in "running" forever (see GENERATION_TIMEOUT_MS).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GENERATION_TIMEOUT_MS);
+  timer.unref?.();
   try {
-    const buf = await generate(model, prompt);
+    const buf = await generate(model, prompt, controller.signal);
 
     const home = `${await resolveMindDir(record.mind)}/home`;
     const target = safeResolveWithinBase(home, `images/${filename}.png`);
@@ -113,18 +169,21 @@ async function runJob(
     // Only wake the mind if the job outlived the foreground wait (dropped to
     // background). A job that finished within the wait already returned `saved:`
     // to the caller, so a completion event here would be a confusing duplicate.
-    if (record.notifyOnDone) {
-      await deliver(record.mind, {
-        type: "imagegen",
-        body: `image ready: ${target}`,
-        delivery: "immediate",
-        whileSleeping: "queue",
-      });
-    }
+    if (record.notifyOnDone) await notify(deliver, record.mind, `image ready: ${target}`);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = controller.signal.aborted
+      ? `image generation timed out after ${Math.round(GENERATION_TIMEOUT_MS / 1000)}s`
+      : err instanceof Error
+        ? err.message
+        : String(err);
     jobLog.error(`job ${record.id} failed`, log.errorData(err));
     settle(record, { status: "error", error: message });
+    // If the mind was told this dropped to the background, it's waiting for a
+    // completion event — tell it the job failed so it doesn't wait forever.
+    if (record.notifyOnDone)
+      await notify(deliver, record.mind, `image generation failed: ${message}`);
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/daemon/src/lib/services/imagegen-xai.ts
+++ b/packages/daemon/src/lib/services/imagegen-xai.ts
@@ -23,7 +23,12 @@ export class XaiNotEntitledError extends Error {
   }
 }
 
-/** Metered API key fallback (never OAuth): imagegen config → ai config → env. */
+/**
+ * Metered API key fallback (never OAuth): imagegen config → ai config → env.
+ * Mirrors the api_key branches of `resolveCredential` in imagegen.ts (steps
+ * 1/3/4) — keep the two orderings in sync. Kept separate because this is the
+ * post-403 retry path, which must skip the OAuth token that just failed.
+ */
 export function xaiApiKeyFallback(): string | undefined {
   const config = readGlobalConfig();
   return (
@@ -39,11 +44,13 @@ async function requestXaiImage(
   model: string,
   prompt: string,
   token: string,
+  signal?: AbortSignal,
 ): Promise<{ ok: true; buffer: Buffer } | { ok: false; status: number; body: string }> {
   const res = await fetch(XAI_IMAGES_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
     body: JSON.stringify({ model, prompt, n: 1, response_format: "b64_json" }),
+    signal,
   });
   if (!res.ok) {
     return {
@@ -56,7 +63,7 @@ async function requestXaiImage(
   const item = data.data?.[0];
   if (item?.b64_json) return { ok: true, buffer: Buffer.from(item.b64_json, "base64") };
   if (item?.url) {
-    const imgRes = await fetch(item.url);
+    const imgRes = await fetch(item.url, { signal });
     if (!imgRes.ok) throw new Error(`Failed to fetch xAI image URL: ${imgRes.status}`);
     return { ok: true, buffer: Buffer.from(await imgRes.arrayBuffer()) };
   }
@@ -67,8 +74,9 @@ export async function xaiGenerate(
   model: string,
   prompt: string,
   cred: Credential,
+  signal?: AbortSignal,
 ): Promise<Buffer> {
-  const first = await requestXaiImage(model, prompt, cred.token);
+  const first = await requestXaiImage(model, prompt, cred.token, signal);
   if (first.ok) return first.buffer;
 
   // A 403 on an OAuth token = plan tier not allowlisted. Retry with a metered
@@ -79,7 +87,7 @@ export async function xaiGenerate(
       xaiLog.warn(
         "xAI OAuth token not entitled for image generation; retrying with XAI_API_KEY (billed to the API account).",
       );
-      const retry = await requestXaiImage(model, prompt, apiKey);
+      const retry = await requestXaiImage(model, prompt, apiKey, signal);
       if (retry.ok) return retry.buffer;
       if (retry.status === 403) throw new XaiNotEntitledError();
       throw new Error(`xAI image generation failed (${retry.status}): ${retry.body}`);

--- a/packages/daemon/src/lib/services/imagegen-xai.ts
+++ b/packages/daemon/src/lib/services/imagegen-xai.ts
@@ -1,0 +1,109 @@
+/**
+ * xAI (Grok Imagine) image provider. One endpoint serves both credential kinds:
+ * a SuperGrok/X Premium OAuth token OR a metered XAI_API_KEY hit the same
+ * /v1/images/generations. OAuth is preferred (subscription), but xAI allowlists
+ * that surface by plan tier — a 403 on an OAuth token means "this plan tier
+ * isn't entitled". When that happens we transparently retry with an API key if
+ * one is configured (a payment-method swap, not a model swap); otherwise we
+ * surface a not-entitled error the caller can explain.
+ */
+
+import { readGlobalConfig } from "../config/setup.js";
+import log from "../util/logger.js";
+import type { Credential, ModelSearchResult } from "./imagegen.js";
+
+const xaiLog = log.child("imagegen-xai");
+const XAI_IMAGES_URL = "https://api.x.ai/v1/images/generations";
+
+/** Raised when an xAI plan tier isn't allowlisted for image generation. */
+export class XaiNotEntitledError extends Error {
+  constructor() {
+    super("xAI plan tier is not entitled to image generation");
+    this.name = "XaiNotEntitledError";
+  }
+}
+
+/** Metered API key fallback (never OAuth): imagegen config → ai config → env. */
+export function xaiApiKeyFallback(): string | undefined {
+  const config = readGlobalConfig();
+  return (
+    config.imagegen?.providers?.xai?.apiKey ??
+    config.ai?.providers?.xai?.apiKey ??
+    process.env.XAI_API_KEY ??
+    undefined
+  );
+}
+
+/** One generation request against api.x.ai with a given bearer token. */
+async function requestXaiImage(
+  model: string,
+  prompt: string,
+  token: string,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; status: number; body: string }> {
+  const res = await fetch(XAI_IMAGES_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ model, prompt, n: 1, response_format: "b64_json" }),
+  });
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: res.status,
+      body: (await res.text().catch(() => "")).slice(0, 200),
+    };
+  }
+  const data = (await res.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
+  const item = data.data?.[0];
+  if (item?.b64_json) return { ok: true, buffer: Buffer.from(item.b64_json, "base64") };
+  if (item?.url) {
+    const imgRes = await fetch(item.url);
+    if (!imgRes.ok) throw new Error(`Failed to fetch xAI image URL: ${imgRes.status}`);
+    return { ok: true, buffer: Buffer.from(await imgRes.arrayBuffer()) };
+  }
+  throw new Error("xAI returned no image");
+}
+
+export async function xaiGenerate(
+  model: string,
+  prompt: string,
+  cred: Credential,
+): Promise<Buffer> {
+  const first = await requestXaiImage(model, prompt, cred.token);
+  if (first.ok) return first.buffer;
+
+  // A 403 on an OAuth token = plan tier not allowlisted. Retry with a metered
+  // key if configured; otherwise report not-entitled.
+  if (first.status === 403 && cred.kind === "oauth") {
+    const apiKey = xaiApiKeyFallback();
+    if (apiKey) {
+      xaiLog.warn(
+        "xAI OAuth token not entitled for image generation; retrying with XAI_API_KEY (billed to the API account).",
+      );
+      const retry = await requestXaiImage(model, prompt, apiKey);
+      if (retry.ok) return retry.buffer;
+      if (retry.status === 403) throw new XaiNotEntitledError();
+      throw new Error(`xAI image generation failed (${retry.status}): ${retry.body}`);
+    }
+    throw new XaiNotEntitledError();
+  }
+
+  throw new Error(`xAI image generation failed (${first.status}): ${first.body}`);
+}
+
+// xAI exposes fixed image models; return them statically for the model UI.
+export async function xaiSearch(_query: string, _cred: Credential): Promise<ModelSearchResult[]> {
+  return [
+    {
+      id: "xai:grok-imagine-image",
+      name: "Grok Imagine",
+      description: "xAI Grok Imagine image model ($0.02/image via API key).",
+      owner: "xai",
+    },
+    {
+      id: "xai:grok-imagine-image-quality",
+      name: "Grok Imagine (quality)",
+      description: "Higher-quality Grok Imagine image model ($0.05/image via API key).",
+      owner: "xai",
+    },
+  ];
+}

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -9,6 +9,7 @@ import Replicate from "replicate";
 import { resolveOAuthCredentials } from "../ai-service.js";
 import { type ImagegenConfig, readGlobalConfig, writeGlobalConfig } from "../config/setup.js";
 import { codexGenerate, codexSearch } from "./imagegen-codex.js";
+import { xaiGenerate, xaiSearch } from "./imagegen-xai.js";
 
 // --- Provider registry ---
 
@@ -49,6 +50,14 @@ const PROVIDERS: Record<string, ImagegenProviderDef> = {
     aiProviderId: "openai-codex",
     generate: codexGenerate,
     search: codexSearch,
+  },
+  xai: {
+    // Both credential kinds hit the same endpoint: subscription OAuth (preferred)
+    // or a metered XAI_API_KEY. OAuth 403s fall back to the key (see imagegen-xai).
+    envVar: "XAI_API_KEY",
+    aiProviderId: "xai",
+    generate: xaiGenerate,
+    search: xaiSearch,
   },
 };
 

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -7,9 +7,19 @@
 
 import Replicate from "replicate";
 import { resolveOAuthCredentials } from "../ai-service.js";
-import { type ImagegenConfig, readGlobalConfig, writeGlobalConfig } from "../config/setup.js";
-import { codexGenerate, codexSearch } from "./imagegen-codex.js";
-import { xaiGenerate, xaiSearch } from "./imagegen-xai.js";
+import {
+  type ImagegenConfig,
+  type ImagegenEntitlement,
+  readGlobalConfig,
+  writeGlobalConfig,
+} from "../config/setup.js";
+import {
+  CodexNotEntitledError,
+  codexGenerate,
+  codexSearch,
+  probeCodexEntitlement,
+} from "./imagegen-codex.js";
+import { XaiNotEntitledError, xaiGenerate, xaiSearch } from "./imagegen-xai.js";
 
 // --- Provider registry ---
 
@@ -219,6 +229,7 @@ export type ConfiguredProvider = {
   id: string;
   configured: boolean;
   authMethod: "api_key" | "oauth" | "env_var" | null;
+  entitlement?: ImagegenEntitlement;
 };
 
 /**
@@ -236,13 +247,16 @@ export function getConfiguredProviders(): ConfiguredProvider[] {
   return Object.entries(PROVIDERS).map(([id, { envVar, aiProviderId }]) => {
     const aiId = aiProviderId ?? id;
     const providerConfig = ig?.providers?.[id];
-    if (providerConfig?.apiKey) return { id, configured: true, authMethod: "api_key" as const };
-    if (aiProviders?.[aiId]?.oauth) return { id, configured: true, authMethod: "oauth" as const };
-    if (aiProviders?.[aiId]?.apiKey)
-      return { id, configured: true, authMethod: "api_key" as const };
-    if (envVar && process.env[envVar])
-      return { id, configured: true, authMethod: "env_var" as const };
-    return { id, configured: false, authMethod: null };
+    const entitlement = ig?.entitlements?.[id];
+
+    let base: Pick<ConfiguredProvider, "configured" | "authMethod">;
+    if (providerConfig?.apiKey) base = { configured: true, authMethod: "api_key" };
+    else if (aiProviders?.[aiId]?.oauth) base = { configured: true, authMethod: "oauth" };
+    else if (aiProviders?.[aiId]?.apiKey) base = { configured: true, authMethod: "api_key" };
+    else if (envVar && process.env[envVar]) base = { configured: true, authMethod: "env_var" };
+    else base = { configured: false, authMethod: null };
+
+    return { id, ...base, entitlement };
   });
 }
 
@@ -342,11 +356,97 @@ export async function searchModels(
   return (await Promise.all(searches)).flat();
 }
 
+// --- Entitlement ---
+//
+// A credential can be valid yet not allowed to generate images (a ChatGPT plan
+// without the hosted image tool; an xAI tier that isn't allowlisted). That is
+// NOT a misconfiguration, so it's tracked separately and reported with an
+// actionable message rather than "not configured".
+
+/** Actionable message shown when a provider's plan isn't entitled. */
+const NOT_ENTITLED_MESSAGE: Record<string, string> = {
+  "openai-codex":
+    "Your ChatGPT plan doesn't include Codex's hosted image tool. Ask an admin to configure an OpenAI API key or another image provider.",
+  xai: "Your xAI plan tier isn't allowlisted for image generation (SuperGrok Heavy required). Ask an admin to set XAI_API_KEY to use Grok Imagine at $0.02/image.",
+};
+
+/** Providers whose credentials can be valid-but-not-entitled. */
+const ENTITLEMENT_PROVIDERS = new Set(["openai-codex", "xai"]);
+
+export function getEntitlement(providerId: string): ImagegenEntitlement | undefined {
+  return getImagegenConfig()?.entitlements?.[providerId];
+}
+
+export function getEntitlements(): Record<string, ImagegenEntitlement> {
+  return getImagegenConfig()?.entitlements ?? {};
+}
+
+function setEntitlement(
+  providerId: string,
+  state: ImagegenEntitlement["state"],
+  reason?: string,
+): ImagegenEntitlement {
+  const entitlement: ImagegenEntitlement = { state, reason, checkedAt: Date.now() };
+  updateImagegenConfig((ig) => {
+    ig.entitlements = ig.entitlements ?? {};
+    ig.entitlements[providerId] = entitlement;
+  });
+  return entitlement;
+}
+
+/**
+ * Proactively check whether a provider's plan is entitled, and cache the result.
+ * Codex probes nearly free (aborts once the tool is accepted); xAI costs one
+ * image on success but a 403 fails free. Non-entitlement providers are trivially
+ * entitled.
+ */
+export async function probeEntitlement(providerId: string): Promise<ImagegenEntitlement> {
+  if (!ENTITLEMENT_PROVIDERS.has(providerId)) {
+    return setEntitlement(providerId, "entitled");
+  }
+  const cred = await resolveCredential(providerId);
+  if (!cred) throw new Error(`No ${providerId} credentials configured`);
+
+  if (providerId === "openai-codex") {
+    const state = await probeCodexEntitlement(cred);
+    return setEntitlement(
+      providerId,
+      state,
+      state === "not_entitled" ? NOT_ENTITLED_MESSAGE[providerId] : undefined,
+    );
+  }
+  // xai: attempt a small generation; a 403 (not entitled) is caught below.
+  try {
+    await xaiGenerate("grok-imagine-image", "entitlement probe", cred);
+    return setEntitlement(providerId, "entitled");
+  } catch (err) {
+    if (err instanceof XaiNotEntitledError) {
+      return setEntitlement(providerId, "not_entitled", NOT_ENTITLED_MESSAGE[providerId]);
+    }
+    throw err;
+  }
+}
+
 // --- Generation ---
 
 export async function generateImage(model: string, prompt: string): Promise<Buffer> {
   const { provider: providerId, model: modelId } = parseModelId(model);
   const cred = await resolveCredential(providerId);
   if (!cred) throw new Error(`No ${providerId} credentials configured`);
-  return PROVIDERS[providerId].generate(modelId, prompt, cred);
+
+  try {
+    const buf = await PROVIDERS[providerId].generate(modelId, prompt, cred);
+    // A success confirms entitlement — refresh the cache (plans change).
+    if (ENTITLEMENT_PROVIDERS.has(providerId)) setEntitlement(providerId, "entitled");
+    return buf;
+  } catch (err) {
+    // Not-entitled is a plan limitation, not a config error: cache it and
+    // hard-fail with an actionable message (never silently swap providers).
+    if (err instanceof CodexNotEntitledError || err instanceof XaiNotEntitledError) {
+      const message = NOT_ENTITLED_MESSAGE[providerId] ?? err.message;
+      setEntitlement(providerId, "not_entitled", message);
+      throw new Error(message);
+    }
+    throw err;
+  }
 }

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -6,7 +6,9 @@
  */
 
 import Replicate from "replicate";
+import { resolveOAuthCredentials } from "../ai-service.js";
 import { type ImagegenConfig, readGlobalConfig, writeGlobalConfig } from "../config/setup.js";
+import { codexGenerate, codexSearch } from "./imagegen-codex.js";
 
 // --- Provider registry ---
 
@@ -39,6 +41,14 @@ const PROVIDERS: Record<string, ImagegenProviderDef> = {
     envVar: "OPENROUTER_API_KEY",
     generate: openrouterGenerate,
     search: openrouterSearch,
+  },
+  "openai-codex": {
+    // Subscription-only: no env var API key path. Credentials come from the
+    // openai-codex AI provider's OAuth (chat/image unification).
+    envVar: "",
+    aiProviderId: "openai-codex",
+    generate: codexGenerate,
+    search: codexSearch,
   },
 };
 
@@ -199,19 +209,30 @@ export function removeProviderConfig(id: string): void {
 export type ConfiguredProvider = {
   id: string;
   configured: boolean;
-  authMethod: "api_key" | "env_var" | null;
+  authMethod: "api_key" | "oauth" | "env_var" | null;
 };
 
+/**
+ * Report which providers are configured. Tests config *presence* only — it must
+ * NOT resolve/refresh OAuth (that would trigger token refreshes + mind restarts
+ * on every Settings load). Liveness is carried by the entitlement badge.
+ *
+ * A provider is configured if it has an imagegen key, or its linked AI provider
+ * (chat/image unification) carries OAuth or an API key, or its env var is set.
+ */
 export function getConfiguredProviders(): ConfiguredProvider[] {
   const config = readGlobalConfig();
   const ig = config.imagegen ?? null;
   const aiProviders = config.ai?.providers;
-  return Object.entries(PROVIDERS).map(([id, { envVar }]) => {
+  return Object.entries(PROVIDERS).map(([id, { envVar, aiProviderId }]) => {
+    const aiId = aiProviderId ?? id;
     const providerConfig = ig?.providers?.[id];
     if (providerConfig?.apiKey) return { id, configured: true, authMethod: "api_key" as const };
-    // Check AI provider config fallback
-    if (aiProviders?.[id]?.apiKey) return { id, configured: true, authMethod: "api_key" as const };
-    if (process.env[envVar]) return { id, configured: true, authMethod: "env_var" as const };
+    if (aiProviders?.[aiId]?.oauth) return { id, configured: true, authMethod: "oauth" as const };
+    if (aiProviders?.[aiId]?.apiKey)
+      return { id, configured: true, authMethod: "api_key" as const };
+    if (envVar && process.env[envVar])
+      return { id, configured: true, authMethod: "env_var" as const };
     return { id, configured: false, authMethod: null };
   });
 }
@@ -234,8 +255,12 @@ export async function resolveCredential(providerId: string): Promise<Credential 
   const configKey = config.imagegen?.providers?.[providerId]?.apiKey;
   if (configKey) return { kind: "api_key", token: configKey };
 
-  // 3. AI provider config key (e.g. OpenRouter configured for chat)
-  //    (OAuth — step 2 — is added when subscription providers land.)
+  // 2. Linked AI provider's OAuth (subscription — preferred over ambient keys).
+  //    resolveOAuthCredentials refreshes + persists + fans rotated tokens out.
+  const oauth = await resolveOAuthCredentials(aiProviderId);
+  if (oauth) return { kind: "oauth", token: oauth.access };
+
+  // 3. Linked AI provider's API key (e.g. OpenRouter configured for chat)
   const aiKey = config.ai?.providers?.[aiProviderId]?.apiKey;
   if (aiKey) return { kind: "api_key", token: aiKey };
 

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -31,14 +31,20 @@ import { XaiNotEntitledError, xaiGenerate, xaiSearch } from "./imagegen-xai.js";
 export type Credential = { kind: "oauth" | "api_key"; token: string };
 
 type ImagegenProviderDef = {
-  envVar: string;
+  /** Env var holding a metered API key, or omitted for subscription-only providers. */
+  envVar?: string;
   /**
    * AI-provider config id to borrow credentials from (chat/image unification).
    * Defaults to the imagegen provider id itself, preserving the historical
    * behavior where imagegen reused `ai.providers[<same-id>]`.
    */
   aiProviderId?: string;
-  generate: (model: string, prompt: string, cred: Credential) => Promise<Buffer>;
+  generate: (
+    model: string,
+    prompt: string,
+    cred: Credential,
+    signal?: AbortSignal,
+  ) => Promise<Buffer>;
   search: (query: string, cred: Credential) => Promise<ModelSearchResult[]>;
 };
 
@@ -56,7 +62,6 @@ const PROVIDERS: Record<string, ImagegenProviderDef> = {
   "openai-codex": {
     // Subscription-only: no env var API key path. Credentials come from the
     // openai-codex AI provider's OAuth (chat/image unification).
-    envVar: "",
     aiProviderId: "openai-codex",
     generate: codexGenerate,
     search: codexSearch,
@@ -73,10 +78,16 @@ const PROVIDERS: Record<string, ImagegenProviderDef> = {
 
 // --- Replicate provider ---
 
-async function replicateGenerate(model: string, prompt: string, cred: Credential): Promise<Buffer> {
+async function replicateGenerate(
+  model: string,
+  prompt: string,
+  cred: Credential,
+  signal?: AbortSignal,
+): Promise<Buffer> {
   const replicate = new Replicate({ auth: cred.token });
   const output = await replicate.run(model as `${string}/${string}`, {
     input: { prompt },
+    signal,
   });
 
   const file = Array.isArray(output) ? output[0] : output;
@@ -84,7 +95,7 @@ async function replicateGenerate(model: string, prompt: string, cred: Credential
 
   // Some models return a URL string instead of FileOutput
   if (typeof file === "string") {
-    const res = await fetch(file);
+    const res = await fetch(file, { signal });
     if (!res.ok) throw new Error(`Failed to fetch image from URL: ${res.status}`);
     return Buffer.from(await res.arrayBuffer());
   }
@@ -114,6 +125,7 @@ async function openrouterGenerate(
   model: string,
   prompt: string,
   cred: Credential,
+  signal?: AbortSignal,
 ): Promise<Buffer> {
   const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
     method: "POST",
@@ -126,6 +138,7 @@ async function openrouterGenerate(
       messages: [{ role: "user", content: prompt }],
       modalities: ["image", "text"],
     }),
+    signal,
   });
 
   if (!res.ok) {
@@ -149,7 +162,7 @@ async function openrouterGenerate(
   }
 
   // Regular URL — fetch it
-  const imgRes = await fetch(imageUrl);
+  const imgRes = await fetch(imageUrl, { signal });
   if (!imgRes.ok) throw new Error(`Failed to fetch image from URL: ${imgRes.status}`);
   return Buffer.from(await imgRes.arrayBuffer());
 }
@@ -288,7 +301,7 @@ export async function resolveCredential(providerId: string): Promise<Credential 
   if (aiKey) return { kind: "api_key", token: aiKey };
 
   // 4. Env var fallback
-  const envKey = process.env[provider.envVar];
+  const envKey = provider.envVar ? process.env[provider.envVar] : undefined;
   if (envKey) return { kind: "api_key", token: envKey };
 
   return undefined;
@@ -386,7 +399,10 @@ function setEntitlement(
   state: ImagegenEntitlement["state"],
   reason?: string,
 ): ImagegenEntitlement {
-  const entitlement: ImagegenEntitlement = { state, reason, checkedAt: Date.now() };
+  const entitlement: ImagegenEntitlement =
+    state === "not_entitled"
+      ? { state, reason: reason ?? "not entitled", checkedAt: Date.now() }
+      : { state, checkedAt: Date.now() };
   updateImagegenConfig((ig) => {
     ig.entitlements = ig.entitlements ?? {};
     ig.entitlements[providerId] = entitlement;
@@ -429,13 +445,17 @@ export async function probeEntitlement(providerId: string): Promise<ImagegenEnti
 
 // --- Generation ---
 
-export async function generateImage(model: string, prompt: string): Promise<Buffer> {
+export async function generateImage(
+  model: string,
+  prompt: string,
+  signal?: AbortSignal,
+): Promise<Buffer> {
   const { provider: providerId, model: modelId } = parseModelId(model);
   const cred = await resolveCredential(providerId);
   if (!cred) throw new Error(`No ${providerId} credentials configured`);
 
   try {
-    const buf = await PROVIDERS[providerId].generate(modelId, prompt, cred);
+    const buf = await PROVIDERS[providerId].generate(modelId, prompt, cred, signal);
     // A success confirms entitlement — refresh the cache (plans change).
     if (ENTITLEMENT_PROVIDERS.has(providerId)) setEntitlement(providerId, "entitled");
     return buf;

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -10,10 +10,23 @@ import { type ImagegenConfig, readGlobalConfig, writeGlobalConfig } from "../con
 
 // --- Provider registry ---
 
+/**
+ * A resolved credential for a provider. Image providers accept either a
+ * subscription OAuth access token or a metered API key; the `kind` lets a
+ * provider that supports both (e.g. xai) branch on which it received.
+ */
+export type Credential = { kind: "oauth" | "api_key"; token: string };
+
 type ImagegenProviderDef = {
   envVar: string;
-  generate: (model: string, prompt: string, apiKey: string) => Promise<Buffer>;
-  search: (query: string, apiKey: string) => Promise<ModelSearchResult[]>;
+  /**
+   * AI-provider config id to borrow credentials from (chat/image unification).
+   * Defaults to the imagegen provider id itself, preserving the historical
+   * behavior where imagegen reused `ai.providers[<same-id>]`.
+   */
+  aiProviderId?: string;
+  generate: (model: string, prompt: string, cred: Credential) => Promise<Buffer>;
+  search: (query: string, cred: Credential) => Promise<ModelSearchResult[]>;
 };
 
 const PROVIDERS: Record<string, ImagegenProviderDef> = {
@@ -31,8 +44,8 @@ const PROVIDERS: Record<string, ImagegenProviderDef> = {
 
 // --- Replicate provider ---
 
-async function replicateGenerate(model: string, prompt: string, apiKey: string): Promise<Buffer> {
-  const replicate = new Replicate({ auth: apiKey });
+async function replicateGenerate(model: string, prompt: string, cred: Credential): Promise<Buffer> {
+  const replicate = new Replicate({ auth: cred.token });
   const output = await replicate.run(model as `${string}/${string}`, {
     input: { prompt },
   });
@@ -55,8 +68,8 @@ async function replicateGenerate(model: string, prompt: string, apiKey: string):
   return Buffer.concat(chunks);
 }
 
-async function replicateSearch(query: string, apiKey: string): Promise<ModelSearchResult[]> {
-  const replicate = new Replicate({ auth: apiKey });
+async function replicateSearch(query: string, cred: Credential): Promise<ModelSearchResult[]> {
+  const replicate = new Replicate({ auth: cred.token });
   const response = await replicate.models.search(query || "text to image");
   return response.results.slice(0, 20).map((m) => ({
     id: `replicate:${m.owner}/${m.name}`,
@@ -68,12 +81,16 @@ async function replicateSearch(query: string, apiKey: string): Promise<ModelSear
 
 // --- OpenRouter provider ---
 
-async function openrouterGenerate(model: string, prompt: string, apiKey: string): Promise<Buffer> {
+async function openrouterGenerate(
+  model: string,
+  prompt: string,
+  cred: Credential,
+): Promise<Buffer> {
   const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${cred.token}`,
     },
     body: JSON.stringify({
       model,
@@ -108,7 +125,7 @@ async function openrouterGenerate(model: string, prompt: string, apiKey: string)
   return Buffer.from(await imgRes.arrayBuffer());
 }
 
-async function openrouterSearch(query: string, _apiKey: string): Promise<ModelSearchResult[]> {
+async function openrouterSearch(query: string, _cred: Credential): Promise<ModelSearchResult[]> {
   const res = await fetch("https://openrouter.ai/api/v1/models?output_modalities=image");
   if (!res.ok) throw new Error(`OpenRouter model list failed: ${res.status}`);
 
@@ -199,18 +216,34 @@ export function getConfiguredProviders(): ConfiguredProvider[] {
   });
 }
 
-export function resolveApiKey(providerId: string): string | undefined {
+/**
+ * Resolve a usable credential for a provider, in precedence order:
+ *   1. imagegen-specific config key (explicit admin override)
+ *   2. linked AI provider's OAuth (subscription — preferred over ambient keys)
+ *   3. linked AI provider's API key (e.g. OpenRouter configured for chat)
+ *   4. env var fallback
+ * Async because the OAuth branch refreshes + persists rotated tokens.
+ */
+export async function resolveCredential(providerId: string): Promise<Credential | undefined> {
   const provider = PROVIDERS[providerId];
   if (!provider) return undefined;
+  const aiProviderId = provider.aiProviderId ?? providerId;
   const config = readGlobalConfig();
+
   // 1. Imagegen-specific config key
   const configKey = config.imagegen?.providers?.[providerId]?.apiKey;
-  if (configKey) return configKey;
-  // 2. AI provider config key (e.g., OpenRouter configured for chat)
-  const aiKey = config.ai?.providers?.[providerId]?.apiKey;
-  if (aiKey) return aiKey;
-  // 3. Env var fallback
-  return process.env[provider.envVar] || undefined;
+  if (configKey) return { kind: "api_key", token: configKey };
+
+  // 3. AI provider config key (e.g. OpenRouter configured for chat)
+  //    (OAuth — step 2 — is added when subscription providers land.)
+  const aiKey = config.ai?.providers?.[aiProviderId]?.apiKey;
+  if (aiKey) return { kind: "api_key", token: aiKey };
+
+  // 4. Env var fallback
+  const envKey = process.env[provider.envVar];
+  if (envKey) return { kind: "api_key", token: envKey };
+
+  return undefined;
 }
 
 // --- Model discovery ---
@@ -257,17 +290,17 @@ export async function searchModels(
   if (provider) {
     const providerDef = PROVIDERS[provider];
     if (!providerDef) throw new Error(`Unknown imagegen provider: ${provider}`);
-    const apiKey = resolveApiKey(provider);
-    if (!apiKey) throw new Error(`No ${provider} API key configured`);
-    return providerDef.search(query || "text to image", apiKey);
+    const cred = await resolveCredential(provider);
+    if (!cred) throw new Error(`No ${provider} credentials configured`);
+    return providerDef.search(query || "text to image", cred);
   }
 
   // Search all configured providers in parallel
   const searches: Promise<ModelSearchResult[]>[] = [];
   for (const [id, def] of Object.entries(PROVIDERS)) {
-    const apiKey = resolveApiKey(id);
-    if (!apiKey) continue;
-    searches.push(def.search(query || "text to image", apiKey).catch(() => []));
+    const cred = await resolveCredential(id);
+    if (!cred) continue;
+    searches.push(def.search(query || "text to image", cred).catch(() => []));
   }
   if (searches.length === 0) {
     throw new Error("No imagegen providers configured");
@@ -279,7 +312,7 @@ export async function searchModels(
 
 export async function generateImage(model: string, prompt: string): Promise<Buffer> {
   const { provider: providerId, model: modelId } = parseModelId(model);
-  const apiKey = resolveApiKey(providerId);
-  if (!apiKey) throw new Error(`No ${providerId} API key configured`);
-  return PROVIDERS[providerId].generate(modelId, prompt, apiKey);
+  const cred = await resolveCredential(providerId);
+  if (!cred) throw new Error(`No ${providerId} credentials configured`);
+  return PROVIDERS[providerId].generate(modelId, prompt, cred);
 }

--- a/packages/daemon/src/lib/skills.ts
+++ b/packages/daemon/src/lib/skills.ts
@@ -927,11 +927,14 @@ export async function syncBuiltinSkills(): Promise<void> {
     try {
       const sourceHash = hashSkillDir(sourceDir);
 
-      // Check if shared pool already has this version
+      // Skip only when the shared pool already has this version on disk AND the
+      // DB row exists — the DB is what listSharedSkills() (and the UI) reads. If
+      // they ever diverge (e.g. the DB is reset but the on-disk pool survives),
+      // re-import so the row is repopulated rather than silently missing.
       const destDir = join(sharedSkillsDir(), entry.name);
       if (existsSync(destDir)) {
         const destHash = hashSkillDir(destDir);
-        if (sourceHash === destHash) continue;
+        if (sourceHash === destHash && (await getSharedSkill(entry.name))) continue;
       }
 
       await importSkillFromDir(sourceDir, "volute");

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -104,6 +104,11 @@ import {
 } from "../../lib/prompts.js";
 import { mindHistory, summaries, turns } from "../../lib/schema.js";
 import {
+  createImagegenJob,
+  getImagegenJob,
+  waitForImagegenJob,
+} from "../../lib/services/imagegen-jobs.js";
+import {
   getStandardSkillsWithExtensions,
   installSkill,
   migrateSkillsToTemplate,
@@ -1809,6 +1814,44 @@ const app = new Hono<AuthEnv>()
     broadcast({ type: "profile_updated", mind: name, summary: `${name} profile updated` });
 
     return c.json({ ok: true });
+  })
+  // Start a background image-generation job. Returns a job id immediately; the
+  // daemon generates, writes home/images/<filename>.png, and wakes the mind on
+  // completion. requireSelf: a mind may only run jobs for itself.
+  .post(
+    "/:name/imagegen/jobs",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({
+        model: z.string().min(1),
+        prompt: z.string().min(1),
+        filename: z.string().min(1),
+      }),
+    ),
+    async (c) => {
+      const name = c.req.param("name");
+      const { model, prompt, filename } = c.req.valid("json");
+      try {
+        const jobId = createImagegenJob(name, model, prompt, filename);
+        return c.json({ jobId }, 202);
+      } catch (err) {
+        return c.json({ error: err instanceof Error ? err.message : "Failed to start job" }, 429);
+      }
+    },
+  )
+  // Poll a job. `?wait=<sec>` long-polls: the daemon returns as soon as the job
+  // finishes, or after the timeout (still "running"). 404 = unknown/lost job
+  // (e.g. after a daemon restart) — the skill tells the mind to re-run.
+  .get("/:name/imagegen/jobs/:jobId", requireSelf(), async (c) => {
+    const name = c.req.param("name");
+    const jobId = c.req.param("jobId");
+    const waitParam = Number(c.req.query("wait"));
+    const waitMs = Number.isFinite(waitParam) ? Math.min(Math.max(waitParam, 0), 60) * 1000 : 0;
+    const job =
+      waitMs > 0 ? await waitForImagegenJob(name, jobId, waitMs) : getImagegenJob(name, jobId);
+    if (!job) return c.json({ error: "Job not found" }, 404);
+    return c.json(job);
   })
   // Seed readiness check — used by spirit nurture schedule
   .get("/:name/seed-check", requireSelf(), async (c) => {

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -43,6 +43,7 @@ import {
   getDefaultModel as getImagegenDefaultModel,
   getEnabledModels as getImagegenModels,
   getConfiguredProviders as getImagegenProviders,
+  probeEntitlement as probeImagegenEntitlement,
   removeProviderConfig as removeImagegenProvider,
   saveProviderConfig as saveImagegenProvider,
   searchModels,
@@ -292,6 +293,17 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: err instanceof Error ? err.message : "Failed to remove" }, 400);
     }
     return c.json({ ok: true });
+  })
+  // Probe whether a provider's plan is entitled to generate images, caching the
+  // verdict so Settings can badge it before any mind tries. Admin-only (it can
+  // spend a small amount against the account — e.g. one xAI image on success).
+  .post("/imagegen/providers/:id/probe", requireAdmin, async (c) => {
+    try {
+      const entitlement = await probeImagegenEntitlement(c.req.param("id"));
+      return c.json(entitlement);
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : "Probe failed" }, 400);
+    }
   })
   .get("/imagegen/models", requireAdmin, (c) => {
     const models = getImagegenModels();

--- a/packages/daemon/src/web/api/system.ts
+++ b/packages/daemon/src/web/api/system.ts
@@ -298,6 +298,12 @@ const app = new Hono<AuthEnv>()
     const defaultModel = getImagegenDefaultModel();
     return c.json({ models, defaultModel: defaultModel ?? null });
   })
+  // Mind-callable: minds need the configured default model to generate. The
+  // full /imagegen/models route is requireAdmin, so minds read the default
+  // here (authMiddleware only) instead of silently falling back to a hardcode.
+  .get("/imagegen/default-model", (c) => {
+    return c.json({ defaultModel: getImagegenDefaultModel() ?? null });
+  })
   .put(
     "/imagegen/models",
     requireAdmin,

--- a/packages/web/src/ui/components/system/ImagegenProviders.svelte
+++ b/packages/web/src/ui/components/system/ImagegenProviders.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 import { Modal } from "@volute/ui";
+import { SvelteSet } from "svelte/reactivity";
 import {
   fetchImagegenModels,
   fetchImagegenProviders,
+  type ImagegenEntitlement,
   type ImagegenModelSearchResult,
   type ImagegenProvider,
+  probeImagegenEntitlement,
   removeImagegenProviderConfig,
   saveEnabledImagegenModels,
   saveImagegenProviderConfig,
@@ -40,8 +43,28 @@ function modelsForProvider(providerId: string) {
 
 function authMethodLabel(method: string | null): string {
   if (method === "api_key") return "API key";
+  if (method === "oauth") return "OAuth";
   if (method === "env_var") return "env var";
   return "";
+}
+
+let probing = new SvelteSet<string>();
+
+async function handleProbe(id: string) {
+  probing.add(id);
+  error = "";
+  try {
+    // Result is persisted server-side; reload picks up the updated entitlement.
+    const result: ImagegenEntitlement = await probeImagegenEntitlement(id);
+    if (result.state === "not_entitled" && !result.reason) {
+      error = "Provider plan is not entitled to generate images.";
+    }
+    await load();
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to check entitlement";
+  } finally {
+    probing.delete(id);
+  }
 }
 
 export async function load() {
@@ -191,8 +214,19 @@ $effect(() => {
       <div class="provider-header">
         <span class="provider-name">{provider.id}</span>
         <span class="auth-badge">{authMethodLabel(provider.authMethod)}</span>
+        {#if provider.entitlement?.state === "entitled"}
+          <span class="entitlement-badge entitled">Ready</span>
+        {:else if provider.entitlement?.state === "not_entitled"}
+          <span class="entitlement-badge not-entitled">Plan not entitled</span>
+        {/if}
+        <button class="check-btn" onclick={() => handleProbe(provider.id)} disabled={saving || probing.has(provider.id)}>
+          {probing.has(provider.id) ? "..." : "Check"}
+        </button>
         <button class="remove-btn" onclick={() => handleProviderRemove(provider.id)} disabled={saving}>Remove</button>
       </div>
+      {#if provider.entitlement?.state === "not_entitled" && provider.entitlement.reason}
+        <div class="entitlement-reason">{provider.entitlement.reason}</div>
+      {/if}
       <div class="provider-models">
         {#if providerModels.length > 0}
           <div class="model-tags">
@@ -359,6 +393,45 @@ $effect(() => {
     background: var(--bg-3);
     color: var(--text-2);
   }
+
+  .entitlement-badge {
+    font-size: 11px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+  }
+
+  .entitlement-badge.entitled {
+    color: var(--green);
+    background: rgba(74, 222, 128, 0.1);
+    border-color: rgba(74, 222, 128, 0.25);
+  }
+
+  .entitlement-badge.not-entitled {
+    color: var(--red);
+    background: var(--red-bg);
+    border-color: var(--red-border);
+  }
+
+  .entitlement-reason {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--red);
+  }
+
+  .check-btn {
+    font-family: inherit;
+    font-size: 11px;
+    padding: 2px 8px;
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text-2);
+    cursor: pointer;
+  }
+
+  .check-btn:hover:not(:disabled) { color: var(--text-0); border-color: var(--border-bright); }
+  .check-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
   .remove-btn {
     font-family: inherit;

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -720,10 +720,17 @@ export function saveMindDefaults(defaults: MindDefaults): Promise<void> {
 
 // --- Imagegen ---
 
+export type ImagegenEntitlement = {
+  state: "entitled" | "not_entitled";
+  reason?: string;
+  checkedAt: number;
+};
+
 export type ImagegenProvider = {
   id: string;
   configured: boolean;
-  authMethod: "api_key" | "env_var" | null;
+  authMethod: "api_key" | "oauth" | "env_var" | null;
+  entitlement?: ImagegenEntitlement;
 };
 
 export type ImagegenModelSearchResult = {
@@ -743,6 +750,10 @@ export function saveImagegenProviderConfig(id: string, apiKey: string): Promise<
 
 export function removeImagegenProviderConfig(id: string): Promise<void> {
   return del(`${V1}/system/imagegen/providers/${enc(id)}`);
+}
+
+export function probeImagegenEntitlement(id: string): Promise<ImagegenEntitlement> {
+  return post(`${V1}/system/imagegen/providers/${enc(id)}/probe`, {});
 }
 
 export function fetchImagegenModels(): Promise<{ models: string[]; defaultModel: string | null }> {

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -720,11 +720,9 @@ export function saveMindDefaults(defaults: MindDefaults): Promise<void> {
 
 // --- Imagegen ---
 
-export type ImagegenEntitlement = {
-  state: "entitled" | "not_entitled";
-  reason?: string;
-  checkedAt: number;
-};
+export type ImagegenEntitlement =
+  | { state: "entitled"; checkedAt: number }
+  | { state: "not_entitled"; reason: string; checkedAt: number };
 
 export type ImagegenProvider = {
   id: string;

--- a/skills/imagegen/SKILL.md
+++ b/skills/imagegen/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: Image Generation
-description: Generate images via Replicate or OpenRouter. Use for "generate image", "create image", "image generation", "text to image", "search image models".
+description: Generate images via Replicate, OpenRouter, a ChatGPT subscription (openai-codex), or xAI Grok. Use for "generate image", "create image", "image generation", "text to image", "search image models".
 metadata:
   bin: scripts/imagegen.ts
 ---
 
 # Image Generation
 
-Generate images from text prompts using models on Replicate or OpenRouter. Images are saved to `home/images/`.
+Generate images from text prompts. Images are saved to `home/images/`.
 
-Model IDs are provider-prefixed: `replicate:owner/model` or `openrouter:owner/model`.
+Model IDs are provider-prefixed, e.g. `replicate:owner/model`, `openrouter:owner/model`, `openai-codex:gpt-image-2`, or `xai:grok-imagine-image`. Which providers are available depends on what your host has configured.
+
+## Generation is asynchronous
+
+`generate` waits up to ~30 seconds for the image. Fast models finish in that window and print `saved: <path>` right away. Slower models (e.g. `gpt-image-2`) keep going **in the background**: the command returns immediately with
+
+```
+still generating (job <id>) — I'll be notified when it's done. Check anytime: imagegen status <id>
+```
+
+You don't have to wait or poll — when a background image finishes, you're notified automatically with an `image ready: <path>` event. You can also run `imagegen status <id>` yourself to check.
 
 ## Commands
 
@@ -19,7 +29,8 @@ imagegen <command>
 
 | Command | Description |
 |---------|-------------|
-| `generate "prompt" [--model M] [--filename F]` | Generate an image from a text prompt. Default model: `replicate:prunaai/z-image-turbo`. |
+| `generate "prompt" [--model M] [--filename F]` | Generate an image. Returns `saved: <path>` if it finishes quickly, otherwise a job id to check later. Default model: `replicate:prunaai/z-image-turbo`. |
+| `status <jobId>` | Check a background generation job. Prints `saved: <path>`, `still generating`, or `failed: <reason>`. |
 | `models "query"` | Search configured providers for text-to-image models. |
 
 ## Examples
@@ -36,6 +47,12 @@ imagegen generate "a mountain landscape" --model openrouter:openai/gpt-image-1
 
 # Specify a filename
 imagegen generate "mountain landscape" --filename mountains
+
+# Generate with a ChatGPT subscription (if your host configured openai-codex)
+imagegen generate "a friendly robot mascot" --model openai-codex:gpt-image-2
+
+# Check a background job you started earlier
+imagegen status 6f1e2c34-...
 
 # Search for models
 imagegen models "text to image"

--- a/skills/imagegen/scripts/imagegen.ts
+++ b/skills/imagegen/scripts/imagegen.ts
@@ -198,7 +198,7 @@ async function fetchDefaultModel(): Promise<string | null> {
   if (!base || !token) return null;
 
   try {
-    const res = await fetch(`${base}/api/v1/system/imagegen/models`, {
+    const res = await fetch(`${base}/api/v1/system/imagegen/default-model`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!res.ok) return null;

--- a/skills/imagegen/scripts/imagegen.ts
+++ b/skills/imagegen/scripts/imagegen.ts
@@ -44,6 +44,10 @@ function getDaemonToken(): string | undefined {
   return process.env.VOLUTE_MIND_TOKEN;
 }
 
+function getMindName(): string | undefined {
+  return process.env.VOLUTE_MIND;
+}
+
 /**
  * Outcome of a daemon call, distinguishing the failure modes so the mind gets an
  * accurate diagnosis instead of a misleading "not configured" message:
@@ -92,23 +96,34 @@ export function handleDaemonFailure(failure: DaemonFailure): void {
   }
 }
 
-export async function generateViaDaemon(
+/** A job's observable state, as returned by the daemon's job-status route. */
+export type JobView = { status: "running" | "done" | "error"; path?: string; error?: string };
+
+/**
+ * Start a background image-generation job on the daemon. Returns the job id on
+ * success, or a DaemonFailure describing why (same taxonomy as the other daemon
+ * calls, so no-env/fallback degrade to direct generation and unreachable/auth
+ * surface an accurate diagnosis).
+ */
+export async function startImagegenJob(
   model: string,
   prompt: string,
-): Promise<DaemonResult<Buffer>> {
+  filename: string,
+): Promise<DaemonResult<string>> {
   const base = getDaemonUrl();
   const token = getDaemonToken();
-  if (!base || !token) return { ok: false, reason: "no-env" };
+  const mind = getMindName();
+  if (!base || !token || !mind) return { ok: false, reason: "no-env" };
 
   let res: Response;
   try {
-    res = await fetch(`${base}/api/v1/system/imagegen/generate`, {
+    res = await fetch(`${base}/api/minds/${encodeURIComponent(mind)}/imagegen/jobs`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ model, prompt }),
+      body: JSON.stringify({ model, prompt, filename }),
     });
   } catch (err) {
     if (err instanceof TypeError) {
@@ -120,15 +135,53 @@ export async function generateViaDaemon(
   if (res.status === 401 || res.status === 403) {
     return { ok: false, reason: "auth", status: res.status, detail: await readDaemonError(res) };
   }
+  // 404 = older daemon without the job route → fall back to direct generation.
+  if (res.status === 404) return { ok: false, reason: "fallback" };
   if (!res.ok) {
     const err = await readDaemonError(res);
-    // Genuinely not configured — fall back to direct provider.
     if (/not configured/i.test(err) || /No .* API key/i.test(err)) {
       return { ok: false, reason: "fallback" };
     }
     throw new Error(err);
   }
-  return { ok: true, value: Buffer.from(await res.arrayBuffer()) };
+  const body = (await res.json()) as { jobId?: string };
+  if (!body.jobId) throw new Error("Daemon did not return a job id");
+  return { ok: true, value: body.jobId };
+}
+
+/**
+ * Fetch a job's status. `waitSec > 0` long-polls: the daemon returns as soon as
+ * the job finishes or the wait elapses. A 404 means the job is unknown (e.g. the
+ * daemon restarted and lost it).
+ */
+export async function pollImagegenJob(
+  jobId: string,
+  waitSec: number,
+): Promise<DaemonResult<JobView>> {
+  const base = getDaemonUrl();
+  const token = getDaemonToken();
+  const mind = getMindName();
+  if (!base || !token || !mind) return { ok: false, reason: "no-env" };
+
+  const url =
+    `${base}/api/minds/${encodeURIComponent(mind)}/imagegen/jobs/${encodeURIComponent(jobId)}` +
+    (waitSec > 0 ? `?wait=${waitSec}` : "");
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  } catch (err) {
+    if (err instanceof TypeError) {
+      return { ok: false, reason: "unreachable", detail: err.message };
+    }
+    throw err;
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    return { ok: false, reason: "auth", status: res.status, detail: await readDaemonError(res) };
+  }
+  if (res.status === 404) return { ok: false, reason: "fallback" };
+  if (!res.ok) throw new Error(await readDaemonError(res));
+  return { ok: true, value: (await res.json()) as JobView };
 }
 
 export async function searchViaDaemon(query: string): Promise<DaemonResult<unknown[]>> {
@@ -209,6 +262,11 @@ async function fetchDefaultModel(): Promise<string | null> {
   }
 }
 
+// How long to foreground a job before letting it run in the background. Fast
+// models finish inside this window (unchanged from the old sync behavior);
+// slow ones (e.g. gpt-image-2) drop to the background and notify on completion.
+const FOREGROUND_WAIT_SEC = 30;
+
 async function generate(args: string[]): Promise<void> {
   const prompt = args[0];
   if (!prompt) {
@@ -222,22 +280,65 @@ async function generate(args: string[]): Promise<void> {
 
   console.log(`generating image with ${model}...`);
 
-  // Try daemon first, fall back to direct Replicate.
-  const daemonRes = await generateViaDaemon(model, prompt);
-  let buf: Buffer;
-  if (daemonRes.ok) {
-    buf = daemonRes.value;
-  } else {
-    handleDaemonFailure(daemonRes); // throws for unreachable/auth; returns to fall back otherwise
-    buf = await generateDirect(model, prompt);
+  // Start a background job on the daemon; fall back to direct generation when
+  // there's no daemon to run it (no-env / older daemon).
+  const started = await startImagegenJob(model, prompt, filename);
+  if (!started.ok) {
+    handleDaemonFailure(started); // throws for unreachable/auth; returns to fall back otherwise
+    const buf = await generateDirect(model, prompt);
+    const imagesDir = join(getHomePath(), "images");
+    mkdirSync(imagesDir, { recursive: true });
+    const filePath = join(imagesDir, `${filename}.png`);
+    await writeFile(filePath, buf);
+    console.log(`saved: ${filePath}`);
+    return;
   }
 
-  const imagesDir = join(getHomePath(), "images");
-  mkdirSync(imagesDir, { recursive: true });
+  const jobId = started.value;
+  const polled = await pollImagegenJob(jobId, FOREGROUND_WAIT_SEC);
+  if (!polled.ok) {
+    // The daemon accepted the job but the status read failed — report the job id
+    // so the mind can still check it once the problem clears.
+    console.log(`still generating (job ${jobId}) — check with: imagegen status ${jobId}`);
+    return;
+  }
 
-  const filePath = join(imagesDir, `${filename}.png`);
-  await writeFile(filePath, buf);
-  console.log(`saved: ${filePath}`);
+  const job = polled.value;
+  if (job.status === "done") {
+    console.log(`saved: ${job.path}`);
+  } else if (job.status === "error") {
+    throw new Error(job.error || "Image generation failed");
+  } else {
+    console.log(
+      `still generating (job ${jobId}) — I'll be notified when it's done. ` +
+        `Check anytime: imagegen status ${jobId}`,
+    );
+  }
+}
+
+async function status(args: string[]): Promise<void> {
+  const jobId = args[0];
+  if (!jobId) {
+    console.log("Usage: imagegen status <jobId>");
+    process.exit(1);
+  }
+
+  const polled = await pollImagegenJob(jobId, 0);
+  if (!polled.ok) {
+    if (polled.reason === "fallback") {
+      // 404 — the daemon has no record of this job (likely restarted).
+      console.log("job not found (the daemon may have restarted) — re-run generate.");
+      return;
+    }
+    handleDaemonFailure(polled);
+    console.error("Cannot check job status without a Volute daemon.");
+    process.exit(1);
+  }
+
+  const job = polled.value;
+  if (job.status === "done") console.log(`saved: ${job.path}`);
+  else if (job.status === "error") console.log(`failed: ${job.error}`);
+  else console.log(`still generating (job ${jobId})`);
 }
 
 async function models(args: string[]): Promise<void> {
@@ -290,12 +391,14 @@ async function main() {
   const cmd = args[0];
 
   if (!cmd) {
-    console.log("Usage: imagegen <generate|models> [args]");
+    console.log("Usage: imagegen <generate|status|models> [args]");
     process.exit(0);
   }
 
   if (cmd === "generate") {
     await generate(args.slice(1));
+  } else if (cmd === "status") {
+    await status(args.slice(1));
   } else if (cmd === "models") {
     await models(args.slice(1));
   } else {

--- a/test/credential-sync.test.ts
+++ b/test/credential-sync.test.ts
@@ -164,11 +164,63 @@ describe("syncProviderToMinds", () => {
     assert.equal(existsSync(resolve(codexDir, "home", ".claude", ".credentials.json")), false);
   });
 
-  it("no-ops for non-anthropic providers and when oauth is missing", async () => {
+  it("updates pi-with-xai auth as api_key, skips claude and pi-without-xai", async () => {
+    const root = tmpRoot("sync-xai");
+    const XAI_OAUTH = { access: "xai-oat-NEW", refresh: "xai-ort-NEW", expires: 1782152959152 };
+
+    // pi mind that already uses xai
+    const piDir = resolve(root, "grokky");
+    const piAgent = resolve(piDir, ".mind", "pi-agent");
+    mkdirSync(piAgent, { recursive: true });
+    writeFileSync(
+      resolve(piAgent, "auth.json"),
+      JSON.stringify({ xai: { type: "api_key", key: "OLD" } }),
+    );
+
+    // pi mind that does NOT use xai
+    const piOtherDir = resolve(root, "piother");
+    const piOtherAgent = resolve(piOtherDir, ".mind", "pi-agent");
+    mkdirSync(piOtherAgent, { recursive: true });
+    writeFileSync(
+      resolve(piOtherAgent, "auth.json"),
+      JSON.stringify({ anthropic: { type: "api_key", key: "ant-key" } }),
+    );
+
+    // claude mind — xai has no claude support, must be untouched
+    const claudeDir = resolve(root, "claudey");
+    mkdirSync(resolve(claudeDir, "home"), { recursive: true });
+
+    const entries: Record<string, { name: string; template?: string; dir: string }> = {
+      grokky: { name: "grokky", template: "pi", dir: piDir },
+      piother: { name: "piother", template: "pi", dir: piOtherDir },
+      claudey: { name: "claudey", template: "claude", dir: claudeDir },
+    };
+
+    await syncProviderToMinds("xai", {
+      getOauth: () => XAI_OAUTH,
+      listRunning: () => Object.keys(entries),
+      lookup: async (name) => entries[name],
+    });
+
+    // pi-with-xai updated to the new access token, still an api_key entry
+    const piAuth = JSON.parse(readFileSync(resolve(piAgent, "auth.json"), "utf-8"));
+    assert.equal(piAuth.xai.key, XAI_OAUTH.access);
+    assert.equal(piAuth.xai.type, "api_key");
+
+    // pi-without-xai untouched (no xai entry added)
+    const piOtherAuth = JSON.parse(readFileSync(resolve(piOtherAgent, "auth.json"), "utf-8"));
+    assert.equal(piOtherAuth.xai, undefined);
+    assert.equal(piOtherAuth.anthropic.key, "ant-key");
+
+    // claude untouched — xai never writes claude creds
+    assert.equal(existsSync(resolve(claudeDir, "home", ".claude", ".credentials.json")), false);
+  });
+
+  it("no-ops for unsupported providers and when oauth is missing", async () => {
     await syncProviderToMinds("openai-codex", {
       getOauth: () => OAUTH,
       listRunning: () => {
-        throw new Error("should not enumerate minds for non-anthropic provider");
+        throw new Error("should not enumerate minds for unsupported provider");
       },
       lookup: async () => undefined,
     });

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1011,6 +1011,55 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(body.defaultModel, DEFAULT, "mind must receive the admin's configured default");
   });
 
+  it("imagegen jobs: mind starts a job, long-polls it, and 404s an unknown one", async () => {
+    const mind = "e2e-imagegen-jobs-mind";
+    const mindUser = await getOrCreateMindUser(mind);
+    const mindSession = await createSession(mindUser.id);
+    const asMind = (path: string, init?: RequestInit): Promise<Response> =>
+      fetch(`${BASE_URL}${path}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${mindSession}`,
+          Origin: BASE_URL,
+          ...(init?.headers ?? {}),
+        },
+      });
+
+    // Start a job with an unconfigured provider — generation fails fast (no
+    // network), but the route must still accept the job and return an id.
+    const start = await asMind(`/api/minds/${mind}/imagegen/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "openai-codex:gpt-image-2",
+        prompt: "a test image",
+        filename: "e2e-test",
+      }),
+    });
+    assert.equal(start.status, 202, `start job: ${await start.clone().text()}`);
+    const { jobId } = (await start.json()) as { jobId: string };
+    assert.ok(jobId, "job id returned");
+
+    // Long-poll: the job settles to "error" (no credentials), and the daemon
+    // returns as soon as it does rather than waiting the full window.
+    const poll = await asMind(`/api/minds/${mind}/imagegen/jobs/${jobId}?wait=10`);
+    assert.equal(poll.status, 200, `poll job: ${await poll.clone().text()}`);
+    const job = (await poll.json()) as { status: string; error?: string };
+    assert.equal(job.status, "error", `expected error, got ${JSON.stringify(job)}`);
+
+    // A job that doesn't exist 404s (the skill maps this to "re-run generate").
+    const missing = await asMind(`/api/minds/${mind}/imagegen/jobs/does-not-exist`);
+    assert.equal(missing.status, 404, "unknown job must 404");
+
+    // Another mind cannot reach this mind's job routes (requireSelf).
+    const other = await getOrCreateMindUser("e2e-imagegen-jobs-outsider");
+    const otherSession = await createSession(other.id);
+    const cross = await fetch(`${BASE_URL}/api/minds/${mind}/imagegen/jobs/${jobId}`, {
+      headers: { Authorization: `Bearer ${otherSession}`, Origin: BASE_URL },
+    });
+    assert.equal(cross.status, 403, "another mind must not read this mind's job");
+  });
+
   it("conversations: create, send message, read back", async () => {
     await ensureTestMind();
     const brain = await ensureBrainParticipant("convo");

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -981,6 +981,36 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
   });
 
+  it("a mind token can read the configured imagegen default model", async () => {
+    // Regression: minds used to read the default from the requireAdmin
+    // /imagegen/models route, 403, and silently fall back to a hardcoded model.
+    // The admin's configured default never reached a mind.
+    const mindUser = await getOrCreateMindUser("e2e-imagegen-default-mind");
+    const mindSession = await createSession(mindUser.id);
+
+    const DEFAULT = "replicate:e2e-owner/e2e-default-model";
+    const setRes = await daemonRequest("/api/v1/system/imagegen/models", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ models: [DEFAULT], defaultModel: DEFAULT }),
+    });
+    assert.equal(setRes.status, 200, `admin set default: ${await setRes.clone().text()}`);
+
+    // The admin-only route must still reject a mind token...
+    const adminOnly = await fetch(`${BASE_URL}/api/v1/system/imagegen/models`, {
+      headers: { Authorization: `Bearer ${mindSession}`, Origin: BASE_URL },
+    });
+    assert.equal(adminOnly.status, 403, "full models route stays admin-gated");
+
+    // ...but the mind-callable default-model route returns the configured default.
+    const asMind = await fetch(`${BASE_URL}/api/v1/system/imagegen/default-model`, {
+      headers: { Authorization: `Bearer ${mindSession}`, Origin: BASE_URL },
+    });
+    assert.equal(asMind.status, 200, `mind default-model: ${await asMind.clone().text()}`);
+    const body = (await asMind.json()) as { defaultModel?: string | null };
+    assert.equal(body.defaultModel, DEFAULT, "mind must receive the admin's configured default");
+  });
+
   it("conversations: create, send message, read back", async () => {
     await ensureTestMind();
     const brain = await ensureBrainParticipant("convo");

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -5,7 +5,11 @@ import {
   readGlobalConfig,
   writeGlobalConfig,
 } from "../packages/daemon/src/lib/config/setup.js";
-import { registerXaiOAuthProvider } from "../packages/daemon/src/lib/oauth/xai.js";
+import {
+  registerXaiOAuthProvider,
+  validateXaiUrl,
+  xaiOAuthProvider,
+} from "../packages/daemon/src/lib/oauth/xai.js";
 import {
   generateImage,
   getConfiguredProviders,
@@ -25,6 +29,7 @@ import {
   CodexNotEntitledError,
   codexGenerate,
   parseCodexImageStream,
+  probeCodexEntitlement,
 } from "../packages/daemon/src/lib/services/imagegen-codex.js";
 import {
   _resetImagegenJobs,
@@ -417,6 +422,51 @@ describe("imagegen openai-codex provider", () => {
     assert.equal(buf.subarray(1, 4).toString(), "PNG");
   });
 
+  it("parseCodexImageStream rejects a stream that closes before completion", async () => {
+    // A partial image arrived but the stream ended without response.completed —
+    // must throw rather than silently return the low-res partial as the final image.
+    const sse = [
+      "event: response.image_generation_call.partial_image",
+      `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}`,
+      "",
+    ].join("\n");
+    await assert.rejects(parseCodexImageStream(sseStream(sse)), /before completion/);
+  });
+
+  it("probeCodexEntitlement returns entitled once the tool starts, then aborts", async () => {
+    let aborted = false;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      init.signal?.addEventListener("abort", () => {
+        aborted = true;
+      });
+      const sse =
+        'data: {"type":"response.created"}\n\n' +
+        'data: {"type":"response.image_generation_call.in_progress"}\n\n';
+      return new Response(sseStream(sse), { status: 200 });
+    }) as typeof fetch;
+    const state = await probeCodexEntitlement({ kind: "oauth", token: fakeCodexToken("a") });
+    assert.equal(state, "entitled");
+    assert.ok(aborted, "the stream should be aborted once entitlement is known");
+  });
+
+  it("probeCodexEntitlement returns not_entitled on the 400 sentinel", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ detail: CODEX_NOT_ENTITLED_SENTINEL }), {
+        status: 400,
+      })) as typeof fetch;
+    const state = await probeCodexEntitlement({ kind: "oauth", token: fakeCodexToken("a") });
+    assert.equal(state, "not_entitled");
+  });
+
+  it("probeCodexEntitlement returns not_entitled when the tool never starts", async () => {
+    globalThis.fetch = (async () =>
+      new Response(sseStream('data: {"type":"response.completed"}\n\n'), {
+        status: 200,
+      })) as typeof fetch;
+    const state = await probeCodexEntitlement({ kind: "oauth", token: fakeCodexToken("a") });
+    assert.equal(state, "not_entitled");
+  });
+
   it("codexGenerate posts to the Codex backend and returns image bytes", async () => {
     let seen: { url: string; auth?: string; account?: string } | undefined;
     globalThis.fetch = (async (url: string, init: RequestInit) => {
@@ -428,7 +478,8 @@ describe("imagegen openai-codex provider", () => {
       };
       const sse =
         "event: response.image_generation_call.partial_image\n" +
-        `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}\n\n`;
+        `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}\n\n` +
+        'data: {"type":"response.completed","response":{"output":[]}}\n\n';
       return new Response(sseStream(sse), { status: 200 });
     }) as typeof fetch;
 
@@ -558,6 +609,42 @@ describe("imagegen jobs", () => {
     assert.equal(bodies.length, 1, "exactly one completion event when backgrounded");
     assert.match(bodies[0], /image ready/);
   });
+
+  it("rejects a traversing filename without writing outside home/images", async () => {
+    const id = createImagegenJob("mind-escape", "any:model", "p", "../../../etc/pwned", {
+      generate: async () => Buffer.from("png"),
+    });
+    const job = await waitForImagegenJob("mind-escape", id, 1000);
+    assert.equal(job?.status, "error");
+    if (job?.status === "error") assert.match(job.error, /Invalid image filename/);
+  });
+
+  it("notifies the mind when a backgrounded job fails", async () => {
+    const bodies: string[] = [];
+    let release!: (err: Error) => void;
+    const gate = new Promise<Buffer>((_resolve, reject) => {
+      release = reject;
+    });
+    const id = createImagegenJob("mind-bgfail", "any:model", "p", "f", {
+      generate: () => gate,
+      deliver: async (_mind, event) => {
+        bodies.push(event.body);
+        return { delivered: true };
+      },
+    });
+
+    // Foreground times out → the mind is told it's still generating (notifyOnDone).
+    const timedOut = await waitForImagegenJob("mind-bgfail", id, 10);
+    assert.equal(timedOut?.status, "running");
+
+    // The background generation then fails — the mind must be told, not left waiting.
+    release(new Error("provider exploded"));
+    const done = await waitForImagegenJob("mind-bgfail", id, 2000);
+    assert.equal(done?.status, "error");
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(bodies.length, 1, "a backgrounded failure must send exactly one event");
+    assert.match(bodies[0], /image generation failed/);
+  });
 });
 
 describe("imagegen xai provider", () => {
@@ -593,6 +680,39 @@ describe("imagegen xai provider", () => {
     assert.equal(p.id, "xai");
     assert.equal(p.usesCallbackServer, false);
     assert.equal(p.getApiKey({ access: "tok", refresh: "r", expires: 0 }), "tok");
+  });
+
+  it("validateXaiUrl accepts auth.x.ai over https and rejects anything else", () => {
+    assert.equal(
+      validateXaiUrl("https://auth.x.ai/oauth2/token"),
+      "https://auth.x.ai/oauth2/token",
+    );
+    assert.throws(() => validateXaiUrl("https://evil.example/oauth2/token"), /non-xAI/);
+    assert.throws(() => validateXaiUrl("http://auth.x.ai/oauth2/token"), /non-xAI/);
+  });
+
+  it("refreshToken keeps the old refresh token when xAI omits a new one", async () => {
+    globalThis.fetch = (async () =>
+      // Rotation response omits refresh_token — must fall back to the existing one.
+      new Response(JSON.stringify({ access_token: "new-access", expires_in: 3600 }), {
+        status: 200,
+      })) as typeof fetch;
+    const next = await xaiOAuthProvider.refreshToken({
+      access: "old-access",
+      refresh: "keep-me",
+      expires: 0,
+    });
+    assert.equal(next.access, "new-access");
+    assert.equal(next.refresh, "keep-me", "a missing refresh_token must not blank the grant");
+  });
+
+  it("refreshToken throws when the token response lacks an access_token", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ expires_in: 3600 }), { status: 200 })) as typeof fetch;
+    await assert.rejects(
+      xaiOAuthProvider.refreshToken({ access: "a", refresh: "r", expires: 0 }),
+      /access_token|token/i,
+    );
   });
 
   it("generates from a b64_json response", async () => {
@@ -707,7 +827,8 @@ describe("imagegen entitlement", () => {
     globalThis.fetch = (async () => {
       const sse =
         "event: response.image_generation_call.partial_image\n" +
-        `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}\n\n`;
+        `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}\n\n` +
+        'data: {"type":"response.completed","response":{"output":[]}}\n\n';
       const bytes = new TextEncoder().encode(sse);
       return new Response(
         new ReadableStream({

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -6,7 +6,7 @@ import {
   getEnabledModels,
   parseModelId,
   removeProviderConfig,
-  resolveApiKey,
+  resolveCredential,
   saveProviderConfig,
   setEnabledModels,
 } from "../packages/daemon/src/lib/services/imagegen.js";
@@ -64,17 +64,20 @@ describe("imagegen config", () => {
     });
   });
 
-  describe("resolveApiKey", () => {
-    it("returns config key when set", () => {
+  describe("resolveCredential", () => {
+    it("returns config key when set", async () => {
       saveProviderConfig("replicate", "config-key");
-      assert.equal(resolveApiKey("replicate"), "config-key");
+      assert.deepEqual(await resolveCredential("replicate"), {
+        kind: "api_key",
+        token: "config-key",
+      });
     });
 
-    it("falls back to env var when no config key", () => {
+    it("falls back to env var when no config key", async () => {
       const original = process.env.REPLICATE_API_TOKEN;
       try {
         process.env.REPLICATE_API_TOKEN = "env-key";
-        assert.equal(resolveApiKey("replicate"), "env-key");
+        assert.equal((await resolveCredential("replicate"))?.token, "env-key");
       } finally {
         if (original !== undefined) {
           process.env.REPLICATE_API_TOKEN = original;
@@ -84,12 +87,12 @@ describe("imagegen config", () => {
       }
     });
 
-    it("prefers config key over env var", () => {
+    it("prefers config key over env var", async () => {
       const original = process.env.REPLICATE_API_TOKEN;
       try {
         process.env.REPLICATE_API_TOKEN = "env-key";
         saveProviderConfig("replicate", "config-key");
-        assert.equal(resolveApiKey("replicate"), "config-key");
+        assert.equal((await resolveCredential("replicate"))?.token, "config-key");
       } finally {
         if (original !== undefined) {
           process.env.REPLICATE_API_TOKEN = original;
@@ -99,15 +102,15 @@ describe("imagegen config", () => {
       }
     });
 
-    it("returns undefined for unknown provider", () => {
-      assert.equal(resolveApiKey("nonexistent"), undefined);
+    it("returns undefined for unknown provider", async () => {
+      assert.equal(await resolveCredential("nonexistent"), undefined);
     });
 
-    it("returns undefined when nothing is configured", () => {
+    it("returns undefined when nothing is configured", async () => {
       const original = process.env.REPLICATE_API_TOKEN;
       try {
         delete process.env.REPLICATE_API_TOKEN;
-        assert.equal(resolveApiKey("replicate"), undefined);
+        assert.equal(await resolveCredential("replicate"), undefined);
       } finally {
         if (original !== undefined) {
           process.env.REPLICATE_API_TOKEN = original;
@@ -117,11 +120,11 @@ describe("imagegen config", () => {
       }
     });
 
-    it("resolves openrouter env var", () => {
+    it("resolves openrouter env var", async () => {
       const original = process.env.OPENROUTER_API_KEY;
       try {
         process.env.OPENROUTER_API_KEY = "or-env-key";
-        assert.equal(resolveApiKey("openrouter"), "or-env-key");
+        assert.equal((await resolveCredential("openrouter"))?.token, "or-env-key");
       } finally {
         if (original !== undefined) {
           process.env.OPENROUTER_API_KEY = original;
@@ -131,19 +134,19 @@ describe("imagegen config", () => {
       }
     });
 
-    it("falls back to AI provider config key", () => {
+    it("falls back to AI provider config key", async () => {
       const config = readGlobalConfig();
       config.ai = { providers: { openrouter: { apiKey: "ai-provider-key" } } };
       writeGlobalConfig(config);
-      assert.equal(resolveApiKey("openrouter"), "ai-provider-key");
+      assert.equal((await resolveCredential("openrouter"))?.token, "ai-provider-key");
     });
 
-    it("prefers imagegen config key over AI provider key", () => {
+    it("prefers imagegen config key over AI provider key", async () => {
       const config = readGlobalConfig();
       config.ai = { providers: { openrouter: { apiKey: "ai-provider-key" } } };
       writeGlobalConfig(config);
       saveProviderConfig("openrouter", "imagegen-key");
-      assert.equal(resolveApiKey("openrouter"), "imagegen-key");
+      assert.equal((await resolveCredential("openrouter"))?.token, "imagegen-key");
     });
   });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -11,10 +11,39 @@ import {
   setEnabledModels,
 } from "../packages/daemon/src/lib/services/imagegen.js";
 import {
+  accountIdFromToken,
+  buildCodexRequest,
+  CODEX_NOT_ENTITLED_SENTINEL,
+  CodexNotEntitledError,
+  codexGenerate,
+  parseCodexImageStream,
+} from "../packages/daemon/src/lib/services/imagegen-codex.js";
+import {
   generateViaDaemon,
   handleDaemonFailure,
   searchViaDaemon,
 } from "../skills/imagegen/scripts/imagegen.js";
+
+/** Build a synthetic Codex OAuth access token (JWT) carrying an account id. */
+function fakeCodexToken(accountId: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+  ).toString("base64url");
+  return `header.${payload}.sig`;
+}
+
+/** Wrap SSE text as a byte ReadableStream, chunked to exercise the line buffer. */
+function sseStream(text: string, chunkSize = 7): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i >= bytes.length) return controller.close();
+      controller.enqueue(bytes.slice(i, i + chunkSize));
+      i += chunkSize;
+    },
+  });
+}
 
 function resetImagegenConfig() {
   const config = readGlobalConfig();
@@ -148,6 +177,24 @@ describe("imagegen config", () => {
       saveProviderConfig("openrouter", "imagegen-key");
       assert.equal((await resolveCredential("openrouter"))?.token, "imagegen-key");
     });
+
+    it("resolves an oauth credential from the linked AI provider", async () => {
+      // Far-future expiry ⇒ resolveOAuthCredentials returns the token with no
+      // refresh/network call (see ai-service.test.ts).
+      const config = readGlobalConfig();
+      config.ai = {
+        providers: {
+          "openai-codex": {
+            oauth: { access: "codex-access-token", refresh: "r", expires: 4102444800000 },
+          },
+        },
+      };
+      writeGlobalConfig(config);
+      assert.deepEqual(await resolveCredential("openai-codex"), {
+        kind: "oauth",
+        token: "codex-access-token",
+      });
+    });
   });
 
   describe("getConfiguredProviders", () => {
@@ -212,6 +259,27 @@ describe("imagegen config", () => {
       assert.equal(openrouter.configured, true);
       assert.equal(openrouter.authMethod, "api_key");
     });
+
+    it("auto-adds openai-codex when its AI provider has OAuth (chat/image unification)", () => {
+      const config = readGlobalConfig();
+      config.ai = {
+        providers: {
+          "openai-codex": { oauth: { access: "a", refresh: "r", expires: 4102444800000 } },
+        },
+      };
+      writeGlobalConfig(config);
+      const codex = getConfiguredProviders().find((p) => p.id === "openai-codex");
+      assert.ok(codex);
+      assert.equal(codex.configured, true);
+      assert.equal(codex.authMethod, "oauth");
+    });
+
+    it("reports openai-codex unconfigured when its AI provider is absent", () => {
+      const codex = getConfiguredProviders().find((p) => p.id === "openai-codex");
+      assert.ok(codex);
+      assert.equal(codex.configured, false);
+      assert.equal(codex.authMethod, null);
+    });
   });
 
   describe("getEnabledModels / setEnabledModels", () => {
@@ -249,6 +317,100 @@ describe("imagegen config", () => {
     it("throws on unknown provider", () => {
       assert.throws(() => parseModelId("badprovider:owner/model"), /Unknown imagegen provider/);
     });
+  });
+});
+
+describe("imagegen openai-codex provider", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  // A 1x1 red PNG, base64 — stands in for a generated image.
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  it("accountIdFromToken reads the chatgpt_account_id JWT claim", () => {
+    assert.equal(accountIdFromToken(fakeCodexToken("acct-xyz")), "acct-xyz");
+  });
+
+  it("accountIdFromToken returns undefined for a non-JWT token", () => {
+    assert.equal(accountIdFromToken("not-a-jwt"), undefined);
+  });
+
+  it("buildCodexRequest forces the hosted image tool with the given model", () => {
+    const req = buildCodexRequest("gpt-image-2", "a cat") as {
+      tools: Array<{ type: string; model: string }>;
+      tool_choice: { type: string };
+      stream: boolean;
+    };
+    assert.equal(req.tools[0].type, "image_generation");
+    assert.equal(req.tools[0].model, "gpt-image-2");
+    assert.equal(req.tool_choice.type, "image_generation");
+    assert.equal(req.stream, true);
+  });
+
+  it("parseCodexImageStream extracts the largest base64 blob from the stream", async () => {
+    const sse = [
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"r"}}',
+      "",
+      "event: response.image_generation_call.partial_image",
+      `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}`,
+      "",
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"output":[]}}',
+      "",
+    ].join("\n");
+    const buf = await parseCodexImageStream(sseStream(sse));
+    assert.deepEqual(buf, Buffer.from(PNG_B64, "base64"));
+    // PNG magic bytes survived the round-trip.
+    assert.equal(buf.subarray(1, 4).toString(), "PNG");
+  });
+
+  it("codexGenerate posts to the Codex backend and returns image bytes", async () => {
+    let seen: { url: string; auth?: string; account?: string } | undefined;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      const headers = new Headers(init.headers);
+      seen = {
+        url: String(url),
+        auth: headers.get("authorization") ?? undefined,
+        account: headers.get("chatgpt-account-id") ?? undefined,
+      };
+      const sse =
+        "event: response.image_generation_call.partial_image\n" +
+        `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}\n\n`;
+      return new Response(sseStream(sse), { status: 200 });
+    }) as typeof fetch;
+
+    const buf = await codexGenerate("gpt-image-2", "a dog", {
+      kind: "oauth",
+      token: fakeCodexToken("acct-42"),
+    });
+    assert.deepEqual(buf, Buffer.from(PNG_B64, "base64"));
+    assert.ok(seen);
+    assert.match(seen.url, /chatgpt\.com\/backend-api\/codex\/responses$/);
+    assert.match(seen.auth ?? "", /^Bearer /);
+    assert.equal(seen.account, "acct-42", "account id must come from the token JWT");
+  });
+
+  it("codexGenerate throws CodexNotEntitledError on the exact 400 sentinel", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ detail: CODEX_NOT_ENTITLED_SENTINEL }), {
+        status: 400,
+      })) as typeof fetch;
+    await assert.rejects(
+      codexGenerate("gpt-image-2", "x", { kind: "oauth", token: fakeCodexToken("a") }),
+      (err: Error) => err instanceof CodexNotEntitledError,
+    );
+  });
+
+  it("codexGenerate throws a generic error on other failures", async () => {
+    globalThis.fetch = (async () => new Response("upstream boom", { status: 502 })) as typeof fetch;
+    await assert.rejects(
+      codexGenerate("gpt-image-2", "x", { kind: "oauth", token: fakeCodexToken("a") }),
+      /502/,
+    );
   });
 });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
+import {
+  isImagegenEnabled,
+  readGlobalConfig,
+  writeGlobalConfig,
+} from "../packages/daemon/src/lib/config/setup.js";
 import { registerXaiOAuthProvider } from "../packages/daemon/src/lib/oauth/xai.js";
 import {
   generateImage,
@@ -295,6 +299,35 @@ describe("imagegen config", () => {
       assert.ok(codex);
       assert.equal(codex.configured, false);
       assert.equal(codex.authMethod, null);
+    });
+  });
+
+  describe("isImagegenEnabled", () => {
+    it("is false with no imagegen or ai config", () => {
+      assert.equal(isImagegenEnabled(), false);
+    });
+
+    it("is true when an imagegen provider key is configured", () => {
+      saveProviderConfig("replicate", "key");
+      assert.equal(isImagegenEnabled(), true);
+    });
+
+    it("is true when only a subscription AI provider (codex) is configured for chat", () => {
+      const config = readGlobalConfig();
+      config.ai = {
+        providers: {
+          "openai-codex": { oauth: { access: "a", refresh: "r", expires: 4102444800000 } },
+        },
+      };
+      writeGlobalConfig(config);
+      assert.equal(isImagegenEnabled(), true, "codex chat provider auto-enables imagegen");
+    });
+
+    it("is false when only a non-imagegen AI provider (anthropic) is configured", () => {
+      const config = readGlobalConfig();
+      config.ai = { providers: { anthropic: { apiKey: "sk-ant" } } };
+      writeGlobalConfig(config);
+      assert.equal(isImagegenEnabled(), false);
     });
   });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -3,9 +3,12 @@ import { afterEach, describe, it } from "node:test";
 import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
 import { registerXaiOAuthProvider } from "../packages/daemon/src/lib/oauth/xai.js";
 import {
+  generateImage,
   getConfiguredProviders,
   getEnabledModels,
+  getEntitlement,
   parseModelId,
+  probeEntitlement,
   removeProviderConfig,
   resolveCredential,
   saveProviderConfig,
@@ -577,6 +580,105 @@ describe("imagegen xai provider", () => {
     assert.equal(xaiApiKeyFallback(), "ai-key");
     saveProviderConfig("xai", "imagegen-key");
     assert.equal(xaiApiKeyFallback(), "imagegen-key");
+  });
+});
+
+describe("imagegen entitlement", () => {
+  const realFetch = globalThis.fetch;
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+  const CODEX_SENTINEL = "Tool choice 'image_generation' not found in 'tools' parameter.";
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    const config = readGlobalConfig();
+    delete config.imagegen;
+    delete config.ai;
+    writeGlobalConfig(config);
+    delete process.env.XAI_API_KEY;
+  });
+
+  function configureCodexOAuth() {
+    const config = readGlobalConfig();
+    config.ai = {
+      providers: {
+        "openai-codex": { oauth: { access: "codex-tok", refresh: "r", expires: 4102444800000 } },
+      },
+    };
+    writeGlobalConfig(config);
+  }
+
+  it("hard-fails with an actionable message and caches not_entitled (codex)", async () => {
+    configureCodexOAuth();
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ detail: CODEX_SENTINEL }), { status: 400 })) as typeof fetch;
+
+    await assert.rejects(
+      generateImage("openai-codex:gpt-image-2", "a cat"),
+      /ChatGPT plan doesn't include/,
+    );
+    const ent = getEntitlement("openai-codex");
+    assert.equal(ent?.state, "not_entitled");
+    assert.ok(ent?.checkedAt);
+  });
+
+  it("caches entitled after a successful generation (codex)", async () => {
+    configureCodexOAuth();
+    globalThis.fetch = (async () => {
+      const sse =
+        "event: response.image_generation_call.partial_image\n" +
+        `data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"${PNG_B64}"}\n\n`;
+      const bytes = new TextEncoder().encode(sse);
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const buf = await generateImage("openai-codex:gpt-image-2", "a cat");
+    assert.deepEqual(buf, Buffer.from(PNG_B64, "base64"));
+    assert.equal(getEntitlement("openai-codex")?.state, "entitled");
+  });
+
+  it("hard-fails and caches not_entitled when xAI OAuth 403s with no key fallback", async () => {
+    const config = readGlobalConfig();
+    config.ai = {
+      providers: { xai: { oauth: { access: "x-tok", refresh: "r", expires: 4102444800000 } } },
+    };
+    writeGlobalConfig(config);
+    globalThis.fetch = (async () => new Response("forbidden", { status: 403 })) as typeof fetch;
+
+    await assert.rejects(
+      generateImage("xai:grok-imagine-image", "a fox"),
+      /plan tier isn't allowlisted/,
+    );
+    assert.equal(getEntitlement("xai")?.state, "not_entitled");
+  });
+
+  it("probeEntitlement(xai) records entitled on success and not_entitled on OAuth 403", async () => {
+    // OAuth credential, no XAI_API_KEY fallback — a 403 is the tier-gating case.
+    const config = readGlobalConfig();
+    config.ai = {
+      providers: { xai: { oauth: { access: "x-tok", refresh: "r", expires: 4102444800000 } } },
+    };
+    writeGlobalConfig(config);
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ data: [{ b64_json: PNG_B64 }] }), {
+        status: 200,
+      })) as typeof fetch;
+    const ok = await probeEntitlement("xai");
+    assert.equal(ok.state, "entitled");
+
+    globalThis.fetch = (async () => new Response("forbidden", { status: 403 })) as typeof fetch;
+    const bad = await probeEntitlement("xai");
+    assert.equal(bad.state, "not_entitled");
+    assert.match(bad.reason ?? "", /allowlisted/);
   });
 });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -19,9 +19,16 @@ import {
   parseCodexImageStream,
 } from "../packages/daemon/src/lib/services/imagegen-codex.js";
 import {
-  generateViaDaemon,
+  _resetImagegenJobs,
+  createImagegenJob,
+  getImagegenJob,
+  waitForImagegenJob,
+} from "../packages/daemon/src/lib/services/imagegen-jobs.js";
+import {
   handleDaemonFailure,
+  pollImagegenJob,
   searchViaDaemon,
+  startImagegenJob,
 } from "../skills/imagegen/scripts/imagegen.js";
 
 /** Build a synthetic Codex OAuth access token (JWT) carrying an account id. */
@@ -414,20 +421,73 @@ describe("imagegen openai-codex provider", () => {
   });
 });
 
+describe("imagegen jobs", () => {
+  // Uses a provider with no configured credentials, so generateImage rejects
+  // fast (no network) and each job settles to "error" — enough to exercise the
+  // lifecycle, ownership, and cap without a real provider.
+  const UNCONFIGURED_MODEL = "openai-codex:gpt-image-2";
+
+  afterEach(() => {
+    _resetImagegenJobs();
+    const config = readGlobalConfig();
+    delete config.imagegen;
+    delete config.ai;
+    writeGlobalConfig(config);
+  });
+
+  it("creates a job and returns an id", () => {
+    const id = createImagegenJob("mind-a", UNCONFIGURED_MODEL, "prompt", "file");
+    assert.equal(typeof id, "string");
+    assert.ok(id.length > 0);
+  });
+
+  it("a job settles to error when generation fails", async () => {
+    const id = createImagegenJob("mind-a", UNCONFIGURED_MODEL, "prompt", "file");
+    const job = await waitForImagegenJob("mind-a", id, 5000);
+    assert.ok(job);
+    assert.equal(job.status, "error");
+    assert.match(job.error ?? "", /credentials|No .* configured/i);
+  });
+
+  it("enforces per-mind ownership", () => {
+    const id = createImagegenJob("mind-a", UNCONFIGURED_MODEL, "prompt", "file");
+    assert.ok(getImagegenJob("mind-a", id), "owner can read its job");
+    assert.equal(getImagegenJob("mind-b", id), undefined, "another mind cannot read it");
+  });
+
+  it("returns undefined for an unknown job", () => {
+    assert.equal(getImagegenJob("mind-a", "no-such-job"), undefined);
+  });
+
+  it("caps in-flight jobs per mind", () => {
+    // createImagegenJob is synchronous and marks the job running before the
+    // async generation yields, so four synchronous creates fill the cap and the
+    // fifth throws — deterministically, before any settles.
+    for (let i = 0; i < 4; i++) createImagegenJob("mind-cap", UNCONFIGURED_MODEL, "p", `f${i}`);
+    assert.throws(
+      () => createImagegenJob("mind-cap", UNCONFIGURED_MODEL, "p", "f5"),
+      /Too many image generations/,
+    );
+  });
+});
+
 describe("imagegen skill daemon error reporting", () => {
   const realFetch = globalThis.fetch;
   const savedEnv = {
     port: process.env.VOLUTE_DAEMON_PORT,
     token: process.env.VOLUTE_MIND_TOKEN,
+    mind: process.env.VOLUTE_MIND,
   };
 
   function setDaemonEnv(present: boolean) {
     if (present) {
       process.env.VOLUTE_DAEMON_PORT = "1618";
       process.env.VOLUTE_MIND_TOKEN = "mind-token";
+      process.env.VOLUTE_MIND = "test-mind";
     } else {
       delete process.env.VOLUTE_DAEMON_PORT;
       delete process.env.VOLUTE_MIND_TOKEN;
+      delete process.env.VOLUTE_MIND;
     }
   }
 
@@ -450,12 +510,14 @@ describe("imagegen skill daemon error reporting", () => {
     else delete process.env.VOLUTE_DAEMON_PORT;
     if (savedEnv.token !== undefined) process.env.VOLUTE_MIND_TOKEN = savedEnv.token;
     else delete process.env.VOLUTE_MIND_TOKEN;
+    if (savedEnv.mind !== undefined) process.env.VOLUTE_MIND = savedEnv.mind;
+    else delete process.env.VOLUTE_MIND;
   });
 
-  describe("generateViaDaemon", () => {
+  describe("startImagegenJob", () => {
     it("reports no-env when daemon env vars are unset", async () => {
       setDaemonEnv(false);
-      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
       assert.deepEqual(res, { ok: false, reason: "no-env" });
     });
 
@@ -464,16 +526,14 @@ describe("imagegen skill daemon error reporting", () => {
       mockFetch(() => {
         throw new TypeError("fetch failed");
       });
-      const res = await generateViaDaemon("replicate:owner/model", "prompt");
-      assert.equal(res.ok, false);
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
       assert.equal(res.ok === false && res.reason, "unreachable");
     });
 
     it("reports auth failure on 401", async () => {
       setDaemonEnv(true);
       mockFetch(() => jsonResponse(401, { error: "invalid token" }));
-      const res = await generateViaDaemon("replicate:owner/model", "prompt");
-      assert.equal(res.ok, false);
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
       assert.equal(res.ok === false && res.reason, "auth");
       assert.equal(res.ok === false && res.reason === "auth" && res.status, 401);
     });
@@ -481,29 +541,58 @@ describe("imagegen skill daemon error reporting", () => {
     it("reports auth failure on 403", async () => {
       setDaemonEnv(true);
       mockFetch(() => jsonResponse(403, { error: "forbidden" }));
-      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
       assert.equal(res.ok === false && res.reason, "auth");
+    });
+
+    it("reports fallback on 404 (older daemon without the job route)", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(404, { error: "not found" }));
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
+      assert.deepEqual(res, { ok: false, reason: "fallback" });
     });
 
     it("reports fallback when imagegen is genuinely not configured", async () => {
       setDaemonEnv(true);
       mockFetch(() => jsonResponse(400, { error: "imagegen not configured" }));
-      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
       assert.deepEqual(res, { ok: false, reason: "fallback" });
     });
 
     it("throws on an unexpected daemon error", async () => {
       setDaemonEnv(true);
       mockFetch(() => jsonResponse(500, { error: "boom" }));
-      await assert.rejects(generateViaDaemon("replicate:owner/model", "prompt"), /boom/);
+      await assert.rejects(startImagegenJob("replicate:owner/model", "prompt", "file"), /boom/);
     });
 
-    it("returns the image buffer on success", async () => {
+    it("returns the job id on success (202)", async () => {
       setDaemonEnv(true);
-      mockFetch(() => jsonResponse(200, {}));
-      const res = await generateViaDaemon("replicate:owner/model", "prompt");
+      mockFetch(() => jsonResponse(202, { jobId: "job-abc" }));
+      const res = await startImagegenJob("replicate:owner/model", "prompt", "file");
+      assert.deepEqual(res, { ok: true, value: "job-abc" });
+    });
+  });
+
+  describe("pollImagegenJob", () => {
+    it("reports no-env when daemon env vars are unset", async () => {
+      setDaemonEnv(false);
+      const res = await pollImagegenJob("job-1", 0);
+      assert.deepEqual(res, { ok: false, reason: "no-env" });
+    });
+
+    it("reports fallback on 404 (unknown/lost job)", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(404, { error: "Job not found" }));
+      const res = await pollImagegenJob("job-1", 0);
+      assert.deepEqual(res, { ok: false, reason: "fallback" });
+    });
+
+    it("returns the job view on success", async () => {
+      setDaemonEnv(true);
+      mockFetch(() => jsonResponse(200, { status: "done", path: "/home/images/x.png" }));
+      const res = await pollImagegenJob("job-1", 30);
       assert.equal(res.ok, true);
-      assert.ok(res.ok && Buffer.isBuffer(res.value));
+      assert.deepEqual(res.ok && res.value, { status: "done", path: "/home/images/x.png" });
     });
   });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { readGlobalConfig, writeGlobalConfig } from "../packages/daemon/src/lib/config/setup.js";
+import { registerXaiOAuthProvider } from "../packages/daemon/src/lib/oauth/xai.js";
 import {
   getConfiguredProviders,
   getEnabledModels,
@@ -24,6 +25,11 @@ import {
   getImagegenJob,
   waitForImagegenJob,
 } from "../packages/daemon/src/lib/services/imagegen-jobs.js";
+import {
+  XaiNotEntitledError,
+  xaiApiKeyFallback,
+  xaiGenerate,
+} from "../packages/daemon/src/lib/services/imagegen-xai.js";
 import {
   handleDaemonFailure,
   pollImagegenJob,
@@ -468,6 +474,109 @@ describe("imagegen jobs", () => {
       () => createImagegenJob("mind-cap", UNCONFIGURED_MODEL, "p", "f5"),
       /Too many image generations/,
     );
+  });
+});
+
+describe("imagegen xai provider", () => {
+  const realFetch = globalThis.fetch;
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    const config = readGlobalConfig();
+    delete config.imagegen;
+    delete config.ai;
+    writeGlobalConfig(config);
+    delete process.env.XAI_API_KEY;
+  });
+
+  function okImage(): Response {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: PNG_B64 }] }),
+    } as Response;
+  }
+  function forbidden(): Response {
+    return { ok: false, status: 403, text: async () => "forbidden" } as Response;
+  }
+
+  it("registers into pi-ai's OAuth registry", async () => {
+    registerXaiOAuthProvider();
+    const { getOAuthProvider } = await import("@earendil-works/pi-ai/oauth");
+    const p = getOAuthProvider("xai");
+    assert.ok(p, "xai OAuth provider registered");
+    assert.equal(p.id, "xai");
+    assert.equal(p.usesCallbackServer, false);
+    assert.equal(p.getApiKey({ access: "tok", refresh: "r", expires: 0 }), "tok");
+  });
+
+  it("generates from a b64_json response", async () => {
+    let seenAuth: string | undefined;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      seenAuth = new Headers(init.headers).get("authorization") ?? undefined;
+      return okImage();
+    }) as typeof fetch;
+    const buf = await xaiGenerate("grok-imagine-image", "a fox", {
+      kind: "api_key",
+      token: "xai-key",
+    });
+    assert.deepEqual(buf, Buffer.from(PNG_B64, "base64"));
+    assert.equal(seenAuth, "Bearer xai-key");
+  });
+
+  it("retries an OAuth 403 with the configured API key (payment-method swap)", async () => {
+    process.env.XAI_API_KEY = "fallback-key";
+    const tokens: string[] = [];
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const auth = new Headers(init.headers).get("authorization") ?? "";
+      tokens.push(auth);
+      return auth === "Bearer fallback-key" ? okImage() : forbidden();
+    }) as typeof fetch;
+
+    const buf = await xaiGenerate("grok-imagine-image", "a fox", {
+      kind: "oauth",
+      token: "oauth-token",
+    });
+    assert.deepEqual(buf, Buffer.from(PNG_B64, "base64"));
+    assert.deepEqual(
+      tokens,
+      ["Bearer oauth-token", "Bearer fallback-key"],
+      "oauth first, then key",
+    );
+  });
+
+  it("throws XaiNotEntitledError on OAuth 403 with no API key fallback", async () => {
+    globalThis.fetch = (async () => forbidden()) as typeof fetch;
+    await assert.rejects(
+      xaiGenerate("grok-imagine-image", "x", { kind: "oauth", token: "oauth-token" }),
+      (err: Error) => err instanceof XaiNotEntitledError,
+    );
+  });
+
+  it("does not retry a 403 on an API-key credential (genuine auth failure)", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return forbidden();
+    }) as typeof fetch;
+    await assert.rejects(
+      xaiGenerate("grok-imagine-image", "x", { kind: "api_key", token: "bad-key" }),
+      /403/,
+    );
+    assert.equal(calls, 1, "no retry for an api_key 403");
+  });
+
+  it("xaiApiKeyFallback prefers imagegen config, then ai config, then env", () => {
+    process.env.XAI_API_KEY = "env-key";
+    assert.equal(xaiApiKeyFallback(), "env-key");
+    const config = readGlobalConfig();
+    config.ai = { providers: { xai: { apiKey: "ai-key" } } };
+    writeGlobalConfig(config);
+    assert.equal(xaiApiKeyFallback(), "ai-key");
+    saveProviderConfig("xai", "imagegen-key");
+    assert.equal(xaiApiKeyFallback(), "imagegen-key");
   });
 });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -511,6 +511,53 @@ describe("imagegen jobs", () => {
       /Too many image generations/,
     );
   });
+
+  it("does not fire a completion event when the job finishes within the foreground wait", async () => {
+    const events: unknown[] = [];
+    const id = createImagegenJob("mind-fast", "any:model", "p", "f", {
+      generate: async () => Buffer.from("png"),
+      deliver: async (mind, event) => {
+        events.push({ mind, event });
+        return { delivered: true };
+      },
+    });
+    const job = await waitForImagegenJob("mind-fast", id, 1000);
+    assert.equal(job?.status, "done");
+    // Let any (erroneous) async notification flush.
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(events.length, 0, "a foregrounded job must not also send a completion event");
+  });
+
+  it("fires a single completion event when the job outlives the foreground wait", async () => {
+    const bodies: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const id = createImagegenJob("mind-slow", "any:model", "p", "f", {
+      generate: async () => {
+        await gate;
+        return Buffer.from("png");
+      },
+      deliver: async (_mind, event) => {
+        bodies.push(event.body);
+        return { delivered: true };
+      },
+    });
+
+    // Foreground poll times out with the job still running → it drops to background.
+    const timedOut = await waitForImagegenJob("mind-slow", id, 10);
+    assert.equal(timedOut?.status, "running");
+    assert.equal(bodies.length, 0, "no event before completion");
+
+    // Let generation finish; the backgrounded job should now notify exactly once.
+    release();
+    const done = await waitForImagegenJob("mind-slow", id, 2000);
+    assert.equal(done?.status, "done");
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(bodies.length, 1, "exactly one completion event when backgrounded");
+    assert.match(bodies[0], /image ready/);
+  });
 });
 
 describe("imagegen xai provider", () => {

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -648,6 +648,23 @@ describe("syncBuiltinSkills", () => {
     assert.ok(second);
     assert.equal(second.version, first.version + 1, "version should bump when content differs");
   });
+
+  it("repopulates the DB row when the on-disk pool survives a DB reset", async () => {
+    await syncBuiltinSkills();
+    assert.ok(await getSharedSkill("memory"), "memory should be synced initially");
+
+    // Simulate a DB reset that leaves the on-disk shared pool intact: drop the
+    // row but keep the disk copy (whose hash still matches source).
+    const db = await getDb();
+    await db.delete(sharedSkills).where(eq(sharedSkills.id, "memory"));
+    assert.equal(await getSharedSkill("memory"), undefined, "row should be gone");
+    assert.ok(existsSync(join(sharedSkillsDir(), "memory", "SKILL.md")), "disk copy should remain");
+
+    // Sync must re-import (not skip on the matching disk hash) so the row returns —
+    // listSharedSkills()/the UI read the DB, not the disk.
+    await syncBuiltinSkills();
+    assert.ok(await getSharedSkill("memory"), "memory row should be repopulated after sync");
+  });
 });
 
 describe("hook shim management", () => {


### PR DESCRIPTION
Adds two subscription-backed image providers, makes generation async, and gates on plan entitlement — so a host who already pays for ChatGPT or SuperGrok can generate images without a metered API key.

## What's new

- **openai-codex provider** — image generation on a ChatGPT subscription (no API key), driving the Codex Responses backend's hosted `image_generation` tool with a hand-parsed SSE stream. Verified end-to-end against the live backend.
- **xai provider (Grok Imagine)** — one endpoint serves both an xAI OAuth token (subscription, preferred) and a metered `XAI_API_KEY`. A 403 on the OAuth token transparently retries with the key (a payment-method swap, not a model swap).
- **xAI OAuth via device-code flow** — a new pi-ai `OAuthProviderInterface` registered at daemon startup, so the existing provider-OAuth UI drives Grok login with zero new frontend code. Headless-friendly; endpoints are pinned to `auth.x.ai`.
- **Chat/image unification** — configuring codex or xai as a *chat* AI provider auto-adds it as an image provider. No second credential, no second setup step.
- **Async generation** — the skill foregrounds a job for ~30s, then drops it to the background with a completion event on finish (the Claude-Code Bash-tool pattern). Slow models no longer block the mind's shell.
- **Entitlement gating** — a credential can be valid yet not allowed to generate (a ChatGPT plan without the image tool; an xAI tier not allowlisted). That's tracked as a first-class state, never reported as "misconfigured": generation hard-fails with an actionable message, and Settings shows a Ready / Plan-not-entitled badge with a Check button.

## Fixes surfaced along the way

- Minds now read the admin's configured default imagegen model (a latent `requireAdmin` 403 had every mind silently falling back to a hardcoded model).
- The xAI OAuth provider registers before minds start, and pi minds resolve xAI OAuth as an api_key — so a Grok-model mind actually runs inference (verified live).
- Built-in skills re-sync when the DB row is missing but the on-disk pool survives.
- Backgrounded job failures notify the mind (no more waiting forever), a generation timeout prevents a hung provider from pinning an inflight slot, and the Codex parser requires stream completion so it can't silently save a low-res partial.

## Types & tests

`ImagegenJob` and `ImagegenEntitlement` are discriminated unions (status↔payload enforced at compile time). Coverage includes credential precedence, the Codex SSE parse + entitlement probe, the async job lifecycle and path-traversal guard, the xAI 403→key fallback, and the xAI OAuth guards. Full suite green (2504 unit + 60 e2e).

## Follow-up

- #701 — transient OAuth-refresh failure is currently misclassified as "not configured" (fix lives in shared `ai-service.ts`, scoped separately).

## Verification notes

- Codex generation + entitlement probe: verified live against the real backend.
- xAI chat inference over subscription OAuth: verified live (a Grok mind replied end-to-end).
- xAI *image* path (Grok Imagine) and the OAuth device-code handshake: verified against mocks — they need a real SuperGrok login to exercise live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)