### PR TITLE
fix(ci): pin pi template earendil deps to exact 0.80.6

### DIFF
--- a/templates/pi/package.json.tmpl
+++ b/templates/pi/package.json.tmpl
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",
-    "@earendil-works/pi-ai": "^0.80.6",
-    "@earendil-works/pi-coding-agent": "^0.80.6",
+    "@earendil-works/pi-ai": "0.80.6",
+    "@earendil-works/pi-coding-agent": "0.80.6",
     "@sinclair/typebox": "^0.34.52",
     "tsx": "^4.23.1"
   },


### PR DESCRIPTION
## Why

The **typecheck** CI job (`scripts/typecheck-templates.ts`) started failing on the `pi` template today with:
```
src/agent.ts: Module @earendil-works/pi-coding-agent has no exported member AuthStorage
ModelRegistry.create does not exist / authStorage not in CreateAgentSessionOptions
```
Not a code change — pure upstream drift. `templates/pi/package.json.tmpl` pinned `@earendil-works/pi-ai` and `@earendil-works/pi-coding-agent` at caret `^0.80.6`. The template typecheck renders the tmpl and does a **fresh, lockfile-free install**, so the caret floated to **0.80.8** (published 2026-07-16 14:40 UTC) — a *patch* that removed exports, i.e. an upstream semver violation. Root deps are lockfile-protected (root typecheck stayed green); the composed template is not, which is why main is only stale-green — a re-run would fail too.

## Fix

Pin both earendil deps to exact `0.80.6` (the caret floor the template was authored against). Verified by running the real reproduction `npx tsx scripts/typecheck-templates.ts pi` (fresh install) — now `✓ pi passed`.

## Follow-ups (not here)
- A deliberate upgrade to the newer pi-coding-agent auth/session API is a separate effort.
- Root `package.json` also uses `^0.80.6` (lockfile-protected today); consider pinning for consistency.