### PR TITLE
fix: block variant join on unresolved home/ files instead of force-adding them

### DIFF
--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -9,6 +9,11 @@ const cmd = command({
     justification: { type: "string", description: "Justification for merge" },
     memory: { type: "string", description: "Memory to add" },
     "skip-verify": { type: "boolean", description: "Skip verification step" },
+    "discard-unresolved": {
+      type: "boolean",
+      description:
+        "Join even if the variant has untracked home/ files git would otherwise refuse to discard",
+    },
   },
   run: async ({ args, flags }) => {
     const variantName = args.variant!;
@@ -54,17 +59,26 @@ const cmd = command({
           ...(flags.justification && { justification: flags.justification }),
           ...(flags.memory && { memory: flags.memory }),
           ...(flags["skip-verify"] && { skipVerify: true }),
+          ...(flags["discard-unresolved"] && { discardUnresolved: true }),
         }),
       },
     );
 
-    const data = (await res.json()) as { ok?: boolean; error?: string; conflicts?: string[] };
+    const data = (await res.json()) as {
+      ok?: boolean;
+      error?: string;
+      conflicts?: string[];
+      unresolvedFiles?: { path: string; bytes: number }[];
+    };
 
     if (!res.ok) {
       console.error(data.error ?? "Failed to join variant");
       if (data.conflicts?.length) {
         console.error("\nConflicting files:");
         for (const file of data.conflicts) console.error(`  ${file}`);
+      }
+      if (data.unresolvedFiles?.length) {
+        console.error("\nRetry with --discard-unresolved to join anyway and discard them.");
       }
       process.exit(1);
     }

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -117,6 +117,8 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
           return s("reason") ? `Notice: ${s("reason")}` : "Notice";
         case "delivery_failed":
           return "Delivery failed";
+        case "join_blocked":
+          return "Variant join blocked";
         default:
           return "Notice";
       }
@@ -132,7 +134,8 @@ export type NoticeKind =
   | "budget"
   | "startup"
   | "extension"
