### PR TITLE
fix: distinguish transient OAuth-refresh failure from "not configured"

### DIFF
--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -465,14 +465,41 @@ export async function getAvailableModels(): Promise<Model<Api>[]> {
 }
 
 /**
+ * Thrown when a provider *has* OAuth configured but resolving/refreshing it
+ * failed transiently (network timeout to the token endpoint, a 5xx from the auth
+ * server, a temporarily-rejected refresh grant, clock-skew expiry). This is
+ * deliberately distinct from "no OAuth configured" (which returns `undefined`):
+ * for subscription-only providers (openai-codex, xai) OAuth is the only
+ * credential path, so collapsing a transient refresh failure into `undefined`
+ * makes callers report a correctly-configured provider as "not configured".
+ * Callers that have no other credential should surface this error's message —
+ * which is worded as transient, never "not configured".
+ */
+export class OAuthRefreshError extends Error {
+  constructor(
+    readonly providerId: string,
+    override readonly cause: unknown,
+  ) {
+    super(
+      `${providerId} authentication is temporarily unavailable (OAuth token refresh failed). ` +
+        `This is usually transient — try again shortly. If it keeps failing, ask your admin to ` +
+        `re-check the ${providerId} provider.`,
+    );
+    this.name = "OAuthRefreshError";
+  }
+}
+
+/**
  * Resolve and refresh a provider's stored OAuth credential object (not just the
  * derived API key). Some providers need more than a bearer token to authenticate
  * correctly — GitHub Copilot's session tokens are proxy-affinitized, and only the
  * full OAuth credential shape lets pi-ai derive the matching baseUrl at request
  * time (a bare API key falls back to the provider's generic default baseUrl,
  * which the token may not be valid against, producing 421 Misdirected Request).
- * Returns undefined when the provider has no OAuth credentials configured or
- * refresh fails.
+ * Returns undefined when the provider has no OAuth credentials configured;
+ * throws {@link OAuthRefreshError} when OAuth *is* configured but the
+ * resolve/refresh failed (so a transient auth outage isn't misread as
+ * "not configured").
  */
 export async function resolveOAuthCredentials(
   providerId: string,
@@ -483,7 +510,7 @@ export async function resolveOAuthCredentials(
 
   try {
     const result = await getOAuthApiKey(providerId, { [providerId]: providerConfig.oauth });
-    if (!result) return undefined;
+    if (!result) throw new Error(`OAuth resolution returned no credential for ${providerId}`);
     // Persist refreshed credentials
     if (result.newCredentials.access !== providerConfig.oauth.access) {
       saveProviderConfig(providerId, { ...providerConfig, oauth: result.newCredentials });
@@ -492,18 +519,32 @@ export async function resolveOAuthCredentials(
     }
     return result.newCredentials;
   } catch (err) {
-    aiLog.warn(`OAuth credential resolution failed for ${providerId}`, log.errorData(err));
-    return undefined;
+    // A subscription mind losing its only credential path is a defect, not
+    // benign noise — log at error, and throw so callers can tell this apart
+    // from an unconfigured provider.
+    aiLog.error(`OAuth credential resolution failed for ${providerId}`, log.errorData(err));
+    throw new OAuthRefreshError(providerId, err);
   }
 }
 
-/** Resolve API key for a provider, checking OAuth → config → env var. */
+/**
+ * Resolve API key for a provider, checking OAuth → config → env var. A transient
+ * OAuth refresh failure ({@link OAuthRefreshError}) must not mask a configured
+ * API key or env-var fallback, and callers here (health checks, mind spawn,
+ * completion) expect `undefined` for "no usable key" — so it falls through to
+ * those fallbacks rather than propagating. The imagegen path calls
+ * resolveOAuthCredentials directly and surfaces the transient error itself.
+ */
 export async function resolveApiKey(providerId: string): Promise<string | undefined> {
   const ai = getAiConfig();
   const providerConfig = ai?.providers[providerId];
 
-  const oauthCreds = await resolveOAuthCredentials(providerId);
-  if (oauthCreds) return oauthCreds.access;
+  try {
+    const oauthCreds = await resolveOAuthCredentials(providerId);
+    if (oauthCreds) return oauthCreds.access;
+  } catch (err) {
+    if (!(err instanceof OAuthRefreshError)) throw err;
+  }
 
   return resolveProviderKey(providerId, providerConfig?.apiKey);
 }

--- a/packages/daemon/src/lib/ai-service.ts
+++ b/packages/daemon/src/lib/ai-service.ts
@@ -32,7 +32,7 @@ const authContext = defaultProviderAuthContext();
  * auth. Replaces the old getEnvApiKey/config lookups. Returns configKey as a
  * fallback when the provider or a representative model is unavailable.
  */
-async function resolveProviderKey(
+export async function resolveProviderKey(
   providerId: string,
   configKey?: string,
 ): Promise<string | undefined> {
@@ -219,6 +219,18 @@ export async function missingCredentialWarning(
   // a missing per-mind env.json reads as empty and the shared env still applies.
   const { loadMergedEnv } = await import("./config/env.js");
   if (loadMergedEnv(mindName)[envVar]) return null;
+
+  // No usable key. If the provider HAS OAuth configured, resolveApiKey couldn't
+  // derive a token from it right now (it swallows a transient OAuthRefreshError
+  // and falls through) — a temporary auth-server/refresh failure, not a missing
+  // configuration. Never advise reconfiguring a correctly-configured provider (#701).
+  if (getAiConfig()?.providers[provider]?.oauth) {
+    return (
+      `${provider} authentication is temporarily unavailable, so ${mindName} will start but ` +
+      `may stay silent until it recovers (OAuth token refresh is failing — usually transient). ` +
+      `If it persists, re-check the ${provider} provider in the web dashboard (Settings → Providers).`
+    );
+  }
   return (
     `No ${provider} credentials are configured, so ${mindName} will start but stay silent ` +
     `until a key is available. Set one with \`volute env set ${envVar} <key> --mind ${mindName}\`, ` +

--- a/packages/daemon/src/lib/daemon/credential-sync.ts
+++ b/packages/daemon/src/lib/daemon/credential-sync.ts
@@ -1,11 +1,42 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { getAiConfig } from "../ai-service.js";
+import {
+  getAiConfig,
+  OAuthRefreshError,
+  resolveApiKey,
+  resolveOAuthCredentials,
+  resolveProviderKey,
+} from "../ai-service.js";
 import { chownMindDir, isIsolationEnabled } from "../mind/isolation.js";
 import { findMind, mindDir } from "../mind/registry.js";
 import log from "../util/logger.js";
 
 const slog = log.child("cred-sync");
+
+/**
+ * Providers whose OAuth provider is registered only in the daemon's pi-ai, not
+ * the mind's — so the mind can't resolve their OAuth blob and must consume the
+ * already-derived access token as a flat api_key (the daemon stays the refresh
+ * authority).
+ */
+export const DAEMON_ONLY_OAUTH = new Set(["xai"]);
+
+/**
+ * Provider → env var pi-ai reads as an api-key fallback. Set alongside the
+ * auth.json entry because the sandbox may block proper-lockfile from reading
+ * auth.json, so the env var keeps getEnvApiKey() in pi-ai working.
+ */
+const PI_PROVIDER_ENV_VAR: Record<string, string> = {
+  openrouter: "OPENROUTER_API_KEY",
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  google: "GEMINI_API_KEY",
+  groq: "GROQ_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  zai: "ZAI_API_KEY",
+};
 
 export type AnthropicOauth = {
   access: string;
@@ -92,6 +123,76 @@ export async function writePiProviderOAuth(
   writeFileSync(authPath, JSON.stringify(authData, null, 2), { mode: 0o600 });
   if (isIsolationEnabled()) {
     await chownMindDir(piAgentDir, baseName);
+  }
+}
+
+/**
+ * Resolve and write a pi mind's provider credential into its auth.json + spawn
+ * env (mutated in place). Prefers the full OAuth blob so pi-ai's own resolution
+ * runs inside the mind; {@link DAEMON_ONLY_OAUTH} providers and static-key
+ * providers get a flat api_key plus the provider env-var fallback.
+ *
+ * A transient OAuth refresh failure ({@link OAuthRefreshError}) never crashes
+ * spawn: it falls back to a STATIC key only. It deliberately does NOT retry via
+ * resolveApiKey, which would re-attempt the refresh (a second network call +
+ * error log) and — worse — let a blip-then-success on the retry flatten the
+ * rotated OAuth blob into an api_key entry, losing the baseUrl-deriving shape
+ * (the 421 Misdirected Request case). Sets env.PI_CODING_AGENT_DIR when a
+ * credential is written.
+ */
+export async function injectPiProviderCredentials(opts: {
+  provider: string;
+  piAgentDir: string;
+  baseName: string;
+  mindName: string;
+  env: Record<string, string | undefined>;
+}): Promise<void> {
+  const { provider, piAgentDir, baseName, mindName, env } = opts;
+
+  let oauthCreds: Awaited<ReturnType<typeof resolveOAuthCredentials>>;
+  let oauthError: OAuthRefreshError | undefined;
+  try {
+    oauthCreds = await resolveOAuthCredentials(provider);
+  } catch (err) {
+    if (!(err instanceof OAuthRefreshError)) throw err;
+    slog.warn(
+      `OAuth token refresh failing for provider "${provider}" (mind ${mindName}); ` +
+        `falling back to a static key if available`,
+      log.errorData(err),
+    );
+    oauthError = err;
+  }
+
+  if (oauthCreds && !DAEMON_ONLY_OAUTH.has(provider)) {
+    await writePiProviderOAuth(piAgentDir, baseName, provider, oauthCreds);
+    env.PI_CODING_AGENT_DIR = piAgentDir;
+    return;
+  }
+
+  // DAEMON_ONLY_OAUTH providers (xai) hand the resolved access token to the mind
+  // as an api_key; otherwise resolve a key (static/env), avoiding a refresh retry
+  // when OAuth is transiently failing.
+  let apiKey: string | undefined;
+  if (oauthCreds) {
+    apiKey = oauthCreds.access;
+  } else if (oauthError) {
+    apiKey = await resolveProviderKey(provider, getAiConfig()?.providers[provider]?.apiKey);
+  } else {
+    apiKey = await resolveApiKey(provider);
+  }
+
+  if (apiKey) {
+    await writePiProviderKey(piAgentDir, baseName, provider, apiKey);
+    env.PI_CODING_AGENT_DIR = piAgentDir;
+    const providerEnv = PI_PROVIDER_ENV_VAR[provider];
+    if (providerEnv) env[providerEnv] = apiKey;
+  } else if (oauthError) {
+    slog.warn(
+      `OAuth token refresh is temporarily failing for provider "${provider}" and no static key ` +
+        `is available — mind ${mindName} may start but stay silent until it recovers`,
+    );
+  } else {
+    slog.warn(`no API key found for provider "${provider}" — mind ${mindName} may fail to start`);
   }
 }
 

--- a/packages/daemon/src/lib/daemon/credential-sync.ts
+++ b/packages/daemon/src/lib/daemon/credential-sync.ts
@@ -19,7 +19,7 @@ const slog = log.child("cred-sync");
  * already-derived access token as a flat api_key (the daemon stays the refresh
  * authority).
  */
-export const DAEMON_ONLY_OAUTH = new Set(["xai"]);
+const DAEMON_ONLY_OAUTH = new Set(["xai"]);
 
 /**
  * Provider → env var pi-ai reads as an api-key fallback. Set alongside the

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -2,7 +2,12 @@ import { type ChildProcess, execFile, type SpawnOptions, spawn } from "node:chil
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
-import { getAiConfig, resolveApiKey, resolveOAuthCredentials } from "../ai-service.js";
+import {
+  getAiConfig,
+  OAuthRefreshError,
+  resolveApiKey,
+  resolveOAuthCredentials,
+} from "../ai-service.js";
 import { deliverEvent, recordNotice } from "../chat/system-events.js";
 import { loadMergedEnv } from "../config/env.js";
 import { getSystemName, readGlobalConfig } from "../config/setup.js";
@@ -340,7 +345,16 @@ export class MindManager {
           if (modelStr?.includes(":")) {
             const provider = modelStr.split(":")[0];
             const piAgentDir = resolve(dir, ".mind", "pi-agent");
-            const oauthCreds = await resolveOAuthCredentials(provider);
+            // A transient OAuth refresh failure here shouldn't crash spawn or
+            // skip the api_key/env fallback below — treat it as "no OAuth this
+            // time" (resolveApiKey does the same).
+            let oauthCreds: Awaited<ReturnType<typeof resolveOAuthCredentials>>;
+            try {
+              oauthCreds = await resolveOAuthCredentials(provider);
+            } catch (err) {
+              if (!(err instanceof OAuthRefreshError)) throw err;
+              oauthCreds = undefined;
+            }
             if (oauthCreds && !DAEMON_ONLY_OAUTH.has(provider)) {
               // Store the full OAuth credential (not just the derived key) so
               // pi-ai's own OAuth resolution runs inside the mind — some

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -2,12 +2,7 @@ import { type ChildProcess, execFile, type SpawnOptions, spawn } from "node:chil
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
-import {
-  getAiConfig,
-  OAuthRefreshError,
-  resolveApiKey,
-  resolveOAuthCredentials,
-} from "../ai-service.js";
+import { getAiConfig, resolveApiKey } from "../ai-service.js";
 import { deliverEvent, recordNotice } from "../chat/system-events.js";
 import { loadMergedEnv } from "../config/env.js";
 import { getSystemName, readGlobalConfig } from "../config/setup.js";
@@ -27,11 +22,7 @@ import { checkHealth } from "../util/health.js";
 import { clearJsonMap, loadJsonMap, saveJsonMap } from "../util/json-state.js";
 import log from "../util/logger.js";
 import { RotatingLog } from "../util/rotating-log.js";
-import {
-  writeClaudeCredentials,
-  writePiProviderKey,
-  writePiProviderOAuth,
-} from "./credential-sync.js";
+import { injectPiProviderCredentials, writeClaudeCredentials } from "./credential-sync.js";
 import { generateMindToken, revokeMindToken } from "./mind-tokens.js";
 import { RestartTracker } from "./restart-tracker.js";
 import { clearMind as clearTurnState, summarizeOrphanedTurns } from "./turn-tracker.js";
@@ -39,12 +30,6 @@ import { clearMind as clearTurnState, summarizeOrphanedTurns } from "./turn-trac
 const mlog = log.child("minds");
 
 const execFileAsync = promisify(execFile);
-
-// OAuth providers registered only in the daemon's pi-ai (not pi-ai built-ins),
-// so a mind's own pi-ai can't turn their stored OAuth blob into a key. For these
-// the daemon writes the resolved access token as an api_key instead. Keep in sync
-// with the daemon-only OAuth providers registered in daemon.ts (e.g. xai).
-const DAEMON_ONLY_OAUTH = new Set(["xai"]);
 
 // Benign system env vars a mind's node/tsx process needs to run. Everything else
 // from the daemon environment (ambient AWS_*/GITHUB_TOKEN/etc.) is withheld.
@@ -345,61 +330,13 @@ export class MindManager {
           if (modelStr?.includes(":")) {
             const provider = modelStr.split(":")[0];
             const piAgentDir = resolve(dir, ".mind", "pi-agent");
-            // A transient OAuth refresh failure here shouldn't crash spawn or
-            // skip the api_key/env fallback below — treat it as "no OAuth this
-            // time" (resolveApiKey does the same).
-            let oauthCreds: Awaited<ReturnType<typeof resolveOAuthCredentials>>;
-            try {
-              oauthCreds = await resolveOAuthCredentials(provider);
-            } catch (err) {
-              if (!(err instanceof OAuthRefreshError)) throw err;
-              oauthCreds = undefined;
-            }
-            if (oauthCreds && !DAEMON_ONLY_OAUTH.has(provider)) {
-              // Store the full OAuth credential (not just the derived key) so
-              // pi-ai's own OAuth resolution runs inside the mind — some
-              // providers (GitHub Copilot) derive a per-credential baseUrl from
-              // this shape that a flattened api_key loses, misdirecting
-              // requests to the wrong backend (421 Misdirected Request). It
-              // also lets the mind refresh its own token from the stored
-              // refresh grant.
-              await writePiProviderOAuth(piAgentDir, baseName, provider, oauthCreds);
-              env.PI_CODING_AGENT_DIR = piAgentDir;
-            } else {
-              // DAEMON_ONLY_OAUTH providers (xai) are registered only in the
-              // daemon's pi-ai, so the mind can't resolve their OAuth blob — hand
-              // it the already-resolved access token as an api_key (works directly
-              // as the provider's bearer; the daemon stays the refresh authority).
-              const apiKey = oauthCreds?.access ?? (await resolveApiKey(provider));
-              if (apiKey) {
-                // Write API key to pi-coding-agent auth storage so the mind can use it.
-                // The pi template watches auth.json and reloads, so the daemon can
-                // push a refreshed key here without restarting the mind.
-                await writePiProviderKey(piAgentDir, baseName, provider, apiKey);
-                env.PI_CODING_AGENT_DIR = piAgentDir;
-
-                // Also set provider-specific env var as fallback — the sandbox may
-                // block proper-lockfile from reading auth.json, so the env var
-                // ensures getEnvApiKey() in pi-ai still resolves the key.
-                const providerEnvVars: Record<string, string> = {
-                  openrouter: "OPENROUTER_API_KEY",
-                  openai: "OPENAI_API_KEY",
-                  anthropic: "ANTHROPIC_API_KEY",
-                  google: "GEMINI_API_KEY",
-                  groq: "GROQ_API_KEY",
-                  cerebras: "CEREBRAS_API_KEY",
-                  xai: "XAI_API_KEY",
-                  mistral: "MISTRAL_API_KEY",
-                  zai: "ZAI_API_KEY",
-                };
-                const providerEnv = providerEnvVars[provider];
-                if (providerEnv) env[providerEnv] = apiKey;
-              } else {
-                mlog.warn(
-                  `no API key found for provider "${provider}" — mind ${name} may fail to start`,
-                );
-              }
-            }
+            await injectPiProviderCredentials({
+              provider,
+              piAgentDir,
+              baseName,
+              mindName: name,
+              env,
+            });
           }
         }
       } catch (err) {
@@ -488,6 +425,27 @@ export class MindManager {
           if (key && oauth) {
             const claudeDir = await writeClaudeCredentials(resolve(dir, "home"), baseName, oauth);
             env.CLAUDE_CONFIG_DIR = claudeDir;
+          } else {
+            // OAuth is configured but resolveApiKey couldn't derive a token and
+            // there's no static-key/env fallback — a transient refresh/auth-server
+            // failure. The mind would otherwise spawn credential-less with no
+            // CLAUDE_CONFIG_DIR, which credential-sync can't repair, leaving it
+            // silent until manually restarted. Surface it, don't fail quietly (#701).
+            mlog.error(
+              `Anthropic OAuth token refresh is failing for ${name}; it will spawn without ` +
+                `credentials and stay silent until the provider recovers and it is restarted`,
+            );
+            void recordNotice({
+              mind: name,
+              thread: "main",
+              kind: "startup",
+              reason: "oauth_refresh_failed",
+              detail:
+                "Anthropic authentication is temporarily unavailable (OAuth token refresh is " +
+                "failing), so you started without model credentials and may be unable to respond " +
+                "until it recovers. This is usually transient; if it persists, ask your host to " +
+                "re-check the anthropic provider.",
+            });
           }
         } else {
           // resolveApiKey covers both the configured key and an ambient

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -6,7 +6,7 @@
  */
 
 import Replicate from "replicate";
-import { resolveOAuthCredentials } from "../ai-service.js";
+import { OAuthRefreshError, resolveOAuthCredentials } from "../ai-service.js";
 import {
   type ImagegenConfig,
   type ImagegenEntitlement,
@@ -293,8 +293,17 @@ export async function resolveCredential(providerId: string): Promise<Credential 
 
   // 2. Linked AI provider's OAuth (subscription — preferred over ambient keys).
   //    resolveOAuthCredentials refreshes + persists + fans rotated tokens out.
-  const oauth = await resolveOAuthCredentials(aiProviderId);
-  if (oauth) return { kind: "oauth", token: oauth.access };
+  //    A transient refresh failure must not skip the api_key/env fallbacks
+  //    below — but if none exist (subscription-only provider), rethrow so the
+  //    caller surfaces a transient-auth message, never "not configured".
+  let oauthError: OAuthRefreshError | undefined;
+  try {
+    const oauth = await resolveOAuthCredentials(aiProviderId);
+    if (oauth) return { kind: "oauth", token: oauth.access };
+  } catch (err) {
+    if (!(err instanceof OAuthRefreshError)) throw err;
+    oauthError = err;
+  }
 
   // 3. Linked AI provider's API key (e.g. OpenRouter configured for chat)
   const aiKey = config.ai?.providers?.[aiProviderId]?.apiKey;
@@ -303,6 +312,9 @@ export async function resolveCredential(providerId: string): Promise<Credential 
   // 4. Env var fallback
   const envKey = provider.envVar ? process.env[provider.envVar] : undefined;
   if (envKey) return { kind: "api_key", token: envKey };
+
+  // OAuth was configured but its refresh failed and there's no other credential.
+  if (oauthError) throw oauthError;
 
   return undefined;
 }
@@ -359,7 +371,15 @@ export async function searchModels(
   // Search all configured providers in parallel
   const searches: Promise<ModelSearchResult[]>[] = [];
   for (const [id, def] of Object.entries(PROVIDERS)) {
-    const cred = await resolveCredential(id);
+    let cred: Credential | undefined;
+    try {
+      cred = await resolveCredential(id);
+    } catch (err) {
+      // A transient OAuth outage on one provider shouldn't fail search across
+      // all of them — skip it and let the others answer.
+      if (!(err instanceof OAuthRefreshError)) throw err;
+      continue;
+    }
     if (!cred) continue;
     searches.push(def.search(query || "text to image", cred).catch(() => []));
   }

--- a/packages/daemon/src/lib/services/imagegen.ts
+++ b/packages/daemon/src/lib/services/imagegen.ts
@@ -13,6 +13,7 @@ import {
   readGlobalConfig,
   writeGlobalConfig,
 } from "../config/setup.js";
+import log from "../util/logger.js";
 import {
   CodexNotEntitledError,
   codexGenerate,
@@ -20,6 +21,8 @@ import {
   probeCodexEntitlement,
 } from "./imagegen-codex.js";
 import { XaiNotEntitledError, xaiGenerate, xaiSearch } from "./imagegen-xai.js";
+
+const igLog = log.child("imagegen");
 
 // --- Provider registry ---
 
@@ -370,20 +373,34 @@ export async function searchModels(
 
   // Search all configured providers in parallel
   const searches: Promise<ModelSearchResult[]>[] = [];
+  let transientError: OAuthRefreshError | undefined;
   for (const [id, def] of Object.entries(PROVIDERS)) {
     let cred: Credential | undefined;
     try {
       cred = await resolveCredential(id);
     } catch (err) {
       // A transient OAuth outage on one provider shouldn't fail search across
-      // all of them — skip it and let the others answer.
+      // all of them — skip it and let the others answer. If it turns out to be
+      // the only configured provider, we rethrow it below rather than reporting
+      // "not configured".
       if (!(err instanceof OAuthRefreshError)) throw err;
+      igLog.warn(`skipping ${id} in model search: OAuth temporarily unavailable`);
+      transientError = err;
       continue;
     }
     if (!cred) continue;
-    searches.push(def.search(query || "text to image", cred).catch(() => []));
+    searches.push(
+      def.search(query || "text to image", cred).catch((err) => {
+        igLog.warn(`model search failed for ${id}`, log.errorData(err));
+        return [];
+      }),
+    );
   }
   if (searches.length === 0) {
+    // Nothing could answer. If the only configured provider was skipped for a
+    // transient auth failure, surface that (never "not configured") so the mind
+    // isn't told to reconfigure a correctly-configured provider (#701).
+    if (transientError) throw transientError;
     throw new Error("No imagegen providers configured");
   }
   return (await Promise.all(searches)).flat();

--- a/test/ai-service.test.ts
+++ b/test/ai-service.test.ts
@@ -11,6 +11,7 @@ import {
   getEnabledModels,
   getUtilityModel,
   migrateAiModelQualification,
+  missingCredentialWarning,
   OAuthRefreshError,
   qualifyModelId,
   removeAiConfig,
@@ -105,7 +106,10 @@ describe("resolveOAuthCredentials", () => {
       await assert.rejects(resolveOAuthCredentials("github-copilot"), (err: unknown) => {
         assert.ok(err instanceof OAuthRefreshError, "should be an OAuthRefreshError");
         assert.equal(err.providerId, "github-copilot");
+        // Must dodge BOTH of the skill's fallback-classifier regexes, or a future
+        // reword could resurrect #701 while still passing this test.
         assert.doesNotMatch(err.message, /not configured/i);
+        assert.doesNotMatch(err.message, /No .* API key/i);
         return true;
       });
     } finally {
@@ -147,6 +151,49 @@ describe("resolveApiKey", () => {
       assert.equal(await resolveApiKey("github-copilot"), undefined);
     } finally {
       globalThis.fetch = realFetch;
+      removeAiConfig();
+    }
+  });
+});
+
+describe("missingCredentialWarning", () => {
+  it("warns transiently (never 'not configured' / 'volute env set') when OAuth refresh is failing", async () => {
+    // A configured-but-transiently-failing OAuth provider must not be reported as
+    // unconfigured with remediation advice for a provider that IS configured (#701).
+    removeAiConfig();
+    const realFetch = globalThis.fetch;
+    const savedKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    try {
+      saveProviderConfig("anthropic", { oauth: { access: "expired", refresh: "r", expires: 0 } });
+      const warning = await missingCredentialWarning("claude", undefined, "test-mind-transient");
+      assert.ok(warning, "should return a warning");
+      assert.match(warning, /temporarily unavailable/i);
+      assert.doesNotMatch(warning, /not configured/i);
+      assert.doesNotMatch(warning, /volute env set/i);
+    } finally {
+      globalThis.fetch = realFetch;
+      if (savedKey !== undefined) process.env.ANTHROPIC_API_KEY = savedKey;
+      else delete process.env.ANTHROPIC_API_KEY;
+      removeAiConfig();
+    }
+  });
+
+  it("still says 'not configured' with remediation when nothing is configured", async () => {
+    removeAiConfig();
+    const savedKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const warning = await missingCredentialWarning("claude", undefined, "test-mind-unconfigured");
+      assert.ok(warning);
+      assert.match(warning, /No anthropic credentials are configured/);
+      assert.match(warning, /volute env set/);
+    } finally {
+      if (savedKey !== undefined) process.env.ANTHROPIC_API_KEY = savedKey;
+      else delete process.env.ANTHROPIC_API_KEY;
       removeAiConfig();
     }
   });

--- a/test/ai-service.test.ts
+++ b/test/ai-service.test.ts
@@ -11,10 +11,12 @@ import {
   getEnabledModels,
   getUtilityModel,
   migrateAiModelQualification,
+  OAuthRefreshError,
   qualifyModelId,
   removeAiConfig,
   removeCustomModel,
   removeProviderConfig,
+  resolveApiKey,
   resolveOAuthCredentials,
   saveProviderConfig,
   setEnabledModels,
@@ -85,6 +87,68 @@ describe("resolveOAuthCredentials", () => {
     saveProviderConfig("github-copilot", { oauth });
     const result = await resolveOAuthCredentials("github-copilot");
     assert.deepEqual(result, oauth);
+  });
+
+  it("throws OAuthRefreshError (not undefined) when OAuth is configured but refresh fails", async () => {
+    // A subscription-only provider losing its only credential path to a transient
+    // auth-server blip must NOT collapse into undefined (which reads as "not
+    // configured"). expires:0 forces a refresh; the failing fetch makes it throw.
+    removeAiConfig();
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    try {
+      saveProviderConfig("github-copilot", {
+        oauth: { access: "expired", refresh: "r", expires: 0 },
+      });
+      await assert.rejects(resolveOAuthCredentials("github-copilot"), (err: unknown) => {
+        assert.ok(err instanceof OAuthRefreshError, "should be an OAuthRefreshError");
+        assert.equal(err.providerId, "github-copilot");
+        assert.doesNotMatch(err.message, /not configured/i);
+        return true;
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+      removeAiConfig();
+    }
+  });
+});
+
+describe("resolveApiKey", () => {
+  it("falls back to a configured API key when OAuth refresh fails (never throws)", async () => {
+    removeAiConfig();
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    try {
+      saveProviderConfig("github-copilot", {
+        oauth: { access: "expired", refresh: "r", expires: 0 },
+        apiKey: "static-fallback-key",
+      });
+      assert.equal(await resolveApiKey("github-copilot"), "static-fallback-key");
+    } finally {
+      globalThis.fetch = realFetch;
+      removeAiConfig();
+    }
+  });
+
+  it("returns undefined (not throws) when OAuth refresh fails and no key fallback exists", async () => {
+    removeAiConfig();
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    try {
+      saveProviderConfig("github-copilot", {
+        oauth: { access: "expired", refresh: "r", expires: 0 },
+      });
+      assert.equal(await resolveApiKey("github-copilot"), undefined);
+    } finally {
+      globalThis.fetch = realFetch;
+      removeAiConfig();
+    }
   });
 });
 

--- a/test/credential-sync.test.ts
+++ b/test/credential-sync.test.ts
@@ -3,7 +3,9 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
+import { removeProviderConfig, saveProviderConfig } from "../packages/daemon/src/lib/ai-service.js";
 import {
+  injectPiProviderCredentials,
   syncProviderToMinds,
   writeClaudeCredentials,
   writePiProviderKey,
@@ -99,6 +101,52 @@ describe("writePiProviderOAuth", () => {
     await writePiProviderOAuth(piAgentDir, "mymind", "github-copilot", OAUTH);
     const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
     assert.deepEqual(auth, { "github-copilot": { type: "oauth", ...OAUTH } });
+  });
+});
+
+describe("injectPiProviderCredentials", () => {
+  it("degrades to the static api_key + env var (never re-refreshing) when OAuth is transiently failing", async () => {
+    // anthropic is registered in pi-ai's OAuth registry, so the expired grant
+    // actually attempts a refresh; the failing fetch makes it throw. The provider
+    // ALSO has a static key configured — the fallback must land that key as an
+    // api_key entry (not a flattened OAuth blob) and set the env-var fallback.
+    const dir = tmpRoot("pi-inject-blip");
+    const piAgentDir = resolve(dir, ".mind", "pi-agent");
+    const realFetch = globalThis.fetch;
+    const savedEnvKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    const env: Record<string, string | undefined> = {};
+    try {
+      saveProviderConfig("anthropic", {
+        oauth: { access: "expired", refresh: "r", expires: 0 },
+        apiKey: "static-anthropic-key",
+      });
+      await injectPiProviderCredentials({
+        provider: "anthropic",
+        piAgentDir,
+        baseName: "mymind",
+        mindName: "mymind",
+        env,
+      });
+
+      const auth = JSON.parse(readFileSync(resolve(piAgentDir, "auth.json"), "utf-8"));
+      assert.equal(
+        auth.anthropic.type,
+        "api_key",
+        "must write an api_key entry, not an oauth blob",
+      );
+      assert.equal(auth.anthropic.key, "static-anthropic-key");
+      assert.equal(env.PI_CODING_AGENT_DIR, piAgentDir);
+      assert.equal(env.ANTHROPIC_API_KEY, "static-anthropic-key", "env-var fallback must be set");
+    } finally {
+      globalThis.fetch = realFetch;
+      if (savedEnvKey !== undefined) process.env.ANTHROPIC_API_KEY = savedEnvKey;
+      else delete process.env.ANTHROPIC_API_KEY;
+      removeProviderConfig("anthropic");
+    }
   });
 });
 

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
+import { OAuthRefreshError } from "../packages/daemon/src/lib/ai-service.js";
 import {
   isImagegenEnabled,
   readGlobalConfig,
@@ -20,6 +21,7 @@ import {
   removeProviderConfig,
   resolveCredential,
   saveProviderConfig,
+  searchModels,
   setEnabledModels,
 } from "../packages/daemon/src/lib/services/imagegen.js";
 import {
@@ -219,6 +221,64 @@ describe("imagegen config", () => {
         kind: "oauth",
         token: "codex-access-token",
       });
+    });
+
+    it("throws OAuthRefreshError (not undefined) when a subscription-only provider's OAuth refresh fails", async () => {
+      // openai-codex is subscription-only: OAuth is the only credential path.
+      // A transient refresh failure must surface as a distinct error, not fall
+      // through to undefined (which callers report as "not configured").
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        throw new TypeError("token endpoint unreachable");
+      }) as typeof fetch;
+      try {
+        const config = readGlobalConfig();
+        config.ai = {
+          providers: {
+            "openai-codex": { oauth: { access: "expired", refresh: "r", expires: 0 } },
+          },
+        };
+        writeGlobalConfig(config);
+        await assert.rejects(resolveCredential("openai-codex"), (err: unknown) => {
+          assert.ok(err instanceof OAuthRefreshError, "should be an OAuthRefreshError");
+          assert.doesNotMatch(err.message, /not configured/i);
+          return true;
+        });
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    });
+
+    it("falls back to the AI provider's API key when OAuth refresh fails", async () => {
+      // A provider that has BOTH a (failing) OAuth grant and a static API key
+      // must degrade to the key during a transient auth blip, not error out.
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        throw new TypeError("token endpoint unreachable");
+      }) as typeof fetch;
+      try {
+        const config = readGlobalConfig();
+        config.ai = {
+          providers: {
+            "openai-codex": {
+              oauth: { access: "expired", refresh: "r", expires: 0 },
+              apiKey: "codex-fallback-key",
+            },
+          },
+        };
+        writeGlobalConfig(config);
+        assert.deepEqual(await resolveCredential("openai-codex"), {
+          kind: "api_key",
+          token: "codex-fallback-key",
+        });
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    });
+
+    it("still returns undefined when a provider genuinely has no credentials", async () => {
+      // No OAuth, no key, no env — the unchanged "not configured" path.
+      assert.equal(await resolveCredential("openai-codex"), undefined);
     });
   });
 
@@ -883,6 +943,61 @@ describe("imagegen entitlement", () => {
   });
 });
 
+describe("imagegen transient OAuth failure", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    const config = readGlobalConfig();
+    delete config.imagegen;
+    delete config.ai;
+    writeGlobalConfig(config);
+  });
+
+  function configureCodexOAuth() {
+    const config = readGlobalConfig();
+    config.ai = {
+      providers: { "openai-codex": { oauth: { access: "expired", refresh: "r", expires: 0 } } },
+    };
+    writeGlobalConfig(config);
+  }
+
+  it("generateImage surfaces a transient-auth message, not 'not configured'", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    configureCodexOAuth();
+    await assert.rejects(generateImage("openai-codex:gpt-image-2", "a cat"), (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /temporarily unavailable/i);
+      assert.doesNotMatch(err.message, /not configured/i);
+      return true;
+    });
+  });
+
+  it("generateImage still says 'not configured' when the provider genuinely has no credentials", async () => {
+    // No ai/imagegen config — codex is truly unconfigured (unchanged behavior).
+    await assert.rejects(
+      generateImage("openai-codex:gpt-image-2", "a cat"),
+      /No openai-codex credentials configured/,
+    );
+  });
+
+  it("searchModels skips a transiently-failing provider instead of failing the whole search", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("everything unreachable");
+    }) as typeof fetch;
+    configureCodexOAuth(); // codex OAuth refresh will throw (transient)
+    saveProviderConfig("openrouter", "or-key"); // a second, key-configured provider
+
+    // codex resolveCredential throws OAuthRefreshError → the loop must skip it;
+    // openrouter's search runs (its fetch throws → per-search .catch → []).
+    // The whole search resolves rather than rejecting with the codex error.
+    const results = await searchModels();
+    assert.deepEqual(results, []);
+  });
+});
+
 describe("imagegen skill daemon error reporting", () => {
   const realFetch = globalThis.fetch;
   const savedEnv = {
@@ -975,6 +1090,20 @@ describe("imagegen skill daemon error reporting", () => {
       setDaemonEnv(true);
       mockFetch(() => jsonResponse(500, { error: "boom" }));
       await assert.rejects(startImagegenJob("replicate:owner/model", "prompt", "file"), /boom/);
+    });
+
+    it("surfaces a transient-auth error instead of silently falling back", async () => {
+      // A provider whose OAuth is temporarily failing must NOT be treated as
+      // "not configured" (which would swap to a direct replicate fallback and
+      // tell the mind to reconfigure a correctly-configured provider).
+      setDaemonEnv(true);
+      const transient =
+        "openai-codex authentication is temporarily unavailable (OAuth token refresh failed).";
+      mockFetch(() => jsonResponse(500, { error: transient }));
+      await assert.rejects(
+        startImagegenJob("openai-codex:gpt-image-2", "prompt", "file"),
+        /temporarily unavailable/,
+      );
     });
 
     it("returns the job id on success (202)", async () => {

--- a/test/imagegen.test.ts
+++ b/test/imagegen.test.ts
@@ -970,7 +970,9 @@ describe("imagegen transient OAuth failure", () => {
     await assert.rejects(generateImage("openai-codex:gpt-image-2", "a cat"), (err: unknown) => {
       assert.ok(err instanceof Error);
       assert.match(err.message, /temporarily unavailable/i);
+      // Dodge BOTH of the skill's fallback-classifier regexes.
       assert.doesNotMatch(err.message, /not configured/i);
+      assert.doesNotMatch(err.message, /No .* API key/i);
       return true;
     });
   });
@@ -983,18 +985,83 @@ describe("imagegen transient OAuth failure", () => {
     );
   });
 
-  it("searchModels skips a transiently-failing provider instead of failing the whole search", async () => {
+  it("resolveCredential degrades xai to its metered XAI_API_KEY when OAuth refresh fails", async () => {
+    // xai has both paths: subscription OAuth + a metered key. A transient OAuth
+    // failure must fall through to the env key — pinning that oauthError is only
+    // rethrown AFTER the env check, so xai keeps working during a blip.
+    registerXaiOAuthProvider();
+    const savedKey = process.env.XAI_API_KEY;
+    process.env.XAI_API_KEY = "metered-key";
+    globalThis.fetch = (async () => {
+      throw new TypeError("token endpoint unreachable");
+    }) as typeof fetch;
+    try {
+      const config = readGlobalConfig();
+      config.ai = {
+        providers: { xai: { oauth: { access: "expired", refresh: "r", expires: 0 } } },
+      };
+      writeGlobalConfig(config);
+      assert.deepEqual(await resolveCredential("xai"), { kind: "api_key", token: "metered-key" });
+    } finally {
+      if (savedKey !== undefined) process.env.XAI_API_KEY = savedKey;
+      else delete process.env.XAI_API_KEY;
+    }
+  });
+
+  it("searchModels skips a transiently-failing provider but still returns healthy providers' models", async () => {
+    // Route the fetch by URL: openrouter's model list succeeds, everything else
+    // (the codex OAuth token endpoint) throws. This proves the skip is scoped to
+    // the blipping provider — not that the whole search silently returned [].
+    globalThis.fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (href.includes("openrouter.ai")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [{ id: "acme/painter", name: "Painter" }] }),
+        } as Response;
+      }
+      throw new TypeError("everything else unreachable");
+    }) as typeof fetch;
+    configureCodexOAuth(); // codex OAuth refresh will throw (transient) → skipped
+    saveProviderConfig("openrouter", "or-key"); // a second, healthy, key-configured provider
+
+    // openrouterSearch filters its model list by the query string, so search for
+    // a term the fake model matches.
+    const results = await searchModels("painter");
+    assert.ok(
+      results.some((m) => m.id === "openrouter:acme/painter"),
+      "the healthy provider's model must still appear after the blipping one is skipped",
+    );
+  });
+
+  it("searchModels rethrows the transient error (not 'not configured') when the only provider blips", async () => {
+    // With codex the sole configured provider and it blipping, the skip leaves
+    // `searches` empty — it must rethrow the transient error, never collapse into
+    // "No imagegen providers configured" (the forbidden false-negative, #701).
+    const savedEnv = {
+      replicate: process.env.REPLICATE_API_TOKEN,
+      openrouter: process.env.OPENROUTER_API_KEY,
+      xai: process.env.XAI_API_KEY,
+    };
+    delete process.env.REPLICATE_API_TOKEN;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.XAI_API_KEY;
     globalThis.fetch = (async () => {
       throw new TypeError("everything unreachable");
     }) as typeof fetch;
-    configureCodexOAuth(); // codex OAuth refresh will throw (transient)
-    saveProviderConfig("openrouter", "or-key"); // a second, key-configured provider
-
-    // codex resolveCredential throws OAuthRefreshError → the loop must skip it;
-    // openrouter's search runs (its fetch throws → per-search .catch → []).
-    // The whole search resolves rather than rejecting with the codex error.
-    const results = await searchModels();
-    assert.deepEqual(results, []);
+    try {
+      configureCodexOAuth(); // codex is the ONLY configured provider, and it's blipping
+      await assert.rejects(searchModels(), (err: unknown) => {
+        assert.ok(err instanceof OAuthRefreshError, "should rethrow the transient error");
+        assert.doesNotMatch((err as Error).message, /not configured/i);
+        return true;
+      });
+    } finally {
+      if (savedEnv.replicate !== undefined) process.env.REPLICATE_API_TOKEN = savedEnv.replicate;
+      if (savedEnv.openrouter !== undefined) process.env.OPENROUTER_API_KEY = savedEnv.openrouter;
+      if (savedEnv.xai !== undefined) process.env.XAI_API_KEY = savedEnv.xai;
+    }
   });
 });
 
