### PR TITLE
fix: sandboxed minds can't use bash here-documents on macOS

### DIFF
--- a/packages/daemon/src/lib/mind/sandbox.ts
+++ b/packages/daemon/src/lib/mind/sandbox.ts
@@ -221,6 +221,22 @@ export function shellEscape(s: string): string {
 }
 
 /**
+ * Extra directories a sandboxed mind must be able to write to for the shell's
+ * here-documents to work.
+ *
+ * macOS ships bash 3.2, whose here-document handling writes the body to a temp
+ * file under /tmp (→ /private/tmp, then /var/tmp) and IGNORES $TMPDIR — so a
+ * mind running `cat <<'X' … X` fails with "cannot create temp file for here
+ * document: operation not permitted" unless the seatbelt sandbox can write
+ * there. sandbox-runtime only whitelists /tmp/claude (the dir it points TMPDIR
+ * at), which bash 3.2 never consults. Linux ships modern bash that honors that
+ * TMPDIR=/tmp/claude, so it needs nothing extra here.
+ */
+export function shellTempWritePaths(): string[] {
+  return process.platform === "darwin" ? ["/private/tmp", "/private/var/tmp"] : [];
+}
+
+/**
  * Wrap a command for sandbox execution.
  * Returns [cmd, args] ready for spawn().
  * If sandbox is not available, returns the original command unchanged.
@@ -245,7 +261,7 @@ export async function wrapForSandbox(
     filesystem: {
       denyRead,
       allowRead,
-      allowWrite: allowWrite ?? [mindDir],
+      allowWrite: [...(allowWrite ?? [mindDir]), ...shellTempWritePaths()],
       denyWrite: [],
     },
   };

--- a/test/sandbox-heredoc.test.ts
+++ b/test/sandbox-heredoc.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
+import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
+import { initSandbox, wrapForSandbox } from "../packages/daemon/src/lib/mind/sandbox.js";
+
+// Real-sandbox regression test for the here-document temp-file bug: macOS ships
+// bash 3.2, which writes here-doc temp files to /tmp and ignores $TMPDIR, so a
+// sandboxed mind's `cat <<'X'` failed with "cannot create temp file for here
+// document: operation not permitted" until shellTempWritePaths() granted the tmp
+// root. On Linux, modern bash uses the sandbox's TMPDIR=/tmp/claude (already
+// whitelisted by sandbox-runtime), so this also guards that path from regressing.
+//
+// This actually spawns a sandboxed bash, so it needs the sandbox runtime's OS
+// deps (bwrap on Linux). It skips cleanly when they're absent.
+//
+// Lives in its own file so initSandbox()'s module-level state doesn't leak into
+// sandbox.test.ts's passthrough assertions (node runs each test file in its own
+// process).
+describe("sandbox here-document (real exec)", () => {
+  it("runs a bash here-document inside the sandbox without EPERM", async (t) => {
+    const { SandboxManager } = await import("@anthropic-ai/sandbox-runtime");
+    const { errors } = SandboxManager.checkDependencies();
+    // On macOS the seatbelt profile does its own glob matching, so dependency
+    // "errors" (missing ripgrep) are non-fatal; on Linux they mean no bwrap, so
+    // the mind can't be sandboxed at all — nothing to assert.
+    if (errors.length && process.platform !== "darwin") {
+      t.skip(`sandbox runtime unavailable: ${errors.join(", ")}`);
+      return;
+    }
+
+    mkdirSync(voluteSystemDir(), { recursive: true });
+    writeFileSync(
+      resolve(voluteSystemDir(), "config.json"),
+      JSON.stringify({ setup: { isolation: "sandbox" } }),
+    );
+    _resetConfigCache();
+    await initSandbox();
+
+    const mindDir = mkdtempSync(resolve(tmpdir(), "sandbox-heredoc-"));
+    try {
+      const [cmd, args] = await wrapForSandbox(
+        "bash",
+        ["-c", "cat <<'MSG'\nsandbox-heredoc-ok\nMSG"],
+        mindDir,
+        "alice",
+        [mindDir],
+      );
+      const { status, stdout, stderr } = spawnSync(cmd, args, { encoding: "utf-8" });
+      assert.equal(status, 0, `here-document failed inside sandbox: ${stderr}`);
+      assert.match(stdout, /sandbox-heredoc-ok/);
+    } finally {
+      rmSync(mindDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -18,6 +18,7 @@ import {
   isSandboxEnabled,
   SandboxUnavailableError,
   shellEscape,
+  shellTempWritePaths,
   wrapForSandbox,
 } from "../packages/daemon/src/lib/mind/sandbox.js";
 
@@ -186,6 +187,19 @@ describe("shellEscape", () => {
 
   it("handles empty strings", () => {
     assert.equal(shellEscape(""), "''");
+  });
+});
+
+describe("shellTempWritePaths", () => {
+  // macOS bash 3.2 writes here-document temp files to /tmp (ignoring $TMPDIR),
+  // so a sandboxed mind needs the tmp root writable. Linux's modern bash uses
+  // the sandbox's already-whitelisted TMPDIR=/tmp/claude, so it needs nothing.
+  it("grants the here-doc temp root on macOS and nothing elsewhere", () => {
+    if (process.platform === "darwin") {
+      assert.deepEqual(shellTempWritePaths(), ["/private/tmp", "/private/var/tmp"]);
+    } else {
+      assert.deepEqual(shellTempWritePaths(), []);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

On the local install, `dizzy` (a sandboxed `claude`-template mind) intermittently failed when sending messages via a here-document:

```
cat <<'MSG' | volute chat send @psamiton
...
MSG
```

with:

```
can't create temp file for here document: operation not permitted
```

## Root cause

The error is from **bash**, not volute. When bash evaluates a here-document it first writes the body to a temp file. macOS ships Apple's **bash 3.2.57**, which writes that temp file under `/tmp` (→ `/private/tmp`) and **ignores `$TMPDIR`**.

Sandboxed minds (macOS seatbelt via `@anthropic-ai/sandbox-runtime`) are granted write access to `[mindDir, mindStateDir, mindDir/.mind/tmp]` only. `sandbox-runtime` additionally whitelists `/tmp/claude` — the dir it points `TMPDIR` at — but bash 3.2 never consults `TMPDIR`, so the here-doc temp write to `/private/tmp` is denied with EPERM.

- **Why intermittent:** only here-documents (and a few other constructs) need that temp file; ordinary quoted commands don't.
- **Why only some minds:** `codex`-template minds are excluded from the macOS sandbox, so they're unaffected. Only sandboxed `claude`-template minds hit it.
- PR #695's `CLAUDE_CODE_TMPDIR=mindTmp` correctly redirects Claude Code's *own* scratch dir, but can't help here because bash 3.2 ignores `TMPDIR`.

Reproduced in isolation against the live sandbox-runtime; adding `/private/tmp` to `allowWrite` is what unblocks the here-doc.

## Fix

Grant the tmp root bash actually uses (`/private/tmp`, `/private/var/tmp`) in the mind's sandbox `allowWrite`, on darwin only. Linux ships modern bash that honors the sandbox's `TMPDIR=/tmp/claude` (already whitelisted), so it needs nothing extra and is untouched.

## Tests

- **`test/sandbox-heredoc.test.ts`** — real-exec regression test: spawns an actual sandboxed bash running a here-document and asserts no EPERM. Verified it **fails without the fix** (exact original error) and passes with it. Skips cleanly where the sandbox runtime's OS deps are absent (e.g. no `bwrap` on Linux CI). Covers both platforms' code paths.
- **`test/sandbox.test.ts`** — unit test for the platform write-path logic.

## Trade-off

This makes `/private/tmp` writable (shared across minds) in the macOS sandbox — a modest reduction in isolation, limited to ephemeral temp writes; reads of other minds' dirs and system state stay blocked. It only affects the local macOS `sandbox` isolation mode, not Linux / user-isolation.

## Follow-up

Running minds (`dizzy`, the spirit) need a restart to pick up the new wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)