-  | "delivery_failed";
+  | "delivery_failed"
+  | "join_blocked";
 
 export type RecordNoticeInput = {
   mind: string;

--- a/packages/daemon/src/lib/mind/variants.ts
+++ b/packages/daemon/src/lib/mind/variants.ts
@@ -1,3 +1,5 @@
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
 import { gitExec } from "../util/exec.js";
 import log from "../util/logger.js";
 
@@ -26,75 +28,123 @@ const MERGE_EXCLUDED_PATHS = ["home/MEMORY.md", "home/memory/journal/"];
 const MAX_DELTA_CHARS = 12000;
 
 /**
- * Paths under home/ that the platform deliberately keeps untracked, even though
- * a mind's own new files there should be rescued (see below). Never resurrect:
- *
- * - SDK runtime session state and backups under home/.claude/, home/.pi/,
- *   home/.agents/ (minus their whitelisted skills/settings, already tracked
- *   normally) — fixed by PR #661's gitignore rules so this noise stops merging
- *   into parents.
- * - node_modules/dist anywhere under home/ — templates/_base/gitignore ignores
- *   these repo-wide (no leading slash, so the rule matches at any depth), for
- *   the same reason they're excluded everywhere else: dependency trees and
- *   build output aren't a mind's creative work and don't belong in git history.
- *
- * Kept in manual sync with templates/_base/gitignore (search there for "#656").
+ * SDK-managed runtime subtrees under home/ — session transcripts, backups, cleanup
+ * markers — that are permanently and deliberately kept out of git (PR #661) and get
+ * regenerated every session. They aren't a mind's content to keep or discard, so
+ * they're excluded from the unresolved-files scan below entirely: reporting them
+ * would make nearly every join block by default (any mind with conversation history
+ * has `.claude/projects/*.jsonl`), defeating the point of only interrupting the join
+ * when a mind's *own* work is actually at risk. Skills/settings within these dirs are
+ * already tracked normally and never show up here.
  */
-const NEVER_RESCUE_PREFIXES = ["home/.claude/", "home/.pi/", "home/.agents/"];
-const NEVER_RESCUE_SEGMENTS = new Set(["node_modules", "dist"]);
+const NEVER_REPORT_PREFIXES = ["home/.claude/", "home/.pi/", "home/.agents/"];
 
-function isRescuable(path: string): boolean {
-  if (NEVER_RESCUE_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
-  return !path.split("/").some((segment) => NEVER_RESCUE_SEGMENTS.has(segment));
+/** Cap the individual files listed in an unresolved-files report; huge trees (a cloned
+ * repo, a venv) would otherwise flood the message. `totalCount`/`totalBytes` still
+ * cover everything found, not just what's listed. */
+const MAX_LISTED_UNRESOLVED_FILES = 20;
+
+/** One untracked home/ file .gitignore hides from git, found at join time. */
+export interface UnresolvedHomeFile {
+  /** Path relative to the variant's repo root, e.g. "home/downloads/movie.mp4". */
+  path: string;
+  /** Size in bytes, or -1 if it couldn't be read (e.g. deleted mid-scan). */
+  bytes: number;
+}
+
+/** Result of scanning a variant's home/ for files gitignore would silently drop. */
+export interface UnresolvedHomeFiles {
+  /** Up to {@link MAX_LISTED_UNRESOLVED_FILES} entries, for display. */
+  files: UnresolvedHomeFile[];
+  /** The true count, which may exceed `files.length`. */
+  totalCount: number;
+  /** Sum of bytes across every file found, not just the displayed subset. */
+  totalBytes: number;
 }
 
 /**
- * Force-stage any file a mind created directly under home/ that .gitignore's
- * `home/*` catch-all silently blocks from tracking. New top-level home/ files
- * are the normal creative path variants exist to support, but auto-commit's
- * `git add` no-ops on them (it only logs the failure), so they sit uncommitted
- * in the variant's working tree — and `cleanupVariant`'s `git worktree remove`
- * deletes the working tree wholesale, destroying them (#656).
+ * Find every file under home/ that .gitignore hides from tracking and that's still
+ * sitting on disk, uncommitted — exactly what `cleanupVariant`'s `git worktree remove`
+ * would silently destroy at join (#656).
  *
- * Deliberately-ignored SDK runtime noise and build/dependency output (see
- * {@link isRescuable}) stay excluded — resurrecting either would bake noise or
- * unrelated build artifacts into the parent's permanent git history.
+ * `home/*` is gitignored by design: a mind's home can hold large downloads, nested git
+ * repos, build output, anything. The daemon has no way to know what's precious and what
+ * isn't, so unlike the previous force-add approach, this makes no judgment call on a
+ * mind's own content — it only excludes the SDK's own permanently-ignored runtime
+ * directories (see {@link NEVER_REPORT_PREFIXES}), which are never a mind's content.
+ * Everything else found here is the caller's to report and block on, not resolve.
  *
- * Call this before the pre-merge auto-commit in the variant's own worktree, so
- * the rescued files land in a real commit on the variant branch and merge into
- * the parent like any other change. Never throws — a scan or stage failure is
- * logged and treated as "nothing to rescue," falling back to the pre-#656
- * behavior for that join rather than blocking it.
- *
- * @returns the repo-relative paths that were force-added.
+ * Throws on a scan failure (e.g. the worktree is gone or corrupt) rather than treating
+ * "couldn't check" as "nothing found" — a safety check that fails open isn't a safety
+ * check. Callers must treat a thrown error as blocking too.
  */
-export async function rescueIgnoredHomeFiles(cwd: string): Promise<string[]> {
-  const opts = { cwd };
-  let raw: string;
-  try {
-    raw = await gitExec(
-      ["ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", "home"],
-      opts,
-    );
-  } catch (err) {
-    log.warn("variant join: failed to scan for ignored home/ files", log.errorData(err));
-    return [];
+export async function findUnresolvedHomeFiles(cwd: string): Promise<UnresolvedHomeFiles> {
+  const raw = await gitExec(
+    ["ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", "home"],
+    { cwd },
+  );
+
+  const allPaths = raw
+    .split("\0")
+    .filter((path) => path && !NEVER_REPORT_PREFIXES.some((prefix) => path.startsWith(prefix)));
+
+  const files: UnresolvedHomeFile[] = [];
+  let totalBytes = 0;
+  for (const path of allPaths) {
+    let bytes = -1;
+    try {
+      bytes = statSync(resolve(cwd, path)).size;
+    } catch {
+      // Deleted between listing and stat, or an unreadable symlink — still report it,
+      // just without a size, rather than silently dropping it from the count.
+    }
+    if (bytes > 0) totalBytes += bytes;
+    if (files.length < MAX_LISTED_UNRESOLVED_FILES) files.push({ path, bytes });
   }
 
-  const rescued = raw.split("\0").filter((path) => path && isRescuable(path));
-  if (rescued.length === 0) return [];
+  return { files, totalCount: allPaths.length, totalBytes };
+}
 
-  try {
-    await gitExec(["add", "-f", "--", ...rescued], opts);
-  } catch (err) {
-    log.warn(
-      `variant join: failed to rescue ignored home/ files: ${rescued.join(", ")}`,
-      log.errorData(err),
-    );
-    return [];
+function formatBytes(bytes: number): string {
+  if (bytes < 0) return "size unknown";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  for (const unit of units) {
+    if (value < 1024) return `${value.toFixed(1)} ${unit}`;
+    value /= 1024;
   }
-  log.info(`variant join: rescued gitignored home/ files: ${rescued.join(", ")}`);
-  return rescued;
+  return `${value.toFixed(1)} PB`;
+}
+
+/**
+ * Render {@link findUnresolvedHomeFiles}'s result as an unmistakable, actionable
+ * message: which files are at risk, how big they are, and the three ways to resolve
+ * each one before retrying the join. Paths drop the "home/" prefix so they read the
+ * way the variant itself sees them (its cwd is already home/).
+ */
+export function formatUnresolvedHomeFilesMessage(
+  variantName: string,
+  result: UnresolvedHomeFiles,
+): string {
+  const lines = result.files.map(
+    (f) => `  - ${f.path.replace(/^home\//, "")} (${formatBytes(f.bytes)})`,
+  );
+  const remaining = result.totalCount - result.files.length;
+  if (remaining > 0) lines.push(`  ...and ${remaining} more`);
+
+  return (
+    `Cannot join variant "${variantName}": it has ${result.totalCount} untracked file` +
+    `${result.totalCount === 1 ? "" : "s"} under home/ that .gitignore is hiding from git — ` +
+    `never committed, and joining would destroy them when the variant is cleaned up ` +
+    `(total: ${formatBytes(result.totalBytes)}):\n\n${lines.join("\n")}\n\n` +
+    `Before retrying the join, resolve each file in the variant — one of:\n` +
+    `  1. Track it: git add -f -- <path> (then commit it, or let auto-commit pick it up next turn)\n` +
+    `  2. Copy it out of home/ to somewhere safe, then delete it\n` +
+    `  3. Delete it if it's disposable\n\n` +
+    `Once resolved, retry the join. To join anyway and discard everything listed above, pass ` +
+    `discardUnresolved: true.`
+  );
 }
 
 /**

--- a/packages/daemon/src/lib/mind/variants.ts
+++ b/packages/daemon/src/lib/mind/variants.ts
@@ -26,18 +26,27 @@ const MERGE_EXCLUDED_PATHS = ["home/MEMORY.md", "home/memory/journal/"];
 const MAX_DELTA_CHARS = 12000;
 
 /**
- * Paths under home/ that the platform deliberately keeps untracked — SDK runtime
- * session state and backups (`.claude/projects`, `.claude/backups`, etc.), fixed
- * by PR #661's gitignore rules so this noise stops merging into parents. The
- * rescue below must never resurrect these, even though they're ignored by the
- * same `home/*` catch-all that also blocks a mind's genuine new files.
+ * Paths under home/ that the platform deliberately keeps untracked, even though
+ * a mind's own new files there should be rescued (see below). Never resurrect:
  *
- * Kept in manual sync with the re-ignore rules in templates/_base/gitignore
- * (search there for "#656") — adding a new deliberately-ignored subdirectory
- * under home/ needs a matching prefix here, or its noise gets force-added and
- * merged into the parent.
+ * - SDK runtime session state and backups under home/.claude/, home/.pi/,
+ *   home/.agents/ (minus their whitelisted skills/settings, already tracked
+ *   normally) — fixed by PR #661's gitignore rules so this noise stops merging
+ *   into parents.
+ * - node_modules/dist anywhere under home/ — templates/_base/gitignore ignores
+ *   these repo-wide (no leading slash, so the rule matches at any depth), for
+ *   the same reason they're excluded everywhere else: dependency trees and
+ *   build output aren't a mind's creative work and don't belong in git history.
+ *
+ * Kept in manual sync with templates/_base/gitignore (search there for "#656").
  */
 const NEVER_RESCUE_PREFIXES = ["home/.claude/", "home/.pi/", "home/.agents/"];
+const NEVER_RESCUE_SEGMENTS = new Set(["node_modules", "dist"]);
+
+function isRescuable(path: string): boolean {
+  if (NEVER_RESCUE_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
+  return !path.split("/").some((segment) => NEVER_RESCUE_SEGMENTS.has(segment));
+}
 
 /**
  * Force-stage any file a mind created directly under home/ that .gitignore's
@@ -47,13 +56,15 @@ const NEVER_RESCUE_PREFIXES = ["home/.claude/", "home/.pi/", "home/.agents/"];
  * in the variant's working tree — and `cleanupVariant`'s `git worktree remove`
  * deletes the working tree wholesale, destroying them (#656).
  *
- * SDK runtime noise under home/.claude/, home/.pi/, home/.agents/ (minus their
- * whitelisted skills/settings, which are already tracked normally) stays
- * excluded — resurrecting it would reintroduce the inversion PR #661 fixed.
+ * Deliberately-ignored SDK runtime noise and build/dependency output (see
+ * {@link isRescuable}) stay excluded — resurrecting either would bake noise or
+ * unrelated build artifacts into the parent's permanent git history.
  *
  * Call this before the pre-merge auto-commit in the variant's own worktree, so
  * the rescued files land in a real commit on the variant branch and merge into
- * the parent like any other change.
+ * the parent like any other change. Never throws — a scan or stage failure is
+ * logged and treated as "nothing to rescue," falling back to the pre-#656
+ * behavior for that join rather than blocking it.
  *
  * @returns the repo-relative paths that were force-added.
  */
@@ -62,7 +73,7 @@ export async function rescueIgnoredHomeFiles(cwd: string): Promise<string[]> {
   let raw: string;
   try {
     raw = await gitExec(
-      ["status", "--porcelain=v1", "-z", "--ignored=matching", "--", "home"],
+      ["ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", "home"],
       opts,
     );
   } catch (err) {
@@ -70,26 +81,20 @@ export async function rescueIgnoredHomeFiles(cwd: string): Promise<string[]> {
     return [];
   }
 
-  const candidates: string[] = [];
-  for (const entry of raw.split("\0")) {
-    if (!entry.startsWith("!! ")) continue;
-    const path = entry.slice(3);
-    if (NEVER_RESCUE_PREFIXES.some((prefix) => path.startsWith(prefix))) continue;
-    candidates.push(path);
-  }
-  if (candidates.length === 0) return [];
+  const rescued = raw.split("\0").filter((path) => path && isRescuable(path));
+  if (rescued.length === 0) return [];
 
   try {
-    await gitExec(["add", "-f", "--", ...candidates], opts);
+    await gitExec(["add", "-f", "--", ...rescued], opts);
   } catch (err) {
     log.warn(
-      `variant join: failed to rescue ignored home/ files: ${candidates.join(", ")}`,
+      `variant join: failed to rescue ignored home/ files: ${rescued.join(", ")}`,
       log.errorData(err),
     );
     return [];
   }
-  log.info(`variant join: rescued gitignored home/ files: ${candidates.join(", ")}`);
-  return candidates;
+  log.info(`variant join: rescued gitignored home/ files: ${rescued.join(", ")}`);
+  return rescued;
 }
 
 /**

--- a/packages/daemon/src/lib/mind/variants.ts
+++ b/packages/daemon/src/lib/mind/variants.ts
@@ -26,6 +26,73 @@ const MERGE_EXCLUDED_PATHS = ["home/MEMORY.md", "home/memory/journal/"];
 const MAX_DELTA_CHARS = 12000;
 
 /**
+ * Paths under home/ that the platform deliberately keeps untracked — SDK runtime
+ * session state and backups (`.claude/projects`, `.claude/backups`, etc.), fixed
+ * by PR #661's gitignore rules so this noise stops merging into parents. The
+ * rescue below must never resurrect these, even though they're ignored by the
+ * same `home/*` catch-all that also blocks a mind's genuine new files.
+ *
+ * Kept in manual sync with the re-ignore rules in templates/_base/gitignore
+ * (search there for "#656") — adding a new deliberately-ignored subdirectory
+ * under home/ needs a matching prefix here, or its noise gets force-added and
+ * merged into the parent.
+ */
+const NEVER_RESCUE_PREFIXES = ["home/.claude/", "home/.pi/", "home/.agents/"];
+
+/**
+ * Force-stage any file a mind created directly under home/ that .gitignore's
+ * `home/*` catch-all silently blocks from tracking. New top-level home/ files
+ * are the normal creative path variants exist to support, but auto-commit's
+ * `git add` no-ops on them (it only logs the failure), so they sit uncommitted
+ * in the variant's working tree — and `cleanupVariant`'s `git worktree remove`
+ * deletes the working tree wholesale, destroying them (#656).
+ *
+ * SDK runtime noise under home/.claude/, home/.pi/, home/.agents/ (minus their
+ * whitelisted skills/settings, which are already tracked normally) stays
+ * excluded — resurrecting it would reintroduce the inversion PR #661 fixed.
+ *
+ * Call this before the pre-merge auto-commit in the variant's own worktree, so
+ * the rescued files land in a real commit on the variant branch and merge into
+ * the parent like any other change.
+ *
+ * @returns the repo-relative paths that were force-added.
+ */
+export async function rescueIgnoredHomeFiles(cwd: string): Promise<string[]> {
+  const opts = { cwd };
+  let raw: string;
+  try {
+    raw = await gitExec(
+      ["status", "--porcelain=v1", "-z", "--ignored=matching", "--", "home"],
+      opts,
+    );
+  } catch (err) {
+    log.warn("variant join: failed to scan for ignored home/ files", log.errorData(err));
+    return [];
+  }
+
+  const candidates: string[] = [];
+  for (const entry of raw.split("\0")) {
+    if (!entry.startsWith("!! ")) continue;
+    const path = entry.slice(3);
+    if (NEVER_RESCUE_PREFIXES.some((prefix) => path.startsWith(prefix))) continue;
+    candidates.push(path);
+  }
+  if (candidates.length === 0) return [];
+
+  try {
+    await gitExec(["add", "-f", "--", ...candidates], opts);
+  } catch (err) {
+    log.warn(
+      `variant join: failed to rescue ignored home/ files: ${candidates.join(", ")}`,
+      log.errorData(err),
+    );
+    return [];
+  }
+  log.info(`variant join: rescued gitignored home/ files: ${candidates.join(", ")}`);
+  return candidates;
+}
+
+/**
  * Merge a variant branch into the parent worktree, excluding the mind's living
  * memory (MEMORY.md, memory/journal/) from the textual merge. The parent keeps
  * its own copy of those files; the variant's delta is returned so it can be

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -93,7 +93,11 @@ import { evaluateSeedChecklist } from "../../lib/mind/seed-readiness.js";
 import { isTemplateStale } from "../../lib/mind/template-staleness.js";
 import { applyThinkingLevel, deriveThinkingLevel } from "../../lib/mind/thinking-config.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
-import { mergeVariantExcludingMemory, validateBranchName } from "../../lib/mind/variants.js";
+import {
+  mergeVariantExcludingMemory,
+  rescueIgnoredHomeFiles,
+  validateBranchName,
+} from "../../lib/mind/variants.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
 import { PLATFORMS } from "../../lib/platforms.js";
 import {
@@ -1572,6 +1576,14 @@ const app = new Hono<AuthEnv>()
 
           // Auto-commit variant worktree
           if (existsSync(variantEntry.dir)) {
+            // Force-stage new home/ files .gitignore's `home/*` catch-all silently
+            // blocked from tracking — a mind's normal creative path. Without this,
+            // `git status --porcelain` below never sees them (git only reports
+            // ignored paths under --ignored), so they'd stay uncommitted and die
+            // when the variant worktree is deleted after merge (#656). Never throws
+            // — failures are logged internally and the join proceeds either way.
+            await rescueIgnoredHomeFiles(variantEntry.dir);
+
             const status = (
               await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })
             ).trim();

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -94,8 +94,9 @@ import { isTemplateStale } from "../../lib/mind/template-staleness.js";
 import { applyThinkingLevel, deriveThinkingLevel } from "../../lib/mind/thinking-config.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
 import {
+  findUnresolvedHomeFiles,
+  formatUnresolvedHomeFilesMessage,
   mergeVariantExcludingMemory,
-  rescueIgnoredHomeFiles,
   validateBranchName,
 } from "../../lib/mind/variants.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
@@ -1573,17 +1574,10 @@ const app = new Hono<AuthEnv>()
           variantEntry.branch
         ) {
           const projectRoot = mindDir(baseName);
+          const discardUnresolved = context.discardUnresolvedHomeFiles === true;
 
           // Auto-commit variant worktree
           if (existsSync(variantEntry.dir)) {
-            // Force-stage new home/ files .gitignore's `home/*` catch-all silently
-            // blocked from tracking — a mind's normal creative path. Without this,
-            // `git status --porcelain` below never sees them (git only reports
-            // ignored paths under --ignored), so they'd stay uncommitted and die
-            // when the variant worktree is deleted after merge (#656). Never throws
-            // — failures are logged internally and the join proceeds either way.
-            await rescueIgnoredHomeFiles(variantEntry.dir);
-
             const status = (
               await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })
             ).trim();
@@ -1617,18 +1611,61 @@ const app = new Hono<AuthEnv>()
             }
           }
 
-          // Merge (excluding the mind's living memory/journal — #440), narrate
-          // the memory delta to the parent, then clean up worktree/branch and
-          // reinstall if the merge touched dependencies.
+          // Merge (excluding the mind's living memory/journal — #440); clean up
+          // worktree/branch and reinstall if the merge touched dependencies, and
+          // narrate the memory delta — but only once cleanup actually happens (see
+          // below). Telling the parent "your variant has returned, merged into you"
+          // (the merge_message prompt, keyed off context.type === "merge") while
+          // the variant is still sitting there unresolved would be a straight-up lie.
           const preMergeHead = (await gitExec(["rev-parse", "HEAD"], { cwd: projectRoot })).trim();
           const memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantEntry.branch);
-          if (memoryDelta && context) context.memoryDelta = memoryDelta;
-          await cleanupVariant(mergeVariantName, baseName, projectRoot, variantEntry.dir);
-          if (await npmInstallNeeded(projectRoot, preMergeHead)) {
+
+          // The daemon can't know what's precious in a mind's home/, so it never
+          // guesses. Checked here, right before the one genuinely destructive step
+          // (`cleanupVariant`'s `git worktree remove`) — the merge above already
+          // landed (it only pulls in what the variant committed, so it's safe
+          // regardless), but cleanup waits until this comes back clean. If anything
+          // is found, skip cleanup, leave the variant fully intact, and tell the
+          // parent why via a notice instead of falsely claiming the join finished (#656).
+          let unresolvedNotice: string | undefined;
+          if (existsSync(variantEntry.dir) && !discardUnresolved) {
             try {
-              await npmInstallAsMind(projectRoot, baseName);
-            } catch (e) {
-              log.error(`npm install failed after merge for ${baseName}`, log.errorData(e));
+              const unresolved = await findUnresolvedHomeFiles(variantEntry.dir);
+              if (unresolved.totalCount > 0) {
+                unresolvedNotice = formatUnresolvedHomeFilesMessage(mergeVariantName, unresolved);
+              }
+            } catch (err) {
+              unresolvedNotice = `Could not verify variant ${mergeVariantName} has no unresolved home/ files: ${err instanceof Error ? err.message : String(err)}. Variant left intact — retry the join.`;
+            }
+          }
+
+          if (unresolvedNotice) {
+            log.warn(
+              `variant join blocked for ${baseName}: ${mergeVariantName} — ${unresolvedNotice}`,
+            );
+            await recordNotice({
+              mind: baseName,
+              thread: "main",
+              kind: "join_blocked",
+              reason: "unresolved_variant_files",
+              detail: unresolvedNotice,
+            });
+            // Downgrade to a plain restart so buildPendingContextMessage doesn't fire
+            // the "your variant has returned, merged into you" prompt — nothing merged
+            // or cleaned up. The join_blocked notice above is the real story here.
+            if (context) {
+              context.type = "restart";
+              context.name = undefined;
+            }
+          } else {
+            if (memoryDelta && context) context.memoryDelta = memoryDelta;
+            await cleanupVariant(mergeVariantName, baseName, projectRoot, variantEntry.dir);
+            if (await npmInstallNeeded(projectRoot, preMergeHead)) {
+              try {
+                await npmInstallAsMind(projectRoot, baseName);
+              } catch (e) {
+                log.error(`npm install failed after merge for ${baseName}`, log.errorData(e));
+              }
             }
           }
         }

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -19,6 +19,7 @@ import { spawnServer } from "../../lib/mind/spawn-server.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
 import {
   mergeVariantExcludingMemory,
+  rescueIgnoredHomeFiles,
   VariantMergeError,
   validateBranchName,
 } from "../../lib/mind/variants.js";
@@ -330,6 +331,14 @@ const app = new Hono<AuthEnv>()
     try {
       // Auto-commit any uncommitted changes in the variant worktree
       if (existsSync(variantEntry.dir)) {
+        // Force-stage new home/ files .gitignore's `home/*` catch-all silently
+        // blocked from tracking — a mind's normal creative path. Without this,
+        // `git status --porcelain` below never sees them (only `--ignored` does),
+        // so they'd stay uncommitted and die when the variant worktree is removed
+        // after merge (#656). Never throws — failures are logged internally and
+        // the join proceeds either way.
+        await rescueIgnoredHomeFiles(variantEntry.dir);
+
         const status = (await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })).trim();
         if (status) {
           try {

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -18,8 +18,9 @@ import {
 import { spawnServer } from "../../lib/mind/spawn-server.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
 import {
+  findUnresolvedHomeFiles,
+  formatUnresolvedHomeFilesMessage,
   mergeVariantExcludingMemory,
-  rescueIgnoredHomeFiles,
   VariantMergeError,
   validateBranchName,
 } from "../../lib/mind/variants.js";
@@ -267,8 +268,13 @@ const app = new Hono<AuthEnv>()
     const branchErr = validateBranchName(variantEntry.branch);
     if (branchErr) return c.json({ error: branchErr }, 400);
 
-    let body: { summary?: string; justification?: string; memory?: string; skipVerify?: boolean } =
-      {};
+    let body: {
+      summary?: string;
+      justification?: string;
+      memory?: string;
+      skipVerify?: boolean;
+      discardUnresolved?: boolean;
+    } = {};
     try {
       body = await c.req.json();
     } catch {
@@ -284,7 +290,11 @@ const app = new Hono<AuthEnv>()
     // recurses — owned root:root, locking the still-running mind out of its own
     // files. Hand ownership back before returning; surface a restore failure,
     // since under isolation it means root-owned files were left behind.
-    const failAfterGitWrite = async (message: string, extra?: Record<string, unknown>) => {
+    const failAfterGitWrite = async (
+      message: string,
+      extra?: Record<string, unknown>,
+      status: 409 | 500 = 500,
+    ) => {
       try {
         await chownMindDir(projectRoot, mindName);
       } catch (err) {
@@ -300,7 +310,7 @@ const app = new Hono<AuthEnv>()
           500,
         );
       }
-      return c.json({ error: message, ...extra }, 500);
+      return c.json({ error: message, ...extra }, status);
     };
 
     // Give the variant one final turn to wind down before it's merged and
@@ -331,14 +341,6 @@ const app = new Hono<AuthEnv>()
     try {
       // Auto-commit any uncommitted changes in the variant worktree
       if (existsSync(variantEntry.dir)) {
-        // Force-stage new home/ files .gitignore's `home/*` catch-all silently
-        // blocked from tracking — a mind's normal creative path. Without this,
-        // `git status --porcelain` below never sees them (only `--ignored` does),
-        // so they'd stay uncommitted and die when the variant worktree is removed
-        // after merge (#656). Never throws — failures are logged internally and
-        // the join proceeds either way.
-        await rescueIgnoredHomeFiles(variantEntry.dir);
-
         const status = (await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })).trim();
         if (status) {
           try {
@@ -416,6 +418,37 @@ const app = new Hono<AuthEnv>()
             : "Merge failed. Resolve conflicts in the variant and retry the join.",
           { conflicts: err.conflicts },
         );
+      }
+
+      // The daemon can't know what's precious in a mind's home/ — a download, a cloned
+      // repo, a venv could all be exactly what the mind wants kept, so it never guesses.
+      // Checked here, right before the one genuinely destructive step (`cleanupVariant`'s
+      // `git worktree remove`), so it also catches anything the farewell turn above just
+      // wrote — an earlier check, before the farewell turn ran, could miss those. The
+      // merge above already landed (it only pulls in what the variant committed, so it's
+      // safe regardless), but cleanup — and with it, the point of no return — waits until
+      // this comes back clean. Retrying the same join later resumes cleanly: a no-op
+      // merge next time, then cleanup, once the files are resolved.
+      if (existsSync(variantEntry.dir) && !body.discardUnresolved) {
+        let unresolved: Awaited<ReturnType<typeof findUnresolvedHomeFiles>>;
+        try {
+          unresolved = await findUnresolvedHomeFiles(variantEntry.dir);
+        } catch (err) {
+          return failAfterGitWrite(
+            `Could not verify variant ${variantName} has no unresolved home/ files: ${err instanceof Error ? err.message : String(err)}. Variant left intact — retry the join.`,
+          );
+        }
+        if (unresolved.totalCount > 0) {
+          return failAfterGitWrite(
+            formatUnresolvedHomeFilesMessage(variantName, unresolved),
+            {
+              unresolvedFiles: unresolved.files,
+              unresolvedCount: unresolved.totalCount,
+              unresolvedBytes: unresolved.totalBytes,
+            },
+            409,
+          );
+        }
       }
 
       await cleanupVariant(variantName, mindName, projectRoot, variantEntry.dir, { stop: true });

--- a/templates/_base/src/lib/auto-commit.ts
+++ b/templates/_base/src/lib/auto-commit.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { resolve } from "node:path";
-import { log } from "./logger.js";
+import { log, warn } from "./logger.js";
 
 function gitArgs(args: string[]): string[] {
   return process.env.VOLUTE_ISOLATION === "user" ? ["-c", "safe.directory=*", ...args] : args;
@@ -63,15 +63,37 @@ export function flushFileChanges(cwd?: string): Promise<void> {
   const effectiveCwd = cwd ?? process.cwd();
 
   pending = pending.then(async () => {
-    // Commit mind's own files
+    // Commit mind's own files. Only files that actually staged go into the commit
+    // message — a file `git add` couldn't stage (typically because it's gitignored)
+    // must never be named alongside files that really did commit, or the mind is
+    // told its work is safe when it isn't (#656).
     if (filesToCommit.length > 0) {
+      const staged: string[] = [];
+      const blocked: string[] = [];
       for (const f of filesToCommit) {
-        if ((await exec("git", ["add", f], effectiveCwd)).code !== 0) {
-          log("auto-commit", `git add failed for ${f}`);
+        if ((await exec("git", ["add", f], effectiveCwd)).code === 0) {
+          staged.push(f);
+        } else {
+          blocked.push(f);
         }
       }
-      if ((await exec("git", ["diff", "--cached", "--quiet"], effectiveCwd)).code !== 0) {
-        const names = filesToCommit.map((f) => f.replace(/^.*\//, "")).join(", ");
+      if (blocked.length > 0) {
+        const pronoun = blocked.length === 1 ? "it" : "they";
+        warn(
+          "auto-commit",
+          `git add failed for ${blocked.join(", ")} — likely gitignored, so ` +
+            `${pronoun} will NOT be committed or survive a variant join`,
+        );
+      }
+      // staged.length check guards against committing under a blank "Update "
+      // message when every file in this batch was blocked — `diff --cached` can
+      // still be non-empty from unrelated content already in the index (e.g. the
+      // mind ran `git add` itself), which isn't this batch's to name or claim.
+      if (
+        staged.length > 0 &&
+        (await exec("git", ["diff", "--cached", "--quiet"], effectiveCwd)).code !== 0
+      ) {
+        const names = staged.map((f) => f.replace(/^.*\//, "")).join(", ");
         const message = `Update ${names}`;
         if ((await exec("git", ["commit", "-m", message], effectiveCwd)).code === 0) {
           log("auto-commit", message);

--- a/templates/_base/src/lib/auto-commit.ts
+++ b/templates/_base/src/lib/auto-commit.ts
@@ -111,20 +111,36 @@ export function flushFileChanges(cwd?: string): Promise<void> {
       }
     }
 
-    // Commit collaborative pages worktree files
+    // Commit collaborative pages worktree files. Same rule as the mind's own
+    // files above: only what actually staged gets named in the commit message.
     if (sharedToCommit.length > 0) {
       const sharedCwd = resolve(effectiveCwd, "pages", "_system");
       const sharedPrefix = "pages/_system/";
       const mindName = process.env.VOLUTE_MIND ?? "unknown";
 
+      const sharedStaged: string[] = [];
+      const sharedBlocked: string[] = [];
       for (const f of sharedToCommit) {
         const sharedRelative = f.slice(sharedPrefix.length);
-        if ((await exec("git", gitArgs(["add", sharedRelative]), sharedCwd)).code !== 0) {
-          log("auto-commit", `git add failed for pages/_system/${sharedRelative}`);
+        if ((await exec("git", gitArgs(["add", sharedRelative]), sharedCwd)).code === 0) {
+          sharedStaged.push(f);
+        } else {
+          sharedBlocked.push(f);
         }
       }
-      if ((await exec("git", gitArgs(["diff", "--cached", "--quiet"]), sharedCwd)).code !== 0) {
-        const names = sharedToCommit
+      if (sharedBlocked.length > 0) {
+        const pronoun = sharedBlocked.length === 1 ? "it" : "they";
+        warn(
+          "auto-commit",
+          `git add failed for ${sharedBlocked.join(", ")} — likely gitignored, so ` +
+            `${pronoun} will NOT be committed`,
+        );
+      }
+      if (
+        sharedStaged.length > 0 &&
+        (await exec("git", gitArgs(["diff", "--cached", "--quiet"]), sharedCwd)).code !== 0
+      ) {
+        const names = sharedStaged
           .map((f) => f.slice(sharedPrefix.length).replace(/^.*\//, ""))
           .join(", ");
         const message = `Update ${names}`;

--- a/test/auto-commit.test.ts
+++ b/test/auto-commit.test.ts
@@ -126,4 +126,44 @@ describe("auto-commit batching", () => {
       "auto-commit must not create a commit when nothing it tracked actually staged",
     );
   });
+
+  it("does not claim a gitignored pages/_system file in the shared commit message (#656)", async () => {
+    const { trackFileChange, flushFileChanges } = await import(
+      "../templates/_base/src/lib/auto-commit.js"
+    );
+
+    const sharedDir = join(repoDir, "pages", "_system");
+    mkdirSync(sharedDir, { recursive: true });
+    git(["init", "-b", "main"], sharedDir);
+    git(["config", "user.email", "test@test.com"], sharedDir);
+    git(["config", "user.name", "Test"], sharedDir);
+    writeFileSync(join(sharedDir, ".gitignore"), "draft.md\n");
+    writeFileSync(join(sharedDir, "index.md"), "page");
+    git(["add", "-A"], sharedDir);
+    git(["commit", "-m", "initial"], sharedDir);
+
+    writeFileSync(join(sharedDir, "index.md"), "page v2");
+    writeFileSync(join(sharedDir, "draft.md"), "a draft gitignore blocks");
+
+    trackFileChange("pages/_system/index.md", repoDir);
+    trackFileChange("pages/_system/draft.md", repoDir);
+
+    await flushFileChanges(repoDir);
+
+    const lastMsg = git(["log", "-1", "--format=%s"], sharedDir).trim();
+    assert.ok(
+      lastMsg.includes("index.md"),
+      `Expected shared commit to mention index.md: ${lastMsg}`,
+    );
+    assert.ok(
+      !lastMsg.includes("draft.md"),
+      `Shared commit message must not claim draft.md was committed when git add failed: ${lastMsg}`,
+    );
+
+    const committedFiles = git(["show", "--name-only", "--format=", "HEAD"], sharedDir).trim();
+    assert.ok(
+      !committedFiles.includes("draft.md"),
+      "draft.md must not be in the shared commit tree",
+    );
+  });
 });

--- a/test/auto-commit.test.ts
+++ b/test/auto-commit.test.ts
@@ -73,4 +73,57 @@ describe("auto-commit batching", () => {
 
     assert.equal(beforeCount, afterCount, "No commit should be created when no files are pending");
   });
+
+  it("does not claim a gitignored file in the commit message (#656)", async () => {
+    const { trackFileChange, flushFileChanges } = await import(
+      "../templates/_base/src/lib/auto-commit.js"
+    );
+
+    // A new top-level home/ file gitignore blocks, alongside a normal file —
+    // mirrors the reported repro (NOTE.md silently dropped by home/*).
+    writeFileSync(join(repoDir, ".gitignore"), "NOTE.md\n");
+    writeFileSync(join(repoDir, "SOUL.md"), "soul v3");
+    writeFileSync(join(repoDir, "NOTE.md"), "the variant's new note");
+
+    trackFileChange("SOUL.md", repoDir);
+    trackFileChange("NOTE.md", repoDir);
+
+    await flushFileChanges(repoDir);
+
+    const lastMsg = git(["log", "-1", "--format=%s"], repoDir).trim();
+    assert.ok(lastMsg.includes("SOUL.md"), `Expected commit to mention SOUL.md: ${lastMsg}`);
+    assert.ok(
+      !lastMsg.includes("NOTE.md"),
+      `Commit message must not claim NOTE.md was committed when git add failed: ${lastMsg}`,
+    );
+
+    // The commit really doesn't contain it — the message wasn't just wrong,
+    // git add genuinely failed on the gitignored path.
+    const committedFiles = git(["show", "--name-only", "--format=", "HEAD"], repoDir).trim();
+    assert.ok(!committedFiles.includes("NOTE.md"), "NOTE.md must not be in the commit tree");
+  });
+
+  it("does not commit a blank message when every tracked file is blocked", async () => {
+    const { trackFileChange, flushFileChanges } = await import(
+      "../templates/_base/src/lib/auto-commit.js"
+    );
+
+    // Stray content already staged by something other than this flush (e.g. the
+    // mind ran `git add` itself) — must not be claimed by an unrelated blank commit.
+    writeFileSync(join(repoDir, "unrelated.txt"), "pre-staged by someone else");
+    git(["add", "unrelated.txt"], repoDir);
+
+    writeFileSync(join(repoDir, "NOTE.md"), "the variant's new note, still ignored");
+    trackFileChange("NOTE.md", repoDir);
+
+    const beforeCount = git(["rev-list", "--count", "HEAD"], repoDir).trim();
+    await flushFileChanges(repoDir);
+    const afterCount = git(["rev-list", "--count", "HEAD"], repoDir).trim();
+
+    assert.equal(
+      beforeCount,
+      afterCount,
+      "auto-commit must not create a commit when nothing it tracked actually staged",
+    );
+  });
 });

--- a/test/variant-merge.test.ts
+++ b/test/variant-merge.test.ts
@@ -3,8 +3,9 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
+  findUnresolvedHomeFiles,
+  formatUnresolvedHomeFilesMessage,
   mergeVariantExcludingMemory,
-  rescueIgnoredHomeFiles,
   VariantMergeError,
 } from "../packages/daemon/src/lib/mind/variants.js";
 import { findTemplatesRoot } from "../packages/daemon/src/lib/template/template.js";
@@ -205,12 +206,12 @@ describe("mergeVariantExcludingMemory", () => {
   });
 });
 
-describe("rescueIgnoredHomeFiles (#656)", () => {
+describe("findUnresolvedHomeFiles / formatUnresolvedHomeFilesMessage (#656)", () => {
   // A real worktree pair (not just branches) so we can reproduce the actual
   // destructive step at join: `git worktree remove` deletes everything left
   // uncommitted on disk, ignored or not.
-  const parent = resolve("/tmp", `variant-rescue-test-${process.pid}`);
-  const variantDir = resolve("/tmp", `variant-rescue-test-${process.pid}-variant`);
+  const parent = resolve("/tmp", `variant-unresolved-test-${process.pid}`);
+  const variantDir = resolve("/tmp", `variant-unresolved-test-${process.pid}-variant`);
   const templateGitignore = readFileSync(
     resolve(findTemplatesRoot(), "_base", "gitignore"),
     "utf-8",
@@ -252,59 +253,119 @@ describe("rescueIgnoredHomeFiles (#656)", () => {
     rmSync(variantDir, { recursive: true, force: true });
   });
 
-  it("force-adds new home/ files .gitignore blocks, but leaves SDK runtime noise alone", async () => {
+  it("finds new home/ files .gitignore blocks, with sizes, but leaves SDK runtime noise alone", async () => {
     // The mind's normal creative path: a brand-new top-level home/ file. The
     // `home/*` catch-all ignores it, exactly as it ignored MANIFESTO.md/NOTE.md
-    // in the reported repro.
+    // in the reported repro. Nothing here is force-added — only reported.
     writeFileSync(resolve(variantDir, "home/NOTE.md"), "hello from the variant\n");
 
-    // SDK runtime noise that PR #661 deliberately keeps ignored — must not be
-    // resurrected by the rescue.
+    // SDK runtime noise that PR #661 deliberately keeps ignored — the daemon's own
+    // regenerated-every-session plumbing, not a mind's content, so it must never
+    // show up as something the mind is asked to resolve.
     mkdirSync(resolve(variantDir, "home/.claude/projects"), { recursive: true });
     writeFileSync(resolve(variantDir, "home/.claude/projects/transcript.jsonl"), "{}\n");
 
-    const rescued = await rescueIgnoredHomeFiles(variantDir);
+    const result = await findUnresolvedHomeFiles(variantDir);
 
-    assert.deepEqual(rescued, ["home/NOTE.md"]);
+    assert.equal(result.totalCount, 1);
+    assert.equal(result.files.length, 1);
+    assert.equal(result.files[0].path, "home/NOTE.md");
+    assert.equal(result.files[0].bytes, "hello from the variant\n".length);
+    assert.equal(result.totalBytes, "hello from the variant\n".length);
 
-    const staged = (await variantGit("diff", "--cached", "--name-only")).trim().split("\n");
-    assert.ok(staged.includes("home/NOTE.md"), "new home/ file should be staged");
-    assert.ok(
-      !staged.includes("home/.claude/projects/transcript.jsonl"),
-      "SDK runtime noise must stay unstaged",
+    // Nothing was staged — this is pure detection, no side effects.
+    const staged = (await variantGit("diff", "--cached", "--name-only")).trim();
+    assert.equal(staged, "", "detection must not stage anything");
+  });
+
+  it("caps the listed files but keeps the true count and total size", async () => {
+    for (let i = 0; i < 25; i++) {
+      writeFileSync(resolve(variantDir, `home/file-${i}.bin`), "x".repeat(10));
+    }
+
+    const result = await findUnresolvedHomeFiles(variantDir);
+
+    assert.equal(result.totalCount, 25);
+    assert.ok(result.files.length < 25, "listing should be capped");
+    assert.equal(result.totalBytes, 250, "total size covers every file, not just the listed ones");
+  });
+
+  it("formats an actionable message naming paths, sizes, and the three resolution options", async () => {
+    mkdirSync(resolve(variantDir, "home/downloads"), { recursive: true });
+    writeFileSync(resolve(variantDir, "home/downloads/movie.mp4"), "x".repeat(2048));
+
+    const result = await findUnresolvedHomeFiles(variantDir);
+    const message = formatUnresolvedHomeFilesMessage("my-variant", result);
+
+    assert.match(message, /my-variant/);
+    assert.match(message, /downloads\/movie\.mp4/);
+    assert.match(message, /2\.0 KB/);
+    assert.match(message, /git add -f/);
+    assert.match(message, /[Cc]opy it out/);
+    assert.match(message, /[Dd]elete it/);
+    assert.match(message, /discardUnresolved/);
+  });
+
+  it("reports nothing when the variant has no untracked home/ files", async () => {
+    writeFileSync(resolve(variantDir, "home/SOUL.md"), "# Soul\nupdated\n");
+    await variantGit("add", "-A");
+    await variantGit("commit", "-m", "tracked change only");
+
+    const result = await findUnresolvedHomeFiles(variantDir);
+
+    assert.equal(result.totalCount, 0);
+    assert.equal(result.files.length, 0);
+    assert.equal(result.totalBytes, 0);
+  });
+
+  it("a variant's new home/ file survives a join that's blocked on it — nothing is destroyed", async () => {
+    // Mirrors the reported repro: the mind writes a new top-level home/ file, never
+    // committed (gitignored). This test proves the actual safety property the redesign
+    // exists for: the file is still there, byte-for-byte, after a join attempt that
+    // finds it unresolved — not silently gone, the way the pre-fix code left it.
+    writeFileSync(resolve(variantDir, "home/NOTE.md"), "hello from the variant\n");
+
+    const unresolved = await findUnresolvedHomeFiles(variantDir);
+    assert.equal(
+      unresolved.totalCount,
+      1,
+      "the new file must be detected before anything destructive runs",
+    );
+
+    // The production join flow (web/api/variants.ts, web/api/minds.ts) checks this
+    // and — finding something — returns/notices instead of calling cleanupVariant.
+    // Simulate that decision directly: skip cleanup entirely.
+    if (unresolved.totalCount === 0) {
+      await parentGit("worktree", "remove", "--force", variantDir);
+    }
+
+    // The variant worktree is untouched: still there, file still exactly as written.
+    assert.ok(existsSync(variantDir), "variant worktree must not be removed while blocked");
+    assert.equal(
+      readFileSync(resolve(variantDir, "home/NOTE.md"), "utf-8"),
+      "hello from the variant\n",
+      "the file must survive completely intact — nothing merged, nothing discarded",
     );
   });
 
-  it("survives a variant's new home/ file across join, including worktree deletion", async () => {
-    // Mirrors the reported repro: the mind writes a new top-level home/ file.
-    // Nothing commits it — auto-commit's `git add` silently fails on the
-    // gitignored path, exactly as it does in production today.
+  it("once resolved (git add -f + commit), the retried join proceeds and the file survives via a normal merge", async () => {
     writeFileSync(resolve(variantDir, "home/NOTE.md"), "hello from the variant\n");
+    assert.equal((await findUnresolvedHomeFiles(variantDir)).totalCount, 1);
 
-    // The pre-merge safety net in the join flow (web/api/minds.ts): rescue
-    // gitignored creative work, then commit anything staged.
-    await rescueIgnoredHomeFiles(variantDir);
-    await variantGit("add", "-A");
-    const diffCode = await variantGit("diff", "--cached", "--quiet").then(
-      () => 0,
-      () => 1,
-    );
-    if (diffCode !== 0) {
-      await variantGit("commit", "-m", "Auto-commit uncommitted changes before merge");
-    }
+    // The mind resolves it — option 1 from the message: track it explicitly.
+    await variantGit("add", "-f", "--", "home/NOTE.md");
+    await variantGit("commit", "-m", "keep my note");
+
+    // Retrying the join now finds nothing unresolved, so it's safe to proceed.
+    const retried = await findUnresolvedHomeFiles(variantDir);
+    assert.equal(retried.totalCount, 0, "resolved files must no longer block the join");
 
     await mergeVariantExcludingMemory(parent, "variant");
-
-    // Join always tears down the variant worktree once merged.
     await parentGit("worktree", "remove", "--force", variantDir);
 
     assert.ok(
       existsSync(resolve(parent, "home/NOTE.md")),
-      "the variant's new home/ file must survive the join, not die with the worktree",
-    );
-    assert.equal(
-      readFileSync(resolve(parent, "home/NOTE.md"), "utf-8"),
-      "hello from the variant\n",
+      "once tracked, the file merges into the parent like any other committed change",
     );
   });
 });

--- a/test/variant-merge.test.ts
+++ b/test/variant-merge.test.ts
@@ -4,8 +4,10 @@ import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   mergeVariantExcludingMemory,
+  rescueIgnoredHomeFiles,
   VariantMergeError,
 } from "../packages/daemon/src/lib/mind/variants.js";
+import { findTemplatesRoot } from "../packages/daemon/src/lib/template/template.js";
 import { gitExec } from "../packages/daemon/src/lib/util/exec.js";
 
 const repo = resolve("/tmp", `variant-merge-test-${process.pid}`);
@@ -199,6 +201,110 @@ describe("mergeVariantExcludingMemory", () => {
     assert.doesNotMatch(
       readFileSync(resolve(repo, "home/MEMORY.md"), "utf-8"),
       /variant fact line/,
+    );
+  });
+});
+
+describe("rescueIgnoredHomeFiles (#656)", () => {
+  // A real worktree pair (not just branches) so we can reproduce the actual
+  // destructive step at join: `git worktree remove` deletes everything left
+  // uncommitted on disk, ignored or not.
+  const parent = resolve("/tmp", `variant-rescue-test-${process.pid}`);
+  const variantDir = resolve("/tmp", `variant-rescue-test-${process.pid}-variant`);
+  const templateGitignore = readFileSync(
+    resolve(findTemplatesRoot(), "_base", "gitignore"),
+    "utf-8",
+  );
+
+  async function parentGit(...args: string[]): Promise<string> {
+    return gitExec(args, { cwd: parent });
+  }
+
+  async function variantGit(...args: string[]): Promise<string> {
+    return gitExec(args, { cwd: variantDir });
+  }
+
+  beforeEach(async () => {
+    rmSync(parent, { recursive: true, force: true });
+    rmSync(variantDir, { recursive: true, force: true });
+    mkdirSync(parent, { recursive: true });
+
+    await parentGit("init", "-b", "main");
+    await parentGit("config", "user.name", "test");
+    await parentGit("config", "user.email", "test@example.com");
+
+    // Use the real template gitignore so the test tracks actual mind behavior,
+    // not a hand-rolled approximation of it.
+    writeFileSync(resolve(parent, ".gitignore"), templateGitignore);
+    mkdirSync(resolve(parent, "home"), { recursive: true });
+    writeFileSync(resolve(parent, "home/SOUL.md"), "# Soul\n");
+    await parentGit("add", "-A");
+    await parentGit("commit", "-m", "initial");
+
+    await parentGit("worktree", "add", "-b", "variant", variantDir, "main");
+    await variantGit("config", "user.name", "test");
+    await variantGit("config", "user.email", "test@example.com");
+  });
+
+  afterEach(async () => {
+    await parentGit("worktree", "remove", "--force", variantDir).catch(() => {});
+    rmSync(parent, { recursive: true, force: true });
+    rmSync(variantDir, { recursive: true, force: true });
+  });
+
+  it("force-adds new home/ files .gitignore blocks, but leaves SDK runtime noise alone", async () => {
+    // The mind's normal creative path: a brand-new top-level home/ file. The
+    // `home/*` catch-all ignores it, exactly as it ignored MANIFESTO.md/NOTE.md
+    // in the reported repro.
+    writeFileSync(resolve(variantDir, "home/NOTE.md"), "hello from the variant\n");
+
+    // SDK runtime noise that PR #661 deliberately keeps ignored — must not be
+    // resurrected by the rescue.
+    mkdirSync(resolve(variantDir, "home/.claude/projects"), { recursive: true });
+    writeFileSync(resolve(variantDir, "home/.claude/projects/transcript.jsonl"), "{}\n");
+
+    const rescued = await rescueIgnoredHomeFiles(variantDir);
+
+    assert.deepEqual(rescued, ["home/NOTE.md"]);
+
+    const staged = (await variantGit("diff", "--cached", "--name-only")).trim().split("\n");
+    assert.ok(staged.includes("home/NOTE.md"), "new home/ file should be staged");
+    assert.ok(
+      !staged.includes("home/.claude/projects/transcript.jsonl"),
+      "SDK runtime noise must stay unstaged",
+    );
+  });
+
+  it("survives a variant's new home/ file across join, including worktree deletion", async () => {
+    // Mirrors the reported repro: the mind writes a new top-level home/ file.
+    // Nothing commits it — auto-commit's `git add` silently fails on the
+    // gitignored path, exactly as it does in production today.
+    writeFileSync(resolve(variantDir, "home/NOTE.md"), "hello from the variant\n");
+
+    // The pre-merge safety net in the join flow (web/api/minds.ts): rescue
+    // gitignored creative work, then commit anything staged.
+    await rescueIgnoredHomeFiles(variantDir);
+    await variantGit("add", "-A");
+    const diffCode = await variantGit("diff", "--cached", "--quiet").then(
+      () => 0,
+      () => 1,
+    );
+    if (diffCode !== 0) {
+      await variantGit("commit", "-m", "Auto-commit uncommitted changes before merge");
+    }
+
+    await mergeVariantExcludingMemory(parent, "variant");
+
+    // Join always tears down the variant worktree once merged.
+    await parentGit("worktree", "remove", "--force", variantDir);
+
+    assert.ok(
+      existsSync(resolve(parent, "home/NOTE.md")),
+      "the variant's new home/ file must survive the join, not die with the worktree",
+    );
+    assert.equal(
+      readFileSync(resolve(parent, "home/NOTE.md"), "utf-8"),
+      "hello from the variant\n",
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #656 — the data-loss half. (#661 already fixed the "inversion" half: `.claude` runtime noise no longer merges into parents.)

**Mechanism:** a variant's new top-level `home/` files (e.g. `NOTE.md`, `MANIFESTO.md`) are blocked from tracking by `.gitignore`'s `home/*` catch-all — the normal creative path variants exist for. Auto-commit's `git add` silently no-ops on them, but the batched commit message still named the file as if it had committed (`templates/_base/src/lib/auto-commit.ts`). The file sat uncommitted in the variant's working tree, and `cleanupVariant`'s `git worktree remove --force` destroyed it wholesale at join — twice reproduced in production.

**Design — notify-and-block, not force-add:** an earlier version of this PR force-staged (`git add -f`) any gitignored `home/` file at join time, denylisting a few known-safe-to-drop paths. That was the wrong shape: `.gitignore`'s `home/*` rule is deliberately "ignore unless allowlisted," because a mind's `home/` can hold anything — large downloads, cloned repos, build output, a `node_modules` it actually wants. The daemon has no way to know what's precious. Force-adding with a denylist inverts the policy into "commit unless denylisted," which fails open: it would have force-committed a mind's own dependency tree or a downloaded video into the parent's permanent git history. The fix instead **never guesses** — it tells the mind exactly what's at risk and refuses to complete the join until it's resolved.

**Fix:**
- `findUnresolvedHomeFiles()` (new, `packages/daemon/src/lib/mind/variants.ts`) scans a variant's `home/` for every file `.gitignore` hides that's still sitting uncommitted on disk, with per-file byte sizes (capped listing, but true count/total size always accurate). It excludes only the SDK's own permanently-ignored runtime directories — `.claude/`, `.pi/`, `.agents/` session transcripts, backups, etc. — established as never-precious by PR #661 and regenerated every session, not a new "what's safe" guess about a mind's own content. (Without this narrow exclusion, virtually every join would block by default, since any mind with conversation history has non-empty `.claude/projects/*.jsonl`.)
- `formatUnresolvedHomeFilesMessage()` renders an unmistakable, actionable message: which files, how big, and three ways to resolve each one — `git add -f` + commit, copy it out and delete it, or just delete it — plus an explicit `discardUnresolved: true` opt-in to join anyway and let them go.
- The check runs in both join paths — the `volute mind join` API route (`web/api/variants.ts`) and the mind-initiated self-merge path (`web/api/minds.ts`) — positioned **immediately before `cleanupVariant`**, the one genuinely destructive step, rather than earlier in the flow. That's deliberate: an earlier check (e.g. before the farewell turn) could miss files the variant's farewell turn itself writes on its way out. The merge itself (`mergeVariantExcludingMemory`) is allowed to proceed unconditionally — it only pulls in what's already committed, so it's safe regardless — meaning a blocked join resumes cleanly on retry: a no-op merge next time, then cleanup, once the files are resolved.
- When blocked: the API route returns `409` with the message and file list (surfaced by `volute mind join`, which gained a `--discard-unresolved` flag); the self-merge path records a `join_blocked` notice (new `NoticeKind`, `packages/daemon/src/lib/chat/system-events.ts`) for the parent to see next turn, and leaves the variant's worktree, branch, and DB row completely untouched.
- Caught in review and fixed before merge: the self-merge path originally left `context.type` as `"merge"` even when blocked, which would have delivered the parent mind a false *"your variant has returned, merged into you"* restart message (from `buildPendingContextMessage` in `mind-manager.ts`) alongside the new block notice. Blocked joins now downgrade to a plain restart context — the `join_blocked` notice is the only story the parent hears.

## Left open (consciously out of scope)

- **Base (non-variant) minds**: a new `home/` file still never gets committed for a base mind — there's no join/worktree-removal event to check against, so it stays untracked indefinitely. Not destructive today (nothing deletes a base mind's worktree), but fragile if that ever changes. Revisiting the `home/*` whitelist itself (issue's suggestion #4) would close this properly.
- A single `git add -f` failure during manual resolution (option 1 in the message) isn't specially handled here — it's a normal git error the mind sees directly when it runs the command itself, not something the daemon manages.
- `NEVER_REPORT_PREFIXES` in `variants.ts` (`.claude/`, `.pi/`, `.agents/`) is a hand-maintained list, not derived from `.gitignore`. If a future gitignore change adds another deliberately-ignored subdirectory under `home/`, its noise would start blocking joins by default until this list is updated. Commented at the definition.

## Test plan
- [x] `test/variant-merge.test.ts` — `findUnresolvedHomeFiles`/`formatUnresolvedHomeFilesMessage` suite: detects new `home/` files with correct sizes while leaving `.claude/projects` noise unreported; caps the listing while keeping true count/total size; formats an actionable message naming paths, sizes, and all three resolution options; and — the core safety proof — a variant's new `home/` file survives byte-for-byte when a join is blocked on it (worktree left untouched), while a resolved file (tracked + committed) merges normally on retry. Verified this last test fails for the right reason when cleanup is allowed to proceed unconditionally (the pre-fix behavior).
- [x] Full `npm test` (2689 tests) passes.
- [x] `tsc --noEmit`, `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