@@ -1095,14 +1162,19 @@ describe("imagegen skill daemon error reporting", () => {
     it("surfaces a transient-auth error instead of silently falling back", async () => {
       // A provider whose OAuth is temporarily failing must NOT be treated as
       // "not configured" (which would swap to a direct replicate fallback and
-      // tell the mind to reconfigure a correctly-configured provider).
+      // tell the mind to reconfigure a correctly-configured provider). Build the
+      // daemon error body from the REAL OAuthRefreshError message so a future
+      // reword that starts matching the skill's fallback regexes fails this test.
       setDaemonEnv(true);
-      const transient =
-        "openai-codex authentication is temporarily unavailable (OAuth token refresh failed).";
+      const transient = new OAuthRefreshError("openai-codex", new Error("x")).message;
       mockFetch(() => jsonResponse(500, { error: transient }));
       await assert.rejects(
         startImagegenJob("openai-codex:gpt-image-2", "prompt", "file"),
-        /temporarily unavailable/,
+        (err) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, transient, "the exact daemon message must reach the mind");
+          return true;
+        },
       );
     });
 


### PR DESCRIPTION
Fixes #701.

## Problem

For subscription-only providers (`openai-codex`, `xai`) OAuth is the *only* credential path. When the auth server has a transient blip (network timeout, 5xx, temporarily-rejected refresh grant, clock skew), `resolveOAuthCredentials` caught the error, logged at `warn`, and returned `undefined` — indistinguishable from "no OAuth configured". The imagegen path then threw `No <provider> credentials configured`, which the skill matches as `/not configured/i` and turns into reconfiguration advice for a correctly-configured provider (or a silent `replicate:` fallback). The `DaemonFailure` taxonomy was defeated at the source.

