### PR TITLE
fix(security): sanitize extension-supplied SVG icons in App.svelte

### DIFF
--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -2,6 +2,7 @@
 import type { Conversation, Mind } from "@volute/api";
 import { Icon, Modal, tooltip } from "@volute/ui";
 import { icons } from "@volute/ui/icons";
+import { sanitizeSvg } from "@volute/ui/sanitize";
 import { onMount } from "svelte";
 import ChannelMembersPanel from "./components/ChannelMembersPanel.svelte";
 import ConnectionSetup from "./components/ConnectionSetup.svelte";
@@ -796,7 +797,7 @@ function handleGlobalClick(e: MouseEvent) {
                     onclick={() => handleSelectMindSection(activeMindName!, sec.key, sec.defaultPath)}
                     use:tooltip={{ text: sec.label, position: "bottom" }}
                   >
-                    {#if sec.icon}<span class="tab-icon">{@html sec.icon}</span>{/if}
+                    {#if sec.icon}<span class="tab-icon">{@html sanitizeSvg(sec.icon)}</span>{/if}
                   </button>
                 {/each}
               </div>
@@ -819,7 +820,7 @@ function handleGlobalClick(e: MouseEvent) {
                       onclick={() => handleSelectExtension(ext.id)}
                       use:tooltip={{ text: ext.systemSection.label, position: "bottom" }}
                     >
-                      <span class="tab-icon">{@html ext.icon ?? '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2h5v5H2zM9 2h5v5H9zM2 9h5v5H2zM9 9h5v5H9z"/></svg>'}</span>
+                      <span class="tab-icon">{@html sanitizeSvg(ext.icon ?? '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2h5v5H2zM9 2h5v5H9zM2 9h5v5H2zM9 9h5v5H9z"/></svg>')}</span>
                     </button>
                   {/if}
                 {/each}

--- a/test/svg-icon-sanitize.test.ts
+++ b/test/svg-icon-sanitize.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { before, describe, it } from "node:test";
 import { JSDOM } from "jsdom";
 import { enrichActivityMetadata } from "../packages/daemon/src/lib/extensions.js";
@@ -107,5 +109,50 @@ describe("extension activity metadata enrichment", () => {
     assert.ok(!icon.includes("onload"), "strips inline handler from manifest icon");
     assert.ok(!icon.includes("evil"), "strips handler body");
     assert.equal(out.color, "purple", "keeps color branding");
+  });
+});
+
+// #729: App.svelte's extension tab icons (`sec.icon` for mind-section tabs,
+// `ext.icon` for system-section tabs) are rendered via `{@html ...}` without
+// going through `sanitizeSvg`, unlike every other render-time icon site (#398).
+// Guard against both a functional regression (icon HTML not neutralized) and a
+// source-level regression (someone reverting to a bare `{@html ext.icon}`).
+describe("App.svelte extension tab icons (#729)", () => {
+  it("neutralizes a hostile extension-supplied icon exactly as App.svelte renders it (sanitizeSvg(ext.icon ?? fallback))", () => {
+    // Mirrors App.svelte: {@html sanitizeSvg(ext.icon ?? '<svg ...>')} — an
+    // extension manifest can set `icon` to arbitrary HTML.
+    const hostileExtIcon = '<svg onload="alert(1)"><script>steal()</script><path d="M0 0"/></svg>';
+    const rendered = sanitizeSvg(hostileExtIcon).toLowerCase();
+    assert.ok(!rendered.includes("onload"), "strips inline handler");
+    assert.ok(!rendered.includes("<script"), "strips script tag");
+    assert.ok(!rendered.includes("steal"), "strips script body");
+  });
+
+  it("leaves the trusted fallback SVG intact when ext.icon is unset", () => {
+    // Mirrors App.svelte's fallback branch — sanitizeSvg must not mangle the
+    // hardcoded default icon shown when an extension doesn't supply one.
+    const fallback =
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 2h5v5H2zM9 2h5v5H9zM2 9h5v5H2zM9 9h5v5H9z"/></svg>';
+    const rendered = sanitizeSvg(undefined ?? fallback);
+    assert.ok(rendered.includes("<svg"), "keeps <svg>");
+    assert.ok(rendered.includes('viewBox="0 0 16 16"'), "keeps viewBox");
+    assert.ok(rendered.includes("<path"), "keeps <path>");
+  });
+
+  it("wraps both extension icon {@html} sites in App.svelte with sanitizeSvg", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "../packages/web/src/ui/App.svelte"),
+      "utf-8",
+    );
+    assert.match(
+      source,
+      /\{#if sec\.icon\}.*\{@html sanitizeSvg\(sec\.icon\)\}/,
+      "mind-section tab icon (sec.icon) must be wrapped in sanitizeSvg",
+    );
+    assert.match(
+      source,
+      /\{@html sanitizeSvg\(ext\.icon \?\?/,
+      "system-section tab icon (ext.icon) must be wrapped in sanitizeSvg",
+    );
   });
 });


### PR DESCRIPTION
Fixes #729

## Problem

Extension-supplied icon HTML is injected via `{@html}` in two places in `App.svelte`, both missing the `sanitizeSvg` wrap that every other render-time icon site already uses (established by #398):

- `sec.icon` — mind-section tab icons, sourced from `ext.mindSections`
- `ext.icon` — system-section tab icons, sourced directly from an extension manifest (with a hardcoded fallback SVG when unset)

Per CLAUDE.md's security conventions: "Extension- or mind-supplied SVG icons injected with `{@html}` must go through `sanitizeSvg` (`@volute/ui/sanitize`)."

## Fix

Wrap both sites with the existing `sanitizeSvg()` helper (`packages/ui/src/sanitize.ts`), matching the inline call-site pattern already used in `HistoryEvent.svelte` and `TimelineCard.svelte`.

## Sibling sites checked

Grepped every `{@html}` in `packages/web/src/ui/` — the only other site in `App.svelte` is `{@html icons.history}`, which renders a hardcoded icon from the internal `@volute/ui/icons` set (not extension- or mind-supplied), so it's out of scope. All other `{@html}` sites across the app already go through `renderMarkdown` (DOMPurify-backed) or `sanitizeSvg`.

## Testing

- Added a new `describe` block to `test/svg-icon-sanitize.test.ts` (the existing home for the #398 sanitizer tests):
  - Proves a hostile icon payload (`onload=`, `<script>`) is neutralized through the same `sanitizeSvg()` call these render sites use.
  - Proves the hardcoded fallback SVG survives sanitization unmangled.
  - A static source-level regression guard asserting both `{@html}` sites in `App.svelte` are wrapped in `sanitizeSvg(...)`, since this repo has no Svelte component-rendering test harness to exercise the `.svelte` file directly.
- `npm test` — 2683/2683 passing.
- `npx svelte-check` — 0 errors.

## Test plan

- [x] `npm test` passes
- [x] `npx svelte-check` passes
- [ ] Manual verification: install a local extension with a malicious `icon` manifest field and confirm the tab renders without executing script

🤖 Generated with [Claude Code](https://claude.com/claude-code)