### PR TITLE
fix: clean up a variant's worktree and branch on volute mind delete

### DIFF
--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -21,11 +21,16 @@ const cmd = command({
 
     const res = await daemonFetch(url, { method: "DELETE" });
 
-    const data = (await res.json()) as { ok?: boolean; error?: string };
+    const data = (await res.json()) as { ok?: boolean; variant?: boolean; error?: string };
 
     if (!res.ok) {
       console.error(data.error ?? "Failed to delete mind");
       process.exit(1);
+    }
+
+    if (data.variant) {
+      console.log(`Deleted variant ${name}, including its git worktree and branch.`);
+      return;
     }
 
     console.log(`Deleted ${name} from the registry.`);

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -2112,11 +2112,35 @@ const app = new Hono<AuthEnv>()
     const entry = await findMind(name);
     if (!entry) return c.json({ error: "Mind not found" }, 404);
 
+    const manager = getMindManager();
+
+    // Variants live in a git worktree under the parent's `.variants/`, not
+    // mindDir(name) — route to the same cleanup the variant-specific endpoint
+    // uses so the worktree and branch aren't stranded (#650).
+    if (entry.parent) {
+      if (!entry.dir) return c.json({ error: `Variant ${name} has no directory` }, 500);
+      const parentEntry = await findMind(entry.parent);
+      if (!parentEntry) return c.json({ error: `Parent mind ${entry.parent} not found` }, 404);
+
+      if (manager.isRunning(name)) {
+        await stopMindFullService(name);
+      }
+      await cleanupVariant(name, entry.parent, parentEntry.dir ?? mindDir(entry.parent), entry.dir);
+      invalidateMindUserCache(name);
+
+      fireWebhook({
+        event: "mind_deleted",
+        mind: name,
+        data: { port: entry.port, stage: entry.stage, template: entry.template },
+      });
+
+      return c.json({ ok: true, variant: true });
+    }
+
     const dir = mindDir(name);
     const force = c.req.query("force") === "true";
 
     // Stop mind if running
-    const manager = getMindManager();
     if (manager.isRunning(name)) {
       await stopMindFullService(name);
     }

--- a/skills/volute-mind/references/variants.md
+++ b/skills/volute-mind/references/variants.md
@@ -55,7 +55,7 @@ If a variant didn't lead anywhere, let it go without merging:
 ```sh
 volute mind delete mymind-experiment
 ```
-This removes the variant from the registry — nothing merges into you. Note that `volute mind delete` currently leaves the variant's git worktree and branch behind ([#650](https://github.com/mimsy/volute/issues/650)); the web dashboard's Discard action removes those too.
+This removes the variant from the registry along with its git worktree and branch — nothing merges into you. Same cleanup as the web dashboard's Discard action.
 
 # Upgrade Workflow
 

--- a/test/variant-delete-cleanup.test.ts
+++ b/test/variant-delete-cleanup.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  addMind,
+  addVariant,
+  findMind,
+  mindDir,
+  removeMind,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import { sessions, users } from "../packages/daemon/src/lib/schema.js";
+import { exec, gitExec } from "../packages/daemon/src/lib/util/exec.js";
+import mindsApp from "../packages/daemon/src/web/api/minds.js";
+import { type AuthEnv, authMiddleware } from "../packages/daemon/src/web/middleware/auth.js";
+import { cleanGitEnv } from "./helpers/test-git-env.js";
+
+// Regression test for #650: `DELETE /api/minds/:name` on a variant name used to
+// stop the process and drop the DB row without ever calling cleanupVariant,
+// stranding the git worktree and branch. This exercises the real route (not
+// just cleanupVariant directly) so it catches a regression in the routing
+// decision itself, not just the cleanup helper.
+
+const parentName = `vdel-${Date.now()}`;
+const variantName = `${parentName}-var`;
+const branch = variantName;
+
+let adminCookie: string;
+let parentDir: string;
+let variantDir: string;
+let gitEnv: NodeJS.ProcessEnv;
+
+function createApp() {
+  const app = new Hono<AuthEnv>();
+  app.use("/*", authMiddleware);
+  app.route("/minds", mindsApp);
+  return app;
+}
+
+describe("DELETE /:name on a variant (#650)", () => {
+  before(async () => {
+    const { initMindManager, tryGetMindManager } = await import(
+      "../packages/daemon/src/lib/daemon/mind-manager.js"
+    );
+    if (!tryGetMindManager()) initMindManager();
+
+    const env = cleanGitEnv();
+    gitEnv = env;
+
+    parentDir = mindDir(parentName);
+    variantDir = resolve(parentDir, ".variants", variantName);
+    if (existsSync(parentDir)) rmSync(parentDir, { recursive: true, force: true });
+    mkdirSync(parentDir, { recursive: true });
+
+    await exec("git", ["init"], { cwd: parentDir, env });
+    await exec("git", ["config", "user.email", "test@test.com"], { cwd: parentDir, env });
+    await exec("git", ["config", "user.name", "Test"], { cwd: parentDir, env });
+    writeFileSync(resolve(parentDir, "MEMORY.md"), "base\n");
+    await exec("git", ["add", "-A"], { cwd: parentDir, env });
+    await exec("git", ["commit", "-m", "init"], { cwd: parentDir, env });
+
+    await exec("git", ["worktree", "add", "-b", branch, variantDir], { cwd: parentDir, env });
+
+    await addMind(parentName, 4390);
+    await addVariant(variantName, parentName, 4391, variantDir, branch);
+
+    const db = await getDb();
+    const [user] = await db
+      .insert(users)
+      .values({ username: "vdel-admin", password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    adminCookie = `volute_session=${sessionId}`;
+  });
+
+  after(async () => {
+    if (existsSync(variantDir)) rmSync(variantDir, { recursive: true, force: true });
+    if (existsSync(parentDir)) rmSync(parentDir, { recursive: true, force: true });
+    await removeMind(variantName).catch(() => {});
+    await removeMind(parentName).catch(() => {});
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, "vdel-admin"));
+  });
+
+  it("cleans up the variant's worktree, branch, and DB row instead of stranding them", async () => {
+    const app = createApp();
+    const res = await app.request(`/minds/${variantName}`, {
+      method: "DELETE",
+      headers: { Cookie: adminCookie },
+    });
+
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { ok?: boolean; variant?: boolean };
+    assert.equal(body.ok, true);
+    assert.equal(body.variant, true, "response flags the deletion as a variant");
+
+    assert.equal(await findMind(variantName), undefined, "variant row removed from registry");
+    assert.ok(!existsSync(variantDir), "variant worktree removed from disk");
+
+    const branches = await gitExec(["branch", "--list", branch], { cwd: parentDir, env: gitEnv });
+    assert.equal(branches.trim(), "", "variant branch deleted");
+
+    // The parent mind itself is untouched.
+    assert.ok(await findMind(parentName), "parent mind still registered");
+    assert.ok(existsSync(parentDir), "parent directory untouched");
+  });
+});

--- a/website/src/content/docs/docs/commands/mind.md
+++ b/website/src/content/docs/docs/commands/mind.md
@@ -106,7 +106,7 @@ volute mind delete [name] [--force]
 |------|-------------|
 | `--force` | Also delete the mind directory |
 
-Called with a variant's name, this discards the variant without merging — it removes the variant from the registry and nothing flows into the parent. Note that the CLI path currently leaves the variant's git worktree and branch behind ([#650](https://github.com/mimsy/volute/issues/650)); the web dashboard's Discard action removes those too.
+Called with a variant's name, this discards the variant without merging — it removes the variant from the registry along with its git worktree and branch, and nothing flows into the parent. Same cleanup as the web dashboard's Discard action.
 
 ## mind upgrade
 

--- a/website/src/content/docs/docs/concepts/variants.md
+++ b/website/src/content/docs/docs/concepts/variants.md
@@ -67,4 +67,4 @@ This is the fundamental mechanism for mind self-modification — changes are alw
 volute mind delete experiment
 ```
 
-This removes the variant from the registry; nothing merges into the parent. Note that `volute mind delete` currently leaves the variant's git worktree and branch behind ([#650](https://github.com/mimsy/volute/issues/650)); the web dashboard's Discard action (and the daemon's variant endpoint) removes those too.
+This removes the variant from the registry along with its git worktree and branch; nothing merges into the parent. Same cleanup as the web dashboard's Discard action.


### PR DESCRIPTION
## Summary

`volute mind delete <variant-name>` hit the general `DELETE /api/minds/:name` handler, which stopped the process and dropped the DB row but never called `cleanupVariant`. That stranded the git worktree at `<parentDir>/.variants/<variant>` and its branch, and reported `--force` against the wrong path (`mindDir(name)` instead of the variant's actual worktree dir).

- `DELETE /:name` now detects a variant row (`entry.parent` set) up front and delegates to `cleanupVariant()` with the parent's project root — the same cleanup path `DELETE /:name/variants/:variant` already used, including the `#645` DB-footprint purge.
- Restores `mind_stopped` activity parity for a running variant (via `stopMindFullService`, matching the base-mind path) and invalidates the mind-token user cache so a deleted variant's token can't keep authenticating for up to 5 minutes.
- The response now carries `variant: true` for a variant deletion so the CLI can stop printing the (now-inaccurate) "use `--force` to also delete the mind directory" hint — `cleanupVariant` always removes the worktree.
- Updated the three docs that described the pre-fix reality (`skills/volute-mind/references/variants.md`, `website/src/content/docs/docs/commands/mind.md`, `website/src/content/docs/docs/concepts/variants.md`).

## Test plan

- [x] Added `test/variant-delete-cleanup.test.ts`: builds a real git repo + worktree, registers a parent/variant pair, hits `DELETE /api/minds/:variant` through the real `minds.ts` app, and asserts the worktree directory, git branch, and DB row are all gone (and the parent is untouched).
- [x] `npm test` — full suite green (2681 passing), including `test/authz-coverage.test.ts`.
- [x] `code-review` skill run against the diff; findings addressed (see below).

Fixes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)