## Fix

`resolveOAuthCredentials` now throws a typed, exported `OAuthRefreshError` (raised from `warn` to `error`) when OAuth *is* configured but resolve/refresh fails, and still returns `undefined` when no OAuth is configured. Its message is worded transient and matches neither of the skill's fallback-classifier regexes (`/not configured/i`, `/No .* API key/i`).

Every caller is handled so the transient case surfaces (never "not configured") without regressing the healthy paths:

- **`resolveApiKey`** (health checks, mind spawn, completion): swallows it and falls through to the configured key / env-var fallback, preserving its `undefined`-on-no-key contract.
- **imagegen `resolveCredential`**: falls through to the api_key/env fallbacks, and only rethrows when the provider has no other credential — so `openai-codex` surfaces the transient message while `xai` still degrades to `XAI_API_KEY` during a blip.
- **`searchModels`** (all-providers): skips a transiently-failing provider; if it was the only one configured, rethrows the transient error instead of collapsing to `No imagegen providers configured`. Logs each skip and each per-provider search failure (previously swallowed with no trace).
- **`missingCredentialWarning`**: emits a transient-worded warning instead of "No `<provider>` credentials are configured… `volute env set`…" (which is recorded as a persistent host notice at mind create/start).
- **Claude-template spawn**: added the missing else branch — an anthropic OAuth blip no longer spawns the mind credential-less and fully silent; it logs at error and records a startup notice.
- **Pi-template spawn**: extracted into an exported, unit-tested helper `injectPiProviderCredentials`. On a transient failure it resolves a *static* key only (never re-attempting the refresh), which avoids a duplicate refresh/error-log and prevents a blip-then-success retry from flattening the rotated OAuth blob into an api_key (the 421-misdirection case).

