### PR TITLE
fix: keep mind upgrades from starving the system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,9 +1917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1937,9 +1934,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1957,9 +1951,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1968,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,9 +1985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -228,11 +228,11 @@ export class MindManager {
     return { dir, port: entry.port, baseName: name, template: entry.template };
   }
 
-  async startMind(name: string): Promise<void> {
-    return this.withLock(name, () => this._startMind(name));
+  async startMind(name: string, opts?: { healthTimeoutMs?: number }): Promise<void> {
+    return this.withLock(name, () => this._startMind(name, opts));
   }
 
-  private async _startMind(name: string): Promise<void> {
+  private async _startMind(name: string, opts?: { healthTimeoutMs?: number }): Promise<void> {
     if (this.minds.has(name)) {
       throw new Error(`Mind ${name} is already running`);
     }
@@ -544,9 +544,10 @@ export class MindManager {
     // or an early child exit/error (e.g. a `tsx` syntax error from a self-edit). Polling
     // /health is more robust than scraping stdout for "listening on :PORT".
     try {
+      const healthTimeoutMs = opts?.healthTimeoutMs ?? 30000;
       await new Promise<void>((resolve, reject) => {
         let settled = false;
-        const deadline = Date.now() + 30000;
+        const deadline = Date.now() + healthTimeoutMs;
 
         const onExit = (code: number | null) => {
           // Extract the most useful error line from stderr
@@ -586,7 +587,7 @@ export class MindManager {
             finish(() =>
               reject(
                 new MindStartupError(
-                  `Mind ${name} did not become healthy within 30s`,
+                  `Mind ${name} did not become healthy within ${Math.round(healthTimeoutMs / 1000)}s`,
                   recentStderr.join("\n"),
                 ),
               ),

--- a/packages/daemon/src/lib/mind/npm-install.ts
+++ b/packages/daemon/src/lib/mind/npm-install.ts
@@ -1,0 +1,73 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { exec, gitExec } from "../util/exec.js";
+import { isIsolationEnabled, wrapForIsolation } from "./isolation.js";
+
+// Skip npm's audit/funding network round-trips and prefer the local cache —
+// installs here always run against a committed lockfile.
+const NPM_INSTALL_ARGS = [
+  "install",
+  "--no-audit",
+  "--no-fund",
+  "--prefer-offline",
+  "--loglevel=error",
+];
+
+/**
+ * Prefix an argv with nice (and ionice where available) so a large install's
+ * CPU/disk load can't starve the daemon and other minds. ionice only takes
+ * effect under the bfq I/O scheduler; elsewhere it's a harmless no-op.
+ */
+export function lowPriorityArgv(cmd: string, args: string[], ionice: boolean): [string, string[]] {
+  return ionice
+    ? ["ionice", ["-c2", "-n7", "nice", "-n19", cmd, ...args]]
+    : ["nice", ["-n19", cmd, ...args]];
+}
+
+function hasIonice(): boolean {
+  return (
+    process.platform === "linux" && (existsSync("/usr/bin/ionice") || existsSync("/bin/ionice"))
+  );
+}
+
+/**
+ * Run npm install in a directory, using the mind user's identity when isolation is enabled.
+ * This avoids creating root-owned node_modules that the mind can't modify later.
+ */
+export async function npmInstallAsMind(cwd: string, mindName: string): Promise<void> {
+  const [cmd, args] = lowPriorityArgv("npm", NPM_INSTALL_ARGS, hasIonice());
+  if (isIsolationEnabled()) {
+    const [wrappedCmd, wrappedArgs] = await wrapForIsolation(cmd, args, mindName);
+    await exec(wrappedCmd, wrappedArgs, {
+      cwd,
+      env: { ...process.env, HOME: resolve(cwd, "home") },
+    });
+  } else {
+    await exec(cmd, args, { cwd });
+  }
+}
+
+/**
+ * True if package.json or package-lock.json changed between fromRef and HEAD.
+ * Errs on the side of true (install) if the diff can't be computed.
+ */
+export async function depsChangedSince(dir: string, fromRef: string): Promise<boolean> {
+  try {
+    await gitExec(["diff", "--quiet", fromRef, "HEAD", "--", "package.json", "package-lock.json"], {
+      cwd: dir,
+    });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Whether a merge landed anything that requires an npm install. Skipping the
+ * no-op case matters: npm install rewrites enough of node_modules to saturate
+ * slow storage for a minute even when nothing changed.
+ */
+export async function npmInstallNeeded(dir: string, preMergeRef: string): Promise<boolean> {
+  if (!existsSync(resolve(dir, "node_modules"))) return true;
+  return depsChangedSince(dir, preMergeRef);
+}

--- a/packages/daemon/src/lib/mind/variant-cleanup.ts
+++ b/packages/daemon/src/lib/mind/variant-cleanup.ts
@@ -10,9 +10,14 @@ import { deleteMindDbFootprint, mindDir, readAllMinds, removeMind } from "./regi
  * Clean up a variant's git resources: stop process, remove worktree, delete branch,
  * remove from DB, and fix ownership. Each step is independently guarded so failures
  * don't prevent subsequent cleanup.
+ *
+ * `baseName` is the parent mind that owns projectRoot — passed explicitly because
+ * upgrade variants have no DB row to derive it from, and a wrong fallback chowns
+ * the mind dir to a nonexistent user, leaving merge-written files root-owned.
  */
 export async function cleanupVariant(
   variantName: string,
+  baseName: string,
   projectRoot: string,
   variantPath: string,
   opts?: { stop?: boolean },
@@ -48,9 +53,6 @@ export async function cleanupVariant(
   } catch (err) {
     log.warn(`failed to delete branch ${branchName} for ${variantName}`, log.errorData(err));
   }
-
-  // Get the base name before removing from DB (uses variantEntry.parent which is already fetched)
-  const baseName = variantEntry?.parent ?? variantName;
 
   try {
     await removeMind(variantName);
@@ -100,7 +102,7 @@ export async function reconcileVariants(): Promise<void> {
       `reconcile: dropping stale variant row ${v.name} (worktree ${v.dir ?? "<none>"} missing)`,
     );
     try {
-      await cleanupVariant(v.name, baseDir(v.parent!), v.dir ?? "");
+      await cleanupVariant(v.name, v.parent!, baseDir(v.parent!), v.dir ?? "");
     } catch (err) {
       log.warn(`reconcile: failed to drop stale variant ${v.name}`, log.errorData(err));
     }

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -68,9 +68,9 @@ import {
   deleteMindUser as deleteIsolationUser,
   ensureVoluteGroup,
   isIsolationEnabled,
-  wrapForIsolation,
 } from "../../lib/mind/isolation.js";
 import { commitSrcChanges, rollbackSrcChanges } from "../../lib/mind/last-known-good.js";
+import { npmInstallAsMind, npmInstallNeeded } from "../../lib/mind/npm-install.js";
 import {
   addMind,
   countCappedMinds,
@@ -132,7 +132,7 @@ import {
   type TemplateManifest,
 } from "../../lib/template/template.js";
 import { computeTemplateHash } from "../../lib/template/template-hash.js";
-import { exec, gitExec } from "../../lib/util/exec.js";
+import { gitExec } from "../../lib/util/exec.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
 import { safeResolveWithinBase } from "../../lib/util/paths.js";
@@ -424,19 +424,6 @@ async function mergeTemplateBranch(worktreeDir: string): Promise<boolean> {
 }
 
 /**
- * Run npm install in a directory, using the mind user's identity when isolation is enabled.
- * This avoids creating root-owned node_modules that the mind can't modify later.
- */
-async function npmInstallAsMind(cwd: string, mindName: string): Promise<void> {
-  if (isIsolationEnabled()) {
-    const [cmd, args] = await wrapForIsolation("npm", ["install"], mindName);
-    await exec(cmd, args, { cwd, env: { ...process.env, HOME: resolve(cwd, "home") } });
-  } else {
-    await exec("npm", ["install"], { cwd });
-  }
-}
-
-/**
  * Merge the upgrade branch back into main, clean up, install deps, and restart.
  * Returns { ok, warning? } on success, throws on merge failure.
  */
@@ -457,11 +444,12 @@ async function mergeUpgradeAndRestart(
     await gitExec(["commit", "-m", "Auto-commit before upgrade merge"], { cwd: dir });
   }
 
+  const preMergeHead = (await gitExec(["rev-parse", "HEAD"], { cwd: dir })).trim();
   await gitExec(["merge", upgradeBranch], { cwd: dir });
 
   // Merge succeeded — everything below is best-effort cleanup/restart
   try {
-    await cleanupVariant(upgradeVariantName, dir, worktreeDir);
+    await cleanupVariant(upgradeVariantName, mindName, dir, worktreeDir);
   } catch (err) {
     log.warn(`failed to clean up upgrade worktree for ${mindName}`, log.errorData(err));
   }
@@ -517,14 +505,20 @@ async function mergeUpgradeAndRestart(
     log.warn(`failed to update template for ${mindName}`, log.errorData(err));
   }
 
-  try {
-    await npmInstallAsMind(dir, mindName);
-  } catch (err) {
-    log.warn(`npm install failed after upgrade merge for ${mindName}`, log.errorData(err));
-    return {
-      ok: true,
-      warning: `Upgrade merged but npm install failed: ${err instanceof Error ? err.message : String(err)}. You may need to run npm install manually.`,
-    };
+  // Skip npm install when the merge didn't touch dependencies — even a no-op
+  // install writes enough to freeze slow storage for a minute or more.
+  if (await npmInstallNeeded(dir, preMergeHead)) {
+    try {
+      await npmInstallAsMind(dir, mindName);
+    } catch (err) {
+      log.warn(`npm install failed after upgrade merge for ${mindName}`, log.errorData(err));
+      return {
+        ok: true,
+        warning: `Upgrade merged but npm install failed: ${err instanceof Error ? err.message : String(err)}. You may need to run npm install manually.`,
+      };
+    }
+  } else {
+    log.info(`skipping npm install for ${mindName} — dependencies unchanged by upgrade`);
   }
 
   // Restart mind with upgrade context
@@ -534,7 +528,10 @@ async function mergeUpgradeAndRestart(
       await manager.stopMind(mindName);
     }
     manager.setPendingContext(mindName, { type: "upgraded" });
-    await manager.startMind(mindName);
+    // Generous health budget: right after an npm install the disk cache is
+    // cold and I/O may still be saturated, so a tsx cold start can exceed the
+    // default 30s — timing out here kills the child and leaves the mind down.
+    await manager.startMind(mindName, { healthTimeoutMs: 120_000 });
   } catch (e) {
     return {
       ok: true,
@@ -1605,14 +1602,17 @@ const app = new Hono<AuthEnv>()
 
           // Merge (excluding the mind's living memory/journal — #440), narrate
           // the memory delta to the parent, then clean up worktree/branch and
-          // reinstall.
+          // reinstall if the merge touched dependencies.
+          const preMergeHead = (await gitExec(["rev-parse", "HEAD"], { cwd: projectRoot })).trim();
           const memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantEntry.branch);
           if (memoryDelta && context) context.memoryDelta = memoryDelta;
-          await cleanupVariant(mergeVariantName, projectRoot, variantEntry.dir);
-          try {
-            await npmInstallAsMind(projectRoot, baseName);
-          } catch (e) {
-            log.error(`npm install failed after merge for ${baseName}`, log.errorData(e));
+          await cleanupVariant(mergeVariantName, baseName, projectRoot, variantEntry.dir);
+          if (await npmInstallNeeded(projectRoot, preMergeHead)) {
+            try {
+              await npmInstallAsMind(projectRoot, baseName);
+            } catch (e) {
+              log.error(`npm install failed after merge for ${baseName}`, log.errorData(e));
+            }
           }
         }
       }
@@ -2120,7 +2120,7 @@ const app = new Hono<AuthEnv>()
     const variants = await findVariants(name);
     for (const s of variants) {
       if (s.dir) {
-        await cleanupVariant(s.name, dir, s.dir, { stop: true });
+        await cleanupVariant(s.name, name, dir, s.dir, { stop: true });
       }
     }
 
@@ -2196,7 +2196,7 @@ const app = new Hono<AuthEnv>()
           }
         } catch {}
 
-        await cleanupVariant(upgradeVariantName, dir, worktreeDir, { stop: true });
+        await cleanupVariant(upgradeVariantName, mindName, dir, worktreeDir, { stop: true });
 
         // Also delete the upgrade branch directly — cleanupVariant uses the variant
         // name as fallback branch, but the actual branch is UPGRADE_BRANCH
@@ -2285,7 +2285,7 @@ const app = new Hono<AuthEnv>()
       // Legacy — upgrades now auto-merge. Clean up any old-style upgrade state.
       if (existsSync(worktreeDir)) {
         try {
-          await cleanupVariant(upgradeVariantName, dir, worktreeDir, { stop: true });
+          await cleanupVariant(upgradeVariantName, mindName, dir, worktreeDir, { stop: true });
         } catch (err) {
           log.warn(`failed to clean up legacy upgrade variant for ${mindName}`, log.errorData(err));
         }
@@ -2447,7 +2447,7 @@ const app = new Hono<AuthEnv>()
     } catch (err) {
       // Merge failed — clean up
       try {
-        await cleanupVariant(upgradeVariantName, dir, worktreeDir);
+        await cleanupVariant(upgradeVariantName, mindName, dir, worktreeDir);
       } catch (cleanupErr) {
         log.warn(`cleanup failed after upgrade error for ${mindName}`, log.errorData(cleanupErr));
       }

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -157,19 +157,9 @@ const app = new Hono<AuthEnv>()
     // retry with the same name isn't blocked by a half-created variant (#444).
     const rollbackSplit = async () => {
       try {
-        await cleanupVariant(variantName, projectRoot, variantDir, { stop: true });
+        await cleanupVariant(variantName, mindName, projectRoot, variantDir, { stop: true });
       } catch (err) {
         log.warn(`failed to roll back split of ${variantName}`, log.errorData(err));
-      }
-      // cleanupVariant hands ownership to the variant's base name, which before DB
-      // registration resolves to the variant itself — restore it to the parent mind.
-      try {
-        await chownMindDir(projectRoot, mindName);
-      } catch (err) {
-        log.warn(
-          `failed to restore ${mindName} ownership after split rollback`,
-          log.errorData(err),
-        );
       }
     };
 
@@ -419,7 +409,7 @@ const app = new Hono<AuthEnv>()
         );
       }
 
-      await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
+      await cleanupVariant(variantName, mindName, projectRoot, variantEntry.dir, { stop: true });
 
       // The merge and cleanup git ops ran as the daemon (root). Hand ownership of
       // the parent worktree back to the mind user before the wrapped npm install
@@ -511,7 +501,7 @@ const app = new Hono<AuthEnv>()
 
     const projectRoot = parentEntry.dir ?? mindDir(mindName);
 
-    await cleanupVariant(variantName, projectRoot, variantEntry.dir, { stop: true });
+    await cleanupVariant(variantName, mindName, projectRoot, variantEntry.dir, { stop: true });
 
     return c.json({ ok: true });
   });

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1125,6 +1125,43 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.notEqual(entry?.template, "../../evil");
   });
 
+  it("upgrade: same-template upgrade merges, skips npm install, and restarts the mind", async () => {
+    await ensureTestMind();
+    const dir = mindDir(TEST_MIND);
+
+    // npm install writes this on every run — an unchanged mtime proves the
+    // dependencies-unchanged upgrade skipped the install entirely.
+    const lockStamp = resolve(dir, "node_modules", ".package-lock.json");
+    assert.ok(existsSync(lockStamp), "test mind should have node_modules installed");
+    const mtimeBefore = statSync(lockStamp).mtimeMs;
+
+    const res = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 200, `Upgrade failed: ${res.status} ${await res.clone().text()}`);
+    const body = (await res.json()) as { ok?: boolean; conflicts?: boolean; warning?: string };
+    assert.equal(body.ok, true, `Upgrade not ok: ${JSON.stringify(body)}`);
+    assert.notEqual(body.conflicts, true, "same-template upgrade should not conflict");
+    assert.equal(
+      body.warning?.includes("restart failed") ?? false,
+      false,
+      `Upgrade restart failed: ${body.warning}`,
+    );
+
+    assert.equal(statSync(lockStamp).mtimeMs, mtimeBefore, "npm install should have been skipped");
+
+    // The upgrade worktree and branch must be cleaned up.
+    assert.ok(!existsSync(resolve(dir, ".variants", "upgrade")), "upgrade worktree left behind");
+
+    // Upgrade restarts the mind; stop it so later tests see the usual state.
+    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const status = (await statusRes.json()) as { status?: string };
+    assert.equal(status.status, "running", "mind should be running after upgrade");
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+  });
+
   it("unified chat: send via /api/v1/chat", async () => {
     await ensureTestMind();
     const brain = await ensureBrainParticipant("unified");

--- a/test/npm-install.test.ts
+++ b/test/npm-install.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import {
+  depsChangedSince,
+  lowPriorityArgv,
+  npmInstallNeeded,
+} from "../packages/daemon/src/lib/mind/npm-install.js";
+
+const tmpDir = join(tmpdir(), `.volute-npm-install-test-${process.pid}`);
+
+function git(args: string[], cwd: string): string {
+  // Strip ALL GIT_* env vars set by hooks (e.g. pre-push) that override cwd-based repo discovery
+  const env: Record<string, string> = { LEFTHOOK: "0" };
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
+  }
+  return execFileSync("git", args, { cwd, encoding: "utf-8", env });
+}
+
+function commit(dir: string, message: string): string {
+  git(["add", "-A"], dir);
+  git(["commit", "-m", message], dir);
+  return git(["rev-parse", "HEAD"], dir).trim();
+}
+
+describe("lowPriorityArgv", () => {
+  it("prefixes with ionice and nice when ionice is available", () => {
+    const [cmd, args] = lowPriorityArgv("npm", ["install"], true);
+    assert.equal(cmd, "ionice");
+    assert.deepEqual(args, ["-c2", "-n7", "nice", "-n19", "npm", "install"]);
+  });
+
+  it("prefixes with nice alone when ionice is unavailable", () => {
+    const [cmd, args] = lowPriorityArgv("npm", ["install"], false);
+    assert.equal(cmd, "nice");
+    assert.deepEqual(args, ["-n19", "npm", "install"]);
+  });
+});
+
+describe("depsChangedSince / npmInstallNeeded", () => {
+  const repoDir = join(tmpDir, "repo");
+  let baseRef = "";
+
+  before(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    mkdirSync(repoDir, { recursive: true });
+    git(["init", "-b", "main"], repoDir);
+    git(["config", "user.email", "test@test.com"], repoDir);
+    git(["config", "user.name", "Test"], repoDir);
+    writeFileSync(join(repoDir, "package.json"), '{"name":"t","version":"1.0.0"}\n');
+    writeFileSync(join(repoDir, "README.md"), "hi\n");
+    baseRef = commit(repoDir, "initial");
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false when only non-dependency files changed", async () => {
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+    commit(repoDir, "docs change");
+    assert.equal(await depsChangedSince(repoDir, baseRef), false);
+  });
+
+  it("returns true when package.json changed", async () => {
+    const from = git(["rev-parse", "HEAD"], repoDir).trim();
+    writeFileSync(join(repoDir, "package.json"), '{"name":"t","version":"1.0.1"}\n');
+    commit(repoDir, "bump");
+    assert.equal(await depsChangedSince(repoDir, from), true);
+  });
+
+  it("returns true when package-lock.json changed", async () => {
+    const from = git(["rev-parse", "HEAD"], repoDir).trim();
+    writeFileSync(join(repoDir, "package-lock.json"), "{}\n");
+    commit(repoDir, "lockfile");
+    assert.equal(await depsChangedSince(repoDir, from), true);
+  });
+
+  it("errs toward true when the ref is invalid", async () => {
+    assert.equal(await depsChangedSince(repoDir, "not-a-ref"), true);
+  });
+
+  it("npmInstallNeeded is true when node_modules is missing", async () => {
+    const head = git(["rev-parse", "HEAD"], repoDir).trim();
+    assert.equal(await npmInstallNeeded(repoDir, head), true);
+  });
+
+  it("npmInstallNeeded is false when node_modules exists and deps are unchanged", async () => {
+    mkdirSync(join(repoDir, "node_modules"), { recursive: true });
+    const head = git(["rev-parse", "HEAD"], repoDir).trim();
+    assert.equal(await npmInstallNeeded(repoDir, head), false);
+  });
+});


### PR DESCRIPTION
## Problem

A mind upgrade on a production host (bardo, SD-card storage) freezes **the entire Volute system** for the duration — ~5 minutes on a real version upgrade. Reproduced and instrumented live: during the upgrade's `npm install`, iowait hit 60–70%, an independent shell probe froze for 19s, and daemon `/health` responses stretched to 8.7s. The root cause is the unconditional `npm install` in the mind dir — even a fully-cached no-op install writes enough to saturate slow storage, starving the daemon (whose synchronous libsql/fs calls then block the event loop) and every other mind.

The reproduction also surfaced two adjacent bugs:

- **cleanupVariant chowned the mind dir to a nonexistent user.** Upgrade variants have no DB row, so `baseName = variantEntry?.parent ?? variantName` fell back to the variant name → `chown mind-whorl-upgrade` fails silently → merge-written files (`.git` objects, `src/server.ts`, `package.json`) left **root-owned**, breaking the mind's auto-commit and self-modification under user isolation.
- **Post-upgrade restart has a hard 30s health deadline.** Right after npm install the disk cache is cold and I/O saturated, so the tsx cold start exceeded 30s — the daemon killed the child and left the mind **stopped** ("Upgrade merged but mind restart failed").

## Changes

- **Skip npm install when the merge didn't touch `package.json`/`package-lock.json`** (and `node_modules` exists) — applied to both the upgrade flow and the variant-join flow. This removes the dominant cost for the common template-only upgrade.
- **Run remaining installs at low priority with reduced work**: `nice -n19` (+ `ionice -c2 -n7` where available) and `--no-audit --no-fund --prefer-offline --loglevel=error`. New shared module `packages/daemon/src/lib/mind/npm-install.ts` (moved out of `web/api/minds.ts`).
- **`cleanupVariant` takes the base mind name explicitly**; the broken DB fallback is gone, and the split-rollback's compensating chown (which existed to patch the fallback) is removed.
- **`startMind` accepts `healthTimeoutMs`**; the post-upgrade restart passes 120s so a slow cold start can't leave the mind down.

## Tests

- `test/npm-install.test.ts`: `lowPriorityArgv` shapes, `depsChangedSince`/`npmInstallNeeded` against a real git repo (incl. err-toward-install on bad refs).
- `test/daemon-e2e.test.ts`: new end-to-end test — same-template upgrade merges cleanly, **skips npm install** (asserted via `node_modules/.package-lock.json` mtime), cleans up the worktree, and leaves the mind running.
- Full suite: 2596 unit tests + 62 e2e tests pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)