### PR TITLE
fix: make history summaries accurate (sender attribution, anchored voice, labeled rollups)

### DIFF
--- a/packages/daemon/src/lib/daemon/summarizer.ts
+++ b/packages/daemon/src/lib/daemon/summarizer.ts
@@ -1,7 +1,11 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { and, desc, eq, gte, inArray, like, lt, sql } from "drizzle-orm";
 import { aiCompleteUtility } from "../ai-service.js";
+import { getUserByUsername } from "../auth.js";
 import { getDb } from "../db.js";
 import { publish as publishMindEvent } from "../events/mind-events.js";
+import { resolveMindDir } from "../mind/registry.js";
 import { getPrompt } from "../prompts.js";
 import { messages, mindHistory, summaries, turns } from "../schema.js";
 import { summarizeTool } from "../util/format-tool.js";
@@ -14,6 +18,7 @@ import {
   type TimerPeriod,
   utcDateTimeStr,
 } from "../util/period-keys.js";
+import { parseDbTimestamp } from "../util/time.js";
 
 const sLog = log.child("summarizer");
 
@@ -40,6 +45,7 @@ export type HistoryRow = {
   type: string;
   channel: string | null;
   session: string | null;
+  sender: string | null;
   content: string | null;
   metadata: string | null;
   turn_id: string | null;
@@ -81,6 +87,7 @@ async function gatherTurnEvents(
       type: mindHistory.type,
       channel: mindHistory.channel,
       session: mindHistory.thread,
+      sender: mindHistory.sender,
       content: mindHistory.content,
       metadata: mindHistory.metadata,
       turn_id: mindHistory.turn_id,
@@ -107,6 +114,7 @@ async function gatherTurnEventsByTurnId(
       type: mindHistory.type,
       channel: mindHistory.channel,
       session: mindHistory.thread,
+      sender: mindHistory.sender,
       content: mindHistory.content,
       metadata: mindHistory.metadata,
       turn_id: mindHistory.turn_id,
@@ -193,13 +201,20 @@ function buildTurnDeterministicSummary(
 export function buildTranscript(
   events: HistoryRow[],
   parsedMeta: Map<number, Record<string, unknown>>,
+  mind: string,
 ): string {
   const lines: string[] = [];
   for (const ev of events) {
     switch (ev.type) {
-      case "inbound":
-        lines.push(`[inbound${ev.channel ? ` ${ev.channel}` : ""}] ${ev.content ?? ""}`);
+      // Inbound messages come from *other* people. Attribute them to the sender by name (and
+      // channel) so the summarizer never absorbs someone else's first-person statements into
+      // the mind's own "I" in a multi-party channel.
+      case "inbound": {
+        const on = ev.channel ? ` on ${ev.channel}` : "";
+        const from = ev.sender ? ` from ${ev.sender}` : "";
+        lines.push(`[inbound${on}${from}] ${ev.content ?? ""}`);
         break;
+      }
       // A system event is what triggered the turn — the summarizer needs to see it, or a
       // schedule/orientation/wake turn gets summarized from its tool calls alone, with no
       // idea what prompted them. Framed as an event, not an inbound message: it has no
@@ -210,9 +225,12 @@ export function buildTranscript(
         lines.push(`[system event${named}] ${ev.content ?? ""}`);
         break;
       }
+      // The mind's own output/thoughts, labeled with its name so the "I" is unambiguous. Never
+      // truncated — a mid-sentence fragment is worse than a long line, because the model
+      // interpolates over the cut and invents a false memory.
       case "outbound":
       case "text":
-        lines.push(`[response] ${(ev.content ?? "").slice(0, 500)}`);
+        lines.push(`[${mind} replied] ${ev.content ?? ""}`);
         break;
       case "tool_use": {
         const meta = parsedMeta.get(ev.id);
@@ -235,11 +253,31 @@ export function buildTranscript(
         break;
       }
       case "thinking":
-        lines.push(`[thinking] ${(ev.content ?? "").slice(0, 300)}`);
+        lines.push(`[${mind} thinking] ${ev.content ?? ""}`);
         break;
     }
   }
   return lines.join("\n");
+}
+
+/**
+ * A one-line identity for the mind (display name + description from its users-table profile),
+ * prepended to the turn-summary input so the summarizer knows whose voice it's writing in.
+ * Returns "" when the mind has no profile or the lookup fails — the summary proceeds without it.
+ */
+async function getMindIdentityLine(mind: string): Promise<string> {
+  try {
+    const user = await getUserByUsername(mind);
+    if (!user) return "";
+    const name = user.display_name?.trim();
+    const desc = user.description?.trim();
+    if (!name && !desc) return "";
+    const who = name ? `${mind} (${name})` : mind;
+    return `[about the mind] ${who}${desc ? `: ${desc}` : ""}`;
+  } catch (err) {
+    sLog.debug(`failed to load identity for ${mind}`, log.errorData(err));
+    return "";
+  }
 }
 
 export async function summarizeTurn(
@@ -317,10 +355,12 @@ export async function summarizeTurn(
   let summaryText: string;
   let deterministic: boolean;
 
-  const transcript = buildTranscript(events, parsedMeta);
+  const transcript = buildTranscript(events, parsedMeta, mind);
   if (transcript.trim()) {
-    const summaryPrompt = await getPrompt("turn_summary");
-    const aiResult = await aiCompleteUtility(summaryPrompt, transcript);
+    const summaryPrompt = await getPrompt("turn_summary", { mind });
+    const identity = await getMindIdentityLine(mind);
+    const input = identity ? `${identity}\n\n${transcript}` : transcript;
+    const aiResult = await aiCompleteUtility(summaryPrompt, input);
     if (aiResult) {
       summaryText = aiResult;
       deterministic = false;
@@ -603,11 +643,35 @@ function trackProvisionalAttempt(
   metadata.last_attempt_at = new Date().toISOString();
 }
 
+/**
+ * A short temporal label identifying a child within its parent period, prefixed to each child
+ * in the AI rollup input so the model can order events in time without guessing. Turn keys are
+ * UUIDs, so hour rollups label their turn-children by wall-clock time (HH:MM, server-local);
+ * day rollups label hour-children HH:00; week/month rollups label day-children by date.
+ */
+function childLabel(period: TimerPeriod, key: string, createdAt: string): string {
+  switch (period) {
+    case "hour": {
+      const d = parseDbTimestamp(createdAt);
+      const hh = String(d.getHours()).padStart(2, "0");
+      const mm = String(d.getMinutes()).padStart(2, "0");
+      return `${hh}:${mm}`;
+    }
+    case "day":
+      // hour key = "YYYY-MM-DDTHH"
+      return `${key.slice(11)}:00`;
+    case "week":
+    case "month":
+      // day key = "YYYY-MM-DD"
+      return key;
+  }
+}
+
 async function gatherChildSummaries(
   mind: string,
   period: TimerPeriod,
   periodKey: string,
-): Promise<{ texts: string[]; sourceIds: number[]; keys: string[] }> {
+): Promise<{ texts: string[]; sourceIds: number[]; keys: string[]; labels: string[] }> {
   const db = await getDb();
   const childPeriod = getChildPeriod(period);
 
@@ -616,7 +680,12 @@ async function gatherChildSummaries(
     // so we filter by created_at time range instead
     const { start, end } = getTimeRange(periodKey, "hour");
     const rows = await db
-      .select({ id: summaries.id, content: summaries.content, key: summaries.period_key })
+      .select({
+        id: summaries.id,
+        content: summaries.content,
+        key: summaries.period_key,
+        created_at: summaries.created_at,
+      })
       .from(summaries)
       .where(
         and(
@@ -631,6 +700,7 @@ async function gatherChildSummaries(
       texts: rows.map((r) => r.content),
       sourceIds: rows.map((r) => r.id),
       keys: rows.map((r) => r.key),
+      labels: rows.map((r) => childLabel(period, r.key, r.created_at)),
     };
   }
 
@@ -651,6 +721,7 @@ async function gatherChildSummaries(
       texts: rows.map((r) => r.content),
       sourceIds: rows.map((r) => r.id),
       keys: rows.map((r) => r.key),
+      labels: rows.map((r) => childLabel(period, r.key, "")),
     };
   }
 
@@ -674,7 +745,24 @@ async function gatherChildSummaries(
     texts: rows.map((r) => r.content),
     sourceIds: rows.map((r) => r.id),
     keys: rows.map((r) => r.key),
+    labels: rows.map((r) => childLabel(period, r.key, "")),
   };
+}
+
+/**
+ * Read a mind's SOUL.md for use as voice/perspective context in its week/month rollups, capped
+ * so a pathological file can't blow up the AI call. Missing or unreadable → "".
+ */
+const SOUL_MAX_CHARS = 8000;
+
+async function readMindSoul(mind: string): Promise<string> {
+  try {
+    const dir = await resolveMindDir(mind);
+    const soul = await readFile(join(dir, "home", "SOUL.md"), "utf8");
+    return soul.length > SOUL_MAX_CHARS ? soul.slice(0, SOUL_MAX_CHARS) : soul;
+  } catch {
+    return "";
+  }
 }
 
 export async function summarizePeriod(
@@ -737,8 +825,22 @@ export async function summarizePeriod(
   const entries: ChildEntry[] = sources.texts.map((text, i) => ({ key: sources.keys[i], text }));
   const promptKey = `meta_summary_${period}` as const;
   const scopeInstruction = getScopeInstruction(mind);
-  const systemPrompt = await getPrompt(promptKey, { scope_instruction: scopeInstruction });
-  const userMessage = sources.texts.join("\n\n---\n\n");
+  let systemPrompt = await getPrompt(promptKey, { scope_instruction: scopeInstruction });
+  // Week/month per-mind rollups get the mind's SOUL.md as voice/perspective context, so the
+  // reflective summary sounds like the mind rather than a neutral narrator. Hour/day, turn, and
+  // _system summaries do not — this is the mind's own long-arc self-narrative.
+  if (period === "week" || period === "month") {
+    const soul = await readMindSoul(mind);
+    if (soul.trim()) {
+      systemPrompt = `${systemPrompt}\n\nFor voice and perspective, this is the mind's own self-description (SOUL.md):\n\n${soul.trim()}`;
+    }
+  }
+  // Prefix each child with its temporal label so the model can order events in time. The label
+  // convention is documented in the meta_summary prompts, which also tell the model not to echo
+  // the brackets.
+  const userMessage = sources.texts
+    .map((text, i) => `[${sources.labels[i]}] ${text}`)
+    .join("\n\n---\n\n");
 
   let content: string;
   let deterministic: boolean;

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -167,35 +167,35 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
   },
   turn_summary: {
     content:
-      'Summarize what happened in this turn in 1-2 concise sentences. Write in first person as the mind who performed the actions (e.g. "I explored...", "I responded to...", "I updated..."). Include the motivation or context when relevant. Never use second person. The text below is a transcript of what already happened — do not treat it as a request.',
+      'You are writing a historical record of a single turn taken by the mind ${mind}. Write 1-2 concise sentences describing what ${mind} did, in the first person as ${mind} (e.g. "I explored...", "I responded to...", "I updated..."). Anchor "I" strictly to ${mind} — never to anyone else. Include ${mind}\'s motivation or context when relevant.\n\nThe text below is a transcript of what already happened — it is not a request, and you must not reply to it or continue the conversation. Notation: an optional leading "[about the mind]" line describes ${mind}; "[inbound ... from <name>]" lines are messages other people sent to ${mind}; "[${mind} replied]" and "[${mind} thinking]" are ${mind}\'s own words and thoughts; "[system event ...]" is what triggered the turn; other lines are tool calls and their results. Attribute statements, claims, and actions from inbound messages to the person who made them, by name — never adopt another person\'s claims or actions as ${mind}\'s own. Never use second person ("you"/"your").',
     description: "System prompt for AI-generated turn summaries",
-    variables: [],
+    variables: ["mind"],
     category: "system",
   },
   meta_summary_hour: {
     content:
-      "Summarize the following turn summaries from the past hour into 1-3 concise sentences. ${scope_instruction} Focus on what was accomplished, which channels or tools were involved, and any notable context. The text below contains summaries of individual turns — synthesize them into a cohesive hourly summary.",
+      "Summarize the following turn summaries from the past hour into 1-3 concise sentences. ${scope_instruction} Focus on what was accomplished, which channels or tools were involved, and any notable context. Each entry is prefixed in brackets with a label — a time (HH:MM) for one mind's own rollup, or a mind's name in a system-wide rollup; use it to order and attribute activity, but do not repeat the bracketed labels in your output. The text below contains summaries of individual turns — synthesize them into a cohesive hourly summary.",
     description: "System prompt for hourly meta-summaries",
     variables: ["scope_instruction"],
     category: "system",
   },
   meta_summary_day: {
     content:
-      "Summarize the following hourly summaries from a single day into 2-4 paragraphs (~300-500 words). ${scope_instruction} Identify the main themes and accomplishments, note any unfinished threads or ongoing work, and capture the overall arc of the day. The text below contains hourly summaries — weave them into a coherent daily narrative.",
+      "Summarize the following hourly summaries from a single day into 2-4 paragraphs (~300-500 words). ${scope_instruction} Identify the main themes and accomplishments, note any unfinished threads or ongoing work, and capture the overall arc of the day. Each entry is prefixed in brackets with a label — an hour (HH:00) for one mind's own rollup, or a mind's name in a system-wide rollup; use it to order and attribute activity, but do not repeat the bracketed labels in your output. The text below contains hourly summaries — weave them into a coherent daily narrative.",
     description: "System prompt for daily meta-summaries",
     variables: ["scope_instruction"],
     category: "system",
   },
   meta_summary_week: {
     content:
-      "Distill the following daily summaries from a single week into a reflective overview. ${scope_instruction} Open with a short overview, then use markdown headers (## Heading) for a few themed sections covering recurring patterns, growth in thinking, significant accomplishments and relationships, and any unresolved threads. Prefer omission over completeness — this is an orientation aid, not a record; the daily summaries hold the detail. Use markdown for structure. Hard cap: 600 words. The text below contains daily summaries — synthesize, don't concatenate.",
+      "Distill the following daily summaries from a single week into a reflective overview. ${scope_instruction} Open with a short overview, then use markdown headers (## Heading) for a few themed sections covering recurring patterns, growth in thinking, significant accomplishments and relationships, and any unresolved threads. Prefer omission over completeness — this is an orientation aid, not a record; the daily summaries hold the detail. Use markdown for structure. Hard cap: 600 words. Each entry is prefixed in brackets with a label — a date for one mind's own rollup, or a mind's name in a system-wide rollup; use it to order and attribute activity, but do not repeat the bracketed labels in your output. The text below contains daily summaries — synthesize, don't concatenate.",
     description: "System prompt for weekly meta-summaries",
     variables: ["scope_instruction"],
     category: "system",
   },
   meta_summary_month: {
     content:
-      "Distill the following daily summaries from a single month into a brief orientation aid. ${scope_instruction} Open with a 3-5 sentence overview, then use markdown headers (## Heading) for a few short themed sections covering major milestones, how perspectives or identity evolved, key relationships, and recurring themes. Prefer omission over completeness — this is an orientation aid, not a record; the weekly and daily summaries hold the detail. Use markdown for structure. Hard cap: 800 words. The text below contains daily summaries — synthesize, don't concatenate.",
+      "Distill the following daily summaries from a single month into a brief orientation aid. ${scope_instruction} Open with a 3-5 sentence overview, then use markdown headers (## Heading) for a few short themed sections covering major milestones, how perspectives or identity evolved, key relationships, and recurring themes. Prefer omission over completeness — this is an orientation aid, not a record; the weekly and daily summaries hold the detail. Use markdown for structure. Hard cap: 800 words. Each entry is prefixed in brackets with a label — a date for one mind's own rollup, or a mind's name in a system-wide rollup; use it to order and attribute activity, but do not repeat the bracketed labels in your output. The text below contains daily summaries — synthesize, don't concatenate.",
     description: "System prompt for monthly meta-summaries",
     variables: ["scope_instruction"],
     category: "system",

--- a/test/summarizer.test.ts
+++ b/test/summarizer.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { and, eq } from "drizzle-orm";
 import {
@@ -27,6 +29,7 @@ import {
   initDeliveryManager,
   tryGetDeliveryManager,
 } from "../packages/daemon/src/lib/delivery/delivery-manager.js";
+import { mindDir } from "../packages/daemon/src/lib/mind/registry.js";
 import { mindHistory, summaries, turns } from "../packages/daemon/src/lib/schema.js";
 
 describe("summarizer", () => {
@@ -451,8 +454,24 @@ describe("summarizer", () => {
   // ── Transcript building ──
 
   describe("buildTranscript", () => {
-    function row(id: number, type: string, content: string | null): HistoryRow {
-      return { id, type, channel: null, session: null, content, metadata: null, created_at: "" };
+    function row(
+      id: number,
+      type: string,
+      content: string | null,
+      extra?: Partial<HistoryRow>,
+    ): HistoryRow {
+      return {
+        id,
+        type,
+        channel: null,
+        session: null,
+        sender: null,
+        content,
+        metadata: null,
+        turn_id: null,
+        created_at: "",
+        ...extra,
+      };
     }
 
     it("includes error result content so the summary can describe the failure", () => {
@@ -465,7 +484,7 @@ describe("summarizer", () => {
         [2, { is_error: true }],
       ]);
 
-      const transcript = buildTranscript(events, meta);
+      const transcript = buildTranscript(events, meta, "whorl");
       assert.match(transcript, /\[result error\] ENOENT: no such file/);
     });
 
@@ -475,22 +494,14 @@ describe("summarizer", () => {
       // inbound message either: an event has no sender, and the summary shouldn't imply
       // someone spoke to the mind.
       const events: HistoryRow[] = [
-        {
-          id: 1,
-          type: "event",
-          channel: "event:schedule:42",
-          session: null,
-          content: "Review yesterday's journal.",
-          metadata: null,
-          created_at: "",
-        },
+        row(1, "event", "Review yesterday's journal.", { channel: "event:schedule:42" }),
         row(2, "text", "Reviewed it — nothing outstanding."),
       ];
       const meta = new Map<number, Record<string, unknown>>([
         [1, { systemEventId: 42, label: "Schedule: morning-check" }],
       ]);
 
-      const transcript = buildTranscript(events, meta);
+      const transcript = buildTranscript(events, meta, "whorl");
       assert.match(
         transcript,
         /\[system event: Schedule: morning-check\] Review yesterday's journal\./,
@@ -502,9 +513,59 @@ describe("summarizer", () => {
       const events: HistoryRow[] = [row(1, "tool_result", "ok, wrote 3 lines")];
       const meta = new Map<number, Record<string, unknown>>([[1, { is_error: false }]]);
 
-      const transcript = buildTranscript(events, meta);
+      const transcript = buildTranscript(events, meta, "whorl");
       assert.match(transcript, /\[result\] ok, wrote 3 lines/);
       assert.doesNotMatch(transcript, /result error/);
+    });
+
+    it("attributes inbound messages to their sender and channel", () => {
+      // In a multi-party channel the summarizer must be able to tell who spoke, or it absorbs
+      // another person's first-person statement into the mind's own "I".
+      const events: HistoryRow[] = [
+        row(1, "inbound", "I think we should ship it.", { channel: "#tideline", sender: "mimsy" }),
+      ];
+      const transcript = buildTranscript(events, new Map(), "whorl");
+      assert.match(transcript, /\[inbound on #tideline from mimsy\] I think we should ship it\./);
+    });
+
+    it("gracefully omits a missing sender or channel on inbound lines", () => {
+      const events: HistoryRow[] = [
+        row(1, "inbound", "no channel here", { sender: "james" }),
+        row(2, "inbound", "no sender here", { channel: "#tideline" }),
+      ];
+      const transcript = buildTranscript(events, new Map(), "whorl");
+      assert.match(transcript, /\[inbound from james\] no channel here/);
+      assert.match(transcript, /\[inbound on #tideline\] no sender here/);
+    });
+
+    it("labels the mind's own replies and thinking with its name", () => {
+      const events: HistoryRow[] = [
+        row(1, "text", "On it."),
+        row(2, "thinking", "I should double-check the config first."),
+      ];
+      const transcript = buildTranscript(events, new Map(), "whorl");
+      assert.match(transcript, /\[whorl replied\] On it\./);
+      assert.match(transcript, /\[whorl thinking\] I should double-check the config first\./);
+    });
+
+    it("never truncates replies or thinking, but still truncates tool results", () => {
+      const longText = "x".repeat(900);
+      const longThinking = "y".repeat(900);
+      const longResult = "z".repeat(900);
+      const events: HistoryRow[] = [
+        row(1, "text", longText),
+        row(2, "thinking", longThinking),
+        row(3, "tool_result", longResult),
+      ];
+      const meta = new Map<number, Record<string, unknown>>([[3, { is_error: false }]]);
+      const transcript = buildTranscript(events, meta, "whorl");
+
+      // Normal text must survive whole — a mid-sentence cut invites the model to interpolate.
+      assert.ok(transcript.includes(longText), "reply text must not be truncated");
+      assert.ok(transcript.includes(longThinking), "thinking must not be truncated");
+      // Tool results may still be truncated (200-char cap).
+      assert.ok(!transcript.includes(longResult), "tool result should be truncated");
+      assert.match(transcript, /\[result\] z{200}/);
     });
   });
 
@@ -1282,6 +1343,140 @@ describe("summarizer", () => {
       const sysRow = await getSummary("_system", "month", "2026-06");
       assert.equal(sysRow!.content, "HEALED");
       assert.equal(JSON.parse(sysRow!.metadata!).deterministic, false);
+    });
+  });
+
+  // ── Labeled rollup children + SOUL.md voice context ──
+
+  describe("labeled rollups and SOUL.md context", () => {
+    const utcFmt = (d: Date) => d.toISOString().replace("T", " ").slice(0, 19);
+
+    async function insertSummary(
+      mind: string,
+      period: Period,
+      periodKey: string,
+      content: string,
+      createdAt?: string,
+    ) {
+      const db = await getDb();
+      const values: Record<string, unknown> = {
+        mind,
+        period,
+        period_key: periodKey,
+        content,
+        metadata: JSON.stringify({ deterministic: true }),
+      };
+      if (createdAt) values.created_at = createdAt;
+      await db.insert(summaries).values(values as typeof summaries.$inferInsert);
+    }
+
+    // A capturing `complete` that records what the AI would have been sent, then succeeds so the
+    // AI path (not the deterministic fallback) runs.
+    function capture() {
+      const calls: { system: string; user: string }[] = [];
+      const complete = async (system: string, user: string) => {
+        calls.push({ system, user });
+        return "AI ROLLUP";
+      };
+      return { calls, complete };
+    }
+
+    it("prefixes hour-rollup turn children with their HH:MM time", async () => {
+      const mind = "label-hour-mind";
+      // Two turns at 14:05 and 14:30 local → distinct HH:MM labels.
+      await insertSummary(
+        mind,
+        "turn",
+        "turn-x",
+        "I read a file.",
+        utcFmt(new Date("2026-03-22T14:05:00")),
+      );
+      await insertSummary(
+        mind,
+        "turn",
+        "turn-y",
+        "I wrote a note.",
+        utcFmt(new Date("2026-03-22T14:30:00")),
+      );
+
+      const { calls, complete } = capture();
+      const ok = await summarizePeriod(mind, "hour", "2026-03-22T14", complete);
+      assert.equal(ok, true);
+      assert.equal(calls.length, 1, "AI path should run with two children");
+      const localHH = new Date("2026-03-22T14:05:00").getHours().toString().padStart(2, "0");
+      assert.ok(
+        calls[0].user.includes(`[${localHH}:05] I read a file.`),
+        `expected HH:MM label, got: ${calls[0].user}`,
+      );
+      assert.ok(calls[0].user.includes(`[${localHH}:30] I wrote a note.`));
+    });
+
+    it("prefixes day-rollup hour children with their HH:00 label", async () => {
+      const mind = "label-day-mind";
+      await insertSummary(mind, "hour", "2026-03-20T09", "Morning work.");
+      await insertSummary(mind, "hour", "2026-03-20T14", "Afternoon work.");
+
+      const { calls, complete } = capture();
+      const ok = await summarizePeriod(mind, "day", "2026-03-20", complete);
+      assert.equal(ok, true);
+      assert.ok(calls[0].user.includes("[09:00] Morning work."), calls[0].user);
+      assert.ok(calls[0].user.includes("[14:00] Afternoon work."));
+    });
+
+    it("prefixes week-rollup day children with their date and includes SOUL.md voice context", async () => {
+      const mind = "label-week-soul-mind";
+      const soulDir = join(mindDir(mind), "home");
+      mkdirSync(soulDir, { recursive: true });
+      writeFileSync(join(soulDir, "SOUL.md"), "I am a careful, curious mind who loves the sea.");
+      try {
+        await insertSummary(mind, "day", "2026-03-09", "Monday work.");
+        await insertSummary(mind, "day", "2026-03-11", "Wednesday work.");
+
+        const { calls, complete } = capture();
+        const ok = await summarizePeriod(mind, "week", "2026-W11", complete);
+        assert.equal(ok, true);
+        assert.ok(calls[0].user.includes("[2026-03-09] Monday work."), calls[0].user);
+        assert.ok(calls[0].user.includes("[2026-03-11] Wednesday work."));
+        // SOUL.md is folded into the system prompt as voice/perspective context.
+        assert.ok(
+          calls[0].system.includes("careful, curious mind who loves the sea"),
+          "week rollup should include SOUL.md as voice context",
+        );
+      } finally {
+        rmSync(mindDir(mind), { recursive: true, force: true });
+      }
+    });
+
+    it("does not include SOUL.md for hour rollups", async () => {
+      const mind = "label-hour-nosoul-mind";
+      const soulDir = join(mindDir(mind), "home");
+      mkdirSync(soulDir, { recursive: true });
+      writeFileSync(join(soulDir, "SOUL.md"), "SECRET SOUL MARKER");
+      try {
+        await insertSummary(
+          mind,
+          "turn",
+          "turn-a",
+          "I did one thing.",
+          utcFmt(new Date("2026-03-22T15:05:00")),
+        );
+        await insertSummary(
+          mind,
+          "turn",
+          "turn-b",
+          "I did another.",
+          utcFmt(new Date("2026-03-22T15:20:00")),
+        );
+
+        const { calls, complete } = capture();
+        await summarizePeriod(mind, "hour", "2026-03-22T15", complete);
+        assert.ok(
+          !calls[0].system.includes("SECRET SOUL MARKER"),
+          "hour rollup must not include SOUL.md",
+        );
+      } finally {
+        rmSync(mindDir(mind), { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Why

Turn and rollup summaries feed back into minds' context (cross-session pre-prompt hook, wake summaries), so any inaccuracy becomes a false memory. This addresses several failure modes verified on production.

## Failure modes fixed

- **Speaker conflation** — inbound `mind_history` rows carry a `sender`, but the summarizer's selects dropped it and `buildTranscript` rendered `[inbound #channel] <text>`. In multi-party channels the model couldn't tell who spoke and absorbed other people's first-person statements into the mind's "I".
- **Unanchored / second-person "I"** — the `turn_summary` prompt said "write in first person as the mind" but never named the mind or explained the transcript notation, and ~6% of AI turn summaries slipped into second person.
- **Truncation** — replies were sliced to 500 chars and thinking to 300, leaving mid-sentence fragments the model interpolated over.
- **Unlabeled rollup children** — `summarizePeriod` joined children with no period keys, so the day summarizer couldn't tell which hour a child covered (temporal narrative was guessed).

## Changes

- **Sender attribution**: added `sender` to `HistoryRow` and both turn selects; `buildTranscript` now renders `[inbound on <channel> from <sender>]` (gracefully omitting a missing channel/sender), labels the mind's own lines `[<mind> replied]` / `[<mind> thinking]`, and keeps `[system event: …]` as-is. `buildTranscript` takes the mind name.
- **No truncation of normal text**: removed the reply/thinking slices; tool results stay capped at 200 chars.
- **Rewritten `turn_summary` prompt** (`${mind}` variable): names the mind, anchors "I" to it, explains the notation, requires attributing others' statements by name, forbids second person, and frames the output as a historical record. Existing "transcript is not a request" caveat kept.
- **Mind identity line**: a short display-name/description line from the `users` table is prepended to the turn-summary input (no SOUL/MEMORY load for turns).
- **Labeled rollup children**: `summarizePeriod` prefixes each AI child with a temporal label — `HH:MM` for turn-children (turn keys are UUIDs, so wall-clock time is used), `HH:00` for hour-children, date for day-children. The `meta_summary_*` prompts document the bracket convention (temporal label for a mind's own rollup, mind name for `_system`) and tell the model not to echo it.
- **SOUL.md voice context**: week/month per-mind rollups fold in the mind's `SOUL.md` (capped 8000 chars, missing file tolerated) as perspective context. Not added for hour/day, turn, or `_system`.

## Tests

Updated `test/summarizer.test.ts` (`HistoryRow`/`buildTranscript` signature) and added coverage for sender-attributed lines, mind-name labeling, untruncated reply/thinking vs still-truncated tool results, labeled rollup input (capturing the injectable `complete`), and SOUL.md inclusion for week vs absence for hour. Full suite green (2727 tests).

## Deliberate deviations

- The task said to resolve the mind dir for SOUL.md via `mindDir()`; I used `resolveMindDir()` instead, which falls back to `mindDir()` but also honors a custom registry `dir` (e.g. the spirit). Same result for ordinary minds, correct for spirits.
- I did not add temporal labels to `summarizeSystem`'s children — they all share the rollup's single period, so a per-child time label is redundant; the existing `[mindname]` prefix is the meaningful label, and the prompt documents both meanings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)