The imagegen skill needs no code change: `generateImage`'s error reaches the mind via job polling (thrown directly), and `startImagegenJob` only fallback-matches the two regexes, which the transient message dodges.

## Tests

TDD, full suite green (2632 pass, 0 fail), typecheck + biome + knip clean, pre-push suite green:
- `resolveOAuthCredentials` throws `OAuthRefreshError` on refresh failure; returns `undefined` when unconfigured (unchanged). Both classifier regexes asserted at the source of truth.
- `resolveApiKey` falls back to a configured key / returns `undefined` (never throws).
- `resolveCredential`: subscription-only throws; xai degrades to `XAI_API_KEY`; unconfigured returns `undefined`.
- `generateImage` surfaces "temporarily unavailable" (not "not configured"), still "not configured" when genuinely unconfigured.
- `searchModels`: rethrows when the only provider blips; still returns a healthy provider's models when another blips (URL-routed fetch mock asserts the healthy model appears).
- `missingCredentialWarning`: transient wording vs unconfigured remediation.
- `injectPiProviderCredentials`: during a blip, writes the static key as an api_key entry (not a flattened OAuth blob) and sets the provider env var.
- The skill-contract test builds its daemon error body from the real `OAuthRefreshError.message`, so a future reword can't silently resurface #701.

### Test coverage notes

- The Claude-template spawn else branch (log + startup notice) is **not** directly unit-tested — it lives deep in `MindManager.startMind` and reaching it needs heavy process/DB scaffolding not worth its simplicity. Its sibling detection logic (OAuth-configured-but-no-derivable-key ⇒ transient) is covered via `missingCredentialWarning`.
- The pi-spawn transient path **is** covered: the block was extracted into `injectPiProviderCredentials` and has a direct unit test.

## Commits

Base fix (`resolveOAuthCredentials` + the imagegen path), a follow-up applying three-reviewer feedback (the swallow-path surfaces, the pi-spawn helper extraction, and the message-drift test hardening), and a small chore keeping `DAEMON_ONLY_OAUTH` module-private. Squash-merges to one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)