### PR TITLE
feat: R1 — durable per-user API tokens (api_tokens)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,9 +272,10 @@ Mind-scoped commands (`chat`, `clock`, `skill`) use `--mind <name>` or `VOLUTE_M
 | `config/env.ts` | Environment variables (shared `~/.volute/env.json` + mind-specific state dir env) |
 | `util/format-tool.ts` | Shared tool call summarization (`[toolName primaryArg]` format) |
 | `ai-service.ts` | System AI completion service via `@earendil-works/pi-ai` (multi-provider, OAuth + API key + env var auth, model selection) |
-| `schema.ts` | Drizzle ORM schema (minds, users, conversations, channels, turns, mindHistory, conversationParticipants, sessions, systemPrompts, sharedSkills, deliveryQueue, activity, conversationReads, messages, summaries, systemEvents) |
+| `schema.ts` | Drizzle ORM schema (minds, users, apiTokens, conversations, channels, turns, mindHistory, conversationParticipants, sessions, systemPrompts, sharedSkills, deliveryQueue, activity, conversationReads, messages, summaries, systemEvents) |
 | `db.ts` | libSQL database singleton at `~/.volute/volute.db` (WAL mode, foreign keys) |
 | `auth.ts` | bcrypt password hashing, first user auto-admin, pending approval flow, mind users |
+| `api-tokens.ts` | Durable per-user API tokens (`vmt_`-prefixed, SHA-256 hashed at rest, revoke = row DELETE); issue/list/resolve/revoke. Distinct from the in-memory native-mind token map in `daemon/mind-tokens.ts` |
 | `platforms.ts` | Platform registry with optional drivers (read/send), display names, slug resolution |
 | `packages/platforms/src/drivers/discord.ts` | Discord platform driver (read/send via REST API, slug-to-ID resolution) |
 | `packages/platforms/src/drivers/slack.ts` | Slack platform driver (read/send via Slack API, slug-to-ID resolution) |

--- a/drizzle/0018_api_tokens.sql
+++ b/drizzle/0018_api_tokens.sql
@@ -1,0 +1,20 @@
+-- Durable, hashed, revocable per-user API credentials.
+--
+-- Keyed to a `users` row rather than a mind name, so the same token type serves
+-- external minds (users rows with user_type "mind" and no minds registry row)
+-- and, later, external humans. Only the SHA-256 hash is stored; revocation is a
+-- row DELETE, and the FK cascade drops a user's tokens along with the user.
+--
+-- Orthogonal to the in-memory native-mind token map: these survive a restart.
+
+CREATE TABLE IF NOT EXISTS `api_tokens` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`token_hash` text NOT NULL,
+	`label` text,
+	`created_at` text NOT NULL DEFAULT (datetime('now'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_api_tokens_hash` ON `api_tokens` (`token_hash`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_api_tokens_user` ON `api_tokens` (`user_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1776200000000,
       "tag": "0017_event_history_rows",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1776300000000,
+      "tag": "0018_api_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/daemon/src/lib/api-tokens.ts
+++ b/packages/daemon/src/lib/api-tokens.ts
@@ -1,0 +1,100 @@
+import { createHash, randomBytes } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "./db.js";
+import { apiTokens } from "./schema.js";
+
+/**
+ * Durable per-user API tokens.
+ *
+ * Orthogonal to the in-memory native-mind token map
+ * (`daemon/mind-tokens.ts`): these are DB-backed, so they survive a daemon
+ * restart, and they resolve to a `users` row rather than a mind name.
+ *
+ * The `vmt_` prefix lets the auth path skip the DB entirely for non-prefixed
+ * Bearers (native mind tokens and session ids are bare UUIDs) and makes
+ * log-grep audits feasible.
+ */
+export const API_TOKEN_PREFIX = "vmt_";
+
+/** Mint a new plaintext token: prefix + 256 bits of entropy. */
+function generateToken(): string {
+  return API_TOKEN_PREFIX + randomBytes(32).toString("base64url");
+}
+
+/**
+ * SHA-256 is correct here: the secret is 256-bit random, so there is no
+ * dictionary/brute-force risk that a slow KDF would defend against, and the
+ * hash must support an indexed equality lookup on the auth path. Do NOT swap
+ * this for bcrypt/argon, and do not reduce the token entropy.
+ */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export type ApiTokenInfo = {
+  id: number;
+  label: string | null;
+  created_at: string;
+};
+
+/**
+ * Issue a token for a user. The returned plaintext is the only moment it
+ * exists outside the caller — it is never stored, logged, or re-derivable.
+ */
+export async function issueApiToken(
+  userId: number,
+  label?: string,
+): Promise<{ id: number; token: string; label: string | null; created_at: string }> {
+  const db = await getDb();
+  const token = generateToken();
+  const [row] = await db
+    .insert(apiTokens)
+    .values({ user_id: userId, token_hash: hashToken(token), label: label ?? null })
+    .returning({ id: apiTokens.id, label: apiTokens.label, created_at: apiTokens.created_at });
+  return { id: row.id, token, label: row.label, created_at: row.created_at };
+}
+
+/**
+ * Resolve a Bearer value to a user id, or null. Non-prefixed values return
+ * immediately without touching the DB.
+ */
+export async function resolveApiToken(token: string): Promise<number | null> {
+  if (!token.startsWith(API_TOKEN_PREFIX)) return null;
+  const db = await getDb();
+  const row = await db
+    .select({ user_id: apiTokens.user_id })
+    .from(apiTokens)
+    .where(eq(apiTokens.token_hash, hashToken(token)))
+    .get();
+  return row?.user_id ?? null;
+}
+
+/**
+ * Revoke by deleting the row — a revoked token can never resolve again.
+ * Scoped to `userId` in the DELETE itself, so a token id belonging to another
+ * user cannot be deleted through a path that claims to be this user's.
+ * Returns false when the token doesn't exist or isn't this user's.
+ */
+export async function revokeApiToken(userId: number, id: number): Promise<boolean> {
+  const db = await getDb();
+  const rows = await db
+    .delete(apiTokens)
+    .where(and(eq(apiTokens.id, id), eq(apiTokens.user_id, userId)))
+    .returning({ id: apiTokens.id });
+  return rows.length > 0;
+}
+
+/** List a user's tokens. Never returns the hash, never returns a token. */
+export async function listApiTokens(userId: number): Promise<ApiTokenInfo[]> {
+  const db = await getDb();
+  return (
+    db
+      .select({ id: apiTokens.id, label: apiTokens.label, created_at: apiTokens.created_at })
+      .from(apiTokens)
+      .where(eq(apiTokens.user_id, userId))
+      // By id, not created_at: datetime('now') has second granularity, so two
+      // tokens issued in the same second would order arbitrarily.
+      .orderBy(apiTokens.id)
+      .all()
+  );
+}

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -43,6 +43,27 @@ export const users = sqliteTable("users", {
   created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
 });
 
+// Durable, hashed, revocable per-user API credentials. Keyed to a users row —
+// deliberately user_type-agnostic, so the same token type serves external minds
+// and (later) external humans. Only the SHA-256 hash is stored; revocation is a
+// row DELETE, and the FK cascade drops a user's tokens with the user.
+export const apiTokens = sqliteTable(
+  "api_tokens",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    user_id: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    token_hash: text("token_hash").notNull(),
+    label: text("label"),
+    created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    uniqueIndex("idx_api_tokens_hash").on(table.token_hash),
+    index("idx_api_tokens_user").on(table.user_id),
+  ],
+);
+
 export const conversations = sqliteTable(
   "conversations",
   {

--- a/packages/daemon/src/web/api/auth.ts
+++ b/packages/daemon/src/web/api/auth.ts
@@ -4,6 +4,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { z } from "zod";
+import { issueApiToken, listApiTokens, revokeApiToken } from "../../lib/api-tokens.js";
 import {
   approveUser,
   changePassword,
@@ -39,6 +40,7 @@ import {
   deleteSession,
   getSessionUserId,
   invalidateSessionCache,
+  requireAdminOrSystem,
   SESSION_MAX_AGE,
 } from "../middleware/auth.js";
 
@@ -217,6 +219,50 @@ const admin = new Hono<AuthEnv>()
       return c.json({ ok: true });
     },
   )
+  // --- Durable per-user API tokens ---
+  // requireAdminOrSystem throughout: a role:"user" principal (which every mind
+  // token resolves to) can neither mint nor rotate credentials.
+  .post(
+    "/users/:id/tokens",
+    requireAdminOrSystem,
+    zValidator("json", z.object({ label: z.string().max(200).optional() })),
+    async (c) => {
+      const id = parseInt(c.req.param("id"), 10);
+      if (Number.isNaN(id)) return c.json({ error: "Invalid user ID" }, 400);
+      const target = await getUser(id);
+      if (!target) return c.json({ error: "User not found" }, 404);
+      const { label } = c.req.valid("json");
+      // The plaintext token exists only in this response — never logged.
+      const issued = await issueApiToken(id, label);
+      return c.json(
+        {
+          id: issued.id,
+          token: issued.token,
+          label: issued.label,
+          createdAt: issued.created_at,
+        },
+        201,
+      );
+    },
+  )
+  .get("/users/:id/tokens", requireAdminOrSystem, async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (Number.isNaN(id)) return c.json({ error: "Invalid user ID" }, 400);
+    const target = await getUser(id);
+    if (!target) return c.json({ error: "User not found" }, 404);
+    const tokens = await listApiTokens(id);
+    return c.json(tokens.map((t) => ({ id: t.id, label: t.label, createdAt: t.created_at })));
+  })
+  .delete("/users/:id/tokens/:tokenId", requireAdminOrSystem, async (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    const tokenId = parseInt(c.req.param("tokenId"), 10);
+    if (Number.isNaN(id) || Number.isNaN(tokenId)) return c.json({ error: "Invalid ID" }, 400);
+    // Scoped to :id inside the DELETE, so a token id belonging to another user
+    // can't be revoked through a path that claims to be this user's.
+    const revoked = await revokeApiToken(id, tokenId);
+    if (!revoked) return c.json({ error: "Token not found" }, 404);
+    return c.json({ ok: true });
+  })
   .put("/users/:id/profile", zValidator("json", profileSchema), async (c) => {
     const user = c.get("user");
     if (user.role !== "admin") return c.json({ error: "Forbidden" }, 403);

--- a/packages/daemon/src/web/api/auth.ts
+++ b/packages/daemon/src/web/api/auth.ts
@@ -40,7 +40,7 @@ import {
   deleteSession,
   getSessionUserId,
   invalidateSessionCache,
-  requireAdminOrSystem,
+  requireAdmin,
   SESSION_MAX_AGE,
 } from "../middleware/auth.js";
 
@@ -220,11 +220,15 @@ const admin = new Hono<AuthEnv>()
     },
   )
   // --- Durable per-user API tokens ---
