### PR TITLE
fix: dead-letter and orphan cleanup for delivery_queue

### DIFF
--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -114,6 +114,8 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
           return "Startup notice";
         case "extension":
           return s("reason") ? `Notice: ${s("reason")}` : "Notice";
+        case "delivery_failed":
+          return "Delivery failed";
         default:
           return "Notice";
       }
@@ -123,7 +125,13 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
 }
 
 /** The kinds of failure/informational notice that fold into next-turn events. */
-export type NoticeKind = "turn_error" | "crash" | "budget" | "startup" | "extension";
+export type NoticeKind =
+  | "turn_error"
+  | "crash"
+  | "budget"
+  | "startup"
+  | "extension"
+  | "delivery_failed";
 
 export type RecordNoticeInput = {
   mind: string;

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -1,6 +1,7 @@
 import { realpath } from "node:fs/promises";
 import { resolve } from "node:path";
 import { and, eq, inArray, sql } from "drizzle-orm";
+import { MIND_LEVEL_THREAD, type RecordNoticeInput } from "../chat/system-events.js";
 import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
 import { tryGetMindManager } from "../daemon/mind-manager.js";
 import { linkInboundToActiveTurn } from "../daemon/turn-tracker.js";
@@ -37,6 +38,11 @@ const REDRIVE_INTERVAL_MS = 15_000;
 const RETRY_BASE_MS = 5_000;
 const RETRY_MAX_MS = 5 * 60_000;
 const REDRIVE_BATCH_LIMIT = 200;
+// After this many failed POST attempts a row is dead-lettered (status "dead") instead of
+// retried forever. With the backoff above (capped at 5 min) this is ~30 min of retries —
+// enough to ride out a mind restart or transient fault, but bounded so a payload the mind
+// permanently rejects can't grow the queue without limit. #356
+export const MAX_DELIVERY_ATTEMPTS = 10;
 
 // --- Gated-channel release tuning ---
 // When a routing change matches a previously-gated channel, deliver at most this many
@@ -82,6 +88,17 @@ type QueuedMessage = {
   queueId?: number;
 };
 
+/** The delivery_queue fields a dead-lettered row carries into its failure notice. */
+type DeadLetterRow = {
+  id: number;
+  mind: string;
+  target_mind: string | null;
+  thread: string;
+  channel: string | null;
+  sender: string | null;
+  created_at: string;
+};
+
 // --- Delivery Manager ---
 
 export class DeliveryManager {
@@ -113,6 +130,12 @@ export class DeliveryManager {
     await deliverEvent(mindName, { type: "channel", body: text });
   };
 
+  /** Surfaces a dead-lettered delivery as a next-turn failure notice; overridable in tests. */
+  private notifyFailure: (input: RecordNoticeInput) => Promise<void> = async (input) => {
+    const { recordNotice } = await import("../chat/system-events.js");
+    await recordNotice(input);
+  };
+
   constructor() {
     // Release gated messages when a mind's routes.json changes.
     setRoutesChangeListener((mind) => {
@@ -130,6 +153,11 @@ export class DeliveryManager {
   /** Test seam: capture/override system notifications sent to minds. */
   setNotifier(fn: (mindName: string, text: string) => Promise<void>): void {
     this.notify = fn;
+  }
+
+  /** Test seam: capture/override dead-letter failure notices. */
+  setFailureNotifier(fn: (input: RecordNoticeInput) => Promise<void>): void {
+    this.notifyFailure = fn;
   }
 
   // --- Public API ---
@@ -789,28 +817,141 @@ export class DeliveryManager {
     }
   }
 
-  /** Bump attempt counters and set a backoff window so a down mind isn't hot-looped. */
-  private async scheduleRetry(ids: (number | undefined)[]): Promise<void> {
+  /**
+   * Record the outcome of a failed delivery attempt: set a backoff window so the target
+   * isn't hot-looped, and — for a LIVE rejection — advance the dead-letter counter.
+   *
+   * Only a live rejection (`liveRejection: true`: the target was reachable and answered with
+   * a non-OK HTTP status) counts toward {@link MAX_DELIVERY_ATTEMPTS}. A transport failure
+   * (`liveRejection: false`: connection refused, reset, or timeout — the mind or a detached
+   * variant is simply down/unreachable) backs off WITHOUT advancing the counter, so a merely
+   * offline target is never dead-lettered and its message is preserved until it returns. The
+   * redrive guard only checks the base mind's up-ness, so a stopped variant reaches here on
+   * every sweep — this is what stops that from silently dropping its messages. #356
+   *
+   * A row that reaches the ceiling moves to the terminal `dead` status (excluded from
+   * redrive, which only reads `pending`) and the batch is surfaced as one failure notice.
+   *
+   * Rows here are still `inFlight` (the caller clears ownership in its own `finally`, after
+   * this resolves), so the concurrent redrive sweep skips them and can't race this update.
+   */
+  private async scheduleRetry(
+    ids: (number | undefined)[],
+    opts: { liveRejection: boolean },
+  ): Promise<void> {
     const valid = [...new Set(ids.filter((id): id is number => typeof id === "number"))];
     if (valid.length === 0) return;
     try {
       const db = await getDb();
       const rows = await db
-        .select({ id: deliveryQueue.id, attempts: deliveryQueue.attempts })
+        .select({
+          id: deliveryQueue.id,
+          attempts: deliveryQueue.attempts,
+          mind: deliveryQueue.mind,
+          target_mind: deliveryQueue.target_mind,
+          thread: deliveryQueue.thread,
+          channel: deliveryQueue.channel,
+          sender: deliveryQueue.sender,
+          created_at: deliveryQueue.created_at,
+        })
         .from(deliveryQueue)
         .where(inArray(deliveryQueue.id, valid));
+      const dead: DeadLetterRow[] = [];
       for (const row of rows) {
+        // Transport failure: back off on the current (unadvanced) counter, don't dead-letter.
+        if (!opts.liveRejection) {
+          await db
+            .update(deliveryQueue)
+            .set({ next_attempt_at: this.backoffExpr(row.attempts) })
+            .where(eq(deliveryQueue.id, row.id));
+          continue;
+        }
         const attempts = row.attempts + 1;
-        const backoffSec = Math.round(
-          Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.min(attempts, 20)) / 1000,
-        );
+        if (attempts >= MAX_DELIVERY_ATTEMPTS) {
+          // Log BEFORE the terminal UPDATE so a crash between the two can't drop a message
+          // without a trace. #356
+          dlog.error(
+            `dead-lettering delivery queue row ${row.id} for ${row.mind} after ${attempts} ` +
+              `live rejections (channel=${row.channel ?? "?"}, sender=${row.sender ?? "?"})`,
+          );
+          // Gate the transition on the row still being `pending` and only notify on a row that
+          // actually flipped — so a (currently unreachable) re-process of an already-`dead` row
+          // can't fire a duplicate notice. Makes the terminal-once invariant provable, not assumed.
+          const flipped = await db
+            .update(deliveryQueue)
+            .set({ attempts, status: "dead", next_attempt_at: null })
+            .where(and(eq(deliveryQueue.id, row.id), eq(deliveryQueue.status, "pending")))
+            .returning({ id: deliveryQueue.id });
+          if (flipped.length > 0) dead.push(row);
+          continue;
+        }
         await db
           .update(deliveryQueue)
-          .set({ attempts, next_attempt_at: sql`datetime('now', ${`+${backoffSec} seconds`})` })
+          .set({ attempts, next_attempt_at: this.backoffExpr(attempts) })
           .where(eq(deliveryQueue.id, row.id));
       }
+      if (dead.length > 0) await this.notifyDeadLettered(dead);
     } catch (err) {
-      dlog.warn("failed to schedule delivery retry", log.errorData(err));
+      // This path now guards the dead-letter transition, so a failure here can strand a row
+      // one attempt short of terminal — surface it loudly, not at warn.
+      dlog.error("failed to record delivery retry / dead-letter", log.errorData(err));
+    }
+  }
+
+  /** Exponential backoff window (capped at {@link RETRY_MAX_MS}) as a SQL datetime expr. */
+  private backoffExpr(attempts: number) {
+    const backoffSec = Math.round(
+      Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.min(attempts, 20)) / 1000,
+    );
+    return sql`datetime('now', ${`+${backoffSec} seconds`})`;
+  }
+
+  /**
+   * Surface a batch of dead-lettered rows as ONE next-turn failure notice, so a whole failing
+   * batch can't emit dozens of notices and evict unrelated ones via the per-thread overflow
+   * cap. The notice names the channel(s) and send times and points the mind at the surviving
+   * channel history, and never throws back into the delivery path — the rows are terminal. #356
+   */
+  private async notifyDeadLettered(rows: DeadLetterRow[]): Promise<void> {
+    const mind = rows[0].mind;
+    // Rows in one scheduleRetry call share a (mind, thread) batch. If that thread is an
+    // ephemeral `$new` session, its only message WAS the dropped one — no turn will ever run
+    // to drain a notice parked there — so route the notice to MIND_LEVEL_THREAD instead. #356
+    const threads = new Set(rows.map((r) => r.thread));
+    const single = threads.size === 1 ? [...threads][0] : MIND_LEVEL_THREAD;
+    const thread = single.startsWith("new-") ? MIND_LEVEL_THREAD : single;
+
+    const lines = rows.map((r) => {
+      const from = r.sender ? ` from ${r.sender}` : "";
+      const on = r.channel ? ` on ${r.channel}` : "";
+      // The notice is delivered to the base mind, but the rejecting process may be a variant —
+      // name it so the mind isn't told "your process is rejecting" about a process it isn't. #356
+      const to =
+        r.target_mind && r.target_mind !== r.mind ? ` to your variant ${r.target_mind}` : "";
+      return `- a message${from}${on}${to} (sent ${r.created_at})`;
+    });
+    const channels = [...new Set(rows.map((r) => r.channel).filter((c): c is string => !!c))];
+    const recovery =
+      channels.length > 0
+        ? `The original message(s) remain in the channel history — read them with ` +
+          `${channels.map((c) => `\`volute chat read ${c}\``).join(" or ")}.`
+        : `The original message(s) remain in the channel history.`;
+    const detail = [
+      `${rows.length} message(s) sent to you could not be delivered after ` +
+        `${MAX_DELIVERY_ATTEMPTS} attempts and were dropped:`,
+      ...lines,
+      recovery,
+    ].join("\n");
+    try {
+      await this.notifyFailure({
+        mind,
+        thread,
+        kind: "delivery_failed",
+        reason: "delivery_failed",
+        detail,
+      });
+    } catch (err) {
+      dlog.warn(`failed to send dead-letter notice for ${mind}`, log.errorData(err));
     }
   }
 
@@ -883,18 +1024,20 @@ export class DeliveryManager {
       try {
         const ok = await this.postToMind(port, body);
         if (!ok) {
+          // Reachable but rejected (non-OK HTTP) → a live rejection that counts toward the ceiling.
           this.decrementActive(baseName, session);
           publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-          await this.scheduleRetry([queueId]);
+          await this.scheduleRetry([queueId], { liveRejection: true });
         } else {
           // Mark delivered ONLY on ack, by specific row id — never a broad DELETE.
           await this.deleteQueueRows([queueId]);
         }
       } catch (err) {
+        // Threw → transport failure (mind/variant down or timed out), NOT a live rejection.
         dlog.warn(`failed to deliver to ${mindName}`, log.errorData(err));
         this.decrementActive(baseName, session);
         publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-        await this.scheduleRetry([queueId]);
+        await this.scheduleRetry([queueId], { liveRejection: false });
       } finally {
         if (queueId != null) this.inFlight.delete(queueId);
       }
@@ -1001,9 +1144,10 @@ export class DeliveryManager {
       try {
         const ok = await this.postToMind(port, body);
         if (!ok) {
+          // Reachable but rejected (non-OK HTTP) → a live rejection that counts toward the ceiling.
           this.decrementActive(baseName, session);
           publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-          await this.scheduleRetry(queueIds);
+          await this.scheduleRetry(queueIds, { liveRejection: true });
         } else {
           // Mark delivered ONLY on ack, and ONLY the specific rows in this batch —
           // a broad (mind, session, pending) DELETE would race with rows enqueued
@@ -1011,10 +1155,11 @@ export class DeliveryManager {
           await this.deleteQueueRows(queueIds);
         }
       } catch (err) {
+        // Threw → transport failure (mind/variant down or timed out), NOT a live rejection.
         dlog.warn(`failed to deliver batch to ${mindName}`, log.errorData(err));
         this.decrementActive(baseName, session);
         publishTypingForChannels(typingMap.deleteSender(baseName), typingMap);
-        await this.scheduleRetry(queueIds);
+        await this.scheduleRetry(queueIds, { liveRejection: false });
       } finally {
         for (const id of queueIds) this.inFlight.delete(id);
       }

--- a/packages/daemon/src/lib/mind/registry.ts
+++ b/packages/daemon/src/lib/mind/registry.ts
@@ -268,6 +268,16 @@ export async function addVariant(
 export async function removeMind(name: string) {
   const db = await getDb();
   await db.delete(minds).where(eq(minds.name, name));
+  // Drop any delivery_queue rows owned by (base name) or targeted at (variant name) this mind
+  // so a deleted mind's undelivered/gated/dead rows don't linger forever — the redrive guard
+  // just skips them, it never cleans them up. Two independent statements rather than a
+  // transaction: `removeMind` runs in nearly every teardown, and an async `db.transaction`
+  // (which holds BEGIN open across awaits on libsql's single shared connection) serializes
+  // out concurrent callers and floods them with SQLITE_BUSY. A partial failure here only
+  // leaves a few inert rows the next delete can still reap — not worth that contention. #356
+  await db
+    .delete(deliveryQueue)
+    .where(or(eq(deliveryQueue.mind, name), eq(deliveryQueue.target_mind, name)));
 }
 
 /**

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1198,8 +1198,8 @@ const app = new Hono<AuthEnv>()
       if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
       try {
         await removeMind(name);
-      } catch {
-        // ignore cleanup errors
+      } catch (cleanupErr) {
+        log.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
       }
       return c.json({ error: err instanceof Error ? err.message : "Failed to create mind" }, 500);
     } finally {
@@ -1357,8 +1357,8 @@ const app = new Hono<AuthEnv>()
       if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
       try {
         await removeMind(name);
-      } catch {
-        // ignore cleanup errors
+      } catch (cleanupErr) {
+        log.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
       }
       return c.json({ error: err instanceof Error ? err.message : "Failed to import mind" }, 500);
     } finally {

--- a/test/delivery-durability.test.ts
+++ b/test/delivery-durability.test.ts
@@ -3,9 +3,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
+import { MIND_LEVEL_THREAD } from "../packages/daemon/src/lib/chat/system-events.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { DeliveryManager } from "../packages/daemon/src/lib/delivery/delivery-manager.js";
+import {
+  DeliveryManager,
+  MAX_DELIVERY_ATTEMPTS,
+} from "../packages/daemon/src/lib/delivery/delivery-manager.js";
 import {
   clearConfigCache,
   type RoutingConfig,
@@ -22,12 +26,22 @@ async function startMindServer(delayMs = 0): Promise<{
   received: unknown[];
   fail: () => void;
   ok: () => void;
+  hangup: () => void;
+  connect: () => void;
 }> {
   const received: unknown[] = [];
   let shouldFail = false;
+  let shouldHangup = false;
   const server = createServer((req, res) => {
     if (req.method !== "POST") {
       res.writeHead(404).end();
+      return;
+    }
+    // Simulate a down/unreachable target: drop the connection so the client `fetch` rejects
+    // with a transport error (not an HTTP status) — the "connection refused/reset" case,
+    // distinct from a live 500 rejection.
+    if (shouldHangup) {
+      req.destroy();
       return;
     }
     let raw = "";
@@ -63,6 +77,12 @@ async function startMindServer(delayMs = 0): Promise<{
     },
     ok: () => {
       shouldFail = false;
+    },
+    hangup: () => {
+      shouldHangup = true;
+    },
+    connect: () => {
+      shouldHangup = false;
     },
   };
 }
@@ -121,7 +141,7 @@ describe("DeliveryManager durability", () => {
     // Ack received → row deleted by its specific id, and the mind got exactly one POST.
     assert.equal(srv.received.length, 1);
     assert.equal((await queueRows(name)).length, 0, "row should be deleted after ack");
-    removeMind(name);
+    await removeMind(name);
   });
 
   it("leaves a pending row when the POST fails, then the redrive loop delivers it", async () => {
@@ -154,7 +174,7 @@ describe("DeliveryManager durability", () => {
 
     rows = await queueRows(name);
     assert.equal(rows.length, 0, "row cleaned after successful redrive");
-    removeMind(name);
+    await removeMind(name);
   });
 
   it("marks only the batch's own rows done — no broad DELETE races concurrent inserts", async () => {
@@ -187,7 +207,7 @@ describe("DeliveryManager durability", () => {
     const remaining = await queueRows(name);
     assert.equal(remaining.length, 1, "the concurrently-enqueued row must survive");
     assert.equal(remaining[0].id, id2, "only the batch's own row was deleted");
-    removeMind(name);
+    await removeMind(name);
   });
 
   it("keys variant rows by baseName but redrives to the variant's own port (no restart replay)", async () => {
@@ -238,8 +258,8 @@ describe("DeliveryManager durability", () => {
     await new Promise((r) => setTimeout(r, 100));
     assert.equal(variantSrv.received.length, 0, "cleaned row is not replayed on restart");
 
-    removeMind(variant);
-    removeMind(parent);
+    await removeMind(variant);
+    await removeMind(parent);
   });
 
   it("releases gated messages when a matching route is added — no daemon restart", async () => {
@@ -273,7 +293,313 @@ describe("DeliveryManager durability", () => {
     // released backlog message.
     const releasedMsgs = srv.received.filter((b) => (b as { kind?: string }).kind !== "event");
     assert.equal(releasedMsgs.length, 1, "gated message delivered after the route was added");
-    removeMind(name);
+    await removeMind(name);
+  });
+
+  it("dead-letters a permanently-failing delivery after max attempts and notifies the mind", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.fail(); // mind always 500s → every delivery attempt fails
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+    const notices: {
+      mind: string;
+      kind: string;
+      reason: string;
+      thread: string;
+      detail: string;
+    }[] = [];
+    manager.setFailureNotifier(async (input) => {
+      notices.push({
+        mind: input.mind,
+        kind: input.kind,
+        reason: input.reason,
+        thread: input.thread,
+        detail: input.detail,
+      });
+    });
+
+    // First attempt fails → one pending row with attempts >= 1.
+    await manager.routeAndDeliver(name, { channel: "test:ch", sender: "alice", content: "hi" });
+    const rows = await queueRows(name, "pending");
+    assert.equal(rows.length, 1);
+
+    // Fast-forward the counter to one below the ceiling so the next failure trips it,
+    // and clear the backoff window so redrive picks the row up immediately.
+    const db = await getDb();
+    await db
+      .update(deliveryQueue)
+      .set({ attempts: MAX_DELIVERY_ATTEMPTS - 1, next_attempt_at: null })
+      .where(eq(deliveryQueue.id, rows[0].id));
+
+    await manager.redrive();
+    await waitFor(async () => (await queueRows(name, "dead")).length === 1);
+
+    const dead = await queueRows(name, "dead");
+    assert.equal(dead.length, 1, "row moves to the terminal dead state");
+    assert.equal((await queueRows(name, "pending")).length, 0, "no pending row remains");
+    assert.equal(notices.length, 1, "a failure notice is surfaced, not silent");
+    assert.equal(notices[0].mind, name);
+    assert.equal(notices[0].kind, "delivery_failed");
+    assert.equal(notices[0].reason, "delivery_failed");
+    assert.equal(notices[0].thread, "main", "notice lands on the message's own (non-$new) thread");
+    assert.match(notices[0].detail, /could not be delivered/);
+    assert.match(notices[0].detail, /test:ch/, "detail names the channel for recovery");
+
+    // A dead row must never be redriven again.
+    srv.ok();
+    await manager.redrive();
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(srv.received.length, 0, "dead rows are not re-delivered");
+    await removeMind(name);
+  });
+
+  it("a live rejection on the last permitted attempt still delivers — no dead-letter", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.fail();
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+    const notices: unknown[] = [];
+    manager.setFailureNotifier(async (input) => {
+      notices.push(input);
+    });
+
+    await manager.routeAndDeliver(name, { channel: "test:ch", sender: "a", content: "hi" });
+    const rows = await queueRows(name, "pending");
+    assert.equal(rows.length, 1);
+
+    // Sit at exactly the last permitted attempt, then let the mind recover before the sweep.
+    const db = await getDb();
+    await db
+      .update(deliveryQueue)
+      .set({ attempts: MAX_DELIVERY_ATTEMPTS - 1, next_attempt_at: null })
+      .where(eq(deliveryQueue.id, rows[0].id));
+    srv.ok();
+
+    await manager.redrive();
+    await waitFor(async () => (await queueRows(name)).length === 0);
+    assert.equal(srv.received.length, 1, "the final permitted attempt delivered");
+    assert.equal(notices.length, 0, "a successful final attempt is never dead-lettered");
+    await removeMind(name);
+  });
+
+  it("a down/unreachable target is retried without bumping attempts, never dead-lettered", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.hangup(); // connection drops → transport failure, not a live rejection
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true); // redrive guard checks the BASE mind, which is "up"
+    const notices: unknown[] = [];
+    manager.setFailureNotifier(async (input) => {
+      notices.push(input);
+    });
+
+    await manager.routeAndDeliver(name, { channel: "test:ch", sender: "a", content: "hi" });
+    let rows = await queueRows(name, "pending");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].attempts, 0, "a transport failure must not bump the attempt counter");
+
+    // Across several sweeps the row stays pending with zero attempts — it is NOT progressing
+    // toward the dead-letter ceiling just because the target is offline.
+    const db = await getDb();
+    for (let i = 0; i < 3; i++) {
+      await db
+        .update(deliveryQueue)
+        .set({ next_attempt_at: null })
+        .where(eq(deliveryQueue.id, rows[0].id));
+      await manager.redrive();
+      await waitFor(async () => {
+        const r = (await queueRows(name, "pending"))[0];
+        return r != null && r.next_attempt_at != null; // attempt completed, backoff re-set
+      });
+      rows = await queueRows(name, "pending");
+      assert.equal(rows.length, 1, "row stays pending while the target is unreachable");
+      assert.equal(rows[0].attempts, 0, "still zero attempts after an unreachable sweep");
+    }
+    assert.equal(notices.length, 0, "an unreachable target is never dead-lettered");
+
+    // Target comes back → the preserved message finally delivers.
+    srv.connect();
+    await db
+      .update(deliveryQueue)
+      .set({ next_attempt_at: null })
+      .where(eq(deliveryQueue.id, rows[0].id));
+    await manager.redrive();
+    await waitFor(async () => (await queueRows(name)).length === 0);
+    assert.equal(srv.received.length, 1, "delivered once the target recovered");
+    assert.equal(notices.length, 0, "no dead-letter notice for a recovered target");
+    await removeMind(name);
+  });
+
+  it("routes the dead-letter notice for a $new session to the mind-level thread", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.fail();
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+    const notices: { thread: string }[] = [];
+    manager.setFailureNotifier(async (input) => {
+      notices.push({ thread: input.thread });
+    });
+
+    // A row whose thread is an ephemeral $new-style session — the only message that would
+    // ever run that thread is the one being dropped.
+    const anyMgr = manager as unknown as {
+      persistToQueue: (m: string, s: string, p: unknown) => Promise<number | undefined>;
+      deliverToMind: (m: string, s: string, p: unknown, cfg: unknown, id?: number) => Promise<void>;
+    };
+    const thread = `new-${Date.now()}-abc123`;
+    const payload = { channel: "test:ch", sender: "a", content: "hi" };
+    const id = await anyMgr.persistToQueue(name, thread, payload);
+    assert.ok(id);
+    const db = await getDb();
+    await db
+      .update(deliveryQueue)
+      .set({ attempts: MAX_DELIVERY_ATTEMPTS - 1 })
+      .where(eq(deliveryQueue.id, id));
+    await anyMgr.deliverToMind(name, thread, payload, { delivery: { mode: "immediate" } }, id);
+
+    await waitFor(async () => (await queueRows(name, "dead")).length === 1);
+    assert.equal(notices.length, 1);
+    assert.equal(
+      notices[0].thread,
+      MIND_LEVEL_THREAD,
+      "an ephemeral $new thread routes the notice to MIND_LEVEL_THREAD",
+    );
+    await removeMind(name);
+  });
+
+  it("terminalizes every row of a failing batch even when the failure notifier throws", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.fail();
+    const name = await registerMind(srv.port, IMMEDIATE);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+    manager.setFailureNotifier(async () => {
+      throw new Error("notifier boom");
+    });
+
+    const anyMgr = manager as unknown as {
+      persistToQueue: (m: string, s: string, p: unknown) => Promise<number | undefined>;
+      deliverBatchToMind: (m: string, s: string, msgs: unknown[], cfg: unknown) => Promise<void>;
+    };
+    const p1 = { channel: "test:ch", sender: "a", content: "one" };
+    const p2 = { channel: "test:ch", sender: "b", content: "two" };
+    const id1 = await anyMgr.persistToQueue(name, "main", p1);
+    const id2 = await anyMgr.persistToQueue(name, "main", p2);
+    assert.ok(id1 && id2);
+
+    // Both at the last permitted attempt; the batch POST 500s → both cross the ceiling at once.
+    const db = await getDb();
+    await db
+      .update(deliveryQueue)
+      .set({ attempts: MAX_DELIVERY_ATTEMPTS - 1 })
+      .where(inArray(deliveryQueue.id, [id1, id2]));
+
+    // A throwing notifier must not propagate or leave a row un-terminalized (no hot-loop).
+    await anyMgr.deliverBatchToMind(
+      name,
+      "main",
+      [
+        { payload: p1, channel: "test:ch", sender: "a", createdAt: Date.now(), queueId: id1 },
+        { payload: p2, channel: "test:ch", sender: "b", createdAt: Date.now(), queueId: id2 },
+      ],
+      { delivery: { mode: "immediate" }, interrupt: true },
+    );
+
+    assert.equal((await queueRows(name, "dead")).length, 2, "both batch rows terminalize");
+    assert.equal((await queueRows(name, "pending")).length, 0, "no row left pending to hot-loop");
+    await removeMind(name);
+  });
+
+  it("the terminal transition is idempotent and names the actual rejecting variant target", async () => {
+    const srv = await startMindServer();
+    servers.push(srv.server);
+    srv.fail();
+    const name = await registerMind(srv.port, IMMEDIATE);
+    const variant = `${name}-v1`;
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+    const notices: { detail: string }[] = [];
+    manager.setFailureNotifier(async (input) => {
+      notices.push({ detail: input.detail });
+    });
+
+    // A pending row keyed by the base name but TARGETED at a variant, at the last attempt.
+    const db = await getDb();
+    const inserted = await db
+      .insert(deliveryQueue)
+      .values({
+        mind: name,
+        target_mind: variant,
+        thread: "main",
+        channel: "test:ch",
+        sender: "alice",
+        status: "pending",
+        attempts: MAX_DELIVERY_ATTEMPTS - 1,
+        payload: "{}",
+      })
+      .returning({ id: deliveryQueue.id });
+    const id = inserted[0].id;
+
+    const anyMgr = manager as unknown as {
+      scheduleRetry: (ids: number[], opts: { liveRejection: boolean }) => Promise<void>;
+    };
+
+    // First live rejection trips the ceiling → one notice, row terminal, detail names the variant.
+    await anyMgr.scheduleRetry([id], { liveRejection: true });
+    assert.equal((await queueRows(name, "dead")).length, 1, "row flips to dead");
+    assert.equal(notices.length, 1, "one dead-letter notice");
+    assert.match(
+      notices[0].detail,
+      new RegExp(`variant ${variant}`),
+      "detail names the target variant",
+    );
+
+    // Re-processing the now-dead row must NOT fire a second notice (idempotent transition).
+    await anyMgr.scheduleRetry([id], { liveRejection: true });
+    assert.equal(notices.length, 1, "no duplicate notice on a re-processed dead row");
+    assert.equal((await queueRows(name, "dead")).length, 1);
+    await removeMind(name);
+  });
+
+  it("removeMind purges the mind's delivery_queue rows (owned and variant-targeted)", async () => {
+    const db = await getDb();
+    const base = `dur-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const variant = `${base}-v1`;
+    const other = `dur-other-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+    // Rows owned by the mind (keyed by base name) plus a row keyed under a different base
+    // but targeted at our mind's variant. removeMind must drop both.
+    await db.insert(deliveryQueue).values([
+      { mind: base, target_mind: base, thread: "main", status: "pending", payload: "{}" },
+      { mind: base, target_mind: base, thread: "main", status: "dead", payload: "{}" },
+      { mind: other, target_mind: variant, thread: "main", status: "pending", payload: "{}" },
+      // An unrelated row that must survive.
+      { mind: other, target_mind: other, thread: "main", status: "pending", payload: "{}" },
+    ]);
+
+    await removeMind(base);
+    assert.equal((await queueRows(base)).length, 0, "base-owned rows are purged");
+
+    await removeMind(variant);
+    const survivors = await db.select().from(deliveryQueue).where(eq(deliveryQueue.mind, other));
+    assert.equal(survivors.length, 1, "only the variant-targeted row is purged; the rest survive");
+    assert.equal(survivors[0].target_mind, other);
+
+    await db.delete(deliveryQueue).where(eq(deliveryQueue.mind, other));
   });
 
   it("drains two rapid immediate messages to one session in order", async () => {
@@ -295,6 +621,6 @@ describe("DeliveryManager durability", () => {
       return body.content;
     });
     assert.deepEqual(texts, ["one", "two"], "messages delivered in submission order");
-    removeMind(name);
+    await removeMind(name);
   });
 });


### PR DESCRIPTION
Closes #356.

## Problem
`delivery_queue` (durable source of truth since #326) had two unbounded-growth paths:
- `scheduleRetry` incremented `attempts` forever (backoff capped at 5 min), so a payload a running mind permanently rejects (always 500s) was re-POSTed indefinitely.
- Rows for a deleted mind were skipped by the redrive `isMindRunning` guard but never cleaned up.

## Changes
- **Max-attempts dead-letter.** `MAX_DELIVERY_ATTEMPTS = 10`; on the final failed attempt the row moves to a terminal `status: "dead"` and the mind receives a `delivery_failed` failure notice (next-turn, via the system-events mechanism from #684). No schema/migration needed — `status` is a plain text column and the redrive sweep only selects `status = "pending"`. 10 attempts ≈ 30 min of the existing exponential backoff.
- **Only live rejections count toward the ceiling.** `scheduleRetry` distinguishes a reachable target returning non-OK HTTP (`liveRejection: true`, attempts advance) from a thrown fetch — ECONNREFUSED/reset/timeout from a down base mind or stopped variant (`liveRejection: false`, backs off without advancing, never dead-letters). A sleeping mind or paused variant can never have its backlog dropped for being offline.
- **Notice routing and content.** Dead-letter notices for `$new` (`new-*`) sessions route to the mind-level thread so they actually drain (a `$new` thread by construction never runs another turn). Batch failures emit ONE aggregated notice per retry call (not one per row, which could evict unrelated notices via the per-thread event cap). The notice lists each dropped message's send timestamp and points at `volute chat read <channel>` for recovery. When the rejecting process is a variant, the notice names that variant (`target_mind`) instead of telling the base mind its own process is failing.
- **Orphan cleanup.** `removeMind` purges `delivery_queue` rows keyed by base name (`mind`) or targeted at a variant (`target_mind`). The two previously-empty `catch {}` blocks around removeMind cleanup in `web/api/minds.ts` now `log.warn`.
- **Ordering/robustness.** The drop is error-logged BEFORE the terminal UPDATE (no zero-trace window on crash); the terminal transition is guarded so a notice failure can't un-terminalize a row or abort the rest of a retry batch; `scheduleRetry`'s catch is error-level.

## Notes for reviewers
- `removeMind`'s two deletes are deliberately NOT wrapped in `db.transaction`: with libsql's single shared connection, an async transaction held `BEGIN` across await points and produced 160 SQLITE_BUSY failures under `--test-concurrency=4` (removeMind runs in nearly every test teardown). Atomicity is low-value here — a partial failure leaves inert rows that the next delete reaps, and the redrive sweep skips them. Documented in a code comment.
- Dead rows are retained (terminal, purged on mind delete); no separate retention sweep — tracked as a follow-up.
- Dead-lettering is idempotent: the terminal UPDATE is conditional on `status = "pending"`, so a re-processed row can't double-notify.

## Tests
New cases in `test/delivery-durability.test.ts`: dead-letter after max attempts (asserts reason text, thread, channel detail, and that dead rows are never redriven even after recovery); down/unreachable target retried with zero attempt bumps then delivered on recovery; recovery on the last permitted attempt delivers with no notice; a throwing failure-notifier still terminalizes every row of a batch; the terminal transition is idempotent and the notice names the rejecting variant; `removeMind` purges owned and variant-targeted rows. Full suite 2624/0; tsc + biome clean; all hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
