### PR TITLE
fix: deliver newly created conversations to live SSE clients

### DIFF
--- a/packages/api/src/events.ts
+++ b/packages/api/src/events.ts
@@ -29,7 +29,11 @@ export type ActivityEvent = {
 };
 
 /** Unified SSE event envelope sent over /api/v1/events */
-export type SSEEvent = SSESnapshotEvent | SSEActivityEvent | SSEConversationEvent;
+export type SSEEvent =
+  | SSESnapshotEvent
+  | SSEActivityEvent
+  | SSEConversationEvent
+  | SSEConversationAddedEvent;
 
 export type SSESnapshotEvent = {
   event: "snapshot";
@@ -53,6 +57,16 @@ export type SSEConversationEvent = {
   event: "conversation";
   conversationId: string;
 } & ConversationEvent;
+
+/**
+ * Sent when the caller becomes a participant of a conversation that did not
+ * exist (or wasn't theirs) at connect time — e.g. a seed's first DM. Lets the
+ * client add the conversation to its list live, without a reconnect/snapshot.
+ */
+export type SSEConversationAddedEvent = {
+  event: "conversation_added";
+  conversation: ConversationWithParticipants;
+};
 
 /** Sequenced event wrapper for Last-Event-ID reconnection */
 export type SequencedEvent = {

--- a/packages/daemon/src/lib/events/conversation-events.ts
+++ b/packages/daemon/src/lib/events/conversation-events.ts
@@ -33,6 +33,33 @@ export function subscribe(conversationId: string, callback: Callback): () => voi
   };
 }
 
+// Global (not per-conversation) pub-sub for "a user became a participant of a
+// conversation". Lets already-connected SSE streams start following a
+// conversation that was created after they connected (e.g. a seed's first DM).
+// Not buffered in the sequencer — a reconnect rebuilds subscriptions from a
+// fresh snapshot, so replay is unnecessary.
+type ParticipantAddedEvent = { conversationId: string; userId: number };
+type ParticipantCallback = (event: ParticipantAddedEvent) => void;
+
+const participantSubscribers = new Set<ParticipantCallback>();
+
+export function subscribeParticipantAdded(callback: ParticipantCallback): () => void {
+  participantSubscribers.add(callback);
+  return () => participantSubscribers.delete(callback);
+}
+
+export function publishParticipantAdded(conversationId: string, userId: number): void {
+  for (const cb of participantSubscribers) {
+    try {
+      cb({ conversationId, userId });
+    } catch (err) {
+      // Drop a throwing subscriber (likely a dead stream), mirroring publish().
+      console.error("[conversation-events] participant subscriber threw:", err);
+      participantSubscribers.delete(cb);
+    }
+  }
+}
+
 export function publish(conversationId: string, event: ConversationEvent): void {
   const set = subscribers.get(conversationId);
   if (!set) return;

--- a/packages/daemon/src/lib/events/conversations.ts
+++ b/packages/daemon/src/lib/events/conversations.ts
@@ -18,7 +18,7 @@ import {
   users,
 } from "../schema.js";
 import { fireWebhook } from "../webhook.js";
-import { publish } from "./conversation-events.js";
+import { publish, publishParticipantAdded } from "./conversation-events.js";
 
 export type {
   ContentBlock,
@@ -52,6 +52,11 @@ export async function createConversation(opts?: {
         role: i === 0 ? "owner" : "member",
       })),
     );
