### PR TITLE
fix: expand $new to a unique thread for system events (#735)

### DIFF
--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -4,6 +4,7 @@ import { publish as publishMindEvent } from "../events/mind-events.js";
 import { findMind, getBaseName } from "../mind/registry.js";
 import { mindHistory, systemEvents, turns } from "../schema.js";
 import log from "../util/logger.js";
+import { newEphemeralSession } from "../util/session-name.js";
 
 const elog = log.child("system-events");
 
@@ -310,6 +311,23 @@ async function markDelivered(id: number, extraMeta?: Record<string, unknown>): P
 }
 
 /**
+ * Resolve an event's stored thread, expanding the `$new` convention ("a fresh isolated
+ * session per fire") the same way the message path does. Expansion lives here so every
+ * caller passing `$new` — scheduler, default dream autonomy, future — gets isolation without
+ * owning the contract itself (#735).
+ *
+ * `$new` only means something for `immediate` delivery, which POSTs an envelope and runs a
+ * turn in the fresh session. A `next-turn` event stamped to a unique session that never runs
+ * a turn would strand forever (#356/#721), so it collapses to the mind-level sentinel and
+ * drains into whichever thread next runs a clean turn. Uses the shared session-name minter so
+ * the name shape is identical to the message path's mind-side.
+ */
+function resolveEventThread(thread: string, delivery: EventDelivery): string {
+  if (thread !== "$new") return thread;
+  return delivery === "immediate" ? newEphemeralSession() : MIND_LEVEL_THREAD;
+}
+
+/**
  * Deliver a system event to a mind. Inserts the row, then:
  * - `immediate` + awake (or `force`): POSTs the envelope; on success stamps
  *   `delivered_at` and records the event row in mind_history. A failed POST leaves the
@@ -324,8 +342,8 @@ export async function deliverEvent(
   mind: string,
   input: DeliverEventInput,
 ): Promise<{ id?: number; delivered: boolean }> {
-  const thread = input.thread ?? "main";
   const delivery = input.delivery ?? "immediate";
+  const thread = resolveEventThread(input.thread ?? "main", delivery);
   let eventId: number | undefined;
   try {
     const db = await getDb();

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -14,6 +14,7 @@ import { readVoluteConfig } from "../mind/volute-config.js";
 import { channelGates, deliveryQueue, mindHistory } from "../schema.js";
 import { type AvatarBlock, renderAvatarBlock } from "../util/avatar-image.js";
 import log from "../util/logger.js";
+import { newEphemeralSession } from "../util/session-name.js";
 import {
   type DeliveryPayload,
   extractTextContent,
@@ -189,7 +190,7 @@ export class DeliveryManager {
     if (payload.session) {
       let sessionName = payload.session;
       if (sessionName === "$new") {
-        sessionName = `new-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        sessionName = newEphemeralSession();
       }
       const sessionConfig = resolveDeliveryMode(config, sessionName);
       if (sessionConfig.delivery.mode === "batch") {
@@ -244,7 +245,7 @@ export class DeliveryManager {
     // Resolve session name ($new expansion)
     let sessionName = route.session;
     if (sessionName === "$new") {
-      sessionName = `new-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      sessionName = newEphemeralSession();
     }
 
     // Inbound-to-turn linking happens deterministically at turn creation (see
@@ -442,7 +443,7 @@ export class DeliveryManager {
       }
       let session = route.session;
       if (session === "$new") {
-        session = `new-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        session = newEphemeralSession();
       }
       const channel = row.channel ?? payload.channel ?? "unknown";
       const list = byChannel.get(channel) ?? [];

--- a/packages/daemon/src/lib/util/session-name.ts
+++ b/packages/daemon/src/lib/util/session-name.ts
@@ -1,0 +1,11 @@
+/**
+ * A fresh, unique session name for the `$new` convention ("a fresh isolated session per
+ * fire"). The `new-` prefix is a load-bearing contract in the message delivery path:
+ * delivery-manager reclaims `new-*` in-memory session state once idle (they never recur)
+ * and routes dead-lettered notices for a `new-*` thread to the mind level instead of a
+ * session that will never run another turn. Kept in one place so the call sites that mint
+ * these names (message delivery, system events) can't drift on the format.
+ */
+export function newEphemeralSession(): string {
+  return `new-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/test/system-events.test.ts
+++ b/test/system-events.test.ts
@@ -296,6 +296,69 @@ describe("system-events deliverEvent", () => {
   });
 });
 
+describe("system-events $new thread expansion", () => {
+  it("immediate $new: expands to a unique new-* session, stored and POSTed, isolated per fire", async () => {
+    const mind = uniqueMind();
+    const stub = await stubMind(mind);
+    try {
+      const { id: id1, delivered } = await deliverEvent(mind, {
+        type: "schedule",
+        body: "dream one",
+        meta: { scheduleId: "dream" },
+        thread: "$new",
+      });
+      assert.equal(delivered, true);
+
+      // The row is stamped with the expanded thread, never the literal "$new".
+      const row1 = await eventRow(id1!);
+      assert.notEqual(row1?.thread, "$new", "literal $new must not be stored");
+      assert.match(row1!.thread, /^new-/, "expanded to a new-* session");
+
+      // The envelope carries the same expanded session the row was stamped with.
+      assert.equal(stub.posted[0].session, row1!.thread, "POSTed session matches the row thread");
+
+      // A second fire gets a DIFFERENT isolated session — dreams don't share context.
+      const { id: id2 } = await deliverEvent(mind, {
+        type: "schedule",
+        body: "dream two",
+        meta: { scheduleId: "dream" },
+        thread: "$new",
+      });
+      const row2 = await eventRow(id2!);
+      assert.match(row2!.thread, /^new-/);
+      assert.notEqual(row2!.thread, row1!.thread, "each fire is its own session");
+    } finally {
+      stub.close();
+      await cleanupMind(mind);
+    }
+  });
+
+  it("next-turn $new: collapses to mind-level so it can't strand in a session that never runs", async () => {
+    const mind = uniqueMind();
+    try {
+      // A next-turn event stamped to a unique new-* session would never drain (nothing
+      // triggers a turn there); mind-level lets it reach whichever thread next runs.
+      const { id } = await deliverEvent(mind, {
+        type: "notice",
+        body: "mind-level, not stranded",
+        thread: "$new",
+        delivery: "next-turn",
+      });
+      const row = await eventRow(id!);
+      assert.equal(row?.thread, "", "next-turn $new stored as mind-level (MIND_LEVEL_THREAD)");
+
+      // It drains into an arbitrary session's next turn, proving it isn't stranded.
+      const drained = await drainEvents(mind, "some-other-session");
+      assert.deepEqual(
+        drained.map((e) => e.body),
+        ["mind-level, not stranded"],
+      );
+    } finally {
+      await cleanupMind(mind);
+    }
+  });
+});
+
 describe("system-events flushQueuedEvents", () => {
   it("delivers pending events oldest-first", async () => {
     const mind = uniqueMind();


### PR DESCRIPTION
## The regression

`$new` — the routing convention meaning "a fresh isolated session per fire" — was only ever expanded in the **message** delivery path (`delivery-manager`, which rewrites `$new` → `new-<ts>-<rand>`). The **events** path never got it.

Since the system-events migration (#684), `deliverEvent` (`packages/daemon/src/lib/chat/system-events.ts`) stored `input.thread` verbatim. A schedule with `thread: "$new"` inserted an event row with the thread literally `"$new"`, `postEventEnvelope` POSTed `session: "$new"`, and the mind used the string as-is. Net effect: every `$new` schedule fire ran in **one shared persistent session literally named `$new`** — the exact opposite of the documented isolation.

The built-in nightly **dream** schedule (`default-autonomy.ts`) sets `thread: "$new"` precisely to keep each dream isolated, so on every default-configured mind, dreams had been accumulating in a single ever-growing `$new` session (shared context, eventual compaction, no isolation).

## The fix

- `resolveEventThread(thread, delivery)` in `deliverEvent` expands `$new` before the row insert, so `deliverEvent` is the single owner of the events thread contract no matter which caller (scheduler, dream autonomy, future) passes `$new`. The scheduler already forwards `schedule.thread` verbatim, confirmed by its existing pass-through test.
- The `new-<ts>-<rand>` generator is extracted into a shared `newEphemeralSession()` minter (`packages/daemon/src/lib/util/session-name.ts`), now used by all four call sites (message delivery ×3, system events ×1). The `new-` prefix is a load-bearing contract in the message path (in-memory session-state reclamation + dead-letter routing), and one minter keeps the four sites from drifting on the format.

### next-turn + `$new` → mind-level (can't strand)

`$new` only means something for `immediate` delivery, which POSTs an envelope and runs a turn in the fresh session. A `next-turn` event stamped to a *unique* session that never runs a turn would strand forever (the #356/#721 lesson). So for `next-turn`, `$new` collapses to the `MIND_LEVEL_THREAD` sentinel and drains into whichever thread next runs a clean turn. This branch is defensive — no current caller passes `next-turn` + `$new` (notices carry the real errored session) — but it keeps the contract total and strand-proof.

### Pre-existing rows

Left as-is; no migration. Existing literal-`$new` rows are all delivered `immediate` dream events (`delivered_at` stamped); there are no undelivered `next-turn` `$new` rows to sweep, and no literal-`$new` turn will run after this fix.

## Tests

New suite `system-events $new thread expansion`:
- immediate `$new` → stored thread matches `/^new-/`, the POSTed envelope `session` equals the stored row thread, and two fires get **different** sessions;
- next-turn `$new` → stored as `MIND_LEVEL_THREAD` (`""`) and drains into an arbitrary session, proving it isn't stranded.

The existing scheduler `fire passes session from schedule config` test covers `$new` pass-through, and the delivery-manager `new-*` session-state / `$new` expansion tests confirm the shared-minter swap is faithful. Full suite green (2657 pass, 0 fail); typecheck clean.

## Review depth

External code-review pass completed (all 15 `deliverEvent` callers traced; redelivery, the next-turn collapse bound, and non-stranding verified) and both its findings addressed. The separate test-coverage and silent-failure reviewer passes were lost to repeated API overload; coverage was assessed within the code review.

Fixes #735. Follow-on design (making events routable through `routes.json`) tracked in #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)