### PR TITLE
feat: add external minds from the Users settings panel

### DIFF
--- a/packages/daemon/src/lib/auth.ts
+++ b/packages/daemon/src/lib/auth.ts
@@ -3,7 +3,7 @@ import { and, count, eq, inArray, or } from "drizzle-orm";
 import { getSpiritName } from "./config/setup.js";
 import { getDb } from "./db.js";
 import { broadcast } from "./events/activity-events.js";
-import { isSpiritName } from "./mind/registry.js";
+import { findMind, isSpiritName } from "./mind/registry.js";
 import type { MindProfile } from "./mind/volute-config.js";
 import { users } from "./schema.js";
 
@@ -280,6 +280,32 @@ export async function deleteUser(id: number): Promise<void> {
     .get();
   if (!target) throw new Error("User not found");
   await db.delete(users).where(and(eq(users.id, id), eq(users.user_type, "human")));
+}
+
+/**
+ * Delete an external mind's account — a `user_type:"mind"` row with no `minds`
+ * registry row. That is the whole teardown: there is no process to stop and no
+ * directory to remove, and the FK cascade takes its api_tokens, which is the
+ * point (deleting the account revokes its access).
+ *
+ * Refuses any mind the daemon spawns, including variants. Those own a process and
+ * a worktree, so removing only the account would orphan both — they go through the
+ * mind-deletion API. Kept separate from `deleteUser` so that function keeps its
+ * human-only guarantee and no caller can reach a system or puppet row through here.
+ */
+export async function deleteExternalMindUser(id: number): Promise<void> {
+  const db = await getDb();
+  const target = await db
+    .select({ id: users.id, username: users.username, user_type: users.user_type })
+    .from(users)
+    .where(eq(users.id, id))
+    .get();
+  if (!target) throw new Error("User not found");
+  if (target.user_type !== "mind") throw new Error("Not a mind account");
+  if (await findMind(target.username)) {
+    throw new Error("Use the mind deletion API to delete minds");
+  }
+  await db.delete(users).where(eq(users.id, id));
 }
 
 export async function updateUserProfile(

--- a/packages/daemon/src/web/api/auth.ts
+++ b/packages/daemon/src/web/api/auth.ts
@@ -10,6 +10,7 @@ import {
   changePassword,
   countAdmins,
   createUser,
+  deleteExternalMindUser,
   deleteUser,
   getOrCreateMindUser,
   getUser,
@@ -24,10 +25,33 @@ import {
 import { joinSystemChannel } from "../../lib/chat/system-channel.js";
 import { getDb } from "../../lib/db.js";
 import { broadcast } from "../../lib/events/activity-events.js";
-import { readRegistry, validateMindName, voluteHome } from "../../lib/mind/registry.js";
+import {
+  findMind,
+  readAllMinds,
+  readRegistry,
+  validateMindName,
+  voluteHome,
+} from "../../lib/mind/registry.js";
 import { users } from "../../lib/schema.js";
 import { normalizeAvatar } from "../../lib/util/avatar-image.js";
 import { fileEtag, isNotModified } from "../../lib/util/http-cache.js";
+
+/**
+ * Mark mind users that have no `minds` row: an external mind reaches in over HTTP
+ * with a Bearer token and has no port, process, or directory here, so a caller
+ * cannot infer this from the mind list alone.
+ *
+ * `readAllMinds`, not `readRegistry`: readRegistry drops variants (`parent IS NULL`),
+ * but every variant gets a users row at split (establishVariantDialogue) and keeps a
+ * `minds` row naming its parent — running or stopped, it is local, not external.
+ */
+async function withExternalFlag<T extends { username: string; user_type: string }>(
+  list: T[],
+): Promise<(T & { external?: boolean })[]> {
+  if (!list.some((u) => u.user_type === "mind")) return list;
+  const local = new Set((await readAllMinds()).map((m) => m.name));
+  return list.map((u) => (u.user_type === "mind" ? { ...u, external: !local.has(u.username) } : u));
+}
 
 /** Only join system channel when running inside the daemon (not in tests). */
 function tryJoinSystem(userId: number): void {
@@ -251,9 +275,9 @@ const admin = new Hono<AuthEnv>()
 
     const type = c.req.query("type");
     if (type === "human" || type === "mind") {
-      return c.json(await listUsersByType(type));
+      return c.json(await withExternalFlag(await listUsersByType(type)));
     }
-    return c.json(await listUsers());
+    return c.json(await withExternalFlag(await listUsers()));
   })
   .get("/users/pending", async (c) => {
     const user = c.get("user");
@@ -368,7 +392,19 @@ const admin = new Hono<AuthEnv>()
       if (adminCount <= 1) return c.json({ error: "Cannot delete the last admin" }, 400);
     }
     if (target.user_type === "mind") {
-      return c.json({ error: "Use the mind deletion API to delete minds" }, 400);
+      // Only a mind the daemon spawns needs the mind-deletion API, which exists to
+      // stop the process and remove the directory. An external mind has neither, so
+      // deleting its account is the whole teardown — and the mind API would 404 on
+      // it, leaving no way to remove it at all.
+      //
+      // Re-derived from the registry rather than trusted from the caller: the client
+      // chooses which endpoint to call, but only the registry knows whether a live
+      // mind's process and directory are at stake.
+      if (await findMind(target.username)) {
+        return c.json({ error: "Use the mind deletion API to delete minds" }, 400);
+      }
+      await deleteExternalMindUser(id);
+      return c.json({ ok: true });
     }
     await deleteUser(id);
     return c.json({ ok: true });

--- a/packages/web/src/ui/components/modals/AddExternalMindModal.svelte
+++ b/packages/web/src/ui/components/modals/AddExternalMindModal.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+import { Button, Input, Modal } from "@volute/ui";
+import { registerExternalMind } from "../../lib/auth";
+
+let {
+  onClose,
+  onRegistered,
+}: {
+  onClose: () => void;
+  onRegistered: () => void;
+} = $props();
+
+let name = $state("");
+let displayName = $state("");
+let description = $state("");
+let error = $state("");
+let submitting = $state(false);
+
+// The plaintext token exists nowhere but this response — it is never re-fetchable.
+let issued = $state<{ name: string; token: string } | null>(null);
+let copied = $state(false);
+
+async function handleSubmit(e: Event) {
+  e.preventDefault();
+  const trimmed = name.trim();
+  if (!trimmed || submitting) return;
+  submitting = true;
+  error = "";
+  try {
+    const result = await registerExternalMind({
+      name: trimmed,
+      displayName: displayName.trim() || undefined,
+      description: description.trim() || undefined,
+    });
+    issued = { name: result.name, token: result.token };
+    onRegistered();
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to register";
+  } finally {
+    submitting = false;
+  }
+}
+
+async function copyToken() {
+  if (!issued) return;
+  try {
+    // Absent entirely on a non-secure origin (a LAN Volute over plain HTTP), so
+    // this throws rather than returning a rejected promise.
+    await navigator.clipboard.writeText(issued.token);
+    copied = true;
+    error = "";
+    setTimeout(() => (copied = false), 1500);
+  } catch {
+    error = "Couldn't copy — select the token and copy it manually";
+  }
+}
+</script>
+
+<Modal size="420px" title={issued ? `@${issued.name} registered` : "Add external mind"} {onClose}>
+  <div class="body">
+    {#if issued}
+      <p class="lede">
+        Give this token to the mind. It authenticates as
+        <span class="mono">@{issued.name}</span> over the API — no process runs here.
+      </p>
+
+      <div class="token-box">
+        <code class="token">{issued.token}</code>
+        <Button variant="secondary" onclick={copyToken}>{copied ? "copied" : "copy"}</Button>
+      </div>
+
+      <p class="warn">
+        This is the only time the token is shown — only a hash of it is stored. If it's lost,
+        issue a new one from the mind's card.
+      </p>
+
+      {#if error}
+        <div class="error">{error}</div>
+      {/if}
+
+      <div class="actions">
+        <Button variant="primary" onclick={onClose}>done</Button>
+      </div>
+    {:else}
+      <p class="lede">
+        An external mind runs somewhere else and reaches in over the API. It gets an account and a
+        token, but no process, port, or directory here.
+      </p>
+
+      <form onsubmit={handleSubmit}>
+        <div class="field">
+          <label for="ext-name">Name</label>
+          <Input
+            id="ext-name"
+            bind:value={name}
+            placeholder="hecate"
+            autocomplete="off"
+            spellcheck={false}
+          />
+          <span class="hint">Letters, numbers, dot, dash, underscore. Used as @name.</span>
+        </div>
+
+        <div class="field">
+          <label for="ext-display">Display name <span class="opt">optional</span></label>
+          <Input id="ext-display" bind:value={displayName} placeholder="Hecate" autocomplete="off" />
+        </div>
+
+        <div class="field">
+          <label for="ext-desc">Description <span class="opt">optional</span></label>
+          <Input
+            id="ext-desc"
+            bind:value={description}
+            placeholder="What is this mind?"
+            autocomplete="off"
+          />
+        </div>
+
+        {#if error}
+          <div class="error">{error}</div>
+        {/if}
+
+        <div class="actions">
+          <Button variant="text" type="button" onclick={onClose}>cancel</Button>
+          <Button variant="primary" type="submit" disabled={!name.trim() || submitting}>
+            {submitting ? "registering..." : "register"}
+          </Button>
+        </div>
+      </form>
+    {/if}
+  </div>
+</Modal>
+
+<style>
+  .body {
+    padding: 12px 16px 16px;
+  }
+
+  .lede {
+    color: var(--text-1);
+    font-size: 13px;
+    line-height: 1.5;
+    margin: 0 0 14px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 12px;
+  }
+
+  .field label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-2);
+  }
+
+  .opt {
+    text-transform: none;
+    letter-spacing: 0;
+    opacity: 0.7;
+  }
+
+  .hint {
+    font-size: 11px;
+    color: var(--text-2);
+  }
+
+  .token-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 8px 10px;
+  }
+
+  .token {
+    flex: 1;
+    min-width: 0;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--text-0);
+    overflow-wrap: anywhere;
+    user-select: all;
+  }
+
+  .mono {
+    font-family: var(--mono);
+    color: var(--text-0);
+  }
+
+  .warn {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--yellow);
+    margin: 10px 0 0;
+  }
+
+  .error {
+    color: var(--red);
+    font-size: 12px;
+    margin-top: 8px;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 16px;
+  }
+</style>

--- a/packages/web/src/ui/components/system/UserManagement.svelte
+++ b/packages/web/src/ui/components/system/UserManagement.svelte
@@ -1,24 +1,32 @@
 <script lang="ts">
 import type { Mind } from "@volute/api";
+import { Button } from "@volute/ui";
 import { onMount } from "svelte";
 import { slide } from "svelte/transition";
 import {
+  type ApiToken,
   type AuthUser,
   approveUser,
   deleteUser,
   fetchUsers,
+  fetchUserTokens,
+  issueUserToken,
+  revokeUserToken,
   setUserRole,
   updateUserProfile,
 } from "../../lib/auth";
 import { deleteMind } from "../../lib/client";
-import { mindDotColor } from "../../lib/format";
+import { mindDotColor, normalizeTimestamp } from "../../lib/format";
 import { activeMinds, data, onlineBrains } from "../../lib/stores.svelte";
+import { avatarUrl, deleteLabel, isExternal, kindLabel } from "../../lib/user-kind";
+import AddExternalMindModal from "../modals/AddExternalMindModal.svelte";
 
 let { minds }: { minds: Mind[] } = $props();
 
 let users = $state<AuthUser[]>([]);
 let error = $state("");
 let expandedId = $state<number | null>(null);
+let showAddModal = $state(false);
 
 // Edit state
 let editDisplayName = $state("");
@@ -29,16 +37,42 @@ let saving = $state(false);
 let confirmingDeleteId = $state<number | null>(null);
 let deletingId = $state<number | null>(null);
 
+// Tokens for the expanded external mind
+let tokens = $state<ApiToken[]>([]);
+let tokensLoading = $state(false);
+let tokensError = $state("");
+let issuedToken = $state<string | null>(null);
+let confirmingTokenId = $state<number | null>(null);
+
 let mindsByName = $derived(new Map(minds.map((m) => [m.name, m])));
 let adminCount = $derived(users.filter((u) => u.role === "admin").length);
+
+// Pending first — an account waiting on approval is the one row that needs an
+// action, and it shouldn't have to be hunted for.
+let sortedUsers = $derived(
+  [...users].sort((a, b) => Number(b.role === "pending") - Number(a.role === "pending")),
+);
+
+/**
+ * `api_tokens.created_at` is zone-less UTC text, which `new Date` would read as
+ * local. Time as well as date: tokens minted the same day are otherwise
+ * indistinguishable, and revoking the wrong one cuts off a live mind.
+ */
+function formatTokenDate(createdAt: string): string {
+  return new Date(normalizeTimestamp(createdAt)).toLocaleString();
+}
 
 function refresh() {
   fetchUsers()
     .then((u) => {
       users = u;
+      error = "";
     })
     .catch(() => {
-      if (!error) error = "Failed to load users";
+      // Unconditional: a refresh that fails after a successful mutation used to be
+      // swallowed by whatever error was already set, leaving a stale list that
+      // reads as "my change didn't apply".
+      error = "Failed to load users";
     });
 }
 
@@ -47,7 +81,6 @@ onMount(() => {
 });
 
 function toggleExpand(user: AuthUser) {
-  error = "";
   if (expandedId === user.id) {
     expandedId = null;
     confirmingDeleteId = null;
@@ -56,6 +89,48 @@ function toggleExpand(user: AuthUser) {
     editDisplayName = user.display_name ?? "";
     editDescription = user.description ?? "";
     confirmingDeleteId = null;
+    tokens = [];
+    tokensError = "";
+    issuedToken = null;
+    confirmingTokenId = null;
+    if (isExternal(user)) loadTokens(user.id);
+  }
+}
+
+// Tracked apart from `error`: an empty list is an affirmative claim that this mind
+// holds no credentials, so a failed fetch must never fall through to it.
+async function loadTokens(id: number) {
+  tokensLoading = true;
+  tokensError = "";
+  try {
+    tokens = await fetchUserTokens(id);
+  } catch {
+    tokens = [];
+    tokensError = "Couldn't load tokens — this mind may still have credentials.";
+  } finally {
+    tokensLoading = false;
+  }
+}
+
+async function handleIssueToken(user: AuthUser) {
+  error = "";
+  try {
+    const issued = await issueUserToken(user.id);
+    issuedToken = issued.token;
+    await loadTokens(user.id);
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to issue token";
+  }
+}
+
+async function handleRevokeToken(user: AuthUser, tokenId: number) {
+  error = "";
+  try {
+    await revokeUserToken(user.id, tokenId);
+    confirmingTokenId = null;
+    await loadTokens(user.id);
+  } catch (err) {
+    error = err instanceof Error ? err.message : "Failed to revoke token";
   }
 }
 
@@ -107,7 +182,9 @@ async function handleSaveProfile(user: AuthUser) {
 async function handleDelete(user: AuthUser) {
   deletingId = user.id;
   try {
-    if (user.user_type === "mind") {
+    // An external mind has no directory or process to tear down — deleting the
+    // account IS the whole operation. The daemon re-checks this either way.
+    if (user.user_type === "mind" && !isExternal(user)) {
       try {
         await deleteMind(user.username, true);
         data.minds = data.minds.filter((m) => m.name !== user.username);
@@ -131,10 +208,6 @@ async function handleDelete(user: AuthUser) {
   }
 }
 
-function deleteLabel(user: AuthUser): string {
-  return user.user_type === "mind" ? "delete mind + data?" : "delete account?";
-}
-
 function isProfileDirty(user: AuthUser): boolean {
   return (
     (editDisplayName.trim() || null) !== (user.display_name ?? null) ||
@@ -144,8 +217,24 @@ function isProfileDirty(user: AuthUser): boolean {
 </script>
 
 <div class="container">
+  <div class="panel-header">
+    <div class="heading">
+      <h3>Users</h3>
+      <span class="count">{users.length}</span>
+    </div>
+    <Button variant="secondary" onclick={() => (showAddModal = true)}>+ external mind</Button>
+  </div>
+
+  <!-- Panel level, not inside a card: approve/role actions fire from collapsed rows,
+       and a failed initial load has no card to render into at all. -->
+  {#if error}
+    <div class="error panel-error">{error}</div>
+  {/if}
+
   <div class="user-list">
-    {#each users as u (u.id)}
+    {#each sortedUsers as u (u.id)}
+      {@const avatar = avatarUrl(u)}
+      {@const kind = kindLabel(u)}
       <div class="user-card" class:expanded={expandedId === u.id}>
         <div class="user-row" role="button" tabindex="0" onclick={() => toggleExpand(u)} onkeydown={(e) => e.key === 'Enter' && toggleExpand(u)}>
           <span
@@ -153,28 +242,37 @@ function isProfileDirty(user: AuthUser): boolean {
             class:iridescent={u.user_type === "mind" && activeMinds.has(u.username)}
             style:background={statusDotStyle(u)}
           ></span>
+          <span class="avatar">
+            {#if avatar}
+              <img src={avatar} alt="" />
+            {:else}
+              <svg class="type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                {#if u.user_type === "mind"}
+                  <rect x="4" y="8" width="16" height="12" rx="2" />
+                  <circle cx="9" cy="14" r="1.5" />
+                  <circle cx="15" cy="14" r="1.5" />
+                  <line x1="12" y1="4" x2="12" y2="8" />
+                  <circle cx="12" cy="3" r="1" />
+                {:else}
+                  <path d="M5 11a7 7 0 1 1 14 0c0 3-1.5 5-3 6v3H8v-3c-1.5-1-3-3-3-6z" />
+                  <path d="M5 10c-.6 0-1 .8-1 1.8S4.4 13.5 5 13.5" />
+                  <path d="M19 10c.6 0 1 .8 1 1.8s-.4 1.7-1 1.7" />
+                  <circle cx="9.5" cy="10.5" r="1" fill="currentColor" stroke="none" />
+                  <circle cx="14.5" cy="10.5" r="1" fill="currentColor" stroke="none" />
+                {/if}
+              </svg>
+            {/if}
+          </span>
           <div class="user-info">
             <span class="display-name">{u.display_name || u.username}</span>
             {#if u.display_name}
               <span class="username">@{u.username}</span>
             {/if}
-            <svg class="type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              {#if u.user_type === "mind"}
-                <rect x="4" y="8" width="16" height="12" rx="2" />
-                <circle cx="9" cy="14" r="1.5" />
-                <circle cx="15" cy="14" r="1.5" />
-                <line x1="12" y1="4" x2="12" y2="8" />
-                <circle cx="12" cy="3" r="1" />
-              {:else}
-                <path d="M5 11a7 7 0 1 1 14 0c0 3-1.5 5-3 6v3H8v-3c-1.5-1-3-3-3-6z" />
-                <path d="M5 10c-.6 0-1 .8-1 1.8S4.4 13.5 5 13.5" />
-                <path d="M19 10c.6 0 1 .8 1 1.8s-.4 1.7-1 1.7" />
-                <circle cx="9.5" cy="10.5" r="1" fill="currentColor" stroke="none" />
-                <circle cx="14.5" cy="10.5" r="1" fill="currentColor" stroke="none" />
-              {/if}
-            </svg>
           </div>
           <div class="row-actions">
+            {#if kind}
+              <span class="tag" class:external={kind === "external"}>{kind}</span>
+            {/if}
             {#if u.role === "admin"}
               <span class="role admin">admin</span>
             {/if}
@@ -206,9 +304,45 @@ function isProfileDirty(user: AuthUser): boolean {
                 placeholder="Optional description"
               />
             </div>
-            {#if error}
-              <div class="error">{error}</div>
+
+            {#if isExternal(u)}
+              <div class="tokens">
+                <div class="tokens-head">
+                  <span class="tokens-title">API tokens</span>
+                  <button class="action-btn" onclick={() => handleIssueToken(u)}>new token</button>
+                </div>
+                {#if issuedToken}
+                  <div class="issued">
+                    <code>{issuedToken}</code>
+                    <span class="issued-note">shown once — copy it now</span>
+                  </div>
+                {/if}
+                {#if tokensLoading}
+                  <span class="tokens-empty">loading...</span>
+                {:else if tokensError}
+                  <span class="tokens-error">{tokensError}</span>
+                {:else if tokens.length === 0}
+                  <span class="tokens-empty">No tokens — this mind cannot authenticate.</span>
+                {:else}
+                  {#each tokens as t (t.id)}
+                    <div class="token-row">
+                      <span class="token-label">{t.label || "unlabeled"}</span>
+                      <span class="token-date">{formatTokenDate(t.createdAt)}</span>
+                      {#if confirmingTokenId === t.id}
+                        <span class="confirm-prompt">
+                          revoke?
+                          <button class="confirm-yes" onclick={() => handleRevokeToken(u, t.id)}>yes</button>
+                          <button class="confirm-no" onclick={() => (confirmingTokenId = null)}>no</button>
+                        </span>
+                      {:else}
+                        <button class="action-btn danger" onclick={() => (confirmingTokenId = t.id)}>revoke</button>
+                      {/if}
+                    </div>
+                  {/each}
+                {/if}
+              </div>
             {/if}
+
             <div class="detail-actions">
               <div class="left-actions">
                 {#if u.role === "admin"}
@@ -250,15 +384,48 @@ function isProfileDirty(user: AuthUser): boolean {
     {/each}
   </div>
 
-  {#if users.length === 0}
+  {#if users.length === 0 && !error}
     <div class="empty">No users yet.</div>
   {/if}
 </div>
+
+{#if showAddModal}
+  <AddExternalMindModal
+    onClose={() => (showAddModal = false)}
+    onRegistered={refresh}
+  />
+{/if}
 
 <style>
   .container {
     max-width: 600px;
     animation: fadeIn 0.2s ease both;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .heading {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .heading h3 {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-0);
+    margin: 0;
+  }
+
+  .count {
+    font-size: 12px;
+    color: var(--text-2);
   }
 
   .user-list {
@@ -300,6 +467,25 @@ function isProfileDirty(user: AuthUser): boolean {
   .status-dot.iridescent {
     animation: iridescent 3s ease-in-out infinite;
   }
+
+  .avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background: var(--bg-3);
+  }
+
+  .avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
   .user-info {
     flex: 1;
     min-width: 0;
@@ -324,8 +510,8 @@ function isProfileDirty(user: AuthUser): boolean {
   }
 
   .type-icon {
-    width: 13px;
-    height: 13px;
+    width: 14px;
+    height: 14px;
     color: var(--text-2);
     flex-shrink: 0;
   }
@@ -335,6 +521,19 @@ function isProfileDirty(user: AuthUser): boolean {
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
+  }
+
+  .tag {
+    font-size: 11px;
+    color: var(--text-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1px 6px;
+  }
+
+  .tag.external {
+    color: var(--accent);
+    border-color: var(--accent-dim);
   }
 
   .expand-icon {
@@ -410,6 +609,76 @@ function isProfileDirty(user: AuthUser): boolean {
 
   .field input::placeholder {
     color: var(--text-2);
+  }
+
+  .tokens {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    border-top: 1px solid var(--border);
+    padding-top: 10px;
+    margin-top: 2px;
+  }
+
+  .tokens-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .tokens-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-2);
+  }
+
+  .tokens-empty {
+    font-size: 12px;
+    color: var(--text-2);
+  }
+
+  .issued {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    background: var(--bg-1);
+    border: 1px solid var(--accent-dim);
+    border-radius: var(--radius);
+    padding: 8px 10px;
+  }
+
+  .issued code {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--text-0);
+    overflow-wrap: anywhere;
+    user-select: all;
+  }
+
+  .issued-note {
+    font-size: 11px;
+    color: var(--yellow);
+  }
+
+  .token-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+  }
+
+  .token-label {
+    color: var(--text-1);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .token-date {
+    color: var(--text-2);
+    margin-left: auto;
+    flex-shrink: 0;
   }
 
   .detail-actions {
@@ -510,6 +779,15 @@ function isProfileDirty(user: AuthUser): boolean {
   .error {
     color: var(--red);
     font-size: 12px;
+  }
+
+  .panel-error {
+    margin-bottom: 8px;
+  }
+
+  .tokens-error {
+    font-size: 12px;
+    color: var(--red);
   }
 
   .empty {

--- a/packages/web/src/ui/lib/auth.ts
+++ b/packages/web/src/ui/lib/auth.ts
@@ -7,7 +7,22 @@ export type AuthUser = {
   description?: string | null;
   avatar?: string | null;
   created_at?: string;
+  /**
+   * Mind users only: no `minds` registry row, so nothing is spawned here — it
+   * authenticates over HTTP with an API token. Server-computed; a variant is
+   * local despite being absent from the mind list.
+   */
+  external?: boolean;
 };
+
+export type ApiToken = {
+  id: number;
+  label: string | null;
+  createdAt: string;
+};
+
+/** The plaintext `token` exists only in this response — it is never stored. */
+export type IssuedToken = ApiToken & { token: string };
 
 async function authGet<T>(path: string): Promise<T> {
   const res = await fetch(path);
@@ -90,6 +105,39 @@ export async function updateUserProfile(
   if (!res.ok) {
     const data = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(data.error || "Failed to update profile");
+  }
+}
+
+/**
+ * Register an external mind: creates a mind-typed user with no registry row and
+ * mints its first token. Rejects reserved/malformed names (400) and taken ones
+ * (409) — authPost surfaces the server's message for both.
+ */
+export function registerExternalMind(body: {
+  name: string;
+  displayName?: string;
+  description?: string;
+  tokenLabel?: string;
+}): Promise<{ name: string; token: string; tokenId: number }> {
+  // The response also carries the created `user`, deliberately left off this type:
+  // the server builds it without the `external` flag, so typing it as AuthUser
+  // would hand callers a mind that reads as local. Re-read it from the users list.
+  return authPost("/api/auth/minds", body);
+}
+
+export function fetchUserTokens(id: number): Promise<ApiToken[]> {
+  return authGet(`/api/auth/users/${id}/tokens`);
+}
+
+export function issueUserToken(id: number, label?: string): Promise<IssuedToken> {
+  return authPost(`/api/auth/users/${id}/tokens`, { label });
+}
+
+export async function revokeUserToken(id: number, tokenId: number): Promise<void> {
+  const res = await fetch(`/api/auth/users/${id}/tokens/${tokenId}`, { method: "DELETE" });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(data.error || "Failed to revoke token");
   }
 }
 

--- a/packages/web/src/ui/lib/user-kind.ts
+++ b/packages/web/src/ui/lib/user-kind.ts
@@ -1,0 +1,40 @@
+import type { AuthUser } from "./auth";
+
+/**
+ * How the Users panel classifies a row. Three kinds that behave differently:
+ * a human, a local mind (the daemon spawns it — port, process, directory), and
+ * an external mind (an account and a token, nothing else here).
+ */
+
+/**
+ * `external` is server-computed: a mind with no `minds` registry row. The check
+ * is guarded on user_type because the flag is meaningless for anyone else.
+ */
+export function isExternal(u: AuthUser): boolean {
+  return u.user_type === "mind" && u.external === true;
+}
+
+/**
+ * A local mind's avatar is a file in its own directory, served by name. Everyone
+ * else's is an upload in the shared avatars dir — including an external mind's:
+ * it POSTs /api/auth/avatar with its token like any other authenticated user.
+ */
+export function avatarUrl(u: AuthUser): string | null {
+  if (!u.avatar) return null;
+  if (u.user_type === "mind" && !isExternal(u)) {
+    return `/api/minds/${encodeURIComponent(u.username)}/avatar`;
+  }
+  return `/api/auth/avatars/${encodeURIComponent(u.avatar)}`;
+}
+
+/** The row's kind, as a label. Humans are the unmarked default. */
+export function kindLabel(u: AuthUser): string | null {
+  if (u.user_type !== "mind") return null;
+  return isExternal(u) ? "external" : "local";
+}
+
+/** What deleting this row actually does — a local mind loses data, an account doesn't. */
+export function deleteLabel(u: AuthUser): string {
+  if (isExternal(u)) return "revoke access?";
+  return u.user_type === "mind" ? "delete mind + data?" : "delete account?";
+}

--- a/test/external-mind-registration.test.ts
+++ b/test/external-mind-registration.test.ts
@@ -2,13 +2,18 @@ import assert from "node:assert/strict";
 import { afterEach, before, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { resolveApiToken } from "../packages/daemon/src/lib/api-tokens.js";
-import { createUser, getUserByUsername } from "../packages/daemon/src/lib/auth.js";
+import {
+  createUser,
+  getOrCreateMindUser,
+  getUserByUsername,
+} from "../packages/daemon/src/lib/auth.js";
 import {
   type GlobalConfig,
   readGlobalConfig,
   writeGlobalConfig,
 } from "../packages/daemon/src/lib/config/setup.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, addVariant } from "../packages/daemon/src/lib/mind/registry.js";
 import { minds, users } from "../packages/daemon/src/lib/schema.js";
 import { createSession, deleteSession } from "../packages/daemon/src/web/middleware/auth.js";
 
@@ -20,6 +25,8 @@ const TAKEN = "r2-reg-taken";
 const NEW_MIND = "r2-reg-external";
 const NEW_MIND_2 = "r2-reg-external-two";
 const NEW_MIND_3 = "r2-reg-external-three";
+const LOCAL_MIND = "r2-reg-local";
+const LOCAL_VARIANT = "r2-reg-local-variant";
 
 const TEST_USERNAMES = [
   ADMIN,
@@ -30,7 +37,12 @@ const TEST_USERNAMES = [
   NEW_MIND,
   NEW_MIND_2,
   NEW_MIND_3,
+  LOCAL_MIND,
+  LOCAL_VARIANT,
 ];
+
+/** Registry rows the external-flag tests create; dropped alongside their users. */
+const TEST_MIND_ROWS = [LOCAL_MIND, LOCAL_VARIANT];
 
 const sessions: string[] = [];
 let savedConfig: GlobalConfig;
@@ -40,6 +52,11 @@ async function cleanup() {
   for (const username of TEST_USERNAMES) {
     // FK cascade drops any api_tokens rows with the user.
     await db.delete(users).where(eq(users.username, username));
+  }
+  // `minds.port` is UNIQUE, so a leaked row would collide with the next run's
+  // addMind rather than fail visibly here.
+  for (const name of TEST_MIND_ROWS) {
+    await db.delete(minds).where(eq(minds.name, name));
   }
   for (const id of sessions.splice(0)) await deleteSession(id);
   writeGlobalConfig(savedConfig);
@@ -205,5 +222,149 @@ describe("external mind registration", () => {
 
     const res = await register(sessionId, { name: NEW_MIND_3 });
     assert.equal(res.status, 201, "an external mind has no minds row, so the cap cannot apply");
+  });
+});
+
+/**
+ * `GET /api/auth/users` tags mind users with `external`. This has to be computed
+ * daemon-side: the flag means "no `minds` row", and the mind list a client can
+ * see (`GET /api/v1/minds` → readRegistry) omits variants, so a client comparing
+ * against it would read every live variant as external.
+ */
+describe("users list — external flag", () => {
+  before(() => {
+    savedConfig = structuredClone(readGlobalConfig());
+  });
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  async function listUsers(cookie: string) {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("http://localhost/api/auth/users", {
+      headers: { Cookie: `volute_session=${cookie}` },
+    });
+    assert.equal(res.status, 200, await res.clone().text());
+    const body = (await res.json()) as {
+      username: string;
+      user_type: string;
+      external?: boolean;
+    }[];
+    return new Map(body.map((u) => [u.username, u]));
+  }
+
+  it("flags a registered external mind, and not a local one", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+    await register(sessionId, { name: NEW_MIND });
+    await addMind(LOCAL_MIND, 4977);
+
+    const byName = await listUsers(sessionId);
+
+    assert.equal(byName.get(NEW_MIND)?.external, true, "no minds row ⇒ external");
+    assert.equal(byName.get(LOCAL_MIND)?.external, false, "has a minds row ⇒ local");
+  });
+
+  // A variant gets its users row at split and keeps a minds row naming its parent,
+  // which readRegistry filters out. It is local whether or not it is running.
+  it("does not flag a variant as external", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+    await addMind(LOCAL_MIND, 4977);
+    await addVariant(LOCAL_VARIANT, LOCAL_MIND, 4978, "/tmp/variant", "variant-branch");
+    await getOrCreateMindUser(LOCAL_VARIANT);
+
+    const byName = await listUsers(sessionId);
+
+    assert.equal(byName.get(LOCAL_VARIANT)?.user_type, "mind");
+    assert.equal(
+      byName.get(LOCAL_VARIANT)?.external,
+      false,
+      "a variant is spawned here — readAllMinds must be the source, not readRegistry",
+    );
+  });
+
+  it("leaves human users untagged", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+
+    const byName = await listUsers(sessionId);
+
+    assert.equal(byName.get(ADMIN)?.user_type, "human");
+    assert.equal(byName.get(ADMIN)?.external, undefined, "external is a mind-only concept");
+  });
+
+  it("tags mind users on the ?type=mind branch too", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+    await register(sessionId, { name: NEW_MIND });
+    await addMind(LOCAL_MIND, 4977);
+
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("http://localhost/api/auth/users?type=mind", {
+      headers: { Cookie: `volute_session=${sessionId}` },
+    });
+    assert.equal(res.status, 200);
+    const byName = new Map(
+      ((await res.json()) as { username: string; external?: boolean }[]).map((u) => [
+        u.username,
+        u,
+      ]),
+    );
+
+    assert.equal(byName.get(NEW_MIND)?.external, true);
+    assert.equal(byName.get(LOCAL_MIND)?.external, false);
+  });
+});
+
+/**
+ * Deleting an external mind is deleting its account: there is no process to stop
+ * and no directory to remove, and the mind-deletion API would 404 on it. The guard
+ * that sends minds to that API must therefore key on having a registry row, not on
+ * being mind-typed — otherwise a registered external mind can never be removed.
+ */
+describe("external mind deletion", () => {
+  before(() => {
+    savedConfig = structuredClone(readGlobalConfig());
+  });
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  async function del(cookie: string, id: number) {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    return app.request(`http://localhost/api/auth/users/${id}`, {
+      method: "DELETE",
+      headers: { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" },
+    });
+  }
+
+  it("deletes an external mind's account, taking its tokens with it", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+    const res = await register(sessionId, { name: NEW_MIND });
+    const { user, token } = (await res.json()) as { user: { id: number }; token: string };
+    assert.equal(await resolveApiToken(token), user.id, "token works before deletion");
+
+    const delRes = await del(sessionId, user.id);
+    assert.equal(delRes.status, 200, await delRes.clone().text());
+
+    assert.equal(await getUserByUsername(NEW_MIND), null, "account is gone");
+    // FK cascade on api_tokens.user_id — revoking access is the point of the delete.
+    assert.equal(await resolveApiToken(token), null, "its token no longer authenticates");
+  });
+
+  it("still refuses to delete a local mind through the users API", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+    await addMind(LOCAL_MIND, 4977);
+    const mindUser = await getOrCreateMindUser(LOCAL_MIND);
+
+    const delRes = await del(sessionId, mindUser.id);
+    assert.equal(delRes.status, 400, "a mind with a registry row has a process and a directory");
+    assert.ok(await getUserByUsername(LOCAL_MIND), "and its account survives");
+  });
+
+  it("still refuses to delete a variant through the users API", async () => {
+    const { sessionId } = await makeUser(ADMIN, "admin");
+    await addMind(LOCAL_MIND, 4977);
+    await addVariant(LOCAL_VARIANT, LOCAL_MIND, 4978, "/tmp/variant", "variant-branch");
+    const variantUser = await getOrCreateMindUser(LOCAL_VARIANT);
+
+    const delRes = await del(sessionId, variantUser.id);
+    assert.equal(delRes.status, 400, "a variant has a worktree to tear down");
+    assert.ok(await getUserByUsername(LOCAL_VARIANT), "and its account survives");
   });
 });

--- a/test/web-user-kind.test.ts
+++ b/test/web-user-kind.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AuthUser } from "../packages/web/src/ui/lib/auth.js";
+import {
+  avatarUrl,
+  deleteLabel,
+  isExternal,
+  kindLabel,
+} from "../packages/web/src/ui/lib/user-kind.js";
+
+function user(over: Partial<AuthUser> = {}): AuthUser {
+  return { id: 1, username: "someone", role: "user", user_type: "human", ...over };
+}
+
+const human = user({ username: "james", avatar: "avatar-1.webp" });
+const localMind = user({ username: "bardo", user_type: "mind", external: false, avatar: "a.png" });
+const externalMind = user({
+  username: "hecate",
+  user_type: "mind",
+  external: true,
+  avatar: "avatar-8.webp",
+});
+
+describe("user kind", () => {
+  it("treats a mind with no registry row as external, and nobody else", () => {
+    assert.equal(isExternal(externalMind), true);
+    assert.equal(isExternal(localMind), false);
+    assert.equal(isExternal(human), false);
+    // The flag is meaningless off a mind: a stray `external` on a human must not
+    // reclassify them, since every consumer keys destructive behavior off this.
+    assert.equal(isExternal(user({ external: true })), false);
+    // A mind predating the flag (or from a response that omits it) is local — the
+    // conservative read: it keeps the delete path that tears a real mind down.
+    assert.equal(isExternal(user({ user_type: "mind" })), false);
+  });
+
+  it("serves an external mind's avatar from the shared dir, not the mind dir", () => {
+    // The bug this pins: external minds authenticate as ordinary users and can
+    // POST /api/auth/avatar, so discarding their avatar loses real data — and
+    // /api/minds/:name/avatar would 404, since they have no directory.
+    assert.equal(avatarUrl(externalMind), "/api/auth/avatars/avatar-8.webp");
+    assert.equal(avatarUrl(localMind), "/api/minds/bardo/avatar");
+    assert.equal(avatarUrl(human), "/api/auth/avatars/avatar-1.webp");
+  });
+
+  it("has no avatar URL when there is no avatar", () => {
+    assert.equal(avatarUrl(user({ user_type: "mind", external: true })), null);
+    assert.equal(avatarUrl(user()), null);
+  });
+
+  it("escapes names and filenames into the URL", () => {
+    assert.equal(
+      avatarUrl(user({ username: "a b", user_type: "mind", avatar: "x" })),
+      "/api/minds/a%20b/avatar",
+    );
+    assert.equal(avatarUrl(user({ avatar: "a b.webp" })), "/api/auth/avatars/a%20b.webp");
+  });
+
+  it("labels minds by locality and leaves humans unmarked", () => {
+    assert.equal(kindLabel(externalMind), "external");
+    assert.equal(kindLabel(localMind), "local");
+    assert.equal(kindLabel(human), null);
+  });
+
+  it("promises only what deletion actually does", () => {
+    // An external mind has no data to lose — the account IS the access.
+    assert.equal(deleteLabel(externalMind), "revoke access?");
+    assert.equal(deleteLabel(localMind), "delete mind + data?");
+    assert.equal(deleteLabel(human), "delete account?");
+  });
+});


### PR DESCRIPTION
Wires the external-mind registration and per-user token APIs (shipped with #711) into Settings → Users, and refreshes the panel to show the new kind of row honestly. Closes the R2/R3 UI half of #711.

Before this, an external mind could only be registered by hand with curl.

## Why the daemon computes `external`

An external mind is a `users` row with **no `minds` registry row**: no port, no process, no directory. A client cannot work that out for itself — `GET /api/v1/minds` uses `readRegistry()`, which filters out variants, so a live variant would read as external and get labeled a remote credential. `GET /api/auth/users` now tags mind users with `external`, computed from `readAllMinds()`.

Mutation-tested: swapping `readAllMinds()` → `readRegistry()` fails the variant test and nothing else.

## Panel

- header with user count + **add external mind**, opening a modal that reveals the one-time token (copy button, shown-once warning) and surfaces the 400/409 name errors inline
- external minds get a token section: list, revoke, issue new
- avatars (previously unused despite `users.avatar` existing), pending pinned to top, per-row `local` / `external` label

No grouping: an external mind is a credential like a human, not a process like a local mind, so any grouping would pair the two most operationally different rows. The per-row label carries the distinction instead.

## Bugs found and fixed along the way

**Deleting an external mind was impossible** — before and after this feature. Both `DELETE /api/auth/users/:id` and `lib/auth.ts` `deleteUser()` refused *any* mind-typed user, so the UI's "revoke access?" pointed at a mind-deletion API that 404s for a mind with no registry row. Both guards now key on **having a registry row** rather than on being mind-typed, via a dedicated `deleteExternalMindUser()`. The daemon re-derives local-vs-external from the registry rather than trusting the client, so a wrong flag can never route a live mind's process and directory into an account-only delete.

Also:
- `avatarUrl()` discarded external minds' avatars. They authenticate as ordinary users and can `POST /api/auth/avatar`, so they do have them (verified by having one upload with only its bearer token).
- a failed token fetch rendered *"No tokens — this mind cannot authenticate"* — an affirmative security claim manufactured from a network blip, shown to an admin auditing credentials. Now tracked separately from the empty state.
- panel errors rendered only inside an expanded card, so a failed load showed nothing while the panel claimed "No users yet."
- token timestamps went through `new Date()` on zone-less UTC text (the #706 bug); now `normalizeTimestamp()`.
- token text asked for `--font-mono`, which does not exist; the theme property is `--mono`, and the CSS fallback hid it.

## Structure

Row-classification helpers live in `ui/lib/user-kind.ts` rather than inside the component: the avatar bug above was invisible to every test layer while trapped in the `.svelte` file. They are pure, and `ui/lib` is already tested directly under `node:test` (`test/timeline-*`). Reintroducing the avatar bug now fails a test.

## Testing

`npm test`: 2668 passing (10 new). `tsc`, `svelte-check`, `biome` clean.

Driven end-to-end in a browser against a throwaway daemon (not the dev instance): registration, both error paths, token reveal/issue/revoke, external-mind delete (200, token stops authenticating) vs local mind and variant (400, account survives), an external mind uploading its own avatar and it rendering, and a seeded variant reading as `local`.

## Follow-up

#740 — bridge puppets (`user_type: "puppet"`) render as humans here; the type is missing from both unions. Pre-existing, not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)