+    // Notify each participant's live SSE streams so the new conversation shows
+    // up without a reload.
+    for (const uid of opts.participantIds) {
+      publishParticipantAdded(id, uid);
+    }
   }
 
   fireWebhook({
@@ -87,6 +92,8 @@ export async function addParticipant(
     user_id: userId,
     role,
   });
+  // Notify the added user's live SSE streams (e.g. added to a group/channel).
+  publishParticipantAdded(conversationId, userId);
 }
 
 export async function removeParticipant(conversationId: string, userId: number): Promise<void> {
@@ -383,6 +390,15 @@ export async function listConversationsWithParticipants(
 ): Promise<ConversationWithParticipants[]> {
   const convs = await listConversationsForUser(userId);
   return enrichConversations(convs);
+}
+
+export async function getConversationWithParticipants(
+  conversationId: string,
+): Promise<ConversationWithParticipants | null> {
+  const conv = await getConversation(conversationId);
+  if (!conv) return null;
+  const [enriched] = await enrichConversations([conv]);
+  return enriched ?? null;
 }
 
 export async function findDMConversation(participantIds: [number, number]): Promise<string | null> {

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -1,3 +1,4 @@
+import type { SSEConversationAddedEvent } from "@volute/api/events";
 import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -8,8 +9,13 @@ import {
   getOnlineBrains,
   removeConnection,
 } from "../../../lib/events/brain-presence.js";
-import { subscribe as subscribeConversation } from "../../../lib/events/conversation-events.js";
 import {
+  type ConversationEvent,
+  subscribe as subscribeConversation,
+  subscribeParticipantAdded,
+} from "../../../lib/events/conversation-events.js";
+import {
+  getConversationWithParticipants,
   getUnreadCounts,
   listConversationsWithParticipants,
 } from "../../../lib/events/conversations.js";
@@ -132,13 +138,15 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
       });
       cleanups.push(unsubActivity);
 
