### PR TITLE
fix: log restart/stop failures and stop best-effort start steps from 500ing

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -77,8 +77,16 @@ export async function startMindFull(name: string): Promise<void> {
   );
 
   const dir = mindDir(baseName);
-  getScheduler().loadSchedules(baseName);
-  getSleepManagerIfReady()?.loadSleepConfig(baseName);
+  try {
+    getScheduler().loadSchedules(baseName);
+  } catch (err) {
+    log.error(`failed to load schedules for ${baseName}`, log.errorData(err));
+  }
+  try {
+    getSleepManagerIfReady()?.loadSleepConfig(baseName);
+  } catch (err) {
+    log.error(`failed to load sleep config for ${baseName}`, log.errorData(err));
+  }
   ensureMailAddress(baseName).catch((err: unknown) =>
     log.error(`failed to ensure mail address for ${baseName}`, log.errorData(err)),
   );
@@ -100,14 +108,22 @@ export async function startMindFull(name: string): Promise<void> {
   );
 
   if (config?.tokenBudget) {
-    getTokenBudget().setBudget(
-      baseName,
-      config.tokenBudget,
-      config.tokenBudgetPeriodMinutes ?? DEFAULT_BUDGET_PERIOD_MINUTES,
-    );
+    try {
+      getTokenBudget().setBudget(
+        baseName,
+        config.tokenBudget,
+        config.tokenBudgetPeriodMinutes ?? DEFAULT_BUDGET_PERIOD_MINUTES,
+      );
+    } catch (err) {
+      log.error(`failed to set token budget for ${baseName}`, log.errorData(err));
+    }
   }
 
-  notifyExtensionsMindStart(baseName);
+  try {
+    notifyExtensionsMindStart(baseName);
+  } catch (err) {
+    log.error(`failed to notify extensions of mind start for ${baseName}`, log.errorData(err));
+  }
 }
 
 /**

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1690,6 +1690,7 @@ const app = new Hono<AuthEnv>()
       );
       return c.json({ ok: true, port: targetPort });
     } catch (err) {
+      log.error(`failed to restart mind ${name}`, log.errorData(err));
       return c.json({ error: err instanceof Error ? err.message : "Failed to restart mind" }, 500);
     }
   })
@@ -1709,6 +1710,7 @@ const app = new Hono<AuthEnv>()
       await stopMindFullService(name);
       return c.json({ ok: true });
     } catch (err) {
+      log.error(`failed to stop mind ${name}`, log.errorData(err));
       return c.json({ error: err instanceof Error ? err.message : "Failed to stop mind" }, 500);
     }
   })

--- a/test/mind-service-start-tail.test.ts
+++ b/test/mind-service-start-tail.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  initMindManager,
+  tryGetMindManager,
+} from "../packages/daemon/src/lib/daemon/mind-manager.js";
+import { startMindFull } from "../packages/daemon/src/lib/daemon/mind-service.js";
+import { getTokenBudget, initTokenBudget } from "../packages/daemon/src/lib/daemon/token-budget.js";
+import { addMind, mindDir, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+
+// #689: startMindFull's post-start tail (schedule/sleep-config load, token budget,
+// extension notification) ran some steps bare, so a throw there turned a fully
+// successful mind start into a rejected promise — which the restart route caught
+// and turned into a 500, even though the mind process itself started fine. These
+// steps are metadata/best-effort, not load-bearing for "did the mind start", so a
+// throw in any of them must be caught and logged, not left to abort the function.
+describe("startMindFull post-start tail is best-effort (#689)", () => {
+  const mindName = `restart-tail-${process.pid}`;
+
+  beforeEach(async () => {
+    try {
+      initTokenBudget();
+    } catch {
+      // already initialized by another test in this process
+    }
+    await removeMind(mindName);
+    const dir = mindDir(mindName);
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    // A configured token budget routes startMindFull through the (previously bare)
+    // getTokenBudget().setBudget(...) call.
+    writeFileSync(resolve(dir, "home/.config/volute.json"), JSON.stringify({ tokenBudget: 1000 }));
+  });
+
+  afterEach(async () => {
+    await removeMind(mindName);
+    getTokenBudget().removeBudget(mindName);
+  });
+
+  it("does not throw when a post-start step (token budget) throws", async () => {
+    // Stub the mind manager so startMind is a no-op — we exercise startMindFull's
+    // post-start tail, not a real process spawn (same pattern as orientation.test.ts).
+    const mgr = tryGetMindManager() ?? initMindManager();
+    const origStart = mgr.startMind;
+    const origRunning = mgr.isRunning;
+    mgr.startMind = async () => {};
+    mgr.isRunning = () => false;
+
+    const tb = getTokenBudget();
+    const origSetBudget = tb.setBudget;
+    tb.setBudget = () => {
+      throw new Error("boom: simulated token-budget failure");
+    };
+
+    try {
+      await addMind(mindName, 4999, "sprouted", "claude");
+      await assert.doesNotReject(
+        () => startMindFull(mindName),
+        "a throw in a best-effort post-start step must not fail the whole start",
+      );
+    } finally {
+      mgr.startMind = origStart;
+      mgr.isRunning = origRunning;
+      tb.setBudget = origSetBudget;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The `/:name/restart` and `/:name/stop` routes in `packages/daemon/src/web/api/minds.ts` caught errors and returned `c.json({ error: err.message }, 500)` without logging — the only copy of the failure went to the caller, making it unrecoverable post-hoc. Added `log.error` in both catch blocks before the 500 response.
- `startMindFull()` (`packages/daemon/src/lib/daemon/mind-service.ts`) ran several post-start steps bare after the mind process had already started successfully: `getScheduler().loadSchedules(...)`, `getSleepManagerIfReady()?.loadSleepConfig(...)`, `getTokenBudget().setBudget(...)`, and `notifyExtensionsMindStart(...)`. A throw in any of them rejected the whole function, which the restart route turned into a 500 despite the restart having fully succeeded — and mind-side `daemonRestart()` reads a 500 as failure, risking a retry that double-restarts the mind. None of these steps gate whether the mind process is actually running, so they're now wrapped in try/catch with `log.error`, matching the best-effort pattern already used for the other steps in this function (`ensureSystemDM`, `ensureMailAddress`, `syncMindProfile`, `joinSystemChannelForMind`, etc.).

## Test plan

- [x] Added `test/mind-service-start-tail.test.ts`: stubs the mind manager (no-op start), forces `getTokenBudget().setBudget` to throw, and asserts `startMindFull()` still resolves without rejecting.
- [x] `npm test` — full suite passes (2681/2681), including the new test. The test run's log output confirms the new try/catch around `loadSchedules` and `setBudget` both caught and logged errors rather than propagating them.

Fixes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)