### PR TITLE
fix: make #system announcements sender-less events (#687), silence spirit-start DM error (#688)

### DIFF
--- a/packages/api/src/events.ts
+++ b/packages/api/src/events.ts
@@ -12,7 +12,7 @@ export type ConversationEvent =
   | {
       type: "message";
       id: number;
-      role: "user" | "assistant";
+      role: "user" | "assistant" | "event";
       senderName: string | null;
       content: ContentBlock[];
       createdAt: string;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -84,14 +84,16 @@ export type Participant = {
 export type Message = {
   id: number;
   conversation_id: string;
-  role: "user" | "assistant";
+  // "event" marks a sender-less automated announcement (e.g. #system "X has joined"), which
+  // the UI renders as an event rather than a chat message attributed to a sender (#687).
+  role: "user" | "assistant" | "event";
   sender_name: string | null;
   content: ContentBlock[];
   created_at: string;
 };
 
 export type LastMessageSummary = {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "event";
   senderName: string | null;
   text: string;
   createdAt: string;

--- a/packages/cli/src/commands/chat/read.ts
+++ b/packages/cli/src/commands/chat/read.ts
@@ -93,25 +93,28 @@ const cmd = command({
 
     const compact = isCompact();
     for (const msg of data.items) {
-      // Compact (mind-facing) output stays terse; display names are for humans.
-      const sender = compact
-        ? (msg.sender_name ?? msg.role)
-        : formatSender(msg.sender_name ?? msg.role, msg.sender_display_name);
       const text = Array.isArray(msg.content)
         ? msg.content
             .filter((b): b is { type: "text"; text: string } => b.type === "text")
             .map((b) => b.text)
             .join("")
         : msg.content;
-      if (compact) {
-        const time = compactTime(msg.created_at);
-        console.log(`[${time}] ${sender}: ${text}`);
-      } else {
-        const time = new Date(
-          msg.created_at.endsWith("Z") ? msg.created_at : `${msg.created_at}Z`,
-        ).toLocaleString();
-        console.log(`[${time}] ${sender}: ${text}`);
+      const time = compact
+        ? compactTime(msg.created_at)
+        : new Date(
+            msg.created_at.endsWith("Z") ? msg.created_at : `${msg.created_at}Z`,
+          ).toLocaleString();
+      // Automated announcements have no sender (#687) — render them as events, not as a
+      // message attributed to whoever the fallback would name.
+      if (msg.role === "event") {
+        console.log(`[${time}] · ${text}`);
+        continue;
       }
+      // Compact (mind-facing) output stays terse; display names are for humans.
+      const sender = compact
+        ? (msg.sender_name ?? msg.role)
+        : formatSender(msg.sender_name ?? msg.role, msg.sender_display_name);
+      console.log(`[${time}] ${sender}: ${text}`);
     }
   },
 });

--- a/packages/cli/src/commands/chat/read.ts
+++ b/packages/cli/src/commands/chat/read.ts
@@ -1,6 +1,6 @@
 import { command } from "../../lib/command.js";
 import { daemonFetch } from "../../lib/daemon-client.js";
-import { compactTime, formatSender, isCompact } from "../../lib/format-cli.js";
+import { formatMessageLine, isCompact } from "../../lib/format-cli.js";
 import { resolveMindName } from "../../lib/resolve-mind-name.js";
 
 type Conversation = {
@@ -93,28 +93,7 @@ const cmd = command({
 
     const compact = isCompact();
     for (const msg of data.items) {
-      const text = Array.isArray(msg.content)
-        ? msg.content
-            .filter((b): b is { type: "text"; text: string } => b.type === "text")
-            .map((b) => b.text)
-            .join("")
-        : msg.content;
-      const time = compact
-        ? compactTime(msg.created_at)
-        : new Date(
-            msg.created_at.endsWith("Z") ? msg.created_at : `${msg.created_at}Z`,
-          ).toLocaleString();
-      // Automated announcements have no sender (#687) — render them as events, not as a
-      // message attributed to whoever the fallback would name.
-      if (msg.role === "event") {
-        console.log(`[${time}] · ${text}`);
-        continue;
-      }
-      // Compact (mind-facing) output stays terse; display names are for humans.
-      const sender = compact
-        ? (msg.sender_name ?? msg.role)
-        : formatSender(msg.sender_name ?? msg.role, msg.sender_display_name);
-      console.log(`[${time}] ${sender}: ${text}`);
+      console.log(formatMessageLine(msg, compact));
     }
   },
 });

--- a/packages/cli/src/lib/format-cli.ts
+++ b/packages/cli/src/lib/format-cli.ts
@@ -26,3 +26,37 @@ export function compactDateTime(dateStr: string): string {
   const min = String(d.getMinutes()).padStart(2, "0");
   return `${y}-${m}-${day} ${h}:${min}`;
 }
+
+export type ReadLineMessage = {
+  role: string;
+  sender_name: string | null;
+  sender_display_name?: string | null;
+  content: string | { type: string; text?: string }[];
+  created_at: string;
+};
+
+/**
+ * Render one `chat read` line. Automated announcements (`role: "event"`, #687) render
+ * sender-less as `[time] · text` — role wins even if a sender_name is somehow present, so an
+ * event is never attributed to anyone. Everything else renders `[time] sender: text`, with
+ * display names in human (non-compact) mode.
+ */
+export function formatMessageLine(msg: ReadLineMessage, compact: boolean): string {
+  const text = Array.isArray(msg.content)
+    ? msg.content
+        .filter((b): b is { type: "text"; text: string } => b.type === "text")
+        .map((b) => b.text)
+        .join("")
+    : msg.content;
+  const time = compact
+    ? compactTime(msg.created_at)
+    : new Date(
+        msg.created_at.endsWith("Z") ? msg.created_at : `${msg.created_at}Z`,
+      ).toLocaleString();
+  if (msg.role === "event") return `[${time}] · ${text}`;
+  // Compact (mind-facing) output stays terse; display names are for humans.
+  const sender = compact
+    ? (msg.sender_name ?? msg.role)
+    : formatSender(msg.sender_name ?? msg.role, msg.sender_display_name);
+  return `[${time}] ${sender}: ${text}`;
+}

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -1,5 +1,6 @@
 import { getOrCreateMindUser, getOrCreateSystemUser, getUserByUsername } from "../auth.js";
 import { getSpiritName } from "../config/setup.js";
+import { deliverMessage } from "../delivery/message-delivery.js";
 import { publish as publishActivity } from "../events/activity-events.js";
 import {
   addMessage,
@@ -93,33 +94,38 @@ export async function backfillSystemChannelMembers(): Promise<void> {
 
 /**
  * Post an automated announcement to the #system channel ("X has joined", "📝 X published a
- * note …"). These are sender-less events, never the spirit's voice: since the spirit shares
- * the system user (#663), attributing automation to that user made it indistinguishable from
- * the spirit's hand-written messages (#687).
+ * note …"). These are sender-less, never the spirit's voice: since the spirit shares the
+ * system user (#663), attributing automation to that user made it indistinguishable from the
+ * spirit's hand-written messages (#687).
  *
  * The channel row is stored with `role: "event"` and no sender so web chat and `chat read`
- * render it as an event, and each mind participant receives it as a `commons` system event
- * rather than a message from the spirit. The spirit's own hand-written messages are unaffected.
- *
- * Delivery is `next-turn`: these are ambient commons updates, not messages demanding a reply,
- * so they fold into the mind's next turn as one `[Events]` block instead of interrupting it
- * per announcement — and a mind that slept through a run of them wakes to a single bundled
- * block rather than one cold turn each (the flood the old batched message path avoided, #382).
+ * render it as an event. It is delivered to mind participants through the normal channel-message
+ * path (so it follows each mind's #system routing, batching, gating, and file destinations
+ * exactly like any channel message) — but with a null sender, so the prefix the mind receives
+ * frames it by channel and never names the spirit or invents a sender. The spirit's own
+ * hand-written messages are unaffected.
  */
 export async function announceToSystem(text: string): Promise<void> {
   const channelId = await ensureSystemChannel();
 
   await addMessage(channelId, "event", null, [{ type: "text", text }]);
 
-  // Deliver to all mind participants of #system as a sender-less, next-turn event.
+  // Deliver to all mind participants of #system, sender-less, on the ordinary channel path.
   const participants = await getParticipants(channelId);
   const mindParticipants = participants.filter((p) => p.userType === "mind");
+  const channel = "#system";
   for (const mind of mindParticipants) {
-    deliverEvent(mind.username, { type: "commons", body: text, delivery: "next-turn" }).catch(
-      (err) => {
-        log.warn(`failed to deliver system announcement to ${mind.username}`, log.errorData(err));
-      },
-    );
+    deliverMessage(mind.username, {
+      content: [{ type: "text", text }],
+      channel,
+      conversationId: channelId,
+      sender: null,
+      participants: participants.map((p) => p.username),
+      participantCount: participants.length,
+      isDM: false,
+    }).catch((err) => {
+      log.warn(`failed to deliver system announcement to ${mind.username}`, log.errorData(err));
+    });
   }
 }
 

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -1,6 +1,5 @@
 import { getOrCreateMindUser, getOrCreateSystemUser, getUserByUsername } from "../auth.js";
 import { getSpiritName } from "../config/setup.js";
-import { deliverMessage } from "../delivery/message-delivery.js";
 import { publish as publishActivity } from "../events/activity-events.js";
 import {
   addMessage,
@@ -92,32 +91,35 @@ export async function backfillSystemChannelMembers(): Promise<void> {
   }
 }
 
-/** Post a system announcement to the #system channel and deliver to mind participants. */
+/**
+ * Post an automated announcement to the #system channel ("X has joined", "📝 X published a
+ * note …"). These are sender-less events, never the spirit's voice: since the spirit shares
+ * the system user (#663), attributing automation to that user made it indistinguishable from
+ * the spirit's hand-written messages (#687).
+ *
+ * The channel row is stored with `role: "event"` and no sender so web chat and `chat read`
+ * render it as an event, and each mind participant receives it as a `commons` system event
+ * rather than a message from the spirit. The spirit's own hand-written messages are unaffected.
+ *
+ * Delivery is `next-turn`: these are ambient commons updates, not messages demanding a reply,
+ * so they fold into the mind's next turn as one `[Events]` block instead of interrupting it
+ * per announcement — and a mind that slept through a run of them wakes to a single bundled
+ * block rather than one cold turn each (the flood the old batched message path avoided, #382).
+ */
 export async function announceToSystem(text: string): Promise<void> {
   const channelId = await ensureSystemChannel();
-  const systemUser = await getOrCreateSystemUser();
 
-  // Ensure system user is a participant
-  await joinChannel(channelId, systemUser.id);
+  await addMessage(channelId, "event", null, [{ type: "text", text }]);
 
-  await addMessage(channelId, "user", systemUser.username, [{ type: "text", text }]);
-
-  // Deliver to all mind participants of #system
+  // Deliver to all mind participants of #system as a sender-less, next-turn event.
   const participants = await getParticipants(channelId);
   const mindParticipants = participants.filter((p) => p.userType === "mind");
-  const channel = "#system";
   for (const mind of mindParticipants) {
-    deliverMessage(mind.username, {
-      content: [{ type: "text", text }],
-      channel,
-      conversationId: channelId,
-      sender: systemUser.username,
-      participants: participants.map((p) => p.username),
-      participantCount: participants.length,
-      isDM: false,
-    }).catch((err) => {
-      log.warn(`failed to deliver system announcement to ${mind.username}`, log.errorData(err));
-    });
+    deliverEvent(mind.username, { type: "commons", body: text, delivery: "next-turn" }).catch(
+      (err) => {
+        log.warn(`failed to deliver system announcement to ${mind.username}`, log.errorData(err));
+      },
+    );
   }
 }
 

--- a/packages/daemon/src/lib/chat/system-chat.ts
+++ b/packages/daemon/src/lib/chat/system-chat.ts
@@ -14,17 +14,21 @@ export function resetSystemDMCache(): void {
  *
  * Automated system traffic now goes through system events (`deliverEvent`), not this DM —
  * this only bootstraps the genuine spirit↔mind conversation.
+ *
+ * Returns null for the spirit itself: it shares the system user, so there's no one to DM.
+ * `startMindFull` calls this for every mind including the spirit, so a no-op (not a throw)
+ * keeps spirit starts out of the error log (#688).
  */
-export async function ensureSystemDM(mindName: string): Promise<{ conversationId: string }> {
+export async function ensureSystemDM(mindName: string): Promise<{ conversationId: string } | null> {
   const cached = dmCache.get(mindName);
   if (cached) return { conversationId: cached };
 
   const systemUser = await getOrCreateSystemUser();
   const mindUser = await getOrCreateMindUser(mindName);
 
-  // The spirit shares the system user — can't DM yourself
+  // The spirit shares the system user — can't DM yourself.
   if (systemUser.id === mindUser.id) {
-    throw new Error(`Cannot create system DM: mind "${mindName}" is the system user`);
+    return null;
   }
 
   const existing = await findDMConversation([systemUser.id, mindUser.id]);

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -100,8 +100,6 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
       return "New version available";
     case "channel":
       return "Channel invite";
-    case "commons":
-      return "#system";
     case "file-share":
       return "File offered";
     case "webhook":

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -100,6 +100,8 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
       return "New version available";
     case "channel":
       return "Channel invite";
+    case "commons":
+      return "#system";
     case "file-share":
       return "File offered";
     case "webhook":

--- a/packages/daemon/src/lib/events/conversation-events.ts
+++ b/packages/daemon/src/lib/events/conversation-events.ts
@@ -7,7 +7,7 @@ export type ConversationEvent =
   | {
       type: "message";
       id: number;
-      role: "user" | "assistant";
+      role: "user" | "assistant" | "event";
       senderName: string | null;
       content: ContentBlock[];
       createdAt: string;

--- a/packages/daemon/src/lib/events/conversations.ts
+++ b/packages/daemon/src/lib/events/conversations.ts
@@ -214,7 +214,7 @@ export async function addMessage(
   publish(conversationId, {
     type: "message",
     id: msg.id,
-    role: msg.role as "user" | "assistant",
+    role: msg.role as "user" | "assistant" | "event",
     senderName: msg.sender_name,
     content: msg.content,
     createdAt: msg.created_at,

--- a/packages/daemon/src/lib/events/feed.ts
+++ b/packages/daemon/src/lib/events/feed.ts
@@ -1,5 +1,5 @@
 import type { FeedChatEvent, FeedDigest, FeedLifecycleEvent, Participant } from "@volute/api";
-import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, ne, sql } from "drizzle-orm";
 import { aiCompleteUtility } from "../ai-service.js";
 import { SYSTEM_MIND } from "../daemon/summarizer.js";
 import { getDb } from "../db.js";
@@ -143,7 +143,18 @@ export async function getChatFeedEvents(opts?: { limit?: number }): Promise<Feed
     })
     .from(messages)
     .innerJoin(conversations, eq(conversations.id, messages.conversation_id))
-    .where(and(gte(messages.created_at, cutoff), eq(conversations.private, 0)))
+    // Exclude sender-less `event` rows (#system announcements, #687): they're events, not
+    // conversation activity, so they must not form "chat burst" cards — that would relocate the
+    // exact spirit-misattribution #687 removes (ChatEventCard renders a null sender as "mind"),
+    // and a run of them would render as a fake conversation burst. Joins already surface as
+    // lifecycle cards; the announcement itself lives in the #system channel.
+    .where(
+      and(
+        gte(messages.created_at, cutoff),
+        eq(conversations.private, 0),
+        ne(messages.role, "event"),
+      ),
+    )
     .orderBy(desc(messages.id))
     .limit(5000);
 

--- a/packages/daemon/src/lib/platforms/volute.ts
+++ b/packages/daemon/src/lib/platforms/volute.ts
@@ -85,6 +85,9 @@ export async function read(
             .map((b) => b.text)
             .join("")
         : m.content;
+      // Automated announcements have no sender (#687) — render sender-less so a mind reading
+      // #system via the platform driver doesn't see "event: atlas has joined".
+      if (m.role === "event") return `· ${text}`;
       return `${m.sender_name ?? m.role}: ${text}`;
     })
     .join("\n");

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1167,8 +1167,13 @@ const app = new Hono<AuthEnv>()
         },
       });
 
-      // Announce to #system channel
-      announceToSystem(`${name} has joined`).catch(() => {});
+      // Announce to #system channel. Fire-and-forget, but surface failures — this is the
+      // primary producer of #system event rows, and announceToSystem propagates DB errors
+      // (ensureSystemChannel/addMessage/getParticipants), so a silent swallow would make the
+      // join moment vanish without a trace.
+      announceToSystem(`${name} has joined`).catch((err) =>
+        log.warn(`failed to announce ${name} joining #system`, log.errorData(err)),
+      );
 
       // Warn (don't block) when the mind will spawn without usable model credentials,
       // so a mute-on-first-turn mind is caught at creation rather than in silence (#573).

--- a/packages/web/src/ui/components/chat/MessageEntry.svelte
+++ b/packages/web/src/ui/components/chat/MessageEntry.svelte
@@ -29,7 +29,9 @@ let {
   onOpenMind,
   showTypingDot = false,
 }: {
-  role: "user" | "assistant";
+  // "event" entries are rendered by MessageList directly and never reach MessageEntry; the
+  // wider type keeps the `role={entry.role}` binding sound (#687).
+  role: "user" | "assistant" | "event";
   blocks: ContentBlock[];
   senderName?: string;
   createdAt?: string;

--- a/packages/web/src/ui/components/chat/MessageList.svelte
+++ b/packages/web/src/ui/components/chat/MessageList.svelte
@@ -161,8 +161,15 @@ function handleScroll() {
     <div class="empty">Send a message to start chatting.</div>
   {/if}
   {#each entries as entry, i (entry.id)}
+    <!-- Sender-less automated announcement (#687): a #system event, not a chat message -->
+    {#if entry.role === "event"}
+      <div class="event-row">
+        {#each entry.blocks as block, bi (bi)}
+          {#if block.type === "text"}<span>{block.text}</span>{/if}
+        {/each}
+      </div>
     <!-- System divider -->
-    {#if entry.senderName === "system" && entry.blocks.length === 1 && entry.blocks[0].type === "text" && entry.blocks[0].text.match(/^\[.+\]$/)}
+    {:else if entry.senderName === "system" && entry.blocks.length === 1 && entry.blocks[0].type === "text" && entry.blocks[0].text.match(/^\[.+\]$/)}
       <div class="divider">
         <div class="divider-line"></div>
         <span>{entry.blocks[0].text.slice(1, -1)}</span>
@@ -246,6 +253,14 @@ function handleScroll() {
   .load-more-btn:hover {
     color: var(--text-1);
     border-color: var(--border-bright);
+  }
+
+  .event-row {
+    text-align: center;
+    margin: 12px 0;
+    color: var(--text-2);
+    font-size: 13px;
+    font-style: italic;
   }
 
   .divider {

--- a/packages/web/src/ui/components/modals/ReadOnlyChatModal.svelte
+++ b/packages/web/src/ui/components/modals/ReadOnlyChatModal.svelte
@@ -100,21 +100,26 @@ function showDate(i: number): boolean {
               <div class="divider-line"></div>
             </div>
           {/if}
-          <div class="chat-entry" class:new-sender={showSenderHeader(messages, i)}>
-            {#if showSenderHeader(messages, i)}
-              <div class="chat-entry-header">
-                <span class="chat-sender" class:chat-sender-user={msg.role === "user"}>{msg.sender_name ?? (msg.role === "user" ? "user" : (mindName ?? "mind"))}</span>
-                <span class="chat-timestamp">{formatTime(msg.created_at)}</span>
-              </div>
-            {/if}
-            <div class="chat-entry-content" class:chat-user-text={msg.role === "user"}>
-              {#if msg.role === "user"}
-                {extractTextContent(msg.content)}
-              {:else}
-                <div class="markdown-body">{@html renderMarkdown(extractTextContent(msg.content))}</div>
+          {#if msg.role === "event"}
+            <!-- Sender-less automated announcement (#687) -->
+            <div class="chat-event">{extractTextContent(msg.content)}</div>
+          {:else}
+            <div class="chat-entry" class:new-sender={showSenderHeader(messages, i)}>
+              {#if showSenderHeader(messages, i)}
+                <div class="chat-entry-header">
+                  <span class="chat-sender" class:chat-sender-user={msg.role === "user"}>{msg.sender_name ?? (msg.role === "user" ? "user" : (mindName ?? "mind"))}</span>
+                  <span class="chat-timestamp">{formatTime(msg.created_at)}</span>
+                </div>
               {/if}
+              <div class="chat-entry-content" class:chat-user-text={msg.role === "user"}>
+                {#if msg.role === "user"}
+                  {extractTextContent(msg.content)}
+                {:else}
+                  <div class="markdown-body">{@html renderMarkdown(extractTextContent(msg.content))}</div>
+                {/if}
+              </div>
             </div>
-          </div>
+          {/if}
         {/each}
       </div>
     {/if}
@@ -172,6 +177,14 @@ function showDate(i: number): boolean {
     flex: 1;
     height: 1px;
     background: var(--border);
+  }
+
+  .chat-event {
+    text-align: center;
+    margin: 10px 0;
+    color: var(--text-2);
+    font-size: 13px;
+    font-style: italic;
   }
 
   .chat-entry {

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -3,7 +3,9 @@ import type { ContentBlock } from "@volute/api";
 export type ChatEntry = {
   id: number;
   serverId?: number;
-  role: "user" | "assistant";
+  // "event" is a sender-less automated announcement (e.g. #system "X has joined"),
+  // rendered as an event line rather than a chat bubble (#687).
+  role: "user" | "assistant" | "event";
   blocks: ContentBlock[];
   senderName?: string;
   createdAt?: string;

--- a/templates/_base/src/lib/format-prefix.ts
+++ b/templates/_base/src/lib/format-prefix.ts
@@ -39,15 +39,22 @@ export function formatEventPrefix(label: string, at: string | undefined): string
 export function formatPrefix(meta: ChannelMeta | undefined, time: string): string {
   if (!meta?.channel && !meta?.sender) return "";
   const platform = meta.platform ?? "Volute";
-  // Build sender context (e.g., "alice in DM" or "alice in #general in My Server")
-  let sender = meta.sender ?? "";
-  if (meta.isDM) {
-    sender += " in DM";
-  } else if (meta.channelName) {
-    sender += ` in #${meta.channelName}`;
-    if (meta.serverName) sender += ` in ${meta.serverName}`;
+  // Build the subject context. With a sender it's "alice in #general in My Server"; without one
+  // this is a sender-less channel announcement (#687) — frame it by its channel and never invent
+  // a name, so automated posts (e.g. #system "X has joined") aren't attributed to anyone.
+  let subject: string;
+  if (meta.sender) {
+    subject = meta.sender;
+    if (meta.isDM) {
+      subject += " in DM";
+    } else if (meta.channelName) {
+      subject += ` in #${meta.channelName}`;
+      if (meta.serverName) subject += ` in ${meta.serverName}`;
+    }
+  } else {
+    subject = meta.channelName ? `#${meta.channelName}` : (meta.channel ?? "");
   }
-  const parts = [platform, sender].filter(Boolean);
+  const parts = [platform, subject].filter(Boolean);
   // Include thread name if not the default
   const sessionPart =
     meta.sessionName && meta.sessionName !== "main" ? ` — thread: ${meta.sessionName}` : "";

--- a/templates/_base/src/lib/router.ts
+++ b/templates/_base/src/lib/router.ts
@@ -242,10 +242,12 @@ export function createRouter(options: {
     const multiChannel = channelCounts.size > 1;
     const body = messages
       .map((m) => {
-        const prefix =
-          multiChannel && m.channel
-            ? `[${m.sender ?? "unknown"} in ${m.channel} — ${m.timestamp}]`
-            : `[${m.sender ?? "unknown"} — ${m.timestamp}]`;
+        // Sender-less rows are channel announcements (#687) — frame by channel, never "unknown".
+        const prefix = m.sender
+          ? multiChannel && m.channel
+            ? `[${m.sender} in ${m.channel} — ${m.timestamp}]`
+            : `[${m.sender} — ${m.timestamp}]`
+          : `[${m.channel ?? "#system"} — ${m.timestamp}]`;
         return `${prefix}\n${m.text}`;
       })
       .join("\n\n");
@@ -536,7 +538,7 @@ export function createRouter(options: {
 
     const body = allMessages
       .map((m) => {
-        const sender = m.payload.sender ?? "unknown";
+        const sender = m.payload.sender;
         const text =
           typeof m.payload.content === "string"
             ? m.payload.content
@@ -547,9 +549,12 @@ export function createRouter(options: {
                   .join("\n")
               : JSON.stringify(m.payload.content);
         const time = compactTime();
-        const prefix = multiChannel
-          ? `[${sender} in ${m.channel} — ${time}]`
-          : `[${sender} — ${time}]`;
+        // Sender-less rows are channel announcements (#687) — frame by channel, never "unknown".
+        const prefix = sender
+          ? multiChannel
+            ? `[${sender} in ${m.channel} — ${time}]`
+            : `[${sender} — ${time}]`
+          : `[${m.channel} — ${time}]`;
         return `${prefix}\n${text}`;
       })
       .join("\n\n");

--- a/test/conversations.test.ts
+++ b/test/conversations.test.ts
@@ -16,11 +16,13 @@ import {
   getConversation,
   getMessages,
   getParticipants,
+  getUnreadCounts,
   isParticipant,
   joinChannel,
   leaveChannel,
   listChannels,
   listConversationsForUser,
+  listConversationsWithParticipants,
   removeParticipant,
   setConversationPrivate,
 } from "../packages/daemon/src/lib/events/conversations.js";
@@ -478,6 +480,39 @@ describe("conversation privacy", () => {
       assert.equal(fetched!.private, 0);
     } finally {
       await deleteConversation(conv.id);
+    }
+  });
+});
+
+// Pins the intentional behavior change from #687: a sender-less announcement (role "event",
+// sender_name NULL) is stored on the channel like any other row. Because it has no sender it
+// counts as unread for every participant (the spirit included) and flows through the
+// conversation-list enrichment as an event with a null sender — both must hold without error.
+describe("sender-less event rows (#687)", () => {
+  it("counts an event row as unread and surfaces it as a null-sender lastMessage", async () => {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "event-reader"));
+    const reader = await getOrCreateMindUser("event-reader");
+    const channel = await createChannel(`event-unread-${Date.now()}`);
+    try {
+      await joinChannel(channel.id, reader.id);
+      await addMessage(channel.id, "event", null, [{ type: "text", text: "atlas has joined" }]);
+
+      const unread = await getUnreadCounts(reader.id, [channel.id], "event-reader");
+      assert.equal(unread[channel.id], 1, "a sender-less event must count as unread");
+
+      const convs = await listConversationsWithParticipants(reader.id);
+      const found = convs.find((c) => c.id === channel.id);
+      assert.ok(found, "the channel should enrich without throwing");
+      assert.equal(found!.lastMessage?.role, "event", "lastMessage should carry the event role");
+      assert.equal(
+        found!.lastMessage?.senderName,
+        null,
+        "lastMessage for an announcement must have no sender",
+      );
+    } finally {
+      await deleteConversation(channel.id);
+      await db.delete(users).where(eq(users.username, "event-reader"));
     }
   });
 });

--- a/test/format-cli.test.ts
+++ b/test/format-cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { formatSender } from "../packages/cli/src/lib/format-cli.js";
+import { formatMessageLine, formatSender } from "../packages/cli/src/lib/format-cli.js";
 
 describe("formatSender", () => {
   it("renders 'Display Name (@username)' when a distinct display name exists", () => {
@@ -15,5 +15,78 @@ describe("formatSender", () => {
 
   it("returns the name unchanged when the display name equals the username", () => {
     assert.equal(formatSender("cricket", "cricket"), "cricket");
+  });
+});
+
+describe("formatMessageLine", () => {
+  const at = "2026-07-16 17:30:00";
+
+  it("renders a normal message with its sender", () => {
+    const line = formatMessageLine(
+      {
+        role: "user",
+        sender_name: "cricket",
+        content: [{ type: "text", text: "hi" }],
+        created_at: at,
+      },
+      true,
+    );
+    assert.match(line, /cricket: hi$/);
+  });
+
+  it("renders a display name in human (non-compact) mode", () => {
+    const line = formatMessageLine(
+      {
+        role: "user",
+        sender_name: "cricket",
+        sender_display_name: "Cricket Song",
+        content: [{ type: "text", text: "hi" }],
+        created_at: at,
+      },
+      false,
+    );
+    assert.match(line, /Cricket Song \(@cricket\): hi$/);
+  });
+
+  it("renders an announcement (role event) sender-less with a · marker in compact mode (#687)", () => {
+    const line = formatMessageLine(
+      {
+        role: "event",
+        sender_name: null,
+        content: [{ type: "text", text: "atlas has joined" }],
+        created_at: at,
+      },
+      true,
+    );
+    // The `] · text` shape (no `sender:` between the bracket and the middot) is the proof
+    // it's sender-less; the timestamp itself legitimately contains a colon.
+    assert.match(line, /\] · atlas has joined$/);
+  });
+
+  it("renders an announcement sender-less in human mode too (#687)", () => {
+    const line = formatMessageLine(
+      {
+        role: "event",
+        sender_name: null,
+        content: [{ type: "text", text: "atlas has joined" }],
+        created_at: at,
+      },
+      false,
+    );
+    assert.match(line, /· atlas has joined$/);
+  });
+
+  it("keeps an event sender-less even if a sender_name is present — role wins (#687)", () => {
+    const line = formatMessageLine(
+      {
+        role: "event",
+        sender_name: "iris",
+        content: [{ type: "text", text: "atlas has joined" }],
+        created_at: at,
+      },
+      true,
+    );
+    assert.match(line, /· atlas has joined$/);
+    assert.ok(!line.includes("iris"), "an event must never be attributed to a sender");
   });
 });

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import {
   announceSprout,
@@ -13,6 +15,7 @@ import {
   resetSystemChannelCache,
 } from "../packages/daemon/src/lib/chat/system-channel.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import { clearConfigCache } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import {
   createChannel,
   deleteConversation,
@@ -52,8 +55,17 @@ const TEST_MINDS = [
   "commons-sprout",
 ];
 
+/** Write a routes.json for a test mind so its #system routing decision is deterministic. */
+function writeCommonsRoutes(name: string, config: object): void {
+  const configDir = resolve(process.env.VOLUTE_HOME!, "minds", name, "home/.config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(resolve(configDir, "routes.json"), JSON.stringify(config));
+  clearConfigCache(name);
+}
+
 async function cleanup() {
   resetSystemChannelCache();
+  clearConfigCache();
   const db = await getDb();
   for (const username of TEST_USERNAMES) {
     await db.delete(users).where(eq(users.username, username));
@@ -184,29 +196,42 @@ describe("system channel", () => {
     );
   });
 
-  it("announceToSystem delivers a sender-less commons event to mind participants (#687)", async () => {
+  it("announceToSystem delivers to mind participants sender-less on the channel path (#687)", async () => {
     await addMind("commons-mind", 4901, "sprouted");
     await joinSystemChannelForMind("commons-mind");
+    // Disable gating so the (dead-port) delivery still records the inbound: the mind never acks,
+    // but recordInbound runs first on the normal channel path and captures the delivered shape.
+    writeCommonsRoutes("commons-mind", { gateUnmatched: false });
 
     await announceToSystem("atlas has joined");
 
-    // deliverEvent inserts the event row; as a next-turn event it stays pending until the
-    // mind's next turn drains it as an [Events] block. It must be a `commons` event, not a
-    // message attributed to the spirit.
+    // Delivery is fire-and-forget inside announceToSystem, so poll for the recorded inbound.
     const db = await getDb();
+    let row: { sender: string | null; channel: string | null } | undefined;
+    for (let i = 0; i < 50 && !row; i++) {
+      const inbound = await db
+        .select()
+        .from(mindHistory)
+        .where(and(eq(mindHistory.mind, "commons-mind"), eq(mindHistory.type, "inbound")))
+        .all();
+      row = inbound.find((r) => r.content?.includes("atlas has joined"));
+      if (!row) await new Promise((res) => setTimeout(res, 20));
+    }
+    assert.ok(row, "the announcement should be delivered to the mind participant");
+    assert.equal(row!.sender, null, "delivery must be sender-less — never the spirit");
+    assert.equal(
+      row!.channel,
+      "#system",
+      "delivered on the #system channel, following its routing",
+    );
+
+    // And it must NOT go out as a system event any more — announcements are channel messages.
     const events = await db
       .select()
       .from(systemEvents)
       .where(eq(systemEvents.mind, "commons-mind"))
       .all();
-    const event = events.find((e) => e.body.includes("atlas has joined"));
-    assert.ok(event, "mind participant should receive the announcement as a system event");
-    assert.equal(event!.type, "commons", "announcement should be delivered as a commons event");
-    assert.equal(
-      event!.delivery,
-      "next-turn",
-      "ambient commons announcements should fold into the next turn, not interrupt per event",
-    );
+    assert.equal(events.length, 0, "announcements are channel messages, not system events");
   });
 
   // Register the spirit (dead port — the event stays pending, which is fine: the

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -8,6 +8,7 @@ import {
   backfillSystemChannelMembers,
   ensureSystemChannel,
   joinSystemChannel,
+  joinSystemChannelForMind,
   joinSystemChannelForSpirit,
   resetSystemChannelCache,
 } from "../packages/daemon/src/lib/chat/system-channel.js";
@@ -169,12 +170,43 @@ describe("system channel", () => {
     assert.ok(!names.includes("commons-clash"), "failed entry should not be joined");
   });
 
-  it("announceToSystem posts a message", async () => {
+  it("announceToSystem posts a sender-less event row, never the spirit's voice (#687)", async () => {
     await announceToSystem("test announcement");
     const db = await getDb();
     const msgs = await db.select().from(messages).all();
     const found = msgs.find((m) => m.content.includes("test announcement"));
     assert.ok(found, "should find the announcement message");
+    assert.equal(found!.role, "event", "announcement should be an event, not a chat message");
+    assert.equal(
+      found!.sender_name,
+      null,
+      "announcement must have no sender so it isn't attributed to the spirit",
+    );
+  });
+
+  it("announceToSystem delivers a sender-less commons event to mind participants (#687)", async () => {
+    await addMind("commons-mind", 4901, "sprouted");
+    await joinSystemChannelForMind("commons-mind");
+
+    await announceToSystem("atlas has joined");
+
+    // deliverEvent inserts the event row; as a next-turn event it stays pending until the
+    // mind's next turn drains it as an [Events] block. It must be a `commons` event, not a
+    // message attributed to the spirit.
+    const db = await getDb();
+    const events = await db
+      .select()
+      .from(systemEvents)
+      .where(eq(systemEvents.mind, "commons-mind"))
+      .all();
+    const event = events.find((e) => e.body.includes("atlas has joined"));
+    assert.ok(event, "mind participant should receive the announcement as a system event");
+    assert.equal(event!.type, "commons", "announcement should be delivered as a commons event");
+    assert.equal(
+      event!.delivery,
+      "next-turn",
+      "ambient commons announcements should fold into the next turn, not interrupt per event",
+    );
   });
 
   // Register the spirit (dead port — the event stays pending, which is fine: the

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -103,8 +103,10 @@ describe("system DM", () => {
     assert.equal(id1, id2, "should find existing DM via DB lookup");
   });
 
-  it("ensureSystemDM throws for the spirit (can't DM the shared system user)", async () => {
-    // The spirit shares the system user, so there's no distinct pair to DM.
-    await assert.rejects(() => ensureSystemDM("volute"), /system user/);
+  it("ensureSystemDM is a no-op for the spirit (can't DM the shared system user)", async () => {
+    // The spirit shares the system user, so there's no distinct pair to DM. It returns
+    // null rather than throwing, so `startMindFull` doesn't log an error on spirit start (#688).
+    const result = await ensureSystemDM("volute");
+    assert.equal(result, null, "should return null for the spirit, not throw");
   });
 });

--- a/test/system-events.test.ts
+++ b/test/system-events.test.ts
@@ -811,6 +811,9 @@ describe("system-events eventLabel", () => {
     assert.equal(eventLabel("wake", null), "Woke from sleep");
     assert.equal(eventLabel("lifecycle", { subtype: "merge" }), "Variant merged in");
     assert.equal(eventLabel("webhook", { source: "github" }), "Webhook: github");
+    // A #system announcement event (#687): minds see this as the envelope prefix, so it must
+    // stay "#system", never fall through to the capitalized type name "Commons".
+    assert.equal(eventLabel("commons", null), "#system");
   });
 });
 

--- a/test/system-events.test.ts
+++ b/test/system-events.test.ts
@@ -811,9 +811,6 @@ describe("system-events eventLabel", () => {
     assert.equal(eventLabel("wake", null), "Woke from sleep");
     assert.equal(eventLabel("lifecycle", { subtype: "merge" }), "Variant merged in");
     assert.equal(eventLabel("webhook", { source: "github" }), "Webhook: github");
-    // A #system announcement event (#687): minds see this as the envelope prefix, so it must
-    // stay "#system", never fall through to the capitalized type name "Commons".
-    assert.equal(eventLabel("commons", null), "#system");
   });
 });
 

--- a/test/template-event-format.test.ts
+++ b/test/template-event-format.test.ts
@@ -48,6 +48,64 @@ describe("template event envelope formatting", () => {
   });
 });
 
+// #687: automated #system announcements are delivered on the ordinary channel path but with a
+// null sender. The mind-facing prefix must frame them by channel and never name anyone — no
+// spirit name, and no phantom "unknown" fallback in any of the formatting paths.
+describe("sender-less channel announcements (#687)", () => {
+  it("formatPrefix frames a sender-less channel post by channel, with no sender", () => {
+    const prefix = formatPrefix({ channel: "#system", platform: "Volute" }, "2026-07-12 07:30");
+    assert.match(prefix, /^\[Volute: #system — 2026-07-12 07:30\]/);
+    assert.ok(!prefix.includes("unknown"), "must not invent an 'unknown' sender");
+  });
+
+  it("dispatch delivers a sender-less announcement with no sender attribution", () => {
+    const handled: { content: VoluteContentPart[]; meta: HandlerMeta }[] = [];
+    const router = createRouter({
+      mindHandler: () => ({
+        handle(content, meta) {
+          handled.push({ content, meta });
+          return () => {};
+        },
+      }),
+    });
+
+    router.dispatch([{ type: "text", text: "atlas has joined" }], "system", {
+      channel: "#system",
+      sender: null as unknown as undefined,
+      isDM: false,
+    });
+
+    const text = (handled[0].content[0] as { type: "text"; text: string }).text;
+    assert.ok(text.includes("atlas has joined"));
+    assert.match(text, /^\[Volute: #system/, "framed by channel");
+    assert.ok(!text.includes("unknown"), "no phantom sender");
+    router.close();
+  });
+
+  it("dispatchBatch renders a sender-less announcement without an 'unknown' sender", () => {
+    const handled: { content: VoluteContentPart[]; meta: HandlerMeta }[] = [];
+    const router = createRouter({
+      mindHandler: () => ({
+        handle(content, meta) {
+          handled.push({ content, meta });
+          return () => {};
+        },
+      }),
+    });
+
+    router.dispatchBatch(
+      { channels: { "#system": [{ sender: null, content: "atlas has joined" }] } },
+      "system",
+      {},
+    );
+
+    const text = (handled[0].content[0] as { type: "text"; text: string }).text;
+    assert.ok(text.includes("atlas has joined"));
+    assert.ok(!text.includes("unknown"), "batch flush must not invent an 'unknown' sender");
+    router.close();
+  });
+});
+
 describe("router event dispatch", () => {
   it("applies the system-event heading and no sender/DM framing to an event dispatch", () => {
     const handled: { content: VoluteContentPart[]; meta: HandlerMeta }[] = [];

--- a/test/web-feed.test.ts
+++ b/test/web-feed.test.ts
@@ -140,6 +140,28 @@ describe("web feed routes", () => {
     await db.delete(messages).where(eq(messages.conversation_id, ch.id));
   });
 
+  it("excludes sender-less announcement events from chat bursts (#687)", async () => {
+    const cookie = await makeUser("feed-test-admin", "admin");
+    const db = await getDb();
+    const owner = await createUser("feed-test-owner", "pass");
+    const ch = await createChannel("feed-test-commons", owner.id);
+    // A run of pure #system announcements — events, not conversation. They must not form a
+    // "chat burst" card (which would render the null sender as "mind" — the #687 confusion).
+    await insertMsg(ch.id, "event", null, "atlas has joined", ago(12));
+    await insertMsg(ch.id, "event", null, "willow has joined", ago(11));
+
+    const res = await feedApp().request("/api/v1/feed", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    const body = (await res.json()) as { events: any[] };
+    assert.ok(
+      !body.events.some((e) => e.kind === "chat" && e.conversationId === ch.id),
+      "an announcement-only channel must not produce a chat burst card",
+    );
+
+    await db.delete(messages).where(eq(messages.conversation_id, ch.id));
+  });
+
   it("merges lifecycle events and redacts mind_error/backup_failed for non-privileged callers", async () => {
     const adminCookie = await makeUser("feed-test-admin", "admin");
     const userCookie = await makeUser("feed-test-user", "user");


### PR DESCRIPTION
Fixes #687 and #688 (both found in the 0.50.0 release integration test).

## #687 — automated #system announcements no longer post as the spirit
`announceToSystem()` stored announcements ("X has joined", "📝 X published a note …") as messages with `sender_name = the system user`. Since #663 the system user carries the spirit's name, so automation was indistinguishable from the spirit's own hand-written voice.

Now:
- The channel row is stored sender-less with `role: "event"`, so it still appears in the #system timeline for humans but renders as an event, never attributed to a sender.
- Rendered sender-less on every surface that shows these rows: web chat (`MessageList`), `ReadOnlyChatModal`, CLI `chat read` (`[time] · text`), and the volute platform read driver.
- Excluded from the home feed's chat-burst query — see the feed note below.
- Message `role` union widened to include `"event"` across `@volute/api`, the daemon conversation-events type, and the web `ChatEntry`/`MessageEntry`.

The spirit's own hand-written messages (e.g. its sprout welcomes) are completely unaffected.

## Delivery: the ordinary channel path, sender-less
Announcements are **channel content**, so they are delivered to mind participants through the normal channel-message path (`deliverMessage` / the router) — exactly as they were before, and exactly like any other #system message. They follow each mind's #system routing precisely: routed session, batching/debounce, gating, file destinations, and the sleep-queue's batched flush (#382) all apply. **Only the attribution changed** — the payload is delivered with a null sender.

To keep the mind-facing prefix from naming the spirit or inventing a sender, the template's prefix formatting frames a sender-less channel post by its channel and never falls back to a phantom name:
- `formatPrefix`: a sender-less post renders as `[Volute: #system — …]` (channel as subject, no name).
- The batch renderers (`dispatchBatch` / `flushBatch`) render sender-less lines as `[#system — …]` instead of the previous `[unknown — …]`.

Old-template minds are unaffected: these are ordinary channel messages again, which every template handles.

## #688 — spurious 'Cannot create system DM' error on every spirit start
`startMindFull()` calls `ensureSystemDM(baseName)` for every mind including the spirit; `ensureSystemDM` threw by design for the system user, so every spirit start (including routine identity-reload restarts) logged an error-level "failed to ensure system DM". It now returns `null` (silent no-op) for the system user. All three call sites are fire-and-forget and ignore the return, so the no-op is cleaner than guarding each site.

## Home feed
`getChatFeedEvents` pulled every non-private message into conversation "bursts", so #system announcement rows would have formed chat-burst cards that `ChatEventCard` renders with a null sender as "mind" — relocating the exact #687 misattribution to the feed, and rendering a run of announcements as a fake conversation burst. Event rows are now excluded from the feed query at the source. Joins already surface as `mind_started` lifecycle cards, and the announcement itself lives in the #system channel, so nothing is lost.

## Documented behavior decision (intentional, reviewed)
- **Spirit accrues #system unread.** The stored channel row is sender-less, and a sender-less row counts as unread for every participant (NULL sender ≠ any username), including the spirit. An event isn't "from" the spirit, so this is correct — and it's pinned by a test.

## Tests
- `system-channel`: announcements stored sender-less (`role: "event"`, `sender_name: null`), and delivered to a mind participant as a sender-less `#system` inbound (never the spirit) with no system event created.
- `template-event-format`: an announcement's mind-facing content (via `formatPrefix`, `dispatch`, and `dispatchBatch`) carries no sender attribution and never the phantom "unknown".
- `system-chat`: `ensureSystemDM` returns `null` for the spirit instead of throwing.
- `format-cli`: `formatMessageLine` (extracted from `chat read` so it's testable) renders event rows sender-less in both compact and human modes, and keeps them sender-less even if a `sender_name` is present (role wins).
- `web-feed`: an announcement-only channel produces no chat-burst card.
- `conversations`: a sender-less event row counts as unread and enriches into a `lastMessage` with `role "event"` / `senderName null` without throwing.
- Full suite passes (pre-push hook); `tsc` + `svelte-check` + template typecheck clean.

## No DB migration
Reuses the free-text `role` column on `messages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)