### PR TITLE
fix: sweep resolved system events after 30 days

### DIFF
--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, isNull, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
 import { publish as publishMindEvent } from "../events/mind-events.js";
 import { findMind, getBaseName } from "../mind/registry.js";
@@ -38,6 +38,14 @@ const MAX_NEXT_TURN_EVENTS = 100;
 
 /** Pending immediate events older than this are expired at flush, not replayed stale. */
 const FLUSH_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Retention for resolved events (delivered_at set): 30 days. This is the mind-wide,
+ * unbounded-lifetime backstop — the per-(mind,thread) cap above and flush-time expiry
+ * only bound *pending* rows, so a long-lived mind's delivered notices/events would
+ * otherwise accumulate forever (#607).
+ */
+const EVENT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Parse an event row's meta JSON, tolerating corrupt rows: a single bad row must
@@ -496,6 +504,23 @@ export async function pendingEventCount(mind: string): Promise<number> {
   }
 }
 
+/**
+ * Delete resolved (delivered_at IS NOT NULL) events older than {@link EVENT_RETENTION_MS}.
+ * Pending rows are never touched here — they're bounded separately by the per-(mind,thread)
+ * cap on insert and by flush-time expiry, and must survive until actually drained/delivered.
+ * Called from the daemon's hourly maintenance sweep (`daemon/maintenance.ts`).
+ */
+export async function cleanExpiredEvents(): Promise<void> {
+  const db = await getDb();
+  const cutoff = new Date(Date.now() - EVENT_RETENTION_MS)
+    .toISOString()
+    .replace("T", " ")
+    .slice(0, 19);
+  await db
+    .delete(systemEvents)
+    .where(and(isNotNull(systemEvents.delivered_at), lt(systemEvents.created_at, cutoff)));
+}
+
 /** The wake-summary line describing queued events, or "" when none are pending. */
 export function pendingEventsLine(count: number): string {
   if (count <= 0) return "";
@@ -632,8 +657,9 @@ function localHM(createdAt: string): string {
 
 /**
  * Mark next-turn events delivered for a mind+thread up to and including `uptoId`. Unlike
- * the old notices table (which deleted rows), events persist — we stamp `delivered_at` so
- * they stay visible in the events history/UI.
+ * the old notices table (which deleted rows on write), events persist — we stamp
+ * `delivered_at` so they stay visible in the events history/UI until swept by
+ * {@link cleanExpiredEvents} after {@link EVENT_RETENTION_MS}.
  */
 export async function clearDeliveredEvents(
   mind: string,

--- a/packages/daemon/src/lib/daemon/maintenance.ts
+++ b/packages/daemon/src/lib/daemon/maintenance.ts
@@ -1,4 +1,5 @@
 import { cleanExpiredSessions } from "../../web/middleware/auth.js";
+import { cleanExpiredEvents } from "../chat/system-events.js";
 import { cleanExpiredLogs } from "../util/history-cleanup.js";
 import log from "../util/logger.js";
 
@@ -19,6 +20,11 @@ export async function runMaintenance(): Promise<void> {
     await cleanExpiredLogs();
   } catch (err) {
     log.warn("maintenance: failed to clean expired logs", log.errorData(err));
+  }
+  try {
+    await cleanExpiredEvents();
+  } catch (err) {
+    log.warn("maintenance: failed to clean expired events", log.errorData(err));
   }
 }
 

--- a/test/system-events.test.ts
+++ b/test/system-events.test.ts
@@ -5,6 +5,7 @@ import { before, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import {
   captureReflection,
+  cleanExpiredEvents,
   clearDeliveredEvents,
   deliverEvent,
   drainEvents,
@@ -861,6 +862,58 @@ describe("system-events status surfaces", () => {
     });
     assert.equal(await hasUndeliveredEvent(mind, "no_credentials"), true);
     assert.equal(await hasUndeliveredEvent(mind, "process_crash"), false);
+    await cleanupMind(mind);
+  });
+});
+
+describe("system-events cleanExpiredEvents", () => {
+  it("sweeps delivered events past the retention window and keeps everything else", async () => {
+    const mind = uniqueMind();
+    const db = await getDb();
+    const day = 24 * 60 * 60 * 1000;
+    const ago = (ms: number) =>
+      new Date(Date.now() - ms).toISOString().replace("T", " ").slice(0, 19);
+
+    await db.insert(systemEvents).values([
+      // Delivered, well past the 30-day retention window — swept.
+      {
+        mind,
+        type: "notice",
+        body: "old delivered",
+        delivery: "next-turn",
+        thread: "main",
+        created_at: ago(40 * day),
+        delivered_at: ago(40 * day),
+      },
+      // Delivered, but recent — survives.
+      {
+        mind,
+        type: "notice",
+        body: "recent delivered",
+        delivery: "next-turn",
+        thread: "main",
+        created_at: ago(day),
+        delivered_at: ago(day),
+      },
+      // Undelivered and old — must survive: pending rows are never swept by age alone,
+      // only by the per-(mind,thread) cap and flush-time expiry.
+      {
+        mind,
+        type: "notice",
+        body: "old pending",
+        delivery: "next-turn",
+        thread: "main",
+        created_at: ago(40 * day),
+        delivered_at: null,
+      },
+    ]);
+
+    await cleanExpiredEvents();
+
+    const rows = await db.select().from(systemEvents).where(eq(systemEvents.mind, mind));
+    const bodies = rows.map((r) => r.body).sort();
+    assert.deepEqual(bodies, ["old pending", "recent delivered"]);
+
     await cleanupMind(mind);
   });
 });


### PR DESCRIPTION
## Summary

`mind_notices` (referenced in #607) was already superseded by `system_events` in the #681 refactor, but the replacement inherited the same unbounded-growth problem: delivered/resolved rows are stamped `delivered_at` and kept forever with no age bound, so long-lived minds accumulate `system_events` rows indefinitely.

## Approach

The daemon already has an hourly maintenance sweep (`packages/daemon/src/lib/daemon/maintenance.ts`, used today to expire old `mind_history` log rows and stale sessions). Rather than adding new scheduling machinery, this hooks a 30-day age-bound sweep into that existing job:

- `cleanExpiredEvents()` (`packages/daemon/src/lib/chat/system-events.ts`) deletes `system_events` rows where `delivered_at IS NOT NULL` and `created_at` is older than 30 days.
- Pending rows (`delivered_at IS NULL`) are never touched by this sweep — they're already bounded separately by the existing per-(mind,thread) cap on insert (`MAX_NEXT_TURN_EVENTS = 100`) and flush-time expiry (`FLUSH_MAX_AGE_MS = 7 days`).
- `latestFailureEvent()`, `latestEvent()`, `hasUndeliveredEvent()`, and `drainEvents()` (the notice drain on clean turns) all filter on `delivered_at IS NULL`, so they're unaffected by pruning delivered rows.
- Updated a docstring on `clearDeliveredEvents()` that claimed delivered events "stay visible... " indefinitely — no longer accurate now that they're swept after 30 days.

30 days is a plain constant (`EVENT_RETENTION_MS`), matching the existing `LOG_RETENTION_MS` pattern in `history-cleanup.ts` — no new config surface.

Fixes #607

## Test plan

- [x] Added `system-events cleanExpiredEvents` test: old delivered rows are removed, recent delivered rows and old-but-pending rows survive.
- [x] `npm test` — full suite passes (2681 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)