### PR TITLE
fix: pin pi-ai to 0.80.6 so the daemon can start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.65",
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "0.80.6",
         "@hono/node-server": "^2.0.8",
         "@hono/zod-validator": "^0.8.0",
         "@libsql/client": "^0.17.4",
@@ -1917,9 +1917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1937,9 +1934,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1957,9 +1951,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1968,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,9 +1985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.65",
-    "@earendil-works/pi-ai": "^0.80.6",
+    "@earendil-works/pi-ai": "0.80.6",
     "@hono/node-server": "^2.0.8",
     "@hono/zod-validator": "^0.8.0",
     "@libsql/client": "^0.17.4",

--- a/test/pi-ai-pin.test.ts
+++ b/test/pi-ai-pin.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+// pi-ai ships breaking changes in patch releases: 0.80.8 turned the `/oauth`
+// subpath into a type-only entry point (`export {}` at runtime), removing
+// getOAuthApiKey/getOAuthProvider/getOAuthProviders. A caret range let a global
+// `npm i -g volute` resolve to it and crash the daemon at import, while our
+// lockfile kept CI on a working version. Global installs ignore our lockfile,
+// so the declared range is the only thing protecting users here.
+describe("pi-ai dependency pin", () => {
+  it("pins an exact version so installs cannot drift onto an untested release", () => {
+    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+    const range = pkg.dependencies["@earendil-works/pi-ai"];
+
+    assert.match(
+      range,
+      /^\d+\.\d+\.\d+$/,
+      `@earendil-works/pi-ai must be pinned exactly, got "${range}". ` +
+        "Upstream removes runtime exports in patch releases; bump this pin only " +
+        "after verifying the `/oauth` subpath still exports what we import.",
+    );
+  });
+
+  it("resolves the installed pi-ai to the pinned version", async () => {
+    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+    const { getOAuthApiKey } = await import("@earendil-works/pi-ai/oauth");
+
+    assert.equal(typeof getOAuthApiKey, "function");
+    assert.match(pkg.dependencies["@earendil-works/pi-ai"], /^\d+\.\d+\.\d+$/);
+  });
+});


### PR DESCRIPTION
## The crash

Fresh installs of Volute 0.51.0 die on startup before the daemon binds:

```
SyntaxError: The requested module '@earendil-works/pi-ai/oauth'
does not provide an export named 'getOAuthApiKey'
    at async Object.run (.../chunk-IWAVIJO2.js:112:31)
```

## Root cause

pi-ai **0.80.8** turned the `/oauth` subpath into a type-only compatibility entry point. At runtime `dist/oauth.js` is now literally:

```js
export {};
```

`getOAuthApiKey` doesn't exist anywhere in `dist/` from 0.80.8 onward — the OAuth surface moved behind a new `./auth/*` API. Verified by bisecting the published tarballs:

| version | `/oauth` runtime | `import { getOAuthApiKey }` |
|---|---|---|
| 0.80.6 | re-exports `utils/oauth` | ✅ `function` |
| 0.80.7 | re-exports `utils/oauth` | ✅ `function` |
| 0.80.8 | `export {}` | ❌ SyntaxError |
| 0.80.9 | `export {}` | ❌ SyntaxError |

Our range was `^0.80.6`, which admits 0.80.9. bardo had 0.80.9 installed.

## Why CI never caught it

`package-lock.json` pinned 0.80.6, so CI and local dev always tested a working version. **A global `npm i -g volute` ignores our lockfile** and resolves the declared range to the newest match — 0.80.9. The declared range was the only thing protecting real installs, and it was a caret over a dependency that removes runtime exports in *patch* releases.

## The fix

Pin `@earendil-works/pi-ai` exactly to `0.80.6` — the version CI has been testing all along, so this is a zero-behavior-change pin (lockfile resolution is unchanged).

Plus a regression test that fails if the caret comes back:

```
✔ pins an exact version so installs cannot drift onto an untested release
✔ resolves the installed pi-ai to the pinned version
```

## Verification

Reproduced the exact bardo `SyntaxError` against 0.80.8/0.80.9 in a clean project, and confirmed the fix against the path bardo actually takes — a fresh install with **no lockfile present**:

```
resolved version: 0.80.6
daemon import path OK, typeof = function
```

Full suite: **2590 passed, 0 failed**.

## Follow-up (not in this hotfix)

Unpinning requires a real migration, so it shouldn't ride along with an emergency fix. Four call sites still import the removed `/oauth` surface:

- `packages/daemon/src/lib/ai-service.ts` (`getOAuthApiKey`)
- `packages/daemon/src/web/api/system.ts` (`getOAuthProvider`, `getOAuthProviders`)
- `packages/daemon/src/lib/oauth/xai.ts`
- `test/oauth-login-method.test.ts`

Worth considering separately: CI currently only ever tests the lockfile, so it structurally cannot catch this class of break. A smoke test that installs the packed tarball with fresh resolution and runs `volute status` would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm2d2zULYa72FPMi3ujKbs