-      // Subscribe to conversation events for each user conversation
-      for (const conv of conversations) {
-        const unsubConv = subscribeConversation(conv.id, (event) => {
+      // Subscribe to conversation events for a single conversation, forwarding
+      // its messages to this stream.
+      const subscribedConvIds = new Set<string>(conversations.map((c: any) => c.id));
+      function subscribeToConversation(convId: string) {
+        const unsubConv = subscribeConversation(convId, (event) => {
           // Buffered once at the publish site (conversation-events publish); forward
           // using the shared `seq` instead of re-buffering per subscribed connection.
           const { seq, ...rest } = event;
-          const data = { event: "conversation" as const, conversationId: conv.id, ...rest };
+          const data = { event: "conversation" as const, conversationId: convId, ...rest };
           stream
             .writeSSE({
               id: String(seq),
@@ -150,6 +158,64 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
         });
         cleanups.push(unsubConv);
       }
+
+      // Subscribe to conversation events for each conversation known at connect.
+      for (const conv of conversations) {
+        subscribeToConversation(conv.id);
+      }
+
+      // A conversation created after connect (e.g. a seed's first DM) has no
+      // subscription above, so its messages would only surface on reload. When
+      // this caller becomes a participant of such a conversation, subscribe live
+      // and push a `conversation_added` event so the client can add it to its
+      // list immediately. The event is connection-specific, so allocate an ID
+      // without buffering (like the snapshot) — reconnect rebuilds via snapshot.
+      const unsubParticipant = subscribeParticipantAdded(({ conversationId, userId }) => {
+        if (userId !== user.id || subscribedConvIds.has(conversationId)) return;
+        subscribedConvIds.add(conversationId);
+
+        // The client drops message events for conversations it doesn't yet know
+        // about, and the first message can be published before the (async,
+        // DB-backed) conversation_added is written. Queue this conversation's
+        // messages until conversation_added has been sent, then flush in order,
+        // so the first message's preview/unread is never lost.
+        function forward(event: ConversationEvent & { seq: number }) {
+          const { seq, ...rest } = event;
+          const data = { event: "conversation" as const, conversationId, ...rest };
+          stream.writeSSE({ id: String(seq), data: JSON.stringify(data) }).catch((err) => {
+            if (!stream.aborted) log.error("[v1-events] write error:", log.errorData(err));
+          });
+        }
+        let queued: Array<ConversationEvent & { seq: number }> | null = [];
+        const unsubConv = subscribeConversation(conversationId, (event) => {
+          if (queued) queued.push(event);
+          else forward(event);
+        });
+        cleanups.push(unsubConv);
+
+        getConversationWithParticipants(conversationId)
+          .then((conv) => {
+            if (!conv) {
+              log.error("[v1-events] conversation_added: enrich returned null", { conversationId });
+              return;
+            }
+            const data: SSEConversationAddedEvent = {
+              event: "conversation_added",
+              conversation: conv,
+            };
+            return stream.writeSSE({ id: String(nextEventId()), data: JSON.stringify(data) });
+          })
+          .catch((err) => {
+            if (!stream.aborted)
+              log.error("[v1-events] conversation_added error:", log.errorData(err));
+          })
+          .finally(() => {
+            const pending = queued ?? [];
+            queued = null;
+            for (const event of pending) forward(event);
+          });
+      });
+      cleanups.push(unsubParticipant);
 
       // Keep-alive pings every 15s
       const keepAlive = setInterval(() => {

--- a/packages/web/src/ui/lib/stores.svelte.ts
+++ b/packages/web/src/ui/lib/stores.svelte.ts
@@ -248,6 +248,16 @@ function handleSSEEvent(event: SSEEvent) {
           console.warn("[stores] failed to refresh minds:", err);
         });
     }
+  } else if (event.event === "conversation_added") {
+    // A conversation we just became a participant of, created after we connected
+    // (e.g. a seed's first DM, or being added to an existing channel). Add it to
+    // the list live so it appears without a reload. The payload is enriched, so
+    // its last-message preview is pre-filled when the conversation already has
+    // messages; unread starts at 0 and accrues from the message events that
+    // follow (the daemon sends this before forwarding the conversation's messages).
+    if (!data.conversations.some((c) => c.id === event.conversation.id)) {
+      data.conversations = [event.conversation, ...data.conversations];
+    }
   } else if (event.event === "conversation") {
     const conv = data.conversations.find((c) => c.id === event.conversationId);
     if (conv && event.type === "message") {

--- a/test/web-v1-events.test.ts
+++ b/test/web-v1-events.test.ts
@@ -2,6 +2,12 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
 import { publish } from "../packages/daemon/src/lib/events/activity-events.js";
+import { publishParticipantAdded } from "../packages/daemon/src/lib/events/conversation-events.js";
+import {
+  addMessage,
+  addParticipant,
+  createConversation,
+} from "../packages/daemon/src/lib/events/conversations.js";
 import {
   bufferEvent,
   getEventsSince,
@@ -393,5 +399,175 @@ describe("v1 events replay ring buffers each event once", () => {
       if (prevToken === undefined) delete process.env.VOLUTE_DAEMON_TOKEN;
       else process.env.VOLUTE_DAEMON_TOKEN = prevToken;
     }
+  });
+});
+
+describe("v1 events live delivery of newly created conversations", () => {
+  it("delivers a conversation_added event and its messages without reconnecting", async () => {
+    resetSequencer();
+    // Alice is already watching the dashboard (connected before the conversation
+    // exists). Bob will start a brand-new DM with her — the seed-message scenario.
+    const alice = await getOrCreateMindUser("new-conv-alice");
+    const bob = await getOrCreateMindUser("new-conv-bob");
+    const aliceSession = await createSession(alice.id);
+
+    const stream = await openEventStream(`Bearer ${aliceSession}`);
+    // Let the snapshot flush and the live subscriptions register.
+    await delay(200);
+
+    // A conversation that did not exist at connect time, with its first message
+    // sent immediately after — the realistic seed-first-DM flow, no artificial
+    // gap. The daemon must announce the conversation before forwarding messages.
+    const conv = await createConversation({
+      userId: bob.id,
+      participantIds: [bob.id, alice.id],
+      type: "dm",
+    });
+    await addMessage(conv.id, "user", "new-conv-bob", [
+      { type: "text", text: "hello from a brand-new dm" },
+    ]);
+    await delay(200);
+    await stream.close();
+
+    // The new conversation is pushed live so it appears in the list without reload.
+    const added = stream.events.filter(
+      (e) => e.event === "conversation_added" && e.conversation?.id === conv.id,
+    );
+    assert.equal(added.length, 1, "should receive exactly one conversation_added for the new DM");
+    assert.ok(
+      added[0].conversation.participants?.some((p: any) => p.username === "new-conv-alice"),
+      "conversation_added should carry enriched participants",
+    );
+
+    // And messages to that new conversation flow live thereafter.
+    const messages = stream.events.filter(
+      (e) => e.event === "conversation" && e.conversationId === conv.id && e.type === "message",
+    );
+    assert.ok(
+      messages.some((m) =>
+        m.content?.some((b: any) => b.type === "text" && b.text.includes("brand-new dm")),
+      ),
+      "the new conversation's first message should be delivered live",
+    );
+
+    // conversation_added must arrive before the first message: the client drops
+    // messages for conversations it doesn't yet know about, so out-of-order
+    // delivery would lose the first message's preview/unread until reload.
+    const order = stream.events
+      .filter(
+        (e) =>
+          (e.event === "conversation_added" && e.conversation?.id === conv.id) ||
+          (e.event === "conversation" && e.conversationId === conv.id),
+      )
+      .map((e) => e.event);
+    assert.equal(order[0], "conversation_added", "conversation_added must precede its messages");
+  });
+
+  it("delivers conversation_added when added to an existing conversation live", async () => {
+    resetSequencer();
+    // Carl is watching. A group exists between Dana and Erin that already has a
+    // message; Carl is then added to it — the "added to an existing channel" path.
+    const carl = await getOrCreateMindUser("add-part-carl");
+    const dana = await getOrCreateMindUser("add-part-dana");
+    const erin = await getOrCreateMindUser("add-part-erin");
+    const carlSession = await createSession(carl.id);
+
+    const conv = await createConversation({
+      userId: dana.id,
+      participantIds: [dana.id, erin.id],
+      type: "channel",
+    });
+    await addMessage(conv.id, "user", "add-part-dana", [{ type: "text", text: "pre-existing" }]);
+
+    const stream = await openEventStream(`Bearer ${carlSession}`);
+    await delay(200);
+    // Carl isn't a participant yet — nothing for this conversation so far.
+    assert.ok(
+      !stream.events.some(
+        (e) => e.event === "conversation_added" && e.conversation?.id === conv.id,
+      ),
+      "no conversation_added before being added",
+    );
+
+    await addParticipant(conv.id, carl.id);
+    await delay(200);
+    await stream.close();
+
+    const added = stream.events.filter(
+      (e) => e.event === "conversation_added" && e.conversation?.id === conv.id,
+    );
+    assert.equal(added.length, 1, "added participant receives one conversation_added");
+    // The enriched payload carries the pre-existing last message.
+    assert.equal(
+      added[0].conversation.lastMessage?.text,
+      "pre-existing",
+      "conversation_added carries the existing last-message preview",
+    );
+  });
+
+  it("does not re-announce or double-subscribe an already-known conversation", async () => {
+    resetSequencer();
+    const fay = await getOrCreateMindUser("dedup-fay");
+    const gil = await getOrCreateMindUser("dedup-gil");
+    const faySession = await createSession(fay.id);
+
+    const stream = await openEventStream(`Bearer ${faySession}`);
+    await delay(200);
+
+    const conv = await createConversation({
+      userId: gil.id,
+      participantIds: [gil.id, fay.id],
+      type: "dm",
+    });
+    await delay(150);
+    // A duplicate participant-added for the same (conversation, user) — must be
+    // ignored, or messages would be forwarded twice to the UI.
+    publishParticipantAdded(conv.id, fay.id);
+    await delay(50);
+    await addMessage(conv.id, "user", "dedup-gil", [{ type: "text", text: "once" }]);
+    await delay(200);
+    await stream.close();
+
+    const added = stream.events.filter(
+      (e) => e.event === "conversation_added" && e.conversation?.id === conv.id,
+    );
+    assert.equal(added.length, 1, "conversation_added emitted exactly once");
+    const messages = stream.events.filter(
+      (e) => e.event === "conversation" && e.conversationId === conv.id && e.type === "message",
+    );
+    assert.equal(messages.length, 1, "message delivered exactly once (no double subscription)");
+  });
+
+  it("does not leak new conversations to non-participants", async () => {
+    resetSequencer();
+    const viewer = await getOrCreateMindUser("new-conv-viewer");
+    const sender = await getOrCreateMindUser("new-conv-sender");
+    const other = await getOrCreateMindUser("new-conv-other");
+    const viewerSession = await createSession(viewer.id);
+
+    const stream = await openEventStream(`Bearer ${viewerSession}`);
+    await delay(200);
+
+    // A DM between two other users the viewer is not part of.
+    const conv = await createConversation({
+      userId: sender.id,
+      participantIds: [sender.id, other.id],
+      type: "dm",
+    });
+    await delay(100);
+    await addMessage(conv.id, "user", "new-conv-sender", [{ type: "text", text: "private" }]);
+    await delay(200);
+    await stream.close();
+
+    assert.ok(
+      !stream.events.some(
+        (e) => e.event === "conversation_added" && e.conversation?.id === conv.id,
+      ),
+      "viewer must not receive conversation_added for a conversation they are not in",
+    );
+    assert.ok(
+      !stream.events.some((e) => e.event === "conversation" && e.conversationId === conv.id),
+      "viewer must not receive messages for a conversation they are not in",
+    );
   });
 });


### PR DESCRIPTION
## Problem

A new seed's first DM (or any conversation created after a browser connected) did not appear in the web dashboard until the page was reloaded.

Root cause was a three-part gap in the real-time path:
1. The unified `/api/v1/events` stream subscribed to conversation message streams **only for conversations that existed at connect time**.
2. `createConversation` fired a `conversation_created` event that only went to an external **webhook**, never the in-process SSE bus — there was no `conversation_created` type in the SSE union at all.
3. The frontend silently dropped message events for conversations not already in its local list.

So the seed's message was buffered for reconnect but never pushed live. Reloading built a fresh snapshot that included the conversation — which is exactly why reload "fixed" it.

## Fix

- New in-process **`participant-added`** pub-sub, published from `createConversation` and `addParticipant`.
- `/api/v1/events` subscribes to it: when the caller becomes a participant of a new conversation, it starts following that conversation live and pushes a new **`conversation_added`** SSE event carrying the enriched conversation (participants + last message).
- The frontend inserts it into the list; the existing message-event path then drives preview + unread.

Also fixes the same latent gap for being added to a group/channel live, not just seeds. The `conversation_added` payload is connection-specific and unbuffered (like the snapshot) — reconnect rebuilds via the snapshot.

### Ordering guarantee

The first message can be published before the (async, DB-backed) `conversation_added` is written, and the client drops messages for conversations it doesn't yet know about. To prevent losing the first message's preview/unread, the daemon **queues the new conversation's messages until `conversation_added` has been sent, then flushes them in order**.

## Authorization

`participant-added` carries the numeric user id; the events stream only follows a new conversation when `userId === user.id`, so a mind/user never receives `conversation_added` (or messages) for a conversation it isn't a participant of. Covered by a non-participant leak test.

## Tests

`test/web-v1-events.test.ts` — live delivery of a new DM, no-delay ordering (`conversation_added` before its messages), the `addParticipant`-to-existing-channel path, idempotency/no-double-subscription, and non-participant isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)