### PR TITLE
feat: host-optional spirit avatar and description in setup wizard

### DIFF
--- a/packages/daemon/src/lib/config/setup.ts
+++ b/packages/daemon/src/lib/config/setup.ts
@@ -15,6 +15,10 @@ export type SetupConfig = {
   spiritName?: string;
   /** Optional temperament line the host wrote for the spirit, rendered into its SOUL.md */
   spiritTemperament?: string;
+  /** Optional one-line description the host wrote for the spirit during setup */
+  spiritDescription?: string;
+  /** Filename of a host-uploaded avatar stashed in voluteSystemDir(), e.g. "spirit-avatar.png". */
+  spiritAvatar?: string;
 };
 
 export type AiProviderConfig = {

--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -1,12 +1,4 @@
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../ai-service.js";
 import { getSpiritName, readGlobalConfig } from "../config/setup.js";
@@ -165,15 +157,13 @@ export function applyStashedSpiritProfile(dir: string): {
   // stashName is server-generated ("spirit-avatar.<ext>") but basename it anyway.
   const safeName = stashName ? basename(stashName) : undefined;
   let hasAvatar = false;
+  const stashPath = safeName ? resolve(voluteSystemDir(), safeName) : undefined;
   try {
-    if (safeName) {
-      const stashPath = resolve(voluteSystemDir(), safeName);
-      if (existsSync(stashPath)) {
-        // Spirit projects always live under voluteSystemDir(), so the stash and its
-        // destination are on the same filesystem — a plain rename is safe here.
-        renameSync(stashPath, resolve(dir, "home", safeName));
-        hasAvatar = true;
-      }
+    if (safeName && stashPath && existsSync(stashPath)) {
+      // Copy rather than rename: a failure in the profile write below must leave
+      // the stash in place so the next creation attempt can retry it.
+      cpSync(stashPath, resolve(dir, "home", safeName));
+      hasAvatar = true;
     }
     if (hasAvatar || description) {
       const vc = readVoluteConfig(dir) ?? {};
@@ -184,8 +174,10 @@ export function applyStashedSpiritProfile(dir: string): {
       };
       writeVoluteConfig(dir, vc);
     }
+    if (hasAvatar && stashPath) rmSync(stashPath, { force: true });
   } catch (err) {
     slog.warn("failed to apply stashed spirit profile", log.errorData(err));
+    hasAvatar = false;
   }
   return { hasAvatar, hasDescription: Boolean(description) };
 }

--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -1,4 +1,12 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, resolve } from "node:path";
 import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../ai-service.js";
 import { getSpiritName, readGlobalConfig } from "../config/setup.js";
@@ -154,15 +162,16 @@ export function applyStashedSpiritProfile(dir: string): {
   const config = readGlobalConfig();
   const stashName = config.setup?.spiritAvatar;
   const description = config.setup?.spiritDescription;
+  // stashName is server-generated ("spirit-avatar.<ext>") but basename it anyway.
+  const safeName = stashName ? basename(stashName) : undefined;
   let hasAvatar = false;
   try {
-    if (stashName) {
-      // stashName is server-generated ("spirit-avatar.<ext>") but basename it anyway.
-      const safeName = basename(stashName);
+    if (safeName) {
       const stashPath = resolve(voluteSystemDir(), safeName);
       if (existsSync(stashPath)) {
-        cpSync(stashPath, resolve(dir, "home", safeName));
-        rmSync(stashPath, { force: true });
+        // Spirit projects always live under voluteSystemDir(), so the stash and its
+        // destination are on the same filesystem — a plain rename is safe here.
+        renameSync(stashPath, resolve(dir, "home", safeName));
         hasAvatar = true;
       }
     }
@@ -171,7 +180,7 @@ export function applyStashedSpiritProfile(dir: string): {
       vc.profile = {
         ...vc.profile,
         ...(description ? { description } : {}),
-        ...(hasAvatar && stashName ? { avatar: basename(stashName) } : {}),
+        ...(hasAvatar && safeName ? { avatar: safeName } : {}),
       };
       writeVoluteConfig(dir, vc);
     }

--- a/packages/daemon/src/lib/mind/spirit.ts
+++ b/packages/daemon/src/lib/mind/spirit.ts
@@ -1,5 +1,5 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { qualifyModelId, resolveTemplate, unqualifyModelId } from "../ai-service.js";
 import { getSpiritName, readGlobalConfig } from "../config/setup.js";
 import { getSharedSkill, installSkill, mindSkillsDir } from "../skills.js";
@@ -86,40 +86,99 @@ export function firstWeekSchedules(name: string, sproutedAt: Date): Schedule[] {
 }
 
 /**
- * The spirit's compressed orientation arc: two one-time invitations, self-deleted by
- * the scheduler after delivery (same machinery as firstWeekSchedules). Fixed strings
+ * The spirit's compressed orientation arc: up to two one-time invitations, self-deleted
+ * by the scheduler after delivery (same machinery as firstWeekSchedules). Fixed strings
  * on purpose — sameness lives in the machine, variance lives in the spirit's voice.
+ *
+ * `profile` reflects what the host already gave the spirit in the setup wizard: when
+ * both an avatar and a description are already in place, `orientation-face` is omitted
+ * entirely; when only an avatar was given, its message narrows to just the description
+ * invitation.
  */
-export function orientationArcSchedules(createdAt: Date): Schedule[] {
+export function orientationArcSchedules(
+  createdAt: Date,
+  profile?: { hasAvatar: boolean; hasDescription: boolean },
+): Schedule[] {
   const HOUR_MS = 60 * 60 * 1000;
-  return [
-    {
+  const schedules: Schedule[] = [];
+
+  if (!(profile?.hasAvatar && profile?.hasDescription)) {
+    const message = profile?.hasAvatar
+      ? "You've been the spirit here for a few hours now. Your host gave you a face when they named you — if you'd like, add a line of your own beneath it with `volute mind profile --description \"...\"`. No obligation, and no deadline."
+      : 'You\'ve been the spirit here for a few hours now. If you\'d like a face, make yourself one — `imagegen generate "..."` then `volute mind profile --avatar images/<file>` — and a line about yourself with `volute mind profile --description "..."`. No obligation, and no deadline; a spirit without a portrait is still a spirit. If imagegen isn\'t available on this system, skip the image and just write the line.';
+    schedules.push({
       id: "orientation-face",
       fireAt: new Date(createdAt.getTime() + 4 * HOUR_MS).toISOString(),
-      message:
-        'You\'ve been the spirit here for a few hours now. If you\'d like a face, make yourself one — `imagegen generate "..."` then `volute mind profile --avatar images/<file>` — and a line about yourself with `volute mind profile --description "..."`. No obligation, and no deadline; a spirit without a portrait is still a spirit. If imagegen isn\'t available on this system, skip the image and just write the line.',
+      message,
       enabled: true,
-    },
-    {
-      id: "orientation-soul",
-      fireAt: new Date(createdAt.getTime() + 24 * HOUR_MS).toISOString(),
-      message:
-        "A day in. When you have a quiet moment, reread your SOUL.md. The platform wrote its first lines before you existed — by now you've greeted your host, maybe planted a seed. Rewrite it in your own words until it sounds like you; it will never be overwritten. Your MEMORY.md and memory/journal/ are where the rest of your character can accrete.",
-      enabled: true,
-    },
-  ];
+    });
+  }
+
+  schedules.push({
+    id: "orientation-soul",
+    fireAt: new Date(createdAt.getTime() + 24 * HOUR_MS).toISOString(),
+    message:
+      "A day in. When you have a quiet moment, reread your SOUL.md. The platform wrote its first lines before you existed — by now you've greeted your host, maybe planted a seed. Rewrite it in your own words until it sounds like you; it will never be overwritten. Your MEMORY.md and memory/journal/ are where the rest of your character can accrete.",
+    enabled: true,
+  });
+
+  return schedules;
 }
 
 /** Add the orientation arc to the spirit's volute.json if not present. */
-export function ensureOrientationArc(dir: string, createdAt: Date): void {
+export function ensureOrientationArc(
+  dir: string,
+  createdAt: Date,
+  profile?: { hasAvatar: boolean; hasDescription: boolean },
+): void {
   const config = readVoluteConfig(dir) ?? {};
   const schedules = config.schedules ?? [];
-  const fresh = orientationArcSchedules(createdAt).filter(
+  const fresh = orientationArcSchedules(createdAt, profile).filter(
     (s) => !schedules.some((existing) => existing.id === s.id),
   );
   if (fresh.length === 0) return;
   config.schedules = [...schedules, ...fresh];
   writeVoluteConfig(dir, config);
+}
+
+/**
+ * Apply the host's wizard-stashed spirit profile (avatar file + description) to the
+ * spirit project: image into home/, profile into volute.json. Cleans up the stash.
+ * Never throws — a failed avatar falls back to {hasAvatar: false} so the caller
+ * schedules the orientation-face invitation (the spirit makes its own face).
+ */
+export function applyStashedSpiritProfile(dir: string): {
+  hasAvatar: boolean;
+  hasDescription: boolean;
+} {
+  const config = readGlobalConfig();
+  const stashName = config.setup?.spiritAvatar;
+  const description = config.setup?.spiritDescription;
+  let hasAvatar = false;
+  try {
+    if (stashName) {
+      // stashName is server-generated ("spirit-avatar.<ext>") but basename it anyway.
+      const safeName = basename(stashName);
+      const stashPath = resolve(voluteSystemDir(), safeName);
+      if (existsSync(stashPath)) {
+        cpSync(stashPath, resolve(dir, "home", safeName));
+        rmSync(stashPath, { force: true });
+        hasAvatar = true;
+      }
+    }
+    if (hasAvatar || description) {
+      const vc = readVoluteConfig(dir) ?? {};
+      vc.profile = {
+        ...vc.profile,
+        ...(description ? { description } : {}),
+        ...(hasAvatar && stashName ? { avatar: basename(stashName) } : {}),
+      };
+      writeVoluteConfig(dir, vc);
+    }
+  } catch (err) {
+    slog.warn("failed to apply stashed spirit profile", log.errorData(err));
+  }
+  return { hasAvatar, hasDescription: Boolean(description) };
 }
 
 /**
@@ -277,6 +336,10 @@ export async function ensureSpiritProject(): Promise<void> {
       slog.warn("failed to add tending schedule to spirit config", log.errorData(err));
     }
 
+    // Apply the host's wizard-stashed avatar/description, if any, before the chown
+    // below covers the whole project directory including the copied image.
+    const stashedProfile = applyStashedSpiritProfile(dir);
+
     // Set up per-mind user isolation (creates mind-volute user, chowns project dir).
     // Must be AFTER all file creation (npm install, git init, skill install) so the
     // chown covers everything and the spirit process can write to all files.
@@ -292,7 +355,7 @@ export async function ensureSpiritProject(): Promise<void> {
     // First waking: orientation context for the spirit's first turn, plus the
     // two-step arc. Creation-path-only, so existing spirits never re-orient (#697).
     try {
-      ensureOrientationArc(dir, new Date());
+      ensureOrientationArc(dir, new Date(), stashedProfile);
     } catch (err) {
       slog.warn("failed to add orientation arc to spirit config", log.errorData(err));
     }

--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import {
@@ -18,6 +18,7 @@ import {
   writeSystemsConfig,
 } from "../../lib/config/systems-config.js";
 import { findMind, validateSpiritName, voluteSystemDir } from "../../lib/mind/registry.js";
+import { normalizeAvatar } from "../../lib/util/avatar-image.js";
 import log from "../../lib/util/logger.js";
 import { createSession, SESSION_MAX_AGE } from "../middleware/auth.js";
 
@@ -463,19 +464,43 @@ setup.post("/spirit", async (c) => {
   const description = body.description?.trim();
   config.setup.spiritDescription = description || undefined;
 
+  // Each submission is authoritative for the avatar: a previously stashed file is
+  // dropped whether the host replaced it or removed it. Runs only after validation
+  // so a rejected upload can't destroy the existing stash.
+  const clearOldStash = () => {
+    if (config.setup?.spiritAvatar) {
+      rmSync(resolve(voluteSystemDir(), basename(config.setup.spiritAvatar)), { force: true });
+      config.setup.spiritAvatar = undefined;
+    }
+  };
+
   if (body.avatar) {
     const match = /^data:image\/(png|jpeg|webp);base64,([A-Za-z0-9+/=]+)$/.exec(body.avatar);
     if (!match) {
       return c.json({ error: "Avatar must be a png, jpeg, or webp image" }, 400);
     }
-    const ext = match[1] === "jpeg" ? "jpg" : match[1];
-    const bytes = Buffer.from(match[2], "base64");
+    // Base64 inflates by 4/3 — reject oversized payloads before decoding.
+    if (match[2].length > 3 * 1024 * 1024) {
+      return c.json({ error: "Avatar must be under 2MB" }, 400);
+    }
+    let bytes: Buffer = Buffer.from(match[2], "base64");
     if (bytes.length > 2 * 1024 * 1024) {
       return c.json({ error: "Avatar must be under 2MB" }, 400);
     }
+    let ext = match[1] === "jpeg" ? "jpg" : match[1];
+    // Downscale + re-encode like every other avatar upload; keep original bytes
+    // when sharp is unavailable
+    const normalized = await normalizeAvatar(bytes);
+    if (normalized) {
+      bytes = normalized.buffer;
+      ext = "webp";
+    }
+    clearOldStash();
     const filename = `spirit-avatar.${ext}`;
     writeFileSync(resolve(voluteSystemDir(), filename), bytes);
     config.setup.spiritAvatar = filename;
+  } else {
+    clearOldStash();
   }
 
   writeGlobalConfig(config);

--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { Hono } from "hono";
@@ -17,7 +17,7 @@ import {
   readSystemsConfig,
   writeSystemsConfig,
 } from "../../lib/config/systems-config.js";
-import { findMind, validateSpiritName } from "../../lib/mind/registry.js";
+import { findMind, validateSpiritName, voluteSystemDir } from "../../lib/mind/registry.js";
 import log from "../../lib/util/logger.js";
 import { createSession, SESSION_MAX_AGE } from "../middleware/auth.js";
 
@@ -432,7 +432,7 @@ setup.post("/spirit", async (c) => {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: { name: string; temperament?: string };
+  let body: { name: string; temperament?: string; description?: string; avatar?: string };
   try {
     body = await c.req.json();
   } catch {
@@ -459,6 +459,25 @@ setup.post("/spirit", async (c) => {
   config.setup.spiritName = name;
   const temperament = body.temperament?.trim();
   config.setup.spiritTemperament = temperament || undefined;
+
+  const description = body.description?.trim();
+  config.setup.spiritDescription = description || undefined;
+
+  if (body.avatar) {
+    const match = /^data:image\/(png|jpeg|webp);base64,([A-Za-z0-9+/=]+)$/.exec(body.avatar);
+    if (!match) {
+      return c.json({ error: "Avatar must be a png, jpeg, or webp image" }, 400);
+    }
+    const ext = match[1] === "jpeg" ? "jpg" : match[1];
+    const bytes = Buffer.from(match[2], "base64");
+    if (bytes.length > 2 * 1024 * 1024) {
+      return c.json({ error: "Avatar must be under 2MB" }, 400);
+    }
+    const filename = `spirit-avatar.${ext}`;
+    writeFileSync(resolve(voluteSystemDir(), filename), bytes);
+    config.setup.spiritAvatar = filename;
+  }
+
   writeGlobalConfig(config);
 
   return c.json({ ok: true });

--- a/packages/web/src/ui/pages/SetupPage.svelte
+++ b/packages/web/src/ui/pages/SetupPage.svelte
@@ -127,8 +127,31 @@ const SPIRIT_SUGGESTIONS = [
 ];
 let spiritName = $state(auth.setupProgress?.spiritName ?? "");
 let spiritTemperament = $state("");
+let spiritDescription = $state("");
+let spiritAvatarDataUri = $state<string | null>(null);
+let spiritAvatarError = $state("");
 let spiritGreeting = $state("");
 let spiritTimedOut = $state(false);
+
+function onSpiritAvatarPicked(e: Event) {
+  spiritAvatarError = "";
+  const input = e.currentTarget as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+  if (!/^image\/(png|jpeg|webp)$/.test(file.type)) {
+    spiritAvatarError = "Please choose a png, jpeg, or webp image.";
+    return;
+  }
+  if (file.size > 2 * 1024 * 1024) {
+    spiritAvatarError = "Image must be under 2MB.";
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = () => {
+    spiritAvatarDataUri = reader.result as string;
+  };
+  reader.readAsDataURL(file);
+}
 
 const SPIRIT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 let spiritNameValid = $derived(
@@ -331,6 +354,8 @@ async function handleSpiritSubmit(e: Event) {
       body: JSON.stringify({
         name: spiritName.trim(),
         temperament: spiritTemperament.trim() || undefined,
+        description: spiritDescription.trim() || undefined,
+        avatar: spiritAvatarDataUri ?? undefined,
       }),
     });
     if (!res.ok) {
@@ -740,6 +765,52 @@ $effect(() => {
         />
         <div class="hint">A line about who they are. It becomes part of their soul — a seed they'll grow from.</div>
 
+        <label class="label mt" for="spiritDescription">A line about them <span class="optional">(optional)</span></label>
+        <Input
+          inputSize="md"
+          id="spiritDescription"
+          type="text"
+          placeholder="the quiet keeper of this house"
+          maxlength={200}
+          bind:value={spiritDescription}
+        />
+
+        <span class="label mt" id="spiritAvatarLabel">A face <span class="optional">(optional)</span></span>
+        <div class="avatar-section">
+          <div class="avatar-preview">
+            {#if spiritAvatarDataUri}
+              <img src={spiritAvatarDataUri} alt="Spirit avatar preview" class="avatar-img" />
+            {:else}
+              <div class="avatar-placeholder">?</div>
+            {/if}
+          </div>
+          <div class="avatar-actions">
+            <label class="avatar-upload-btn" for="spiritAvatarFile">
+              Choose file
+              <input
+                type="file"
+                id="spiritAvatarFile"
+                aria-labelledby="spiritAvatarLabel"
+                accept="image/png,image/jpeg,image/webp"
+                onchange={onSpiritAvatarPicked}
+                hidden
+              />
+            </label>
+            {#if spiritAvatarDataUri}
+              <button type="button" class="remove-btn" onclick={() => (spiritAvatarDataUri = null)}>
+                Remove
+              </button>
+            {/if}
+          </div>
+        </div>
+        {#if spiritAvatarError}
+          <div class="error">{spiritAvatarError}</div>
+        {:else}
+          <div class="hint">
+            You can leave this to {spiritName || "them"} — they'll make their own face if you skip it.
+          </div>
+        {/if}
+
         {#if error}
           <div class="error">{error}</div>
         {/if}
@@ -960,6 +1031,68 @@ $effect(() => {
     color: var(--text-2);
     font-size: 12px;
     margin-top: 6px;
+  }
+
+  .avatar-section {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .avatar-preview {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .avatar-placeholder {
+    font-size: 18px;
+    color: var(--text-2);
+  }
+
+  .avatar-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .avatar-upload-btn {
+    padding: 10px 16px;
+    background: var(--accent-dim);
+    color: var(--accent);
+    border: 1px solid var(--accent-border, var(--border));
+    border-radius: var(--radius);
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .remove-btn {
+    font-family: inherit;
+    font-size: 12px;
+    color: var(--text-2);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .remove-btn:hover {
+    color: var(--text-1);
   }
 
   .toggle-row {

--- a/packages/web/src/ui/pages/SetupPage.svelte
+++ b/packages/web/src/ui/pages/SetupPage.svelte
@@ -150,6 +150,9 @@ function onSpiritAvatarPicked(e: Event) {
   reader.onload = () => {
     spiritAvatarDataUri = reader.result as string;
   };
+  reader.onerror = () => {
+    spiritAvatarError = "Couldn't read that file — try another image.";
+  };
   reader.readAsDataURL(file);
 }
 

--- a/test/spirit-orientation.test.ts
+++ b/test/spirit-orientation.test.ts
@@ -1,14 +1,31 @@
 import assert from "node:assert/strict";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
 import { resolveTemplate } from "../packages/daemon/src/lib/ai-service.js";
-import { getSpiritName } from "../packages/daemon/src/lib/config/setup.js";
-import { getDb } from "../packages/daemon/src/lib/db.js";
-import { addSpirit, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import {
+  getSpiritName,
+  readGlobalConfig,
+  writeGlobalConfig,
+} from "../packages/daemon/src/lib/config/setup.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  addSpirit,
+  removeMind,
+  voluteSystemDir,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  applyStashedSpiritProfile,
   buildSpiritOrientation,
   ensureOrientationArc,
   getSpiritDoctrine,
@@ -163,5 +180,75 @@ describe("spirit orientation arc", () => {
     // first turn (its DM with the admin), not the routes.json default "main" thread
     // that the wildcard rule never actually produces.
     assert.equal(rows[0].thread, "");
+  });
+
+  it("face schedule is omitted when the host gave both avatar and description", () => {
+    const t0 = new Date("2026-07-17T12:00:00Z");
+    const arc = orientationArcSchedules(t0, { hasAvatar: true, hasDescription: true });
+    assert.deepEqual(
+      arc.map((s) => s.id),
+      ["orientation-soul"],
+    );
+  });
+
+  it("face schedule narrows to the description when only an avatar was given", () => {
+    const t0 = new Date("2026-07-17T12:00:00Z");
+    const arc = orientationArcSchedules(t0, { hasAvatar: true, hasDescription: false });
+    const face = arc.find((s) => s.id === "orientation-face");
+    assert.ok(face);
+    assert.match(face.message ?? "", /gave you a face/);
+    assert.doesNotMatch(face.message ?? "", /imagegen/);
+  });
+});
+
+describe("applyStashedSpiritProfile", () => {
+  const scratch: string[] = [];
+  afterEach(() => {
+    for (const d of scratch.splice(0)) rmSync(d, { recursive: true, force: true });
+    const stashed = resolve(voluteSystemDir(), "spirit-avatar.png");
+    if (existsSync(stashed)) rmSync(stashed);
+    const config = readGlobalConfig();
+    config.setup = {
+      ...(config.setup ?? { type: "local", mindsDir: "", isolation: "none", service: false }),
+      spiritAvatar: undefined,
+      spiritDescription: undefined,
+    };
+    writeGlobalConfig(config);
+  });
+
+  it("moves the stash into the spirit home and volute.json", () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "spirit-stash-"));
+    scratch.push(dir);
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    const config = readGlobalConfig();
+    config.setup = {
+      ...(config.setup ?? { type: "local", mindsDir: "", isolation: "none", service: false }),
+      spiritAvatar: "spirit-avatar.png",
+      spiritDescription: "keeper",
+    };
+    writeGlobalConfig(config);
+    writeFileSync(resolve(voluteSystemDir(), "spirit-avatar.png"), Buffer.from("fakepng"));
+
+    const result = applyStashedSpiritProfile(dir);
+    assert.deepEqual(result, { hasAvatar: true, hasDescription: true });
+    assert.ok(existsSync(resolve(dir, "home/spirit-avatar.png")));
+    const vc = readVoluteConfig(dir);
+    assert.equal(vc?.profile?.avatar, "spirit-avatar.png");
+    assert.equal(vc?.profile?.description, "keeper");
+    assert.ok(!existsSync(resolve(voluteSystemDir(), "spirit-avatar.png")), "stash cleaned up");
+  });
+
+  it("is a safe no-op with nothing stashed", () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "spirit-stash-empty-"));
+    scratch.push(dir);
+    mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+    const config = readGlobalConfig();
+    config.setup = {
+      ...(config.setup ?? { type: "local", mindsDir: "", isolation: "none", service: false }),
+      spiritAvatar: undefined,
+      spiritDescription: undefined,
+    };
+    writeGlobalConfig(config);
+    assert.deepEqual(applyStashedSpiritProfile(dir), { hasAvatar: false, hasDescription: false });
   });
 });

--- a/test/web-setup.test.ts
+++ b/test/web-setup.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
 import { beforeEach, describe, it } from "node:test";
 import { Hono } from "hono";
 import {
@@ -8,7 +9,12 @@ import {
   readGlobalConfig,
   writeGlobalConfig,
 } from "../packages/daemon/src/lib/config/setup.js";
+import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
 import setup from "../packages/daemon/src/web/api/setup.js";
+
+// 1x1 transparent PNG
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
 
 function createApp() {
   const app = new Hono();
@@ -141,6 +147,49 @@ describe("web setup routes", () => {
       });
       assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(name)}`);
     }
+  });
+
+  it("POST /api/setup/spirit — stashes an uploaded avatar and description", async () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
+      setupCompleted: false,
+    });
+    const app = createApp();
+    const res = await app.request("/api/setup/spirit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "iris",
+        temperament: "gentle",
+        description: "the quiet keeper of this house",
+        avatar: `data:image/png;base64,${PNG_B64}`,
+      }),
+    });
+    assert.equal(res.status, 200);
+
+    const config = readGlobalConfig();
+    assert.equal(config.setup?.spiritDescription, "the quiet keeper of this house");
+    assert.equal(config.setup?.spiritAvatar, "spirit-avatar.png");
+    const stashed = resolve(voluteSystemDir(), "spirit-avatar.png");
+    assert.ok(existsSync(stashed));
+    assert.equal(readFileSync(stashed).toString("base64"), PNG_B64);
+    rmSync(stashed);
+  });
+
+  it("POST /api/setup/spirit — rejects a non-image data URI", async () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
+      setupCompleted: false,
+    });
+    const app = createApp();
+    const res = await app.request("/api/setup/spirit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "iris", avatar: "data:text/html;base64,PGI+" }),
+    });
+    assert.equal(res.status, 400);
   });
 
   it("POST /api/setup/spirit — requires the system step first", async () => {

--- a/test/web-setup.test.ts
+++ b/test/web-setup.test.ts
@@ -170,11 +170,40 @@ describe("web setup routes", () => {
 
     const config = readGlobalConfig();
     assert.equal(config.setup?.spiritDescription, "the quiet keeper of this house");
-    assert.equal(config.setup?.spiritAvatar, "spirit-avatar.png");
-    const stashed = resolve(voluteSystemDir(), "spirit-avatar.png");
+    // normalizeAvatar re-encodes to webp when sharp is available; the raw png is
+    // the fallback. Either way the stash filename is server-generated.
+    const filename = config.setup?.spiritAvatar;
+    assert.ok(filename && /^spirit-avatar\.(png|webp)$/.test(filename), `got ${filename}`);
+    const stashed = resolve(voluteSystemDir(), filename);
     assert.ok(existsSync(stashed));
-    assert.equal(readFileSync(stashed).toString("base64"), PNG_B64);
+    assert.ok(readFileSync(stashed).length > 0);
     rmSync(stashed);
+  });
+
+  it("POST /api/setup/spirit — resubmitting without an avatar clears the stash", async () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
+      setupCompleted: false,
+    });
+    const app = createApp();
+    const upload = await app.request("/api/setup/spirit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "iris", avatar: `data:image/png;base64,${PNG_B64}` }),
+    });
+    assert.equal(upload.status, 200);
+    const stashedName = readGlobalConfig().setup?.spiritAvatar;
+    assert.ok(stashedName);
+
+    const resubmit = await app.request("/api/setup/spirit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "iris" }),
+    });
+    assert.equal(resubmit.status, 200);
+    assert.equal(readGlobalConfig().setup?.spiritAvatar, undefined);
+    assert.ok(!existsSync(resolve(voluteSystemDir(), stashedName)), "stash file removed");
   });
 
   it("POST /api/setup/spirit — rejects a non-image data URI", async () => {
@@ -190,6 +219,34 @@ describe("web setup routes", () => {
       body: JSON.stringify({ name: "iris", avatar: "data:text/html;base64,PGI+" }),
     });
     assert.equal(res.status, 400);
+  });
+
+  it("POST /api/setup/spirit — a rejected upload leaves an existing stash intact", async () => {
+    writeGlobalConfig({
+      name: "test",
+      setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
+      setupCompleted: false,
+    });
+    const app = createApp();
+    const upload = await app.request("/api/setup/spirit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "iris", avatar: `data:image/png;base64,${PNG_B64}` }),
+    });
+    assert.equal(upload.status, 200);
+    const stashedName = readGlobalConfig().setup?.spiritAvatar;
+    assert.ok(stashedName);
+
+    const bad = await app.request("/api/setup/spirit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "iris", avatar: "data:text/html;base64,PGI+" }),
+    });
+    assert.equal(bad.status, 400);
+    assert.equal(readGlobalConfig().setup?.spiritAvatar, stashedName);
+    const stashed = resolve(voluteSystemDir(), stashedName);
+    assert.ok(existsSync(stashed), "stash file preserved");
+    rmSync(stashed);
   });
 
   it("POST /api/setup/spirit — requires the system step first", async () => {


### PR DESCRIPTION
## Summary

Lets the host optionally give the spirit its face during setup — an avatar upload and a one-line description in the wizard's "Your spirit" step. The spirit's `orientation-face` arc invitation adapts to what the host provided:
- both avatar and description given → the invitation is omitted entirely
- avatar only → the invitation narrows to just the description
- neither given → the spirit gets the original invitation to make its own face

**Architecture:** `POST /api/setup/spirit` stashes the avatar image + description in the system dir / setup config (the spirit project doesn't exist yet at that step). `ensureSpiritProject()` applies the stash during creation via a new `applyStashedSpiritProfile()` — image into the spirit's home, `profile` into its `volute.json` — and decides the `orientation-face` schedule in the same place, so the avatar and the schedule can never disagree.

**Details:**
- Avatar is upload-only (imagegen isn't configured yet at wizard time) and goes through the same `normalizeAvatar()` downscale/re-encode path as every other avatar upload, not raw stored bytes.
- Each `/spirit` submission is authoritative for the avatar: resubmitting without one clears a previously stashed file; a rejected upload (bad MIME type) leaves an existing stash untouched.
- A failed/skipped avatar always falls back to scheduling `orientation-face` — the spirit makes its own face, which is the designed fallback and can never fail spirit creation.
- Stash filename is server-generated (`spirit-avatar.<ext>` from an image-type allowlist), never taken from client input, and is `basename()`'d again defensively before any filesystem use.

**⚠️ Depends on #751** (`feat/spirit-orientation-core`, not yet merged). This PR is stacked on top of it — base branch is `feat/spirit-orientation-core` so the diff here shows only this PR's changes. It should be retargeted to `main` (or merged) after #751 lands.

## Test plan

- [x] `npm test` — full suite, 2727/2727 pass
- [x] `npx tsc --noEmit` — clean
- [x] `svelte-check` — 0 errors (1 pre-existing unrelated warning)
- [x] Visual verification: drove a throwaway daemon (fresh `VOLUTE_HOME`, `--foreground`) through the full wizard in a real browser — uploaded an avatar, set a description, completed setup, and confirmed in the resulting spirit project that `home/spirit-avatar.png` was written, the stash was cleaned up, `volute.json`'s `profile` had both fields, and the `orientation-face` schedule was correctly omitted (only `tending` + `orientation-soul` present).
- [x] `/code-review` (8-angle automated review) run against the diff; findings addressed (see below)

## Code review findings addressed

- Reused the existing `normalizeAvatar()` helper instead of storing raw uploaded bytes (consistency with every other avatar upload path).
- Fixed stash lifecycle: resubmitting the spirit step without an avatar now clears a previously stashed one; a rejected upload no longer risks destroying an existing valid stash.
- `applyStashedSpiritProfile()` uses copy-then-delete (not a plain rename) so a failure writing the profile leaves the stash in place for retry, rather than silently losing the uploaded image.

## Uncertainties / notes

- Server-side, `spiritDescription` has no explicit length cap (the wizard's `maxlength=200` is client-side only) — matches the plan as written; flagging in case a server-side cap is wanted.
- Unrelated to this PR: while verifying in the browser I found (and reported to the team) that the local dev daemon's own spirit ("suzy") has an existing, unrelated crash-loop issue — already tracked separately, not something this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)