-  // requireAdminOrSystem throughout: a role:"user" principal (which every mind
-  // token resolves to) can neither mint nor rotate credentials.
+  // requireAdmin throughout: durable credential issuance is human-gated. Only a
+  // role:"admin" principal may mint or rotate tokens — a mind gets this power
+  // only by being deliberately made an admin. Neither a role:"user" principal
+  // (what every mind token resolves to) nor the system principal (the spirit)
+  // qualifies, which closes the prompt-injection path where untrusted text
+  // could talk the spirit into issuing a durable credential to an attacker.
   .post(
     "/users/:id/tokens",
-    requireAdminOrSystem,
+    requireAdmin,
     zValidator("json", z.object({ label: z.string().max(200).optional() })),
     async (c) => {
       const id = parseInt(c.req.param("id"), 10);
@@ -245,7 +249,7 @@ const admin = new Hono<AuthEnv>()
       );
     },
   )
-  .get("/users/:id/tokens", requireAdminOrSystem, async (c) => {
+  .get("/users/:id/tokens", requireAdmin, async (c) => {
     const id = parseInt(c.req.param("id"), 10);
     if (Number.isNaN(id)) return c.json({ error: "Invalid user ID" }, 400);
     const target = await getUser(id);
@@ -253,7 +257,7 @@ const admin = new Hono<AuthEnv>()
     const tokens = await listApiTokens(id);
     return c.json(tokens.map((t) => ({ id: t.id, label: t.label, createdAt: t.created_at })));
   })
-  .delete("/users/:id/tokens/:tokenId", requireAdminOrSystem, async (c) => {
+  .delete("/users/:id/tokens/:tokenId", requireAdmin, async (c) => {
     const id = parseInt(c.req.param("id"), 10);
     const tokenId = parseInt(c.req.param("tokenId"), 10);
     if (Number.isNaN(id) || Number.isNaN(tokenId)) return c.json({ error: "Invalid ID" }, 400);

--- a/packages/daemon/src/web/middleware/auth.ts
+++ b/packages/daemon/src/web/middleware/auth.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from "node:crypto";
 import { eq, lt } from "drizzle-orm";
 import { getCookie } from "hono/cookie";
 import { createMiddleware } from "hono/factory";
+import { API_TOKEN_PREFIX, resolveApiToken } from "../../lib/api-tokens.js";
 import { getOrCreateMindUser, getUser, type User } from "../../lib/auth.js";
 import { resolveMindToken } from "../../lib/daemon/mind-tokens.js";
 import { getDb } from "../../lib/db.js";
@@ -180,7 +181,24 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
       return;
     }
 
-    // 3. Session token via Bearer (CLI login)
+    // 3. Durable per-user API token (vmt_-prefixed) — resolves to any users row.
+    // Disjoint from the branches around it by construction: the daemon token and
+    // session ids are bare UUIDs, and the in-memory mind-token map only ever
+    // holds UUIDs, so a vmt_ value misses them and falls through to here.
+    if (token.startsWith(API_TOKEN_PREFIX)) {
+      const userId = await resolveApiToken(token);
+      if (userId != null) {
+        const user = await getUser(userId);
+        if (user) {
+          if (user.role === "pending") return c.json({ error: "Account pending approval" }, 403);
+          c.set("user", user);
+          await next();
+          return;
+        }
+      }
+    }
+
+    // 4. Session token via Bearer (CLI login)
     if (token) {
       const user = await resolveSession(token);
       if (user) {
@@ -192,7 +210,7 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
     }
   }
 
-  // 4. Cookie-based session (web UI)
+  // 5. Cookie-based session (web UI)
   const sessionId = getCookie(c, "volute_session");
   if (!sessionId) return c.json({ error: "Unauthorized" }, 401);
 

--- a/test/api-tokens.test.ts
+++ b/test/api-tokens.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import {
+  hashToken,
+  issueApiToken,
+  listApiTokens,
+  resolveApiToken,
+} from "../packages/daemon/src/lib/api-tokens.js";
+import { createUser, getOrCreateMindUser, setUserRole } from "../packages/daemon/src/lib/auth.js";
+import {
+  generateMindToken,
+  resolveMindToken,
+  revokeMindToken,
+} from "../packages/daemon/src/lib/daemon/mind-tokens.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { apiTokens, users } from "../packages/daemon/src/lib/schema.js";
+import authApp from "../packages/daemon/src/web/api/auth.js";
+import {
+  authMiddleware,
+  createSession,
+  requireSelf,
+} from "../packages/daemon/src/web/middleware/auth.js";
+
+const EXTERNAL_MIND = "api-token-external-mind";
+const OTHER_MIND = "api-token-other-mind";
+const ADMIN_USER = "api-token-admin";
+const PLAIN_USER = "api-token-plain";
+
+const TEST_USERNAMES = [EXTERNAL_MIND, OTHER_MIND, ADMIN_USER, PLAIN_USER];
+
+async function cleanup() {
+  const db = await getDb();
+  for (const username of TEST_USERNAMES) {
+    // FK cascade drops any api_tokens rows with the user.
+    await db.delete(users).where(eq(users.username, username));
+  }
+}
+
+/** A minimal app exposing a requireSelf-guarded route, mirroring mind-scoped routes. */
+function createApp() {
+  const app = new Hono();
+  app.use("/api/minds/*", authMiddleware);
+  app.get("/api/minds/:name/info", requireSelf(), (c) =>
+    c.json({ ok: true, name: c.req.param("name"), caller: c.get("user").username }),
+  );
+  return app;
+}
+
+/**
+ * Create an admin explicitly. `createUser` only auto-admins the FIRST human user,
+ * and `approveUser` grants role "user" — neither is reliable in a shared test DB.
+ */
+async function makeAdmin() {
+  const user = await createUser(ADMIN_USER, "pw-123456");
+  await setUserRole(user.id, "admin");
+  const db = await getDb();
+  const row = await db.select().from(users).where(eq(users.id, user.id)).get();
+  assert.equal(row?.role, "admin");
+  return user;
+}
+
+describe("api tokens", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("authenticates as the token's user on a requireSelf route", async () => {
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+    await getOrCreateMindUser(OTHER_MIND);
+    const { token } = await issueApiToken(mindUser.id, "external heartbeat");
+
+    const app = createApp();
+
+    const ok = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(ok.status, 200, await ok.clone().text());
+    const body = (await ok.json()) as { caller: string };
+    assert.equal(body.caller, EXTERNAL_MIND);
+
+    // The principal is the mind user itself: user_type "mind", non-admin role.
+    assert.equal(mindUser.user_type, "mind");
+    assert.equal(mindUser.role, "user");
+
+    // ...and it cannot reach another mind's route.
+    const forbidden = await app.request(`/api/minds/${OTHER_MIND}/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(forbidden.status, 403);
+  });
+
+  it("skips the DB for non-vmt_ bearers and falls through to session resolution", async () => {
+    const user = await makeAdmin();
+    const sessionId = await createSession(user.id);
+
+    // A bare-UUID session id is not vmt_-prefixed, so resolveApiToken short-circuits...
+    assert.equal(await resolveApiToken(sessionId), null);
+
+    // ...and the request still authenticates via the session-Bearer branch.
+    const app = createApp();
+    const res = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+      headers: { Authorization: `Bearer ${sessionId}` },
+    });
+    assert.equal(res.status, 200, await res.clone().text());
+
+    // An unknown non-prefixed bearer resolves to nothing at all.
+    assert.equal(await resolveApiToken("not-a-vmt-token"), null);
+  });
+
+  it("stores only a sha256 hash at rest, never the plaintext", async () => {
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+    const { id, token } = await issueApiToken(mindUser.id, "at-rest");
+
+    const db = await getDb();
+    const row = await db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    assert.ok(row);
+    assert.notEqual(row.token_hash, token);
+    assert.equal(row.token_hash, createHash("sha256").update(token).digest("hex"));
+    assert.equal(row.token_hash, hashToken(token));
+    assert.ok(token.startsWith("vmt_"));
+
+    // listApiTokens exposes neither the hash nor the token.
+    const listed = await listApiTokens(mindUser.id);
+    const serialized = JSON.stringify(listed);
+    assert.ok(!serialized.includes(row.token_hash), "list must not leak the hash");
+    assert.ok(!serialized.includes(token), "list must not leak the token");
+    assert.deepEqual(Object.keys(listed[0]).sort(), ["created_at", "id", "label"]);
+  });
+
+  it("stops resolving a token once revoked via the API", async () => {
+    const adminSession = await createSession((await makeAdmin()).id);
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+
+    const issueRes = await authApp.request(`/users/${mindUser.id}/tokens`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminSession}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "revoke-me" }),
+    });
+    assert.equal(issueRes.status, 201, await issueRes.clone().text());
+    const issued = (await issueRes.json()) as { id: number; token: string };
+    assert.ok(issued.token.startsWith("vmt_"));
+
+    const app = createApp();
+    const before = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+      headers: { Authorization: `Bearer ${issued.token}` },
+    });
+    assert.equal(before.status, 200);
+
+    const del = await authApp.request(`/users/${mindUser.id}/tokens/${issued.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${adminSession}` },
+    });
+    assert.equal(del.status, 200, await del.clone().text());
+
+    // Revoked: the token no longer resolves and the request is unauthenticated.
+    assert.equal(await resolveApiToken(issued.token), null);
+    const after = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+      headers: { Authorization: `Bearer ${issued.token}` },
+    });
+    assert.equal(after.status, 401);
+  });
+
+  it("restricts issuance to admin/system principals", async () => {
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+
+    // A role:"user" principal (what every mind token resolves to) cannot mint.
+    const { token: userToken } = await issueApiToken(mindUser.id, "non-admin");
+    const forbidden = await authApp.request(`/users/${mindUser.id}/tokens`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${userToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(forbidden.status, 403);
+
+    // Nor list, nor revoke.
+    const listForbidden = await authApp.request(`/users/${mindUser.id}/tokens`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    assert.equal(listForbidden.status, 403);
+
+    // Unauthenticated requests are rejected before authz.
+    const unauth = await authApp.request(`/users/${mindUser.id}/tokens`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(unauth.status, 401);
+  });
+
+  it("returns 404 for an unknown user id", async () => {
+    const adminSession = await createSession((await makeAdmin()).id);
+
+    const res = await authApp.request("/users/99999999/tokens", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminSession}`, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 404);
+  });
+
+  it("lists a user's tokens without hash or token", async () => {
+    const adminSession = await createSession((await makeAdmin()).id);
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+    await issueApiToken(mindUser.id, "first");
+    await issueApiToken(mindUser.id, "second");
+
+    const res = await authApp.request(`/users/${mindUser.id}/tokens`, {
+      headers: { Authorization: `Bearer ${adminSession}` },
+    });
+    assert.equal(res.status, 200);
+    const listed = (await res.json()) as Record<string, unknown>[];
+    assert.equal(listed.length, 2);
+    for (const t of listed) {
+      assert.deepEqual(Object.keys(t).sort(), ["createdAt", "id", "label"]);
+    }
+  });
+
+  it("refuses to revoke a token belonging to a different user", async () => {
+    const adminSession = await createSession((await makeAdmin()).id);
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+    const otherUser = await getOrCreateMindUser(OTHER_MIND);
+    const { id: otherTokenId, token: otherToken } = await issueApiToken(otherUser.id);
+
+    // Token id is real, but it isn't :id's token — the path must not delete it.
+    const res = await authApp.request(`/users/${mindUser.id}/tokens/${otherTokenId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${adminSession}` },
+    });
+    assert.equal(res.status, 404);
+    assert.equal(await resolveApiToken(otherToken), otherUser.id, "token must still resolve");
+  });
+
+  it("is orthogonal to the in-memory native-mind token map", async () => {
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+    const { token: apiToken } = await issueApiToken(mindUser.id, "durable");
+
+    // Native in-memory token: separate path, separate value space.
+    const nativeToken = generateMindToken(EXTERNAL_MIND);
+    assert.equal(resolveMindToken(nativeToken), EXTERNAL_MIND);
+    assert.ok(!nativeToken.startsWith("vmt_"));
+
+    // resolveMindToken stays synchronous — it returns a value, not a promise.
+    assert.ok(!(resolveMindToken(nativeToken) instanceof Promise));
+
+    // Revoking the in-memory token leaves the durable row untouched.
+    revokeMindToken(EXTERNAL_MIND);
+    assert.equal(resolveMindToken(nativeToken), null);
+    assert.equal(await resolveApiToken(apiToken), mindUser.id);
+
+    // ...and the api token never resolves through the native map.
+    assert.equal(resolveMindToken(apiToken), null);
+
+    const db = await getDb();
+    const rows = await db.select().from(apiTokens).where(eq(apiTokens.user_id, mindUser.id)).all();
+    assert.equal(rows.length, 1, "in-memory token churn must not touch api_tokens rows");
+  });
+
+  it("drops a user's tokens when the user is deleted (FK cascade)", async () => {
+    const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
+    const { token } = await issueApiToken(mindUser.id);
+    assert.equal(await resolveApiToken(token), mindUser.id);
+
+    const db = await getDb();
+    await db.delete(users).where(eq(users.id, mindUser.id));
+    assert.equal(await resolveApiToken(token), null);
+  });
+
+  it("rejects a pending user's token", async () => {
+    const user = await createUser(PLAIN_USER, "pw-123456");
+    // Force "pending" explicitly: createUser only auto-admins the first human,
+    // so its default role depends on what else is in the shared test DB.
+    const db = await getDb();
+    await db.update(users).set({ role: "pending" }).where(eq(users.id, user.id));
+    const { token } = await issueApiToken(user.id, "pending-user");
+
+    const app = createApp();
+    const res = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 403);
+  });
+});

--- a/test/api-tokens.test.ts
+++ b/test/api-tokens.test.ts
@@ -162,7 +162,7 @@ describe("api tokens", () => {
     assert.equal(after.status, 401);
   });
 
-  it("restricts issuance to admin/system principals", async () => {
+  it("restricts issuance to admins only (not user or system principals)", async () => {
     const mindUser = await getOrCreateMindUser(EXTERNAL_MIND);
 
     // A role:"user" principal (what every mind token resolves to) cannot mint.
@@ -179,6 +179,19 @@ describe("api tokens", () => {
       headers: { Authorization: `Bearer ${userToken}` },
     });
     assert.equal(listForbidden.status, 403);
+
+    // Nor the system principal (the spirit): durable issuance is human-gated, so
+    // even role:"system" is rejected — closing the prompt-injection path where
+    // untrusted text could talk the spirit into minting a credential.
+    const systemUser = await getOrCreateMindUser(OTHER_MIND);
+    await setUserRole(systemUser.id, "system");
+    const { token: systemToken } = await issueApiToken(systemUser.id, "system-principal");
+    const systemForbidden = await authApp.request(`/users/${mindUser.id}/tokens`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${systemToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(systemForbidden.status, 403);
 
     // Unauthenticated requests are rejected before authz.
     const unauth = await authApp.request(`/users/${mindUser.id}/tokens`, {

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -527,6 +527,71 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
   });
 
+  it("durable API tokens still authenticate across a daemon restart", async () => {
+    // The in-memory native-mind token map is empty after a restart, so only a
+    // DB-backed api_tokens credential can survive this. This is the load-bearing
+    // assertion for durable tokens.
+    const mindUser = await getUserByUsername(TEST_MIND);
+    assert.ok(mindUser, "test mind should have a user record");
+
+    const issueRes = await daemonRequest(`/api/auth/users/${mindUser.id}/tokens`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "e2e-restart" }),
+    });
+    assert.equal(issueRes.status, 201, `issue: ${await issueRes.clone().text()}`);
+    const { id: tokenId, token } = (await issueRes.json()) as { id: number; token: string };
+    assert.ok(token.startsWith("vmt_"), `expected vmt_ prefix, got ${token.slice(0, 8)}...`);
+
+    const tokenRequest = (path: string, options?: RequestInit) =>
+      fetch(`${BASE_URL}${path}`, {
+        ...options,
+        headers: { ...options?.headers, Authorization: `Bearer ${token}`, Origin: BASE_URL },
+      });
+
+    // Authenticates before the restart (requireSelf route, as the mind itself).
+    const before = await tokenRequest(`/api/minds/${TEST_MIND}/sleep`);
+    assert.equal(before.status, 200, `before restart: ${await before.clone().text()}`);
+
+    // Restart the daemon (SIGTERM, as `volute down` does), then bring it back.
+    daemon.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      daemon.on("exit", () => resolve());
+      setTimeout(() => {
+        try {
+          daemon.kill("SIGKILL");
+        } catch {}
+        resolve();
+      }, 5000);
+    });
+
+    daemon = spawn(
+      "npx",
+      ["tsx", "packages/daemon/src/daemon.ts", "--port", String(PORT), "--foreground"],
+      {
+        cwd: process.cwd(),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN, VOLUTE_BASE_PORT: String(MIND_BASE_PORT) },
+      },
+    );
+    daemon.stderr?.on("data", (data: Buffer) => {
+      process.stderr.write(`[daemon] ${data}`);
+    });
+    await waitForHealth();
+
+    // The whole point: the same token still authenticates against a fresh process.
+    const after = await tokenRequest(`/api/minds/${TEST_MIND}/sleep`);
+    assert.equal(after.status, 200, `after restart: ${await after.clone().text()}`);
+
+    // And revocation still takes effect against the new daemon.
+    const del = await daemonRequest(`/api/auth/users/${mindUser.id}/tokens/${tokenId}`, {
+      method: "DELETE",
+    });
+    assert.equal(del.status, 200, `revoke: ${await del.clone().text()}`);
+    const revoked = await tokenRequest(`/api/minds/${TEST_MIND}/sleep`);
+    assert.equal(revoked.status, 401, "revoked token must not authenticate");
+  });
+
   it("crash recovery: daemon restarts a mind whose process dies", { timeout: 60000 }, async () => {
     const entry = await findMind(TEST_MIND);
     assert.ok(entry, "test mind should be registered");


### PR DESCRIPTION
## R1 — durable per-user API tokens (`api_tokens`)

The keystone credential for **first-class external minds** (mimsy/volute#711). An
external mind is a plain `users` row with `user_type:"mind"` and no `minds`
registry row; R1 gives that principal a durable, DB-backed credential (the old
mind tokens are in-memory only, minted at spawn — un-issuable to a process the
daemon didn't start). The token is deliberately `user_type`-agnostic (keyed to
`user_id`), so the same type serves external humans later.

**This is R1 only** — no registration endpoint, no policy setting, no `fan-out`/
`minds`-row/`delivery_mode` changes. That's R2/R3a.

### What's here
- **`api_tokens` table** — SHA-256 hash at rest, `UNIQUE` on the hash, FK cascade
  on user delete. Migration `0018` **hand-written**: `npm run db:generate` is dead
  repo-wide (the drizzle snapshot chain broke at `0007`; `_journal.json` runs to
  `0017`), and hand-written SQL + a hand-appended journal entry has been the repo's
  actual convention since `0008` (verified against `drizzle/` git history, e.g.
  #698's `0017`). Migration application + FK cascade are test-verified, not assumed.
- **`api-tokens.ts`** — `issue`/`resolve`/`revoke`/`list`. Tokens are `vmt_` + 256
  bits of entropy; SHA-256 (not bcrypt) is correct for a high-entropy secret and is
  required for the indexed equality lookup on the hot path. `resolveApiToken`
  prefix-gates: a non-`vmt_` Bearer never touches the DB. Revoke = a `user_id`-scoped
  atomic row DELETE (ownership is enforced *inside* the query, not check-then-delete).
- **Fifth `authMiddleware` branch** — prefix-gated, `pending`-guarded, inserted
  after the in-memory mind-token branch and before session resolution. Disjoint by
  construction (daemon token + session ids + native mind tokens are all bare UUIDs,
  so a `vmt_` value misses them). The in-memory `resolveMindToken` map is **untouched
  and still synchronous** — no async churn.
- **Three admin endpoints** on `/api/auth/users/:id/tokens` (POST issue / GET list /
  DELETE revoke), all `requireAdminOrSystem`. The plaintext token appears in exactly
  one response and is never logged; list never returns a hash or token.

### Verification (I re-ran all of this myself, not just the builder's report)
- `npx tsc --noEmit` — clean.
- `test/api-tokens.test.ts` — **11/11** (covers: authenticates as the user, prefix
  gate skips the DB, sha256-at-rest, revoke stops resolution, issuance authz,
  cross-user revoke refused, orthogonality to native mind tokens, FK cascade,
  pending rejection).
- `npm run test:e2e` — **63/63**, including the load-bearing **"durable API tokens
  still authenticate across a daemon restart"** (proves it's DB-backed, not the
  in-memory kind), plus "admin/daemon token may still query another mind" (existing
  behavior preserved).
- Full unit suite: 6 failures, all in `test/global-config.test.ts`, which is
  non-hermetic (touches real `~/.volute` state) and passes **11/11 in isolation on
  clean `main`**. R1's diff touches none of that code. Not papered over.
- Done-bar: neutering the auth branch turns 4 of the 11 unit tests red.

### One call for the maintainer (@psamiton)
The three token routes use **`requireAdminOrSystem`** (admits `role:"system"` — the
spirit — so it can provision/rotate peer credentials, mirroring the native mind
create route). The *sibling* user-management routes (`/approve`, `/role`, `/profile`)
are **admin-only**. This is per the plan, but it's your credential path — if you'd
rather these be admin-only too, it's a one-line change per route. Flagging rather
than silently smoothing.

### Deferred to R2 (flagged, not decided)
- The `vmt_` branch does **not** capture `X-Volute-Thread` into `mindSession` (turn
  attribution) — an external mind will need it; two lines when R2 lands.
- `GET /api/auth/me` does its own session resolution, so it won't answer a `vmt_`
  principal. R2 will trip on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
