### PR TITLE
fix: route setup wizard to login when resumed without a session

### DIFF
--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -74,7 +74,9 @@ setup.get("/status", async (c) => {
       const brains = await listUsersByType("human");
       hasAccount = brains.length > 0;
     } catch (err) {
-      log.debug("could not check for existing accounts during setup status", log.errorData(err));
+      // Falling through with hasAccount:false sends a resumed browser back into
+      // the wizard (the #690 dead-end) — make the real failure visible.
+      log.error("could not check for existing accounts during setup status", log.errorData(err));
     }
   }
 

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -22,6 +22,7 @@ import PublicFiles from "./components/system/PublicFiles.svelte";
 import SystemLogs from "./components/system/SystemLogs.svelte";
 import UpdateBanner from "./components/system/UpdateBanner.svelte";
 import TurnTimeline from "./components/TurnTimeline.svelte";
+import { resolveScreen } from "./lib/app-screen";
 import { type AuthUser, fetchMe } from "./lib/auth";
 import { deleteConversation } from "./lib/client";
 import {
@@ -294,6 +295,17 @@ let headerMindActive = $derived.by(() => {
 
 // Remote connection state — true when no daemon found and no saved connection
 let needsConnection = $state(false);
+
+// Top-level screen to render (loading / setup / connection / login / app).
+let screen = $derived(
+  resolveScreen({
+    checked: auth.checked,
+    setupComplete: auth.setupComplete,
+    hasAccount: !!auth.setupProgress?.hasAccount,
+    needsConnection,
+    loggedIn: !!auth.user,
+  }),
+);
 
 async function doLogout() {
   await handleLogout();
@@ -673,11 +685,11 @@ function handleGlobalClick(e: MouseEvent) {
 <svelte:window onkeydown={handleEscape} />
 <svelte:document onclick={handleGlobalClick} />
 
-{#if !auth.checked}
+{#if screen === "loading"}
   <div class="app">
     <div class="loading">Loading...</div>
   </div>
-{:else if !auth.setupComplete}
+{:else if screen === "setup"}
   <div class="app full-height">
     <SetupPage onComplete={(spiritName) => {
       auth.setupComplete = true;
@@ -687,7 +699,7 @@ function handleGlobalClick(e: MouseEvent) {
       });
     }} />
   </div>
-{:else if needsConnection}
+{:else if screen === "connection"}
   <div class="app full-height">
     <ConnectionSetup onConnected={(user) => {
       needsConnection = false;
@@ -696,11 +708,12 @@ function handleGlobalClick(e: MouseEvent) {
       handleAuth(user);
     }} />
   </div>
-{:else if !auth.user}
+{:else if screen === "login"}
   <div class="app full-height">
-    <LoginPage {onAuth} />
+    <LoginPage {onAuth} resumeSetup={!auth.setupComplete && !!auth.setupProgress?.hasAccount} />
   </div>
-{:else}
+<!-- screen === "app" implies loggedIn; the auth.user guard is just for TS narrowing. -->
+{:else if auth.user}
   <div class="shell">
     {#if auth.user.role === "admin"}
       <UpdateBanner />

--- a/packages/web/src/ui/components/LoginPage.svelte
+++ b/packages/web/src/ui/components/LoginPage.svelte
@@ -2,7 +2,13 @@
 import { Input } from "@volute/ui";
 import { type AuthUser, login, register } from "../lib/auth";
 
-let { onAuth }: { onAuth: (user: AuthUser) => void } = $props();
+let {
+  onAuth,
+  // When the setup wizard is resumed without a session, an admin account
+  // already exists — offer only sign-in (registering would create a second,
+  // pending account and re-trap the user) and say the wizard resumes after.
+  resumeSetup = false,
+}: { onAuth: (user: AuthUser) => void; resumeSetup?: boolean } = $props();
 
 let mode = $state<"login" | "register">("login");
 let username = $state("");
@@ -61,7 +67,11 @@ async function handleSubmit(e: Event) {
           <span class="logo">volute</span>
         </div>
         <div class="subtitle">
-          {mode === "login" ? "Sign in to continue" : "Create an account"}
+          {resumeSetup
+            ? "Sign in to continue setup"
+            : mode === "login"
+              ? "Sign in to continue"
+              : "Create an account"}
         </div>
       </div>
 
@@ -92,11 +102,13 @@ async function handleSubmit(e: Event) {
         </button>
       </form>
 
-      <div class="toggle">
-        <button class="link-btn" onclick={() => { mode = mode === "login" ? "register" : "login"; error = ""; }}>
-          {mode === "login" ? "Need an account? Register" : "Have an account? Sign in"}
-        </button>
-      </div>
+      {#if !resumeSetup}
+        <div class="toggle">
+          <button class="link-btn" onclick={() => { mode = mode === "login" ? "register" : "login"; error = ""; }}>
+            {mode === "login" ? "Need an account? Register" : "Have an account? Sign in"}
+          </button>
+        </div>
+      {/if}
     </div>
   </div>
 {/if}

--- a/packages/web/src/ui/components/system/AiProviders.svelte
+++ b/packages/web/src/ui/components/system/AiProviders.svelte
@@ -14,6 +14,7 @@ import {
   startAiOAuth,
   submitAiOAuthCode,
 } from "../../lib/client";
+import { loadErrorMessage } from "../../lib/load-error";
 import ModelSelect from "./ModelSelect.svelte";
 
 let {
@@ -130,8 +131,9 @@ export async function load() {
   try {
     providers = await fetchAiProviders();
     aiModels = await fetchAiModels();
-  } catch {
-    loadError = "Failed to load providers. Check your connection and try again.";
+  } catch (err) {
+    console.warn("[AiProviders] failed to load providers/models:", err);
+    loadError = loadErrorMessage(err, "Failed to load providers. Please try again.");
   }
 }
 

--- a/packages/web/src/ui/components/system/ImagegenProviders.svelte
+++ b/packages/web/src/ui/components/system/ImagegenProviders.svelte
@@ -13,6 +13,7 @@ import {
   saveImagegenProviderConfig,
   searchImagegenModels,
 } from "../../lib/client";
+import { loadErrorMessage } from "../../lib/load-error";
 import ModelSelect from "./ModelSelect.svelte";
 
 let providers = $state<ImagegenProvider[]>([]);
@@ -74,8 +75,9 @@ export async function load() {
     const res = await fetchImagegenModels();
     enabledModels = res.models;
     defaultModel = res.defaultModel;
-  } catch {
-    loadError = "Failed to load imagegen config. Check your connection and try again.";
+  } catch (err) {
+    console.warn("[ImagegenProviders] failed to load imagegen config:", err);
+    loadError = loadErrorMessage(err, "Failed to load imagegen config. Please try again.");
   }
 }
 

--- a/packages/web/src/ui/lib/app-screen.ts
+++ b/packages/web/src/ui/lib/app-screen.ts
@@ -1,0 +1,39 @@
+/** Top-level screen the app shows, based on setup + auth + connection state. */
+export type AppScreen = "loading" | "setup" | "connection" | "login" | "app";
+
+export type AppScreenState = {
+  /** True once the initial auth/setup check has resolved. */
+  checked: boolean;
+  /** True when setup has been fully completed. */
+  setupComplete: boolean;
+  /** True when an admin account already exists (mid-setup or after). */
+  hasAccount: boolean;
+  /** True when no daemon connection is configured (remote flow). */
+  needsConnection: boolean;
+  /** True when this browser has an authenticated session. */
+  loggedIn: boolean;
+};
+
+/**
+ * Decide which top-level screen to render.
+ *
+ * The subtle case is a setup wizard resumed in a browser that lacks a session
+ * (a different browser, or after the cookie expired). Setup is incomplete, so
+ * we'd normally show the wizard — but the steps past account creation call
+ * admin-gated endpoints, so an unauthenticated browser would dead-end on 401s.
+ * When an account already exists but this browser isn't authenticated, route to
+ * login first; setup resumes once `loggedIn` flips true.
+ *
+ * `loggedIn` is any authenticated session, not specifically an admin one. That's
+ * fine here: the only account that can exist mid-setup is the first user, who is
+ * auto-admin — additional (non-admin) users can only be created once setup is
+ * complete — so a non-admin session at this point is effectively unreachable.
+ */
+export function resolveScreen(state: AppScreenState): AppScreen {
+  if (!state.checked) return "loading";
+  const needsLoginBeforeSetup = state.hasAccount && !state.loggedIn;
+  if (!state.setupComplete && !needsLoginBeforeSetup) return "setup";
+  if (state.needsConnection) return "connection";
+  if (!state.loggedIn) return "login";
+  return "app";
+}

--- a/packages/web/src/ui/lib/load-error.ts
+++ b/packages/web/src/ui/lib/load-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Turn a caught fetch error into user-facing copy for a failed data load.
+ *
+ * The API client throws `Error(data.error || "Request failed: <status>")`, so an
+ * expired/missing session surfaces as "Unauthorized"/"Forbidden" (the message
+ * the daemon's auth middleware returns) or, when the server sends no body, as
+ * "Request failed: 401". Both mean "log in again" — not "check your connection".
+ * Any other failure keeps its own message so the real cause isn't masked.
+ */
+export function loadErrorMessage(err: unknown, fallback: string): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/\bunauthorized\b|\bforbidden\b|\b401\b|\b403\b/i.test(msg)) {
+    return "Your session has expired — please log in again.";
+  }
+  return msg || fallback;
+}

--- a/test/web-app-screen.test.ts
+++ b/test/web-app-screen.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { type AppScreenState, resolveScreen } from "../packages/web/src/ui/lib/app-screen.js";
+
+const base: AppScreenState = {
+  checked: true,
+  setupComplete: true,
+  hasAccount: true,
+  needsConnection: false,
+  loggedIn: true,
+};
+
+describe("resolveScreen", () => {
+  it("shows loading until the initial check resolves", () => {
+    assert.equal(resolveScreen({ ...base, checked: false }), "loading");
+  });
+
+  it("shows the setup wizard at the very start (no system, no account)", () => {
+    assert.equal(
+      resolveScreen({ ...base, setupComplete: false, hasAccount: false, loggedIn: false }),
+      "setup",
+    );
+  });
+
+  it("resumes the setup wizard when mid-setup and still authenticated", () => {
+    // Same browser: account exists, session intact — keep going in the wizard.
+    assert.equal(
+      resolveScreen({ ...base, setupComplete: false, hasAccount: true, loggedIn: true }),
+      "setup",
+    );
+  });
+
+  it("routes to login when setup is resumed without a session (the #690 bug)", () => {
+    // A different browser (or expired cookie): the account exists but this
+    // browser has no admin session. Provider/model fetches would 401 and the
+    // wizard would dead-end — so send the user to log in first.
+    assert.equal(
+      resolveScreen({ ...base, setupComplete: false, hasAccount: true, loggedIn: false }),
+      "login",
+    );
+  });
+
+  it("shows the connection screen when no daemon connection is configured", () => {
+    assert.equal(resolveScreen({ ...base, needsConnection: true, loggedIn: false }), "connection");
+  });
+
+  it("prefers connection over login when both apply mid-setup", () => {
+    // Resumed without a session AND no daemon connection — the connection screen
+    // wins, matching the original branch order (connection before login).
+    assert.equal(
+      resolveScreen({
+        checked: true,
+        setupComplete: false,
+        hasAccount: true,
+        loggedIn: false,
+        needsConnection: true,
+      }),
+      "connection",
+    );
+  });
+
+  it("prefers setup over connection on a fresh install", () => {
+    // No account yet, so the login gate doesn't apply and the wizard shows even
+    // if a connection isn't configured — setup comes before connection.
+    assert.equal(
+      resolveScreen({
+        checked: true,
+        setupComplete: false,
+        hasAccount: false,
+        loggedIn: false,
+        needsConnection: true,
+      }),
+      "setup",
+    );
+  });
+
+  it("shows login when setup is complete but the user is unauthenticated", () => {
+    assert.equal(resolveScreen({ ...base, loggedIn: false }), "login");
+  });
+
+  it("shows the app when setup is complete and the user is authenticated", () => {
+    assert.equal(resolveScreen(base), "app");
+  });
+});

--- a/test/web-load-error.test.ts
+++ b/test/web-load-error.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { loadErrorMessage } from "../packages/web/src/ui/lib/load-error.js";
+
+describe("loadErrorMessage", () => {
+  it("maps the daemon's 401 'Unauthorized' message to a login prompt", () => {
+    assert.equal(
+      loadErrorMessage(new Error("Unauthorized"), "fallback"),
+      "Your session has expired — please log in again.",
+    );
+  });
+
+  it("maps a 403 'Forbidden' message to a login prompt", () => {
+    assert.equal(
+      loadErrorMessage(new Error("Forbidden"), "fallback"),
+      "Your session has expired — please log in again.",
+    );
+  });
+
+  it("maps a bodyless 'Request failed: 401' to a login prompt", () => {
+    assert.equal(
+      loadErrorMessage(new Error("Request failed: 401"), "fallback"),
+      "Your session has expired — please log in again.",
+    );
+  });
+
+  it("surfaces the real message for non-auth failures (not the connection copy)", () => {
+    assert.equal(
+      loadErrorMessage(new Error("Request failed: 500"), "Failed to load providers."),
+      "Request failed: 500",
+    );
+  });
+
+  it("falls back when the error carries no message", () => {
+    assert.equal(
+      loadErrorMessage(new Error(""), "Failed to load providers."),
+      "Failed to load providers.",
+    );
+  });
+
+  it("handles non-Error throwables", () => {
+    assert.equal(loadErrorMessage("boom", "fallback"), "boom");
+  });
+});


### PR DESCRIPTION
Fixes #690.

## Problem

A setup wizard resumed in a browser without the admin session — a different browser, or after the `volute_session` cookie expired — dead-ended. Setup is incomplete, so the wizard rendered and `initialStep()` returned `"provider"` (because `setupProgress.hasAccount` is true). But every provider/model fetch past account creation needs the admin session the browser lacked, so the provider step rendered **"Failed to load providers. Check your connection and try again."** with a Retry that could never succeed and no way to log in. The copy also misdirected — the real failure was a 401, not a connection problem.

## Fix

Two parts, matching the two halves of the issue:

**1. Routing — give the resume a login path.** When setup is incomplete but an account already exists **and** this browser is unauthenticated, route to the existing `LoginPage` first; the wizard resumes at the provider step once the session exists. The top-level screen decision is extracted into a pure `resolveScreen()` helper (`packages/web/src/ui/lib/app-screen.ts`) so it can be unit-tested, and `App.svelte`'s `{#if}` chain switches on the derived `screen` value. In the resume context the login page hides its Register toggle (registering mid-setup would create a second, pending account and re-trap the user) and shows a "Sign in to continue setup" subtitle.

**2. Error copy — stop misdirecting on 401.** `AiProviders`/`ImagegenProviders` `load()` no longer assert a connection problem for every failure. They surface the real error through a shared `loadErrorMessage()` helper — "Your session has expired — please log in again." on 401/403, otherwise the underlying message — and `console.warn` the raw error instead of swallowing it. The daemon's setup-status `hasAccount` probe now logs failures at `error` rather than `debug`, since silently falling through to `hasAccount:false` reproduces the same dead-end.

The normal same-browser setup flow is unaffected: `setupProgress.hasAccount` is only read at initial load and never re-fetched after account creation, so it stays `false` throughout a live wizard session and the new login gate only ever fires on a genuine resume where an account already exists.

## Tests

- `test/web-app-screen.test.ts` — `resolveScreen` cases including the #690 bug (`setupComplete:false, hasAccount:true, loggedIn:false → "login"`), the same-browser resume (`→ "setup"`), and two precedence cases (connection-beats-login mid-setup; setup-beats-connection fresh install).
- `test/web-load-error.test.ts` — `loadErrorMessage` maps 401/403 (both the daemon's `Unauthorized`/`Forbidden` bodies and the bodyless `Request failed: 401` form) to the login prompt and surfaces the real message otherwise.
- Full suite: 2632 pass / 0 fail. `svelte-check`: 0 errors. `vite build`: clean.

## Manual verification

Run setup through account creation in one browser, then open the app in a second browser (or clear the cookie): you now land on the login page (Register hidden, "continue setup" copy) instead of the provider-load error. After logging in, the wizard resumes at the AI-providers step. If a session expires mid-wizard, the providers step now says the session expired and to log in again, rather than blaming the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)