### PR TITLE
feat: seed fresh persistent sessions from the prior session's transcript (all templates)

### DIFF
--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -858,6 +858,27 @@ export class SleepManager {
         }
       }
     }
+
+    // Codex template: .mind/codex-sessions/ (pointer files holding { threadId }).
+    // Archive them like the claude branch so codex minds get a fresh session on
+    // wake and the old threadId is preserved for session seeding.
+    const codexSessionsDir = resolve(dir, ".mind", "codex-sessions");
+    if (existsSync(codexSessionsDir)) {
+      const archiveDir = resolve(codexSessionsDir, "archive");
+      mkdirSync(archiveDir, { recursive: true });
+
+      for (const file of readdirSync(codexSessionsDir)) {
+        if (file === "archive" || !file.endsWith(".json")) continue;
+        const src = resolve(codexSessionsDir, file);
+        const base = file.replace(/\.json$/, "");
+        const dest = resolve(archiveDir, `${base}-${timestamp}.json`);
+        try {
+          renameSync(src, dest);
+        } catch (err) {
+          slog.warn(`failed to archive codex-session ${file} for ${name}`, log.errorData(err));
+        }
+      }
+    }
   }
 
   private async runWakeContextScript(

--- a/templates/_base/src/lib/codex-session-seed.ts
+++ b/templates/_base/src/lib/codex-session-seed.ts
@@ -1,0 +1,296 @@
+/**
+ * Codex session seeding.
+ *
+ * When a codex mind starts a fresh *persistent* session (no saved thread id —
+ * e.g. after a sleep archived the pointer), we seed the new thread by copying
+ * the tail of the previous session's Codex rollout into a new synthetic rollout
+ * file. The Codex SDK (`codex exec resume <threadId>`) then finds and resumes it
+ * natively, so the mind experiences the conversation continuing rather than
+ * waking into an empty context.
+ *
+ * The rollout is reconstructed selectively, not verbatim:
+ *   - The `session_meta` header is copied with a fresh thread id (`session_id`
+ *     and `id`) and an updated timestamp; `parent_thread_id` is dropped.
+ *   - Body `response_item` lines of type `message` and COMPLETE
+ *     `custom_tool_call`/`custom_tool_call_output` pairs are kept verbatim.
+ *   - `reasoning` items are dropped: their `encrypted_content` is opaque and
+ *     provider-bound, the likeliest thing to poison a resume.
+ *   - `event_msg` (telemetry), `turn_context`, and `world_state` are dropped;
+ *     they carry no conversation content and `turn_context`'s recorded model
+ *     would otherwise trigger a spurious model-mismatch warning on resume.
+ *
+ * Verified against @openai/codex-sdk 0.144.x: `resumeThread` shells out to
+ * `codex exec resume <threadId>`, which locates the rollout by scanning
+ * CODEX_HOME/sessions for a filename containing the thread id, then reconstructs
+ * the conversation from the `response_item` lines. A synthetic rollout with the
+ * dropped line types above (and a tail starting at a user message) loads and
+ * resumes cleanly.
+ *
+ * Nothing here throws: any failure returns null so session start is never blocked.
+ */
+
+import { randomBytes } from "node:crypto";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { findCodexSessionFile } from "./context-breakdown.js";
+import { log } from "./logger.js";
+
+/** Default seed budget (estimated tokens) when config omits continuity.seedTokens. */
+export const DEFAULT_SEED_TOKENS = 30000;
+
+// Archived pointers are named `<name>-<timestamp>.json`, where the timestamp is
+// `new Date().toISOString().replace(/[:.]/g, "-").slice(0, 16)` → `YYYY-MM-DDTHH-MM`
+// (see archiveSessions in the daemon's sleep-manager). Matching the strict shape
+// after the `<name>-` prefix disambiguates `main-...` from a `main-thread-...`.
+const ARCHIVE_SUFFIX = /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})\.json$/;
+
+type RolloutLine = Record<string, unknown> & {
+  type?: string;
+  timestamp?: string;
+  payload?: Record<string, unknown> & {
+    type?: string;
+    role?: string;
+    call_id?: string;
+  };
+};
+
+/**
+ * Newest archived codex thread id for `<name>` under `<sessionsDir>/archive/`,
+ * or null if there's no matching pointer (or it can't be read). Codex pointer
+ * files hold `{ threadId }` (see the codex template's session-store).
+ */
+export function findLatestArchivedThreadId(sessionsDir: string, name: string): string | null {
+  const archiveDir = resolve(sessionsDir, "archive");
+  let files: string[];
+  try {
+    files = readdirSync(archiveDir);
+  } catch {
+    return null;
+  }
+
+  const prefix = `${name}-`;
+  let bestTs = "";
+  let bestFile: string | null = null;
+  for (const file of files) {
+    if (!file.startsWith(prefix)) continue;
+    const match = file.slice(prefix.length).match(ARCHIVE_SUFFIX);
+    if (!match) continue;
+    // Timestamps are zero-padded ISO, so lexicographic comparison is chronological.
+    if (match[1] > bestTs) {
+      bestTs = match[1];
+      bestFile = file;
+    }
+  }
+  if (!bestFile) return null;
+
+  try {
+    const data = JSON.parse(readFileSync(resolve(archiveDir, bestFile), "utf-8"));
+    return typeof data.threadId === "string" ? data.threadId : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Estimate tokens for a raw JSONL line as its JSON text length / 4. */
+function estimateTokens(raw: string): number {
+  return raw.length / 4;
+}
+
+/** A turn starts at a user `message` response_item (the incoming prompt). */
+function isTurnBoundary(o: RolloutLine): boolean {
+  return o.payload?.type === "message" && o.payload?.role === "user";
+}
+
+/** Response-item payload types that carry conversation content we keep. */
+function isKeptBody(o: RolloutLine): boolean {
+  if (o.type !== "response_item") return false;
+  const pt = o.payload?.type;
+  return pt === "message" || pt === "custom_tool_call" || pt === "custom_tool_call_output";
+}
+
+/**
+ * Generate a UUIDv7 thread id, matching the shape Codex uses (`019f…`): a 48-bit
+ * millisecond timestamp prefix plus randomness. The value only needs to be a
+ * valid, unique id embedded in the rollout filename and `session_meta`.
+ */
+export function generateThreadId(now: Date = new Date()): string {
+  const bytes = new Uint8Array(16);
+  const ms = BigInt(now.getTime());
+  for (let i = 0; i < 6; i++) {
+    bytes[i] = Number((ms >> BigInt(40 - i * 8)) & 0xffn);
+  }
+  const rand = randomBytes(10);
+  for (let i = 0; i < 10; i++) bytes[6 + i] = rand[i];
+  bytes[6] = (bytes[6] & 0x0f) | 0x70; // version 7
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export type SeededRollout = { threadId: string; lines: string[] };
+
+/**
+ * Build the seeded rollout from a previous rollout's raw jsonl text: rewrite the
+ * `session_meta` header to `threadId` with an updated timestamp, then take as
+ * many whole trailing turns as fit in `seedTokens` (always at least the final
+ * turn), keeping message and complete tool-call pairs. Returns null if there's
+ * nothing seedable (empty, no session_meta, no genuine turn, or a corrupt line).
+ */
+export function buildSeededRollout(
+  jsonl: string,
+  threadId: string,
+  seedTokens: number,
+  now: Date = new Date(),
+): SeededRollout | null {
+  const rawLines = jsonl.split("\n").filter((l) => l.trim().length > 0);
+  if (rawLines.length === 0) return null;
+
+  let meta: RolloutLine;
+  try {
+    meta = JSON.parse(rawLines[0]);
+  } catch {
+    return null;
+  }
+  if (meta.type !== "session_meta" || typeof meta.payload !== "object" || meta.payload === null) {
+    return null;
+  }
+
+  // Rewrite the header: fresh thread id and timestamp, detached from its parent.
+  const iso = now.toISOString();
+  const mp = meta.payload;
+  mp.session_id = threadId;
+  mp.id = threadId;
+  delete mp.parent_thread_id;
+  mp.timestamp = iso;
+  meta.timestamp = iso;
+
+  // Parse and filter the body down to the response_items we keep.
+  const kept: { obj: RolloutLine; raw: string }[] = [];
+  for (let i = 1; i < rawLines.length; i++) {
+    let obj: RolloutLine;
+    try {
+      obj = JSON.parse(rawLines[i]);
+    } catch {
+      // A corrupt line means we can't faithfully reconstruct — start clean.
+      return null;
+    }
+    if (isKeptBody(obj)) kept.push({ obj, raw: rawLines[i] });
+  }
+  if (kept.length === 0) return null;
+
+  const boundaries: number[] = [];
+  for (let i = 0; i < kept.length; i++) {
+    if (isTurnBoundary(kept[i].obj)) boundaries.push(i);
+  }
+  if (boundaries.length === 0) return null;
+
+  // Turn t spans kept[boundaries[t], boundaries[t+1]); the last turn runs to end.
+  const turnTokens = (t: number): number => {
+    const start = boundaries[t];
+    const end = t + 1 < boundaries.length ? boundaries[t + 1] : kept.length;
+    let sum = 0;
+    for (let i = start; i < end; i++) sum += estimateTokens(kept[i].raw);
+    return sum;
+  };
+
+  // Walk backward from the final turn, adding earlier whole turns while they fit.
+  // The final turn is always included even if it alone exceeds the budget.
+  const last = boundaries.length - 1;
+  let startTurn = last;
+  let accum = turnTokens(last);
+  for (let t = last - 1; t >= 0; t--) {
+    const cost = turnTokens(t);
+    if (accum + cost > seedTokens) break;
+    accum += cost;
+    startTurn = t;
+  }
+
+  let tail = kept.slice(boundaries[startTurn]);
+
+  // Keep only tool calls/outputs whose call_id has BOTH a call and an output in
+  // the tail — never an orphaned call (e.g. a truncated final turn) or output.
+  const callIds = new Set<string>();
+  const outputIds = new Set<string>();
+  for (const { obj } of tail) {
+    const p = obj.payload;
+    if (typeof p?.call_id !== "string") continue;
+    if (p.type === "custom_tool_call") callIds.add(p.call_id);
+    else if (p.type === "custom_tool_call_output") outputIds.add(p.call_id);
+  }
+  tail = tail.filter(({ obj }) => {
+    const p = obj.payload;
+    if (p?.type === "custom_tool_call" || p?.type === "custom_tool_call_output") {
+      return typeof p.call_id === "string" && callIds.has(p.call_id) && outputIds.has(p.call_id);
+    }
+    return true;
+  });
+  if (tail.length === 0) return null;
+
+  const lines = [JSON.stringify(meta), ...tail.map((t) => JSON.stringify(t.obj))];
+  return { threadId, lines };
+}
+
+/** Two-digit zero-padded string for date/time components. */
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/**
+ * Seed a fresh persistent codex session from the mind's previous archived
+ * rollout. Writes the synthetic rollout under `.mind/codex/sessions/YYYY/MM/DD/`
+ * (matching the real Codex layout) and returns the new thread id, or null if
+ * there's nothing to seed. Never throws — any failure returns null so session
+ * start is never blocked.
+ */
+export function seedCodexSession(opts: {
+  mindDir: string;
+  name: string;
+  seedTokens: number;
+  now?: Date;
+}): string | null {
+  const { mindDir, name, seedTokens } = opts;
+  const now = opts.now ?? new Date();
+  // Ephemeral `new-*` sessions are never persisted or archived, so they never
+  // seed. The agent caller already gates on this; guard here too.
+  if (name.startsWith("new-")) return null;
+  if (seedTokens <= 0) return null; // seeding disabled
+
+  try {
+    const sessionsDir = resolve(mindDir, ".mind", "codex-sessions");
+    const oldThreadId = findLatestArchivedThreadId(sessionsDir, name);
+    if (!oldThreadId) return null;
+
+    const sourcePath = findCodexSessionFile(oldThreadId, mindDir);
+    if (!sourcePath) return null; // rollout didn't survive archival — start clean
+
+    const threadId = generateThreadId(now);
+    const seeded = buildSeededRollout(readFileSync(sourcePath, "utf-8"), threadId, seedTokens, now);
+    if (!seeded) return null;
+
+    // Write the seed into the SAME sessions root the source rollout was found in,
+    // so it lands wherever Codex will look on resume. That root is CODEX_HOME/sessions
+    // (`.mind/codex/sessions` when CODEX_HOME is set for the mind) or ~/.codex/sessions
+    // otherwise — findCodexSessionFile already resolved whichever holds the old rollout.
+    // sourcePath is `<sessionsRoot>/YYYY/MM/DD/rollout-*.jsonl`; climb three levels.
+    const sessionsRoot = resolve(dirname(sourcePath), "..", "..", "..");
+
+    // Rollout files live under a local-time YYYY/MM/DD tree, with a local-time
+    // filename timestamp — mirroring how Codex itself names them.
+    const y = String(now.getFullYear());
+    const mo = pad2(now.getMonth() + 1);
+    const d = pad2(now.getDate());
+    const fnTs = `${y}-${mo}-${d}T${pad2(now.getHours())}-${pad2(now.getMinutes())}-${pad2(now.getSeconds())}`;
+    const destDir = resolve(sessionsRoot, y, mo, d);
+    mkdirSync(destDir, { recursive: true });
+    const destPath = resolve(destDir, `rollout-${fnTs}-${threadId}.jsonl`);
+    writeFileSync(destPath, `${seeded.lines.join("\n")}\n`);
+    log(
+      "mind",
+      `session "${name}": seeded ${seeded.lines.length} line(s) from ${oldThreadId} → ${threadId}`,
+    );
+    return threadId;
+  } catch (err) {
+    log("mind", `session "${name}": codex seeding failed, starting fresh:`, err);
+    return null;
+  }
+}

--- a/templates/_base/src/lib/codex-session-seed.ts
+++ b/templates/_base/src/lib/codex-session-seed.ts
@@ -34,6 +34,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { findCodexSessionFile } from "./context-breakdown.js";
 import { log } from "./logger.js";
+import { parseArchiveTimestamp } from "./seed-note.js";
 
 /** Default seed budget (estimated tokens) when config omits continuity.seedTokens. */
 export const DEFAULT_SEED_TOKENS = 30000;
@@ -54,12 +55,16 @@ type RolloutLine = Record<string, unknown> & {
   };
 };
 
+/** A resolved archive pointer: the previous thread id and when it was archived. */
+export type ArchivedThread = { threadId: string; archivedAt: number | null };
+
 /**
- * Newest archived codex thread id for `<name>` under `<sessionsDir>/archive/`,
- * or null if there's no matching pointer (or it can't be read). Codex pointer
- * files hold `{ threadId }` (see the codex template's session-store).
+ * Newest archived codex thread for `<name>` under `<sessionsDir>/archive/`, or
+ * null if there's no matching pointer (or it can't be read). Codex pointer files
+ * hold `{ threadId }` (see the codex template's session-store). `archivedAt` is
+ * the archive timestamp in epoch millis (null if unparseable).
  */
-export function findLatestArchivedThreadId(sessionsDir: string, name: string): string | null {
+export function findLatestArchivedThread(sessionsDir: string, name: string): ArchivedThread | null {
   const archiveDir = resolve(sessionsDir, "archive");
   let files: string[];
   try {
@@ -85,7 +90,8 @@ export function findLatestArchivedThreadId(sessionsDir: string, name: string): s
 
   try {
     const data = JSON.parse(readFileSync(resolve(archiveDir, bestFile), "utf-8"));
-    return typeof data.threadId === "string" ? data.threadId : null;
+    if (typeof data.threadId !== "string") return null;
+    return { threadId: data.threadId, archivedAt: parseArchiveTimestamp(bestTs) };
   } catch {
     return null;
   }
@@ -235,19 +241,22 @@ function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
+/** Result of a successful codex seed: the new thread id and when the source was archived. */
+export type SeededThreadOutcome = { threadId: string; archivedAt: number | null };
+
 /**
  * Seed a fresh persistent codex session from the mind's previous archived
  * rollout. Writes the synthetic rollout under `.mind/codex/sessions/YYYY/MM/DD/`
- * (matching the real Codex layout) and returns the new thread id, or null if
- * there's nothing to seed. Never throws — any failure returns null so session
- * start is never blocked.
+ * (matching the real Codex layout) and returns the new thread id plus the
+ * archived-at time (for the gap note), or null if there's nothing to seed. Never
+ * throws — any failure returns null so session start is never blocked.
  */
 export function seedCodexSession(opts: {
   mindDir: string;
   name: string;
   seedTokens: number;
   now?: Date;
-}): string | null {
+}): SeededThreadOutcome | null {
   const { mindDir, name, seedTokens } = opts;
   const now = opts.now ?? new Date();
   // Ephemeral `new-*` sessions are never persisted or archived, so they never
@@ -257,8 +266,9 @@ export function seedCodexSession(opts: {
 
   try {
     const sessionsDir = resolve(mindDir, ".mind", "codex-sessions");
-    const oldThreadId = findLatestArchivedThreadId(sessionsDir, name);
-    if (!oldThreadId) return null;
+    const archived = findLatestArchivedThread(sessionsDir, name);
+    if (!archived) return null;
+    const oldThreadId = archived.threadId;
 
     const sourcePath = findCodexSessionFile(oldThreadId, mindDir);
     if (!sourcePath) return null; // rollout didn't survive archival — start clean
@@ -288,7 +298,7 @@ export function seedCodexSession(opts: {
       "mind",
       `session "${name}": seeded ${seeded.lines.length} line(s) from ${oldThreadId} → ${threadId}`,
     );
-    return threadId;
+    return { threadId, archivedAt: archived.archivedAt };
   } catch (err) {
     log("mind", `session "${name}": codex seeding failed, starting fresh:`, err);
     return null;

--- a/templates/_base/src/lib/pi-session-seed.ts
+++ b/templates/_base/src/lib/pi-session-seed.ts
@@ -34,6 +34,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { findPiSessionFile } from "./context-breakdown.js";
 import { log } from "./logger.js";
+import { parseArchiveTimestamp } from "./seed-note.js";
 import { DEFAULT_SEED_TOKENS } from "./session-seed.js";
 
 export { DEFAULT_SEED_TOKENS };
@@ -61,11 +62,18 @@ type PiEntry = Record<string, unknown> & {
   message?: { role?: string };
 };
 
+/** A resolved archive directory: its absolute path and when it was archived. */
+export type ArchivedPiSession = { dir: string; archivedAt: number | null };
+
 /**
- * Absolute path of the newest archived pi-session directory for `<name>` under
- * `<piSessionsDir>/archive/`, or null if there's no matching directory.
+ * Newest archived pi-session directory for `<name>` under `<piSessionsDir>/archive/`,
+ * or null if there's no matching directory. `dir` is the absolute path;
+ * `archivedAt` is the archive timestamp in epoch millis (null if unparseable).
  */
-export function findLatestArchivedPiSessionDir(piSessionsDir: string, name: string): string | null {
+export function findLatestArchivedPiSession(
+  piSessionsDir: string,
+  name: string,
+): ArchivedPiSession | null {
   const archiveDir = resolve(piSessionsDir, "archive");
   let entries: import("node:fs").Dirent[];
   try {
@@ -87,7 +95,8 @@ export function findLatestArchivedPiSessionDir(piSessionsDir: string, name: stri
       bestDir = entry.name;
     }
   }
-  return bestDir ? resolve(archiveDir, bestDir) : null;
+  if (!bestDir) return null;
+  return { dir: resolve(archiveDir, bestDir), archivedAt: parseArchiveTimestamp(bestTs) };
 }
 
 /** A turn boundary is a genuine incoming prompt: a `user`-role message entry. */
@@ -200,19 +209,22 @@ export function hasLivePiSession(piSessionsDir: string, name: string): boolean {
   }
 }
 
+/** Result of a successful pi seed: the new session id and when the source was archived. */
+export type SeededPiOutcome = { sessionId: string; archivedAt: number | null };
+
 /**
  * Seed a fresh persistent pi session from the mind's previous archived transcript.
  * Writes the synthetic session file into `<piSessionsDir>/<name>/` and returns the
- * new session id (the header id continueRecent will adopt), or null if there's
- * nothing to seed. Never throws — any failure returns null so session start is
- * never blocked.
+ * new session id (the header id continueRecent will adopt) plus the archived-at
+ * time (for the gap note), or null if there's nothing to seed. Never throws — any
+ * failure returns null so session start is never blocked.
  */
 export function seedPiSession(opts: {
   cwd: string;
   piSessionsDir: string;
   name: string;
   seedTokens: number;
-}): string | null {
+}): SeededPiOutcome | null {
   const { cwd, piSessionsDir, name, seedTokens } = opts;
   // Ephemeral `new-*` sessions are never persisted or archived, so they never
   // seed. The agent caller already gates on this; guard here too so the invariant
@@ -223,12 +235,12 @@ export function seedPiSession(opts: {
   if (hasLivePiSession(piSessionsDir, name)) return null;
 
   try {
-    const archiveDir = findLatestArchivedPiSessionDir(piSessionsDir, name);
-    if (!archiveDir) return null;
+    const archived = findLatestArchivedPiSession(piSessionsDir, name);
+    if (!archived) return null;
 
     // findPiSessionFile picks the latest `.jsonl` in `<base>/<subdir>`; here the
     // subdir is the archived `<name>-<ts>` directory we just located.
-    const sourcePath = findPiSessionFile(resolve(piSessionsDir, "archive"), basename(archiveDir));
+    const sourcePath = findPiSessionFile(resolve(piSessionsDir, "archive"), basename(archived.dir));
     if (!sourcePath) return null; // no transcript survived archival — start clean
 
     const seeded = buildSeededPiTranscript(readFileSync(sourcePath, "utf-8"), {
@@ -247,7 +259,7 @@ export function seedPiSession(opts: {
       "mind",
       `session "${name}": seeded ${seeded.lines.length - 1} entr(ies) from ${sourcePath} → ${seeded.sessionId}`,
     );
-    return seeded.sessionId;
+    return { sessionId: seeded.sessionId, archivedAt: archived.archivedAt };
   } catch (err) {
     log("mind", `session "${name}": seeding failed, starting fresh:`, err);
     return null;

--- a/templates/_base/src/lib/pi-session-seed.ts
+++ b/templates/_base/src/lib/pi-session-seed.ts
@@ -1,0 +1,255 @@
+/**
+ * Session seeding for the pi template.
+ *
+ * When a pi mind starts a fresh *persistent* session (its live
+ * `.mind/pi-sessions/<name>/` directory was archived away on sleep, or never
+ * existed), we seed the new session by copying the tail of the previous
+ * session's transcript into a new session file. `SessionManager.continueRecent`
+ * then resumes it natively, so the mind experiences the same conversation
+ * continuing rather than waking into an empty context.
+ *
+ * Pi's session format differs from the Claude Agent SDK's:
+ *
+ *   - A file is a header line `{type:"session", version, id, timestamp, cwd, …}`
+ *     followed by JSONL entries. Each entry has its own `id`/`parentId` forming a
+ *     tree; the session id lives only in the header, not on every line.
+ *   - Message entries are `{type:"message", id, parentId, timestamp, message}`
+ *     where `message.role` is one of `user` / `assistant` / `toolResult` / `custom`.
+ *     Tool results are their own role, so an incoming prompt is exactly a
+ *     `user`-role message — that is the turn boundary.
+ *   - `continueRecent(cwd, dir)` picks the most-recent `.jsonl` in `dir` **whose
+ *     header cwd matches** `cwd`, so the seed header's cwd must be rewritten to the
+ *     mind's home dir (as `importPiSession` already does for imports).
+ *
+ * The copy is verbatim: message/tool_use/tool_result/thinking entries survive
+ * as-is, keeping their own ids. Only two things are rewritten — the header
+ * (fresh id, correct cwd, new timestamp, source recorded as `parentSession`) and
+ * the first kept entry's `parentId` (nulled, to make the tail a clean root).
+ *
+ * Nothing here throws: any failure returns null so session start is never blocked.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+import { findPiSessionFile } from "./context-breakdown.js";
+import { log } from "./logger.js";
+import { DEFAULT_SEED_TOKENS } from "./session-seed.js";
+
+export { DEFAULT_SEED_TOKENS };
+
+// Archived pi-session directories are named `<name>-<timestamp>`, where the
+// timestamp is `new Date().toISOString().replace(/[:.]/g, "-").slice(0, 16)` →
+// `YYYY-MM-DDTHH-MM` (see archiveSessions in the daemon's sleep-manager).
+// Matching the strict shape after the `<name>-` prefix disambiguates a `main`
+// session from a `main-thread` one.
+const ARCHIVE_DIR_SUFFIX = /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})$/;
+
+type PiHeader = {
+  type: "session";
+  version?: number;
+  id: string;
+  timestamp: string;
+  cwd: string;
+  parentSession?: string;
+};
+
+type PiEntry = Record<string, unknown> & {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  message?: { role?: string };
+};
+
+/**
+ * Absolute path of the newest archived pi-session directory for `<name>` under
+ * `<piSessionsDir>/archive/`, or null if there's no matching directory.
+ */
+export function findLatestArchivedPiSessionDir(piSessionsDir: string, name: string): string | null {
+  const archiveDir = resolve(piSessionsDir, "archive");
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(archiveDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const prefix = `${name}-`;
+  let bestTs = "";
+  let bestDir: string | null = null;
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+    const match = entry.name.slice(prefix.length).match(ARCHIVE_DIR_SUFFIX);
+    if (!match) continue;
+    // Timestamps are zero-padded ISO, so lexicographic comparison is chronological.
+    if (match[1] > bestTs) {
+      bestTs = match[1];
+      bestDir = entry.name;
+    }
+  }
+  return bestDir ? resolve(archiveDir, bestDir) : null;
+}
+
+/** A turn boundary is a genuine incoming prompt: a `user`-role message entry. */
+function isTurnBoundary(entry: PiEntry): boolean {
+  return entry.type === "message" && entry.message?.role === "user";
+}
+
+/** Estimate tokens for a raw JSONL line as its JSON text length / 4. */
+function estimateTokens(raw: string): number {
+  return raw.length / 4;
+}
+
+export type SeededPiTranscript = { sessionId: string; lines: string[] };
+
+/**
+ * Build the seeded transcript from a source pi session file's raw jsonl text:
+ * take as many whole trailing turns as fit in `seedTokens` (always at least the
+ * final turn), keeping the tail entries verbatim; then prepend a fresh header
+ * (new id, `cwd`, source recorded as `parentSession`) and null the first kept
+ * entry's parentId. Returns null if there's nothing seedable (no header, no
+ * genuine turn, or a corrupt line — in which case the caller starts clean).
+ */
+export function buildSeededPiTranscript(
+  jsonl: string,
+  opts: { cwd: string; seedTokens: number; sourcePath?: string },
+): SeededPiTranscript | null {
+  const rawLines = jsonl.split("\n").filter((l) => l.trim().length > 0);
+  if (rawLines.length === 0) return null;
+
+  const parsed: PiEntry[] = [];
+  for (const raw of rawLines) {
+    try {
+      parsed.push(JSON.parse(raw));
+    } catch {
+      // A corrupt line means we can't faithfully reconstruct the tree — start
+      // clean rather than seed a broken transcript.
+      return null;
+    }
+  }
+
+  // First line must be a valid session header (pi rejects files otherwise).
+  const header = parsed[0];
+  if (header.type !== "session" || typeof header.id !== "string") return null;
+
+  // Entries are everything after the header; keep raws aligned for cost estimates.
+  const entries = parsed.slice(1);
+  const entryRaws = rawLines.slice(1);
+
+  const boundaries: number[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    if (isTurnBoundary(entries[i])) boundaries.push(i);
+  }
+  if (boundaries.length === 0) return null;
+
+  // Turn t spans entries [boundaries[t], boundaries[t+1]); the last runs to EOF.
+  const turnTokens = (t: number): number => {
+    const start = boundaries[t];
+    const end = t + 1 < boundaries.length ? boundaries[t + 1] : entries.length;
+    let sum = 0;
+    for (let i = start; i < end; i++) sum += estimateTokens(entryRaws[i]);
+    return sum;
+  };
+
+  // Walk backward from the final turn, adding earlier whole turns while they fit.
+  // The final turn is always included even if it alone exceeds the budget.
+  const last = boundaries.length - 1;
+  let startTurn = last;
+  let accum = turnTokens(last);
+  for (let t = last - 1; t >= 0; t--) {
+    const cost = turnTokens(t);
+    if (accum + cost > opts.seedTokens) break;
+    accum += cost;
+    startTurn = t;
+  }
+
+  const startIdx = boundaries[startTurn];
+  const newId = randomUUID();
+  const newHeader: PiHeader = {
+    type: "session",
+    version: typeof header.version === "number" ? header.version : 3,
+    id: newId,
+    timestamp: new Date().toISOString(),
+    cwd: resolve(opts.cwd),
+    ...(opts.sourcePath ? { parentSession: opts.sourcePath } : {}),
+  };
+
+  // Copy the tail byte-for-byte (tool calls and all), rewriting only the first
+  // kept entry's parentId to null so the tail becomes a clean root. Every other
+  // entry is emitted from its original raw line, so nothing is re-serialized.
+  const lines: string[] = [JSON.stringify(newHeader)];
+  for (let i = startIdx; i < entries.length; i++) {
+    if (i === startIdx) {
+      lines.push(JSON.stringify({ ...entries[i], parentId: null }));
+    } else {
+      lines.push(entryRaws[i]);
+    }
+  }
+  return { sessionId: newId, lines };
+}
+
+/**
+ * True if `<piSessionsDir>/<name>/` already holds a live pi `.jsonl` session —
+ * in which case continueRecent will resume it and we must not seed over it.
+ */
+export function hasLivePiSession(piSessionsDir: string, name: string): boolean {
+  try {
+    return readdirSync(resolve(piSessionsDir, name)).some((f) => f.endsWith(".jsonl"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Seed a fresh persistent pi session from the mind's previous archived transcript.
+ * Writes the synthetic session file into `<piSessionsDir>/<name>/` and returns the
+ * new session id (the header id continueRecent will adopt), or null if there's
+ * nothing to seed. Never throws — any failure returns null so session start is
+ * never blocked.
+ */
+export function seedPiSession(opts: {
+  cwd: string;
+  piSessionsDir: string;
+  name: string;
+  seedTokens: number;
+}): string | null {
+  const { cwd, piSessionsDir, name, seedTokens } = opts;
+  // Ephemeral `new-*` sessions are never persisted or archived, so they never
+  // seed. The agent caller already gates on this; guard here too so the invariant
+  // holds wherever seedPiSession is called.
+  if (name.startsWith("new-")) return null;
+  if (seedTokens <= 0) return null; // seeding disabled
+  // A live session already exists — let continueRecent resume it, don't seed.
+  if (hasLivePiSession(piSessionsDir, name)) return null;
+
+  try {
+    const archiveDir = findLatestArchivedPiSessionDir(piSessionsDir, name);
+    if (!archiveDir) return null;
+
+    // findPiSessionFile picks the latest `.jsonl` in `<base>/<subdir>`; here the
+    // subdir is the archived `<name>-<ts>` directory we just located.
+    const sourcePath = findPiSessionFile(resolve(piSessionsDir, "archive"), basename(archiveDir));
+    if (!sourcePath) return null; // no transcript survived archival — start clean
+
+    const seeded = buildSeededPiTranscript(readFileSync(sourcePath, "utf-8"), {
+      cwd,
+      seedTokens,
+      sourcePath,
+    });
+    if (!seeded) return null;
+
+    const destDir = resolve(piSessionsDir, name);
+    mkdirSync(destDir, { recursive: true });
+    const fileTimestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const destPath = resolve(destDir, `${fileTimestamp}_${seeded.sessionId}.jsonl`);
+    writeFileSync(destPath, `${seeded.lines.join("\n")}\n`);
+    log(
+      "mind",
+      `session "${name}": seeded ${seeded.lines.length - 1} entr(ies) from ${sourcePath} → ${seeded.sessionId}`,
+    );
+    return seeded.sessionId;
+  } catch (err) {
+    log("mind", `session "${name}": seeding failed, starting fresh:`, err);
+    return null;
+  }
+}

--- a/templates/_base/src/lib/seed-note.ts
+++ b/templates/_base/src/lib/seed-note.ts
@@ -1,0 +1,54 @@
+/**
+ * The honest-boundary note injected on the first prompt/turn of a seeded session
+ * (see the session seeders), plus the gap-duration clause the seeders enrich it
+ * with. Shared across the claude, codex, and pi templates so the text stays
+ * identical apart from the computed gap.
+ */
+
+/**
+ * Base note, used verbatim when the gap can't be computed. The seeders enrich the
+ * parenthetical with a coarse gap-duration clause via buildSeededNote().
+ */
+export const SEEDED_SESSION_NOTE_BASE =
+  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
+
+/**
+ * Parse an archive-pointer timestamp into epoch millis, or null if it doesn't
+ * match. The daemon's sleep-manager (archiveSessions) formats it as
+ * `new Date().toISOString().replace(/[:.]/g, "-").slice(0, 16)` → `YYYY-MM-DDTHH-MM`,
+ * which is **UTC** and minute-precision, so we parse it back as UTC.
+ */
+export function parseArchiveTimestamp(ts: string): number | null {
+  const m = ts.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  const ms = Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5]);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** Coarse human phrasing of a gap in millis: minutes, then hours, then days. */
+function formatGap(ms: number): string | null {
+  if (ms < 0) return null;
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 1) return "less than a minute";
+  if (minutes < 60) return `about ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const hours = Math.round(ms / 3_600_000);
+  if (hours < 24) return `about ${hours} hour${hours === 1 ? "" : "s"}`;
+  const days = Math.round(ms / 86_400_000);
+  return `about ${days} day${days === 1 ? "" : "s"}`;
+}
+
+/**
+ * Build the seeded-session note, adding a coarse gap-duration clause when the
+ * archived-at time is known. `archivedAtMs` is epoch millis from
+ * parseArchiveTimestamp() (null → no clause); `nowMs` defaults to now so the gap
+ * reflects when the mind actually reads the note.
+ */
+export function buildSeededNote(archivedAtMs: number | null, nowMs: number = Date.now()): string {
+  if (archivedAtMs == null) return SEEDED_SESSION_NOTE_BASE;
+  const gap = formatGap(nowMs - archivedAtMs);
+  if (!gap) return SEEDED_SESSION_NOTE_BASE;
+  return SEEDED_SESSION_NOTE_BASE.replace(
+    "(restored after archival)",
+    `(restored after archival; the break lasted ${gap})`,
+  );
+}

--- a/templates/_base/src/lib/session-seed.ts
+++ b/templates/_base/src/lib/session-seed.ts
@@ -21,6 +21,7 @@ import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { findClaudeSessionFile } from "./context-breakdown.js";
 import { log } from "./logger.js";
+import { parseArchiveTimestamp } from "./seed-note.js";
 
 /** Default seed budget (estimated tokens) when config omits continuity.seedTokens. */
 export const DEFAULT_SEED_TOKENS = 30000;
@@ -39,11 +40,18 @@ type JsonlLine = Record<string, unknown> & {
   message?: { role?: string; content?: unknown };
 };
 
+/** A resolved archive pointer: the previous session id and when it was archived. */
+export type ArchivedSession = { sessionId: string; archivedAt: number | null };
+
 /**
- * Newest archived session-pointer id for `<name>` under `<sessionsDir>/archive/`,
- * or null if there's no matching pointer (or it can't be read).
+ * Newest archived session pointer for `<name>` under `<sessionsDir>/archive/`,
+ * or null if there's no matching pointer (or it can't be read). `archivedAt` is
+ * the archive timestamp in epoch millis (null if unparseable).
  */
-export function findLatestArchivedSessionId(sessionsDir: string, name: string): string | null {
+export function findLatestArchivedSession(
+  sessionsDir: string,
+  name: string,
+): ArchivedSession | null {
   const archiveDir = resolve(sessionsDir, "archive");
   let files: string[];
   try {
@@ -69,7 +77,8 @@ export function findLatestArchivedSessionId(sessionsDir: string, name: string): 
 
   try {
     const data = JSON.parse(readFileSync(resolve(archiveDir, bestFile), "utf-8"));
-    return typeof data.sessionId === "string" ? data.sessionId : null;
+    if (typeof data.sessionId !== "string") return null;
+    return { sessionId: data.sessionId, archivedAt: parseArchiveTimestamp(bestTs) };
   } catch {
     return null;
   }
@@ -172,18 +181,22 @@ export function buildSeededTranscript(jsonl: string, seedTokens: number): Seeded
   return { sessionId: newId, lines };
 }
 
+/** Result of a successful seed: the new session id and when the source was archived. */
+export type SeedOutcome = { sessionId: string; archivedAt: number | null };
+
 /**
  * Seed a fresh persistent session from the mind's previous archived transcript.
  * Writes the synthetic transcript next to the source file (same project dir) and
- * returns the new SDK session id, or null if there's nothing to seed. Never
- * throws — any failure returns null so session start is never blocked.
+ * returns the new SDK session id plus the archived-at time (for the gap note), or
+ * null if there's nothing to seed. Never throws — any failure returns null so
+ * session start is never blocked.
  */
 export function seedSession(opts: {
   cwd: string;
   sessionsDir: string;
   name: string;
   seedTokens: number;
-}): string | null {
+}): SeedOutcome | null {
   const { cwd, sessionsDir, name, seedTokens } = opts;
   // Ephemeral `new-*` sessions are never persisted or archived, so they never
   // seed. The agent caller already gates on this; guard here too so the invariant
@@ -192,10 +205,10 @@ export function seedSession(opts: {
   if (seedTokens <= 0) return null; // seeding disabled
 
   try {
-    const oldSessionId = findLatestArchivedSessionId(sessionsDir, name);
-    if (!oldSessionId) return null;
+    const archived = findLatestArchivedSession(sessionsDir, name);
+    if (!archived) return null;
 
-    const sourcePath = findClaudeSessionFile(cwd, oldSessionId);
+    const sourcePath = findClaudeSessionFile(cwd, archived.sessionId);
     if (!sourcePath) return null; // transcript didn't survive archival — start clean
 
     const seeded = buildSeededTranscript(readFileSync(sourcePath, "utf-8"), seedTokens);
@@ -205,9 +218,9 @@ export function seedSession(opts: {
     writeFileSync(destPath, `${seeded.lines.join("\n")}\n`);
     log(
       "mind",
-      `session "${name}": seeded ${seeded.lines.length} line(s) from ${oldSessionId} → ${seeded.sessionId}`,
+      `session "${name}": seeded ${seeded.lines.length} line(s) from ${archived.sessionId} → ${seeded.sessionId}`,
     );
-    return seeded.sessionId;
+    return { sessionId: seeded.sessionId, archivedAt: archived.archivedAt };
   } catch (err) {
     log("mind", `session "${name}": seeding failed, starting fresh:`, err);
     return null;

--- a/templates/_base/src/lib/session-seed.ts
+++ b/templates/_base/src/lib/session-seed.ts
@@ -1,0 +1,215 @@
+/**
+ * Session seeding.
+ *
+ * When a mind starts a fresh *persistent* session (no saved session id — e.g.
+ * after a sleep archived the live pointer, or an orphaned reference), we seed the
+ * new session by copying the tail of the previous session's raw SDK transcript
+ * into a new synthetic session file. The Claude Agent SDK then resumes it
+ * natively, so the mind experiences the same conversation continuing rather than
+ * waking into an empty context.
+ *
+ * The copy is verbatim: marker lines, thinking blocks, tool_use/tool_result all
+ * survive as-is. Only two things are rewritten — the `sessionId` on every line
+ * (to the freshly generated session id) and the first chain event's `parentUuid`
+ * (nulled, to detach the tail from the dropped history).
+ *
+ * Nothing here throws: any failure returns null so session start is never blocked.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { findClaudeSessionFile } from "./context-breakdown.js";
+import { log } from "./logger.js";
+
+/** Default seed budget (estimated tokens) when config omits continuity.seedTokens. */
+export const DEFAULT_SEED_TOKENS = 30000;
+
+// Archived pointers are named `<name>-<timestamp>.json`, where the timestamp is
+// `new Date().toISOString().replace(/[:.]/g, "-").slice(0, 16)` → `YYYY-MM-DDTHH-MM`
+// (see archiveSessions in the daemon's sleep-manager). Matching the strict shape
+// after the `<name>-` prefix disambiguates `main-...` from a `main-thread-...`.
+const ARCHIVE_SUFFIX = /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})\.json$/;
+
+type JsonlLine = Record<string, unknown> & {
+  type?: string;
+  uuid?: string;
+  parentUuid?: string | null;
+  sessionId?: string;
+  message?: { role?: string; content?: unknown };
+};
+
+/**
+ * Newest archived session-pointer id for `<name>` under `<sessionsDir>/archive/`,
+ * or null if there's no matching pointer (or it can't be read).
+ */
+export function findLatestArchivedSessionId(sessionsDir: string, name: string): string | null {
+  const archiveDir = resolve(sessionsDir, "archive");
+  let files: string[];
+  try {
+    files = readdirSync(archiveDir);
+  } catch {
+    return null;
+  }
+
+  const prefix = `${name}-`;
+  let bestTs = "";
+  let bestFile: string | null = null;
+  for (const file of files) {
+    if (!file.startsWith(prefix)) continue;
+    const match = file.slice(prefix.length).match(ARCHIVE_SUFFIX);
+    if (!match) continue;
+    // Timestamps are zero-padded ISO, so lexicographic comparison is chronological.
+    if (match[1] > bestTs) {
+      bestTs = match[1];
+      bestFile = file;
+    }
+  }
+  if (!bestFile) return null;
+
+  try {
+    const data = JSON.parse(readFileSync(resolve(archiveDir, bestFile), "utf-8"));
+    return typeof data.sessionId === "string" ? data.sessionId : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A chain event is a real conversation node (has a uuid), not a marker line. */
+function isChainEvent(o: JsonlLine): boolean {
+  return typeof o.uuid === "string" && (o.type === "user" || o.type === "assistant");
+}
+
+/**
+ * A turn boundary is a genuine incoming prompt: a `user` chain event whose
+ * content is NOT tool_result blocks (those are tool-loop continuations, not the
+ * start of a new turn).
+ */
+function isTurnBoundary(o: JsonlLine): boolean {
+  if (o.type !== "user" || typeof o.uuid !== "string") return false;
+  const content = o.message?.content;
+  if (typeof content === "string") return true;
+  if (Array.isArray(content)) {
+    return !content.some(
+      (b) => b && typeof b === "object" && (b as { type?: string }).type === "tool_result",
+    );
+  }
+  // Unusual shape — treat as a boundary rather than folding it into a prior turn.
+  return true;
+}
+
+/** Estimate tokens for a raw JSONL line as its JSON text length / 4. */
+function estimateTokens(raw: string): number {
+  return raw.length / 4;
+}
+
+export type SeededTranscript = { sessionId: string; lines: string[] };
+
+/**
+ * Build the seeded transcript from an old transcript's raw jsonl text: take as
+ * many whole trailing turns as fit in `seedTokens` (always at least the final
+ * turn), rewrite the session id on every line, and null the first chain event's
+ * parentUuid. Returns null if there's nothing seedable (empty, no genuine turn,
+ * or a corrupt line — in which case the caller starts clean).
+ */
+export function buildSeededTranscript(jsonl: string, seedTokens: number): SeededTranscript | null {
+  const rawLines = jsonl.split("\n").filter((l) => l.trim().length > 0);
+  if (rawLines.length === 0) return null;
+
+  const parsed: JsonlLine[] = [];
+  const raws: string[] = [];
+  for (const raw of rawLines) {
+    try {
+      parsed.push(JSON.parse(raw));
+    } catch {
+      // A corrupt line means we can't faithfully reconstruct the chain — start
+      // clean rather than seed a broken transcript.
+      return null;
+    }
+    raws.push(raw);
+  }
+
+  const boundaries: number[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    if (isTurnBoundary(parsed[i])) boundaries.push(i);
+  }
+  if (boundaries.length === 0) return null;
+
+  // Turn t spans lines [boundaries[t], boundaries[t+1]); the last turn runs to EOF.
+  const turnTokens = (t: number): number => {
+    const start = boundaries[t];
+    const end = t + 1 < boundaries.length ? boundaries[t + 1] : parsed.length;
+    let sum = 0;
+    for (let i = start; i < end; i++) sum += estimateTokens(raws[i]);
+    return sum;
+  };
+
+  // Walk backward from the final turn, adding earlier whole turns while they fit.
+  // The final turn is always included even if it alone exceeds the budget.
+  const last = boundaries.length - 1;
+  let startTurn = last;
+  let accum = turnTokens(last);
+  for (let t = last - 1; t >= 0; t--) {
+    const cost = turnTokens(t);
+    if (accum + cost > seedTokens) break;
+    accum += cost;
+    startTurn = t;
+  }
+
+  const startLine = boundaries[startTurn];
+  const newId = randomUUID();
+  const lines: string[] = [];
+  let firstChainSeen = false;
+  for (let i = startLine; i < parsed.length; i++) {
+    const obj = parsed[i];
+    if ("sessionId" in obj) obj.sessionId = newId;
+    if (!firstChainSeen && isChainEvent(obj)) {
+      obj.parentUuid = null;
+      firstChainSeen = true;
+    }
+    lines.push(JSON.stringify(obj));
+  }
+  return { sessionId: newId, lines };
+}
+
+/**
+ * Seed a fresh persistent session from the mind's previous archived transcript.
+ * Writes the synthetic transcript next to the source file (same project dir) and
+ * returns the new SDK session id, or null if there's nothing to seed. Never
+ * throws — any failure returns null so session start is never blocked.
+ */
+export function seedSession(opts: {
+  cwd: string;
+  sessionsDir: string;
+  name: string;
+  seedTokens: number;
+}): string | null {
+  const { cwd, sessionsDir, name, seedTokens } = opts;
+  // Ephemeral `new-*` sessions are never persisted or archived, so they never
+  // seed. The agent caller already gates on this; guard here too so the invariant
+  // holds wherever seedSession is called.
+  if (name.startsWith("new-")) return null;
+  if (seedTokens <= 0) return null; // seeding disabled
+
+  try {
+    const oldSessionId = findLatestArchivedSessionId(sessionsDir, name);
+    if (!oldSessionId) return null;
+
+    const sourcePath = findClaudeSessionFile(cwd, oldSessionId);
+    if (!sourcePath) return null; // transcript didn't survive archival — start clean
+
+    const seeded = buildSeededTranscript(readFileSync(sourcePath, "utf-8"), seedTokens);
+    if (!seeded) return null;
+
+    const destPath = resolve(dirname(sourcePath), `${seeded.sessionId}.jsonl`);
+    writeFileSync(destPath, `${seeded.lines.join("\n")}\n`);
+    log(
+      "mind",
+      `session "${name}": seeded ${seeded.lines.length} line(s) from ${oldSessionId} → ${seeded.sessionId}`,
+    );
+    return seeded.sessionId;
+  } catch (err) {
+    log("mind", `session "${name}": seeding failed, starting fresh:`, err);
+    return null;
+  }
+}

--- a/templates/_base/src/lib/startup.ts
+++ b/templates/_base/src/lib/startup.ts
@@ -44,6 +44,12 @@ export type MindConfig = {
   compaction?: { maxContextTokens?: number };
   /** Idle minutes before a session's SDK subprocess is reaped. 0 disables. Default 30. */
   sessionIdleMinutes?: number;
+  /**
+   * Session continuity across restarts. When a fresh persistent session starts,
+   * the tail of the previous session's transcript (up to `seedTokens` estimated
+   * tokens) is copied into it so the conversation continues. Default 30000; 0 disables.
+   */
+  continuity?: { seedTokens?: number };
   subagents?: Record<string, SubagentConfig>;
   // Template-specific config fields (claude, pi, codex)
   thinking?: ThinkingConfig;

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -22,6 +22,7 @@ import { createPreCompactHook } from "./lib/hooks/pre-compact.js";
 import { createReplyInstructionsHook } from "./lib/hooks/reply-instructions.js";
 import { log } from "./lib/logger.js";
 import { createMessageChannel } from "./lib/message-channel.js";
+import { buildSeededNote } from "./lib/seed-note.js";
 import {
   isSessionReapable,
   reapSessionQuery,
@@ -59,18 +60,13 @@ type Session = {
   lastActivityAt: number;
   /**
    * True when this session was seeded from the previous session's transcript.
-   * Consumed once, on the first prompt, to inject the honest-boundary note.
+   * Injects the honest-boundary note on each prompt until a turn resolves (see
+   * the pre-prompt hook and onTurnEnd), so an interrupted first turn re-offers it.
    */
   seeded: boolean;
+  /** When the seeded-from session was archived (epoch ms), for the gap note; null if unknown. */
+  seededArchivedAt: number | null;
 };
-
-/**
- * Injected on the first prompt of a seeded session so the mind knows the
- * conversation above was restored from its previous (archived) session rather
- * than lived through continuously in this one.
- */
-const SEEDED_SESSION_NOTE =
-  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
 
 export function createMind(options: {
   systemPrompt: string;
@@ -260,13 +256,32 @@ export function createMind(options: {
         // Only UserPromptSubmit hooks can inject additionalContext into the conversation
         if (event !== "pre-prompt") return {};
         let additionalContext = result.additionalContext;
-        // On the first prompt of a seeded session, prepend the honest-boundary
-        // note (consumed once), even if the pre-prompt hooks produced nothing.
+        // On a seeded session, prepend the honest-boundary note. Deliberately NOT
+        // cleared here: this hook only hands the note to the SDK at *dispatch*, and
+        // the SDK cancels UserPromptSubmit hooks when an interrupt arrives (a
+        // `hook_cancelled` transcript entry). That's most likely on the seeded first
+        // turn post-wake, when queued inbound messages flood in — exactly when we'd
+        // lose the note. Clearing on a mere injection attempt could drop it forever
+        // and silently. So the flag is cleared only when a turn actually resolves
+        // (onTurnEnd); an interrupted turn re-offers the note next prompt. Worst case
+        // it fires twice (cosmetic) instead of zero times (unrecoverable, invisible).
         if (session.seeded) {
-          session.seeded = false;
-          additionalContext = additionalContext
-            ? `${SEEDED_SESSION_NOTE}\n\n${additionalContext}`
-            : SEEDED_SESSION_NOTE;
+          const note = buildSeededNote(session.seededArchivedAt);
+          additionalContext = additionalContext ? `${note}\n\n${additionalContext}` : note;
+          // Also surface the note as its own context event (matching codex/pi) so it
+          // isn't delivered only in the same low-salience container as routine
+          // per-prompt hooks. Once per injection attempt; a duplicate on re-offer is fine.
+          const channel = session.currentMessageId
+            ? session.messageChannels.get(session.currentMessageId)?.channel
+            : undefined;
+          daemonEmit({
+            type: "context",
+            content: note,
+            metadata: { source: "seeded-session" },
+            session: session.name,
+            channel,
+            messageId: session.currentMessageId,
+          }).catch((err) => log("mind", "seeded-session context emit failed:", err));
         }
         if (!additionalContext) return {};
         return {
@@ -367,6 +382,11 @@ export function createMind(options: {
           // in-flight set so a later compaction abort won't re-feed it.
           session.channel.ack();
           session.lastActivityAt = Date.now();
+          // A turn resolved — the seeded note's injection had its chance to land
+          // (the pre-prompt hook ran and wasn't cancelled by an interrupt), so stop
+          // re-offering it. This is the honest place to clear: a completed turn is
+          // the closest-to-arrival signal available without reading the transcript back.
+          session.seeded = false;
           await autoCommit.flushFileChanges();
           const wasCompacting = compactionTriggered.get(session.name);
           compactionTriggered.set(session.name, false);
@@ -561,6 +581,7 @@ export function createMind(options: {
       contextTokens: 0,
       lastActivityAt: Date.now(),
       seeded: false,
+      seededArchivedAt: null,
     };
     sessions.set(name, session);
 
@@ -579,17 +600,21 @@ export function createMind(options: {
       // Fresh persistent session — seed it from the previous session's archived
       // transcript so the mind experiences the conversation continuing rather
       // than waking into an empty context. Ephemeral `new-*` sessions never seed.
-      const seededId = seedSession({
+      const seeded = seedSession({
         cwd: options.cwd,
         sessionsDir: options.sessionsDir,
         name,
         seedTokens: options.seedTokens ?? DEFAULT_SEED_TOKENS,
       });
-      if (seededId) {
-        sessionStore.save(name, seededId);
-        savedSessionId = seededId;
+      if (seeded) {
+        sessionStore.save(name, seeded.sessionId);
+        savedSessionId = seeded.sessionId;
         session.seeded = true;
-        log("mind", `session "${name}": seeded from previous transcript, resuming ${seededId}`);
+        session.seededArchivedAt = seeded.archivedAt;
+        log(
+          "mind",
+          `session "${name}": seeded from previous transcript, resuming ${seeded.sessionId}`,
+        );
       } else {
         log("mind", `session "${name}": starting fresh`);
       }

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -27,6 +27,7 @@ import {
   reapSessionQuery,
   reapSessionsForShutdown,
 } from "./lib/session-reaper.js";
+import { DEFAULT_SEED_TOKENS, seedSession } from "./lib/session-seed.js";
 import { createSessionStore } from "./lib/session-store.js";
 import type { EffortLevel, ThinkingConfig } from "./lib/startup.js";
 import { loadPrompts, type SubagentConfig } from "./lib/startup.js";
@@ -56,7 +57,20 @@ type Session = {
   contextTokens: number;
   /** Last inbound message or completed turn — drives idle reaping. */
   lastActivityAt: number;
+  /**
+   * True when this session was seeded from the previous session's transcript.
+   * Consumed once, on the first prompt, to inject the honest-boundary note.
+   */
+  seeded: boolean;
 };
+
+/**
+ * Injected on the first prompt of a seeded session so the mind knows the
+ * conversation above was restored from its previous (archived) session rather
+ * than lived through continuously in this one.
+ */
+const SEEDED_SESSION_NOTE =
+  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
 
 export function createMind(options: {
   systemPrompt: string;
@@ -72,6 +86,8 @@ export function createMind(options: {
   onIdentityReload?: () => Promise<void>;
   /** Idle minutes before a session's SDK subprocess is reaped. 0 disables. Default 30. */
   sessionIdleMinutes?: number;
+  /** Estimated-token budget for seeding a fresh persistent session. 0 disables. Default 30000. */
+  seedTokens?: number;
 }): {
   resolve: HandlerResolver;
   waitForCommits: () => Promise<void>;
@@ -242,11 +258,21 @@ export function createMind(options: {
           }
         }
         // Only UserPromptSubmit hooks can inject additionalContext into the conversation
-        if (event !== "pre-prompt" || !result.additionalContext) return {};
+        if (event !== "pre-prompt") return {};
+        let additionalContext = result.additionalContext;
+        // On the first prompt of a seeded session, prepend the honest-boundary
+        // note (consumed once), even if the pre-prompt hooks produced nothing.
+        if (session.seeded) {
+          session.seeded = false;
+          additionalContext = additionalContext
+            ? `${SEEDED_SESSION_NOTE}\n\n${additionalContext}`
+            : SEEDED_SESSION_NOTE;
+        }
+        if (!additionalContext) return {};
         return {
           hookSpecificOutput: {
             hookEventName: "UserPromptSubmit" as const,
-            additionalContext: result.additionalContext,
+            additionalContext,
           },
         };
       } catch (err) {
@@ -491,6 +517,9 @@ export function createMind(options: {
           log("mind", `session "${session.name}": resume failed, starting fresh:`, err);
           sessionStore.delete(session.name);
           currentSessionId = undefined;
+          // We fell back to a truly empty session — don't tell the mind its
+          // conversation continued when the seeded transcript failed to resume.
+          session.seeded = false;
           streamAbort = new AbortController();
           session.channel = createMessageChannel();
           try {
@@ -531,6 +560,7 @@ export function createMind(options: {
       eventNoteFired: false,
       contextTokens: 0,
       lastActivityAt: Date.now(),
+      seeded: false,
     };
     sessions.set(name, session);
 
@@ -545,6 +575,24 @@ export function createMind(options: {
     }
     if (savedSessionId) {
       log("mind", `session "${name}": resuming ${savedSessionId}`);
+    } else if (!isEphemeral) {
+      // Fresh persistent session — seed it from the previous session's archived
+      // transcript so the mind experiences the conversation continuing rather
+      // than waking into an empty context. Ephemeral `new-*` sessions never seed.
+      const seededId = seedSession({
+        cwd: options.cwd,
+        sessionsDir: options.sessionsDir,
+        name,
+        seedTokens: options.seedTokens ?? DEFAULT_SEED_TOKENS,
+      });
+      if (seededId) {
+        sessionStore.save(name, seededId);
+        savedSessionId = seededId;
+        session.seeded = true;
+        log("mind", `session "${name}": seeded from previous transcript, resuming ${seededId}`);
+      } else {
+        log("mind", `session "${name}": starting fresh`);
+      }
     } else {
       log("mind", `session "${name}": starting fresh`);
     }

--- a/templates/claude/src/server.ts
+++ b/templates/claude/src/server.ts
@@ -36,6 +36,7 @@ const mind = createMind({
   compactionMessage: config.compactionMessage,
   maxContextTokens: config.compaction?.maxContextTokens,
   sessionIdleMinutes: config.sessionIdleMinutes,
+  seedTokens: config.continuity?.seedTokens,
   subagents: config.subagents,
   onIdentityReload: async () => {
     log("server", "identity file changed — restarting to reload");

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -17,6 +17,7 @@ import {
 import { daemonEmit, daemonRestart, type EventType } from "./lib/daemon-client.js";
 import { runHooks } from "./lib/hook-loader.js";
 import { log, warn } from "./lib/logger.js";
+import { buildSeededNote } from "./lib/seed-note.js";
 import { createSessionStore } from "./lib/session-store.js";
 import { getStartupContext, loadPrompts, loadSystemPrompt } from "./lib/startup.js";
 import { filterEvent, loadTransparencyPreset } from "./lib/transparency.js";
@@ -57,15 +58,9 @@ type CodexSession = {
    * Consumed once, on the first turn, to inject the honest-boundary note.
    */
   seeded: boolean;
+  /** When the seeded-from session was archived (epoch ms), for the gap note; null if unknown. */
+  seededArchivedAt: number | null;
 };
-
-/**
- * Injected on the first turn of a seeded session so the mind knows the
- * conversation above was restored from its previous (archived) session rather
- * than lived through continuously in this one.
- */
-const SEEDED_SESSION_NOTE =
-  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
 
 // Loaded once at startup
 const preset = loadTransparencyPreset();
@@ -167,6 +162,7 @@ export function createMind(options: {
       eventNoteFired: false,
       cumulativeInputTokens: 0,
       seeded: false,
+      seededArchivedAt: null,
     };
     sessions.set(name, session);
 
@@ -185,14 +181,15 @@ export function createMind(options: {
         // Fresh persistent session — seed it from the previous session's archived
         // rollout so the mind experiences the conversation continuing rather than
         // waking into an empty context.
-        const seededId = seedCodexSession({
+        const seeded = seedCodexSession({
           mindDir: options.mindDir,
           name: session.name,
           seedTokens: options.seedTokens ?? DEFAULT_SEED_TOKENS,
         });
-        if (seededId) {
-          resumeThreadId = seededId;
+        if (seeded) {
+          resumeThreadId = seeded.threadId;
           session.seeded = true;
+          session.seededArchivedAt = seeded.archivedAt;
           log("mind", `session "${session.name}": seeded from previous transcript`);
         }
       }
@@ -277,15 +274,17 @@ export function createMind(options: {
     }
 
     // On the first turn of a seeded session, prepend the honest-boundary note
-    // (consumed once) so the mind knows the conversation above was restored.
+    // (consumed once) so the mind knows the conversation above was restored. The
+    // note carries a coarse gap-duration clause when the archive time is known.
     if (session.seeded) {
       session.seeded = false;
+      const note = buildSeededNote(session.seededArchivedAt);
       emit(session, {
         type: "context",
-        content: SEEDED_SESSION_NOTE,
+        content: note,
         metadata: { source: "seeded-session" },
       });
-      text = `${SEEDED_SESSION_NOTE}\n\n${text}`;
+      text = `${note}\n\n${text}`;
     }
 
     // Run pre-prompt hooks

--- a/templates/codex/src/agent.ts
+++ b/templates/codex/src/agent.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { Codex } from "@openai/codex-sdk";
 import { flushFileChanges, trackFileChange } from "./lib/auto-commit.js";
+import { DEFAULT_SEED_TOKENS, seedCodexSession } from "./lib/codex-session-seed.js";
 import { extractText } from "./lib/content.js";
 import {
   countSdkInstructionTokens,
@@ -51,7 +52,20 @@ type CodexSession = {
   /** The event note is a standing fact about events, so it fires once per session. */
   eventNoteFired: boolean;
   cumulativeInputTokens: number;
+  /**
+   * True when this session was seeded from the previous session's rollout.
+   * Consumed once, on the first turn, to inject the honest-boundary note.
+   */
+  seeded: boolean;
 };
+
+/**
+ * Injected on the first turn of a seeded session so the mind knows the
+ * conversation above was restored from its previous (archived) session rather
+ * than lived through continuously in this one.
+ */
+const SEEDED_SESSION_NOTE =
+  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
 
 // Loaded once at startup
 const preset = loadTransparencyPreset();
@@ -79,6 +93,8 @@ export function createMind(options: {
   model?: string;
   reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
   maxContextTokens?: number;
+  /** Estimated-token budget for seeding a fresh persistent session. 0 disables. Default 30000. */
+  seedTokens?: number;
 }): {
   resolve: HandlerResolver;
   getContextInfo: () => Promise<ContextInfo>;
@@ -150,6 +166,7 @@ export function createMind(options: {
       firstMessagePerChannel: new Set(),
       eventNoteFired: false,
       cumulativeInputTokens: 0,
+      seeded: false,
     };
     sessions.set(name, session);
 
@@ -163,11 +180,26 @@ export function createMind(options: {
     emit(session, { type: "session_start" });
 
     if (!isEphemeral) {
-      const savedThreadId = sessionStore.load(session.name);
-      if (savedThreadId) {
+      let resumeThreadId = sessionStore.load(session.name);
+      if (!resumeThreadId) {
+        // Fresh persistent session — seed it from the previous session's archived
+        // rollout so the mind experiences the conversation continuing rather than
+        // waking into an empty context.
+        const seededId = seedCodexSession({
+          mindDir: options.mindDir,
+          name: session.name,
+          seedTokens: options.seedTokens ?? DEFAULT_SEED_TOKENS,
+        });
+        if (seededId) {
+          resumeThreadId = seededId;
+          session.seeded = true;
+          log("mind", `session "${session.name}": seeded from previous transcript`);
+        }
+      }
+      if (resumeThreadId) {
         try {
-          log("mind", `session "${session.name}": resuming thread ${savedThreadId}`);
-          session.thread = codex.resumeThread(savedThreadId, {
+          log("mind", `session "${session.name}": resuming thread ${resumeThreadId}`);
+          session.thread = codex.resumeThread(resumeThreadId, {
             workingDirectory: options.cwd,
             model: options.model,
             modelReasoningEffort: options.reasoningEffort,
@@ -181,6 +213,9 @@ export function createMind(options: {
           return;
         } catch (err) {
           warn("mind", `session "${session.name}": failed to resume thread, starting new:`, err);
+          // We fell back to a truly fresh thread — don't tell the mind its
+          // conversation continued when the seeded rollout failed to resume.
+          session.seeded = false;
         }
       }
     }
@@ -239,6 +274,18 @@ export function createMind(options: {
         });
         text = `${startupContext}\n\n${text}`;
       }
+    }
+
+    // On the first turn of a seeded session, prepend the honest-boundary note
+    // (consumed once) so the mind knows the conversation above was restored.
+    if (session.seeded) {
+      session.seeded = false;
+      emit(session, {
+        type: "context",
+        content: SEEDED_SESSION_NOTE,
+        metadata: { source: "seeded-session" },
+      });
+      text = `${SEEDED_SESSION_NOTE}\n\n${text}`;
     }
 
     // Run pre-prompt hooks

--- a/templates/codex/src/server.ts
+++ b/templates/codex/src/server.ts
@@ -31,6 +31,7 @@ const mind = createMind({
   model: config.model,
   reasoningEffort: config.reasoningEffort,
   maxContextTokens: config.compaction?.maxContextTokens,
+  seedTokens: config.continuity?.seedTokens,
 });
 
 const router = createRouter({

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -26,6 +26,7 @@ import { dispatchPrompt } from "./lib/dispatch.js";
 import { createEventHandler, emit } from "./lib/event-handler.js";
 import { runHooks } from "./lib/hook-loader.js";
 import { log } from "./lib/logger.js";
+import { DEFAULT_SEED_TOKENS, seedPiSession } from "./lib/pi-session-seed.js";
 import { createReplyInstructionsExtension } from "./lib/reply-instructions-extension.js";
 import { resolveModel } from "./lib/resolve-model.js";
 import { getStartupContext, loadPrompts, type SubagentConfig } from "./lib/startup.js";
@@ -52,16 +53,33 @@ type PiSession = {
   currentMessageId?: string;
   messageChannels: Map<string, { channel: string; sender?: string }>;
   contextTokens: number;
+  /**
+   * True when this session was seeded from the previous session's transcript.
+   * Consumed once, on the first turn, to inject the honest-boundary note.
+   */
+  seeded?: boolean;
 };
+
+/**
+ * Injected on the first turn of a seeded session so the mind knows the
+ * conversation above was restored from its previous (archived) session rather
+ * than lived through continuously in this one.
+ */
+const SEEDED_SESSION_NOTE =
+  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
 
 export function createMind(options: {
   systemPrompt: string;
   cwd: string;
   mindDir: string;
+  /** Directory holding pi session subdirs (`<sessionsDir>/<name>/*.jsonl`). */
+  sessionsDir: string;
   model?: string;
   thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   compactionMessage?: string;
   maxContextTokens?: number;
+  /** Estimated-token budget for seeding a fresh persistent session. 0 disables. Default 30000. */
+  seedTokens?: number;
   subagents?: Record<string, SubagentConfig>;
 }): {
   resolve: HandlerResolver;
@@ -183,6 +201,18 @@ export function createMind(options: {
         // Inject startup context on the first turn of each session
         if (!startupContextInjected) {
           startupContextInjected = true;
+          // On the first turn of a seeded session, lead with the honest-boundary
+          // note (consumed once) so the restored transcript above isn't mistaken
+          // for a continuously-lived conversation.
+          if (session.seeded) {
+            session.seeded = false;
+            emit(session, {
+              type: "context",
+              content: SEEDED_SESSION_NOTE,
+              metadata: { source: "seeded-session" },
+            });
+            parts.push(SEEDED_SESSION_NOTE);
+          }
           const startupContext = await startupContextPromise;
           if (startupContext) {
             emit(session, {
@@ -273,9 +303,31 @@ export function createMind(options: {
   async function initSession(session: PiSession) {
     const isEphemeral = session.name.startsWith("new-");
 
+    // Fresh persistent session — seed it from the previous session's archived
+    // transcript so the mind experiences the conversation continuing rather than
+    // waking into an empty context. seedPiSession no-ops when a live session
+    // already exists (continueRecent will resume that instead). Ephemeral
+    // `new-*` sessions are never persisted or archived, so they never seed.
+    const seededId = isEphemeral
+      ? null
+      : seedPiSession({
+          cwd: options.cwd,
+          piSessionsDir: options.sessionsDir,
+          name: session.name,
+          seedTokens: options.seedTokens ?? DEFAULT_SEED_TOKENS,
+        });
+
     const sessionManager = isEphemeral
       ? SessionManager.inMemory()
-      : SessionManager.continueRecent(options.cwd, `.mind/pi-sessions/${session.name}`);
+      : SessionManager.continueRecent(options.cwd, resolvePath(options.sessionsDir, session.name));
+
+    // If continueRecent adopted our seed file, its header id is the seeded id;
+    // if it fell back to a truly fresh session it minted a different id, so the
+    // honest-boundary note never lies about a conversation that didn't continue.
+    if (seededId && sessionManager.getSessionId() === seededId) {
+      session.seeded = true;
+      log("mind", `session "${session.name}": seeded from previous transcript`);
+    }
 
     log("mind", `session "${session.name}": ${isEphemeral ? "ephemeral" : "persistent"}`);
 

--- a/templates/pi/src/agent.ts
+++ b/templates/pi/src/agent.ts
@@ -29,6 +29,7 @@ import { log } from "./lib/logger.js";
 import { DEFAULT_SEED_TOKENS, seedPiSession } from "./lib/pi-session-seed.js";
 import { createReplyInstructionsExtension } from "./lib/reply-instructions-extension.js";
 import { resolveModel } from "./lib/resolve-model.js";
+import { buildSeededNote } from "./lib/seed-note.js";
 import { getStartupContext, loadPrompts, type SubagentConfig } from "./lib/startup.js";
 import { createSubagentExtension, type SubagentDefinition } from "./lib/subagents.js";
 import type {
@@ -58,15 +59,9 @@ type PiSession = {
    * Consumed once, on the first turn, to inject the honest-boundary note.
    */
   seeded?: boolean;
+  /** When the seeded-from session was archived (epoch ms), for the gap note; null if unknown. */
+  seededArchivedAt?: number | null;
 };
-
-/**
- * Injected on the first turn of a seeded session so the mind knows the
- * conversation above was restored from its previous (archived) session rather
- * than lived through continuously in this one.
- */
-const SEEDED_SESSION_NOTE =
-  "Note: this session continues from your previous session's transcript (restored after archival). The conversation above happened before the break; a fresh session begins here.";
 
 export function createMind(options: {
   systemPrompt: string;
@@ -206,12 +201,13 @@ export function createMind(options: {
           // for a continuously-lived conversation.
           if (session.seeded) {
             session.seeded = false;
+            const note = buildSeededNote(session.seededArchivedAt ?? null);
             emit(session, {
               type: "context",
-              content: SEEDED_SESSION_NOTE,
+              content: note,
               metadata: { source: "seeded-session" },
             });
-            parts.push(SEEDED_SESSION_NOTE);
+            parts.push(note);
           }
           const startupContext = await startupContextPromise;
           if (startupContext) {
@@ -308,7 +304,7 @@ export function createMind(options: {
     // waking into an empty context. seedPiSession no-ops when a live session
     // already exists (continueRecent will resume that instead). Ephemeral
     // `new-*` sessions are never persisted or archived, so they never seed.
-    const seededId = isEphemeral
+    const seeded = isEphemeral
       ? null
       : seedPiSession({
           cwd: options.cwd,
@@ -324,8 +320,9 @@ export function createMind(options: {
     // If continueRecent adopted our seed file, its header id is the seeded id;
     // if it fell back to a truly fresh session it minted a different id, so the
     // honest-boundary note never lies about a conversation that didn't continue.
-    if (seededId && sessionManager.getSessionId() === seededId) {
+    if (seeded && sessionManager.getSessionId() === seeded.sessionId) {
       session.seeded = true;
+      session.seededArchivedAt = seeded.archivedAt;
       log("mind", `session "${session.name}": seeded from previous transcript`);
     }
 

--- a/templates/pi/src/server.ts
+++ b/templates/pi/src/server.ts
@@ -26,10 +26,12 @@ const mind = createMind({
   systemPrompt,
   cwd: resolve("home"),
   mindDir,
+  sessionsDir: resolve(".mind/pi-sessions"),
   model: config.model,
   thinkingLevel: config.thinkingLevel,
   compactionMessage: config.compactionMessage,
   maxContextTokens: config.compaction?.maxContextTokens,
+  seedTokens: config.continuity?.seedTokens,
   subagents: config.subagents,
 });
 

--- a/test/codex-session-seed.test.ts
+++ b/test/codex-session-seed.test.ts
@@ -1,0 +1,504 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildSeededRollout,
+  findLatestArchivedThreadId,
+  generateThreadId,
+  seedCodexSession,
+} from "../templates/_base/src/lib/codex-session-seed.js";
+
+// --- Rollout line builders (approximate real Codex rollout shapes) ---
+
+const OLD = "019f5e60-86f5-7770-80fa-6e9eadf58c24";
+
+function sessionMeta(id: string): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:06:52.000Z",
+    type: "session_meta",
+    payload: {
+      session_id: id,
+      id,
+      parent_thread_id: "019f-parent-thread",
+      timestamp: "2026-07-13T22:06:52.000Z",
+      cwd: "/minds/x/home",
+      originator: "codex_sdk_ts",
+      cli_version: "0.144.3",
+      history_mode: "legacy",
+    },
+  });
+}
+
+function message(role: string, text: string): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:00.000Z",
+    type: "response_item",
+    payload: { type: "message", role, content: [{ type: "input_text", text }] },
+  });
+}
+
+function toolCall(callId: string, input = "tools.exec_command({})"): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:01.000Z",
+    type: "response_item",
+    payload: {
+      type: "custom_tool_call",
+      id: `ctc_${callId}`,
+      status: "completed",
+      call_id: callId,
+      name: "exec",
+      input,
+    },
+  });
+}
+
+function toolOutput(callId: string): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:02.000Z",
+    type: "response_item",
+    payload: {
+      type: "custom_tool_call_output",
+      call_id: callId,
+      output: [{ type: "input_text", text: "ok" }],
+    },
+  });
+}
+
+function reasoning(): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:03.000Z",
+    type: "response_item",
+    payload: {
+      type: "reasoning",
+      id: "rs_abc",
+      summary: [{ type: "summary_text", text: "thinking" }],
+      encrypted_content: "gAAAAAB-opaque-provider-bound-blob",
+    },
+  });
+}
+
+function eventMsg(kind: string): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:04.000Z",
+    type: "event_msg",
+    payload: { type: kind },
+  });
+}
+
+function turnContext(): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:05.000Z",
+    type: "turn_context",
+    payload: { turn_id: "t1", model: "gpt-5.6-terra", cwd: "/minds/x/home" },
+  });
+}
+
+function worldState(): string {
+  return JSON.stringify({
+    timestamp: "2026-07-13T22:07:06.000Z",
+    type: "world_state",
+    payload: {},
+  });
+}
+
+function parseLines(lines: string[]): Record<string, any>[] {
+  return lines.map((l) => JSON.parse(l));
+}
+
+const NEW = "019f8000-1111-7abc-8def-0123456789ab";
+const NOW = new Date("2026-07-18T16:30:25.000Z");
+
+describe("buildSeededRollout — session_meta rewrite", () => {
+  it("rewrites id/session_id/timestamp and drops parent_thread_id", () => {
+    const jsonl = [sessionMeta(OLD), message("user", "hi")].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 30000, NOW);
+    assert.ok(res);
+    const objs = parseLines(res.lines);
+    const meta = objs[0];
+    assert.equal(meta.type, "session_meta");
+    assert.equal(meta.payload.session_id, NEW);
+    assert.equal(meta.payload.id, NEW);
+    assert.equal("parent_thread_id" in meta.payload, false);
+    assert.equal(meta.payload.timestamp, NOW.toISOString());
+    assert.equal(meta.timestamp, NOW.toISOString());
+    // Non-identity fields are preserved.
+    assert.equal(meta.payload.history_mode, "legacy");
+    assert.equal(meta.payload.originator, "codex_sdk_ts");
+  });
+
+  it("returns the fresh thread id it was given", () => {
+    const res = buildSeededRollout(
+      [sessionMeta(OLD), message("user", "hi")].join("\n"),
+      NEW,
+      30000,
+    );
+    assert.ok(res);
+    assert.equal(res.threadId, NEW);
+  });
+});
+
+describe("buildSeededRollout — line filtering", () => {
+  it("drops reasoning, event_msg, turn_context, world_state; keeps messages and tool pairs", () => {
+    const jsonl = [
+      sessionMeta(OLD),
+      eventMsg("task_started"),
+      message("developer", "sdk instructions"),
+      turnContext(),
+      message("user", "the prompt"),
+      eventMsg("user_message"),
+      reasoning(),
+      toolCall("call_1"),
+      toolOutput("call_1"),
+      eventMsg("token_count"),
+      worldState(),
+      message("assistant", "the reply"),
+      eventMsg("task_complete"),
+    ].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 1_000_000, NOW);
+    assert.ok(res);
+    const objs = parseLines(res.lines);
+    const types = objs.map((o) => o.payload?.type ?? o.type);
+    // No opaque / telemetry / turn-context / world-state lines survive.
+    assert.equal(
+      objs.some((o) => o.type === "event_msg"),
+      false,
+    );
+    assert.equal(
+      objs.some((o) => o.type === "turn_context"),
+      false,
+    );
+    assert.equal(
+      objs.some((o) => o.type === "world_state"),
+      false,
+    );
+    assert.equal(
+      objs.some((o) => o.payload?.type === "reasoning"),
+      false,
+    );
+    // session_meta + user msg + tool call + tool output + assistant msg. The
+    // leading developer message precedes the first user turn boundary, so it's
+    // dropped with everything before the retained tail (the SDK re-injects its
+    // own instruction preamble on resume).
+    assert.deepEqual(types, [
+      "session_meta",
+      "message",
+      "custom_tool_call",
+      "custom_tool_call_output",
+      "message",
+    ]);
+    // The encrypted reasoning blob is gone entirely.
+    assert.equal(res.lines.join("\n").includes("opaque-provider-bound"), false);
+  });
+
+  it("keeps message content verbatim", () => {
+    const jsonl = [sessionMeta(OLD), message("user", 'volute chat send #x "hi"')].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 30000, NOW);
+    assert.ok(res);
+    assert.equal(parseLines(res.lines)[1].payload.content[0].text, 'volute chat send #x "hi"');
+  });
+});
+
+describe("buildSeededRollout — tool-call pairing", () => {
+  it("drops an orphaned trailing tool call (no matching output)", () => {
+    const jsonl = [
+      sessionMeta(OLD),
+      message("user", "prompt"),
+      toolCall("call_1"),
+      toolOutput("call_1"),
+      toolCall("call_2"), // truncated turn — no output
+    ].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 1_000_000, NOW);
+    assert.ok(res);
+    const objs = parseLines(res.lines);
+    const callIds = objs
+      .filter((o) => o.payload?.type === "custom_tool_call")
+      .map((o) => o.payload.call_id);
+    assert.deepEqual(callIds, ["call_1"]);
+    // No custom_tool_call or output ever appears without its partner.
+    assert.equal(
+      objs.some((o) => o.payload?.call_id === "call_2"),
+      false,
+    );
+  });
+
+  it("drops an orphaned tool output (no matching call)", () => {
+    const jsonl = [
+      sessionMeta(OLD),
+      message("user", "prompt"),
+      toolOutput("call_x"), // output whose call isn't present
+      toolCall("call_1"),
+      toolOutput("call_1"),
+    ].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 1_000_000, NOW);
+    assert.ok(res);
+    const objs = parseLines(res.lines);
+    assert.equal(
+      objs.some((o) => o.payload?.call_id === "call_x"),
+      false,
+    );
+    assert.equal(objs.filter((o) => o.payload?.type === "custom_tool_call_output").length, 1);
+  });
+});
+
+describe("buildSeededRollout — budget selection", () => {
+  // Each turn is one user message padded to ~1000 est tokens (4000 chars / 4).
+  const turn = (n: number) => message("user", `${n}:${"z".repeat(4000)}`);
+
+  it("takes as many whole trailing turns as fit in the budget", () => {
+    const jsonl = [sessionMeta(OLD), turn(1), turn(2), turn(3)].join("\n");
+    // Budget fits two turns (~2000) but not three (~3000).
+    const res = buildSeededRollout(jsonl, NEW, 2500, NOW);
+    assert.ok(res);
+    const msgs = parseLines(res.lines).filter((o) => o.payload?.type === "message");
+    assert.equal(msgs.length, 2);
+    assert.ok(msgs[0].payload.content[0].text.startsWith("2:"));
+    assert.ok(msgs[1].payload.content[0].text.startsWith("3:"));
+  });
+
+  it("always keeps at least the final turn even when it alone exceeds the budget", () => {
+    const jsonl = [sessionMeta(OLD), message("user", "small"), turn(2)].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 10, NOW);
+    assert.ok(res);
+    const msgs = parseLines(res.lines).filter((o) => o.payload?.type === "message");
+    assert.equal(msgs.length, 1);
+    assert.ok(msgs[0].payload.content[0].text.startsWith("2:"));
+  });
+
+  it("keeps a complete tool pair inside the retained final turn", () => {
+    const jsonl = [
+      sessionMeta(OLD),
+      turn(1),
+      message("user", "second"),
+      toolCall("call_1"),
+      toolOutput("call_1"),
+      message("assistant", "done"),
+    ].join("\n");
+    const res = buildSeededRollout(jsonl, NEW, 60, NOW);
+    assert.ok(res);
+    const objs = parseLines(res.lines);
+    // Only the final turn's lines survive (meta + user + call + output + assistant).
+    assert.equal(objs.length, 5);
+    assert.equal(objs[1].payload.content[0].text, "second");
+    assert.equal(objs[2].payload.call_id, "call_1");
+    assert.equal(objs[3].payload.call_id, "call_1");
+  });
+});
+
+describe("buildSeededRollout — degenerate inputs", () => {
+  it("returns null for an empty transcript", () => {
+    assert.equal(buildSeededRollout("", NEW, 30000), null);
+    assert.equal(buildSeededRollout("\n\n  \n", NEW, 30000), null);
+  });
+
+  it("returns null when the first line is not session_meta", () => {
+    assert.equal(buildSeededRollout([message("user", "hi")].join("\n"), NEW, 30000), null);
+  });
+
+  it("returns null when there is no user-message turn boundary", () => {
+    const jsonl = [sessionMeta(OLD), message("developer", "x"), reasoning()].join("\n");
+    assert.equal(buildSeededRollout(jsonl, NEW, 30000), null);
+  });
+
+  it("returns null on a corrupt (unparseable) body line", () => {
+    const jsonl = [sessionMeta(OLD), message("user", "hi"), "{not json"].join("\n");
+    assert.equal(buildSeededRollout(jsonl, NEW, 30000), null);
+  });
+});
+
+describe("generateThreadId", () => {
+  it("produces a v7 UUID string with the codex millisecond-timestamp prefix", () => {
+    const id = generateThreadId(NOW);
+    assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    // First 48 bits are the millisecond timestamp — deterministic prefix.
+    const hexTs = NOW.getTime().toString(16).padStart(12, "0");
+    assert.equal(id.replace(/-/g, "").slice(0, 12), hexTs);
+  });
+
+  it("is unique across calls", () => {
+    assert.notEqual(generateThreadId(NOW), generateThreadId(NOW));
+  });
+});
+
+describe("findLatestArchivedThreadId", () => {
+  function scratch(): string {
+    return mkdtempSync(resolve(tmpdir(), "codex-seed-archive-"));
+  }
+
+  it("returns null when the archive dir is missing", () => {
+    assert.equal(findLatestArchivedThreadId(scratch(), "main"), null);
+  });
+
+  it("returns the newest pointer's threadId by timestamp suffix", () => {
+    const dir = scratch();
+    const archive = resolve(dir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ threadId: "old" }),
+    );
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T14-30.json"),
+      JSON.stringify({ threadId: "new" }),
+    );
+    writeFileSync(
+      resolve(archive, "main-2026-07-17T23-59.json"),
+      JSON.stringify({ threadId: "older" }),
+    );
+    assert.equal(findLatestArchivedThreadId(dir, "main"), "new");
+  });
+
+  it("does not confuse `main` with a differently-named session", () => {
+    const dir = scratch();
+    const archive = resolve(dir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ threadId: "m" }),
+    );
+    writeFileSync(
+      resolve(archive, "@suzy-2026-07-18T14-30.json"),
+      JSON.stringify({ threadId: "s" }),
+    );
+    assert.equal(findLatestArchivedThreadId(dir, "main"), "m");
+    assert.equal(findLatestArchivedThreadId(dir, "@suzy"), "s");
+  });
+
+  it("returns null when the pointer is invalid JSON or lacks threadId", () => {
+    const dir = scratch();
+    const archive = resolve(dir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(resolve(archive, "main-2026-07-18T10-00.json"), "{bad");
+    assert.equal(findLatestArchivedThreadId(dir, "main"), null);
+
+    const dir2 = scratch();
+    const archive2 = resolve(dir2, "archive");
+    mkdirSync(archive2, { recursive: true });
+    writeFileSync(
+      resolve(archive2, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ sessionId: "x" }),
+    );
+    assert.equal(findLatestArchivedThreadId(dir2, "main"), null);
+  });
+});
+
+describe("seedCodexSession", () => {
+  /**
+   * Build a mind-like layout: an archived codex pointer to OLD and the old
+   * rollout under .mind/codex/sessions/YYYY/MM/DD/ where findCodexSessionFile
+   * scans for a filename containing the thread id.
+   */
+  function setup(oldId: string, rolloutLines: string[]) {
+    const mindDir = mkdtempSync(resolve(tmpdir(), "codex-seed-mind-"));
+    const archive = resolve(mindDir, ".mind", "codex-sessions", "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ threadId: oldId }),
+    );
+    const rolloutDir = resolve(mindDir, ".mind", "codex", "sessions", "2026", "07", "13");
+    mkdirSync(rolloutDir, { recursive: true });
+    writeFileSync(
+      resolve(rolloutDir, `rollout-2026-07-13T22-06-52-${oldId}.jsonl`),
+      `${rolloutLines.join("\n")}\n`,
+    );
+    return mindDir;
+  }
+
+  const rollout = [sessionMeta(OLD), message("user", "hello"), message("assistant", "hi there")];
+
+  it("seeds a fresh persistent session: writes a rollout under today's date and returns its id", () => {
+    const mindDir = setup(OLD, rollout);
+    const newId = seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW });
+    assert.ok(newId);
+    assert.notEqual(newId, OLD);
+    // Written under .mind/codex/sessions/2026/07/18/ (NOW's local date) with the
+    // rollout-<ts>-<threadId>.jsonl name Codex uses.
+    const y = String(NOW.getFullYear());
+    const mo = String(NOW.getMonth() + 1).padStart(2, "0");
+    const d = String(NOW.getDate()).padStart(2, "0");
+    const dayDir = resolve(mindDir, ".mind", "codex", "sessions", y, mo, d);
+    const files = readdirSync(dayDir);
+    assert.equal(files.length, 1);
+    assert.match(
+      files[0],
+      new RegExp(`^rollout-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-${newId}\\.jsonl$`),
+    );
+    const objs = parseLines(readFileSync(resolve(dayDir, files[0]), "utf-8").trim().split("\n"));
+    assert.equal(objs[0].payload.session_id, newId);
+    assert.equal(objs[1].payload.content[0].text, "hello");
+  });
+
+  it("returns null when seedTokens is 0 (disabled)", () => {
+    const mindDir = setup(OLD, rollout);
+    assert.equal(seedCodexSession({ mindDir, name: "main", seedTokens: 0, now: NOW }), null);
+  });
+
+  it("returns null for an ephemeral new-* session", () => {
+    const mindDir = setup(OLD, rollout);
+    assert.equal(seedCodexSession({ mindDir, name: "new-abc", seedTokens: 30000, now: NOW }), null);
+  });
+
+  it("returns null when there is no archived pointer", () => {
+    const mindDir = mkdtempSync(resolve(tmpdir(), "codex-seed-none-"));
+    mkdirSync(resolve(mindDir, ".mind", "codex-sessions"), { recursive: true });
+    assert.equal(seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW }), null);
+  });
+
+  it("returns null when the archived rollout no longer exists", () => {
+    const mindDir = mkdtempSync(resolve(tmpdir(), "codex-seed-orphan-"));
+    const archive = resolve(mindDir, ".mind", "codex-sessions", "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ threadId: "019f-missing" }),
+    );
+    assert.equal(seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW }), null);
+  });
+
+  it("writes the seed into the source rollout's sessions root (~/.codex case)", () => {
+    // When CODEX_HOME is unset, Codex reads/writes rollouts under ~/.codex/sessions,
+    // so findCodexSessionFile locates the old rollout there — the seed must land in
+    // that same root, not under mindDir/.mind/codex/sessions.
+    const home = mkdtempSync(resolve(tmpdir(), "codex-seed-home-"));
+    const mindDir = mkdtempSync(resolve(tmpdir(), "codex-seed-mind2-"));
+    const archive = resolve(mindDir, ".mind", "codex-sessions", "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ threadId: OLD }),
+    );
+    const homeRollout = resolve(home, ".codex", "sessions", "2026", "07", "13");
+    mkdirSync(homeRollout, { recursive: true });
+    writeFileSync(
+      resolve(homeRollout, `rollout-2026-07-13T22-06-52-${OLD}.jsonl`),
+      `${rollout.join("\n")}\n`,
+    );
+
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    let newId: string | null;
+    try {
+      newId = seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW });
+    } finally {
+      process.env.HOME = prevHome;
+    }
+    assert.ok(newId);
+    // Seed lands under ~/.codex/sessions/<today>, where Codex resume will find it —
+    // and NOT under mindDir/.mind/codex/sessions.
+    const y = String(NOW.getFullYear());
+    const mo = String(NOW.getMonth() + 1).padStart(2, "0");
+    const d = String(NOW.getDate()).padStart(2, "0");
+    const homeDayDir = resolve(home, ".codex", "sessions", y, mo, d);
+    assert.equal(readdirSync(homeDayDir).length, 1);
+    assert.equal(existsSync(resolve(mindDir, ".mind", "codex", "sessions", y, mo, d)), false);
+  });
+});

--- a/test/codex-session-seed.test.ts
+++ b/test/codex-session-seed.test.ts
@@ -12,7 +12,7 @@ import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import {
   buildSeededRollout,
-  findLatestArchivedThreadId,
+  findLatestArchivedThread,
   generateThreadId,
   seedCodexSession,
 } from "../templates/_base/src/lib/codex-session-seed.js";
@@ -328,16 +328,16 @@ describe("generateThreadId", () => {
   });
 });
 
-describe("findLatestArchivedThreadId", () => {
+describe("findLatestArchivedThread", () => {
   function scratch(): string {
     return mkdtempSync(resolve(tmpdir(), "codex-seed-archive-"));
   }
 
   it("returns null when the archive dir is missing", () => {
-    assert.equal(findLatestArchivedThreadId(scratch(), "main"), null);
+    assert.equal(findLatestArchivedThread(scratch(), "main"), null);
   });
 
-  it("returns the newest pointer's threadId by timestamp suffix", () => {
+  it("returns the newest pointer's threadId and archived-at by timestamp suffix", () => {
     const dir = scratch();
     const archive = resolve(dir, "archive");
     mkdirSync(archive, { recursive: true });
@@ -353,7 +353,9 @@ describe("findLatestArchivedThreadId", () => {
       resolve(archive, "main-2026-07-17T23-59.json"),
       JSON.stringify({ threadId: "older" }),
     );
-    assert.equal(findLatestArchivedThreadId(dir, "main"), "new");
+    const found = findLatestArchivedThread(dir, "main");
+    assert.equal(found?.threadId, "new");
+    assert.equal(found?.archivedAt, Date.UTC(2026, 6, 18, 14, 30));
   });
 
   it("does not confuse `main` with a differently-named session", () => {
@@ -368,8 +370,8 @@ describe("findLatestArchivedThreadId", () => {
       resolve(archive, "@suzy-2026-07-18T14-30.json"),
       JSON.stringify({ threadId: "s" }),
     );
-    assert.equal(findLatestArchivedThreadId(dir, "main"), "m");
-    assert.equal(findLatestArchivedThreadId(dir, "@suzy"), "s");
+    assert.equal(findLatestArchivedThread(dir, "main")?.threadId, "m");
+    assert.equal(findLatestArchivedThread(dir, "@suzy")?.threadId, "s");
   });
 
   it("returns null when the pointer is invalid JSON or lacks threadId", () => {
@@ -377,7 +379,7 @@ describe("findLatestArchivedThreadId", () => {
     const archive = resolve(dir, "archive");
     mkdirSync(archive, { recursive: true });
     writeFileSync(resolve(archive, "main-2026-07-18T10-00.json"), "{bad");
-    assert.equal(findLatestArchivedThreadId(dir, "main"), null);
+    assert.equal(findLatestArchivedThread(dir, "main"), null);
 
     const dir2 = scratch();
     const archive2 = resolve(dir2, "archive");
@@ -386,7 +388,7 @@ describe("findLatestArchivedThreadId", () => {
       resolve(archive2, "main-2026-07-18T10-00.json"),
       JSON.stringify({ sessionId: "x" }),
     );
-    assert.equal(findLatestArchivedThreadId(dir2, "main"), null);
+    assert.equal(findLatestArchivedThread(dir2, "main"), null);
   });
 });
 
@@ -415,11 +417,13 @@ describe("seedCodexSession", () => {
 
   const rollout = [sessionMeta(OLD), message("user", "hello"), message("assistant", "hi there")];
 
-  it("seeds a fresh persistent session: writes a rollout under today's date and returns its id", () => {
+  it("seeds a fresh persistent session: writes a rollout under today's date and returns its id + archived-at", () => {
     const mindDir = setup(OLD, rollout);
-    const newId = seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW });
-    assert.ok(newId);
-    assert.notEqual(newId, OLD);
+    const seeded = seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW });
+    assert.ok(seeded);
+    assert.notEqual(seeded.threadId, OLD);
+    // Archived-at parsed from the pointer filename (`main-2026-07-18T10-00.json`).
+    assert.equal(seeded.archivedAt, Date.UTC(2026, 6, 18, 10, 0));
     // Written under .mind/codex/sessions/2026/07/18/ (NOW's local date) with the
     // rollout-<ts>-<threadId>.jsonl name Codex uses.
     const y = String(NOW.getFullYear());
@@ -430,10 +434,10 @@ describe("seedCodexSession", () => {
     assert.equal(files.length, 1);
     assert.match(
       files[0],
-      new RegExp(`^rollout-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-${newId}\\.jsonl$`),
+      new RegExp(`^rollout-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-${seeded.threadId}\\.jsonl$`),
     );
     const objs = parseLines(readFileSync(resolve(dayDir, files[0]), "utf-8").trim().split("\n"));
-    assert.equal(objs[0].payload.session_id, newId);
+    assert.equal(objs[0].payload.session_id, seeded.threadId);
     assert.equal(objs[1].payload.content[0].text, "hello");
   });
 
@@ -485,13 +489,13 @@ describe("seedCodexSession", () => {
 
     const prevHome = process.env.HOME;
     process.env.HOME = home;
-    let newId: string | null;
+    let seeded: ReturnType<typeof seedCodexSession>;
     try {
-      newId = seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW });
+      seeded = seedCodexSession({ mindDir, name: "main", seedTokens: 30000, now: NOW });
     } finally {
       process.env.HOME = prevHome;
     }
-    assert.ok(newId);
+    assert.ok(seeded);
     // Seed lands under ~/.codex/sessions/<today>, where Codex resume will find it —
     // and NOT under mindDir/.mind/codex/sessions.
     const y = String(NOW.getFullYear());

--- a/test/pi-session-seed.test.ts
+++ b/test/pi-session-seed.test.ts
@@ -1,0 +1,466 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import {
+  buildSeededPiTranscript,
+  findLatestArchivedPiSessionDir,
+  hasLivePiSession,
+  seedPiSession,
+} from "../templates/_base/src/lib/pi-session-seed.js";
+
+// --- Pi session-file line builders (mirror the real on-disk JSONL shapes) ---
+
+const SRC_ID = "src-session-0000";
+
+function header(id = SRC_ID, cwd = "/orig/home"): string {
+  return JSON.stringify({
+    type: "session",
+    version: 3,
+    id,
+    timestamp: "2026-07-18T00:00:00.000Z",
+    cwd,
+  });
+}
+
+function userMsg(id: string, parentId: string | null, text: string): string {
+  return JSON.stringify({
+    type: "message",
+    id,
+    parentId,
+    timestamp: "2026-07-18T00:00:01.000Z",
+    message: { role: "user", content: text, timestamp: 0 },
+  });
+}
+
+function assistantMsg(id: string, parentId: string, blocks: unknown[]): string {
+  return JSON.stringify({
+    type: "message",
+    id,
+    parentId,
+    timestamp: "2026-07-18T00:00:02.000Z",
+    message: {
+      role: "assistant",
+      content: blocks,
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-sonnet-4",
+      usage: { totalTokens: 1 },
+      stopReason: "stop",
+      timestamp: 0,
+    },
+  });
+}
+
+function toolResultMsg(id: string, parentId: string, toolCallId: string): string {
+  return JSON.stringify({
+    type: "message",
+    id,
+    parentId,
+    timestamp: "2026-07-18T00:00:03.000Z",
+    message: {
+      role: "toolResult",
+      toolCallId,
+      toolName: "Bash",
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+      timestamp: 0,
+    },
+  });
+}
+
+/** A non-message entry that lives inside a turn (must not be a boundary). */
+function modelChange(id: string, parentId: string): string {
+  return JSON.stringify({
+    type: "model_change",
+    id,
+    parentId,
+    timestamp: "2026-07-18T00:00:04.000Z",
+    provider: "anthropic",
+    modelId: "claude-sonnet-4",
+  });
+}
+
+function parse(lines: string[]): Record<string, any>[] {
+  return lines.map((l) => JSON.parse(l));
+}
+
+function scratch(): string {
+  return mkdtempSync(resolve(tmpdir(), "pi-seed-"));
+}
+
+/** Write a source transcript into an archive dir and return the archive layout. */
+function makeArchive(
+  piSessionsDir: string,
+  name: string,
+  ts: string,
+  transcriptLines: string[],
+  filename = "2026-07-18T00-00-00-000Z_src-session-0000.jsonl",
+): string {
+  const dir = resolve(piSessionsDir, "archive", `${name}-${ts}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(resolve(dir, filename), `${transcriptLines.join("\n")}\n`);
+  return dir;
+}
+
+// --- buildSeededPiTranscript: turn boundaries ------------------------------
+
+describe("buildSeededPiTranscript — turn boundaries", () => {
+  it("keeps a whole turn including its tool_result continuation", () => {
+    const lines = [
+      header(),
+      userMsg("u1", null, "first prompt"),
+      assistantMsg("a1", "u1", [{ type: "text", text: "hi" }]),
+      userMsg("u2", "a1", "second prompt"),
+      assistantMsg("a2", "u2", [{ type: "toolCall", id: "t1", name: "Bash", input: {} }]),
+      toolResultMsg("tr1", "a2", "t1"),
+      assistantMsg("a3", "tr1", [{ type: "text", text: "done" }]),
+    ];
+    const res = buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 1_000_000 });
+    assert.ok(res);
+    // header + all 6 entries (both turns fit).
+    assert.equal(res.lines.length, 7);
+  });
+
+  it("treats only user-role messages as boundaries (toolResult/model_change are continuations)", () => {
+    // One turn whose body has a model_change and a toolResult — a tight budget
+    // must keep the whole turn, not split at the non-user entries.
+    const lines = [
+      header(),
+      userMsg("u1", null, "x".repeat(400)),
+      assistantMsg("a1", "u1", [{ type: "text", text: "y".repeat(400) }]),
+      userMsg("u2", "a1", "second"),
+      modelChange("m1", "u2"),
+      assistantMsg("a2", "u2", [{ type: "toolCall", id: "t1", name: "Bash", input: {} }]),
+      toolResultMsg("tr1", "a2", "t1"),
+      assistantMsg("a3", "tr1", [{ type: "text", text: "done" }]),
+    ];
+    const res = buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 60 });
+    assert.ok(res);
+    // header + turn2's 5 entries (u2, m1, a2, tr1, a3).
+    assert.equal(res.lines.length, 6);
+    const objs = parse(res.lines);
+    assert.equal(objs[1].message.content, "second");
+    assert.ok(objs.some((o) => o.type === "model_change"));
+    assert.ok(objs.some((o) => o.message?.role === "toolResult"));
+  });
+});
+
+// --- buildSeededPiTranscript: budget selection -----------------------------
+
+describe("buildSeededPiTranscript — token budget selection", () => {
+  it("takes as many whole trailing turns as fit in the budget", () => {
+    const big = "z".repeat(4000); // ~1000 est tokens per turn
+    const lines = [
+      header(),
+      userMsg("u1", null, big),
+      userMsg("u2", "u1", big),
+      userMsg("u3", "u2", big),
+    ];
+    // Budget fits two turns (~2000) but not three (~3000).
+    const res = buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 2500 });
+    assert.ok(res);
+    // header + 2 entries.
+    assert.equal(res.lines.length, 3);
+    const objs = parse(res.lines);
+    assert.equal(objs[1].id, "u2");
+    assert.equal(objs[2].id, "u3");
+  });
+
+  it("always keeps at least the final turn even when it alone exceeds the budget", () => {
+    const lines = [
+      header(),
+      userMsg("u1", null, "small"),
+      userMsg("u2", "u1", "q".repeat(4000)), // ~1000 est tokens
+    ];
+    const res = buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 10 });
+    assert.ok(res);
+    assert.equal(res.lines.length, 2); // header + u2
+    assert.equal(parse(res.lines)[1].id, "u2");
+  });
+});
+
+// --- buildSeededPiTranscript: header + entry rewrites ----------------------
+
+describe("buildSeededPiTranscript — rewrites", () => {
+  it("writes a fresh header (new id, rewritten cwd, source recorded) and preserves version", () => {
+    const lines = [
+      header(SRC_ID, "/orig/home"),
+      userMsg("u1", null, "hello"),
+      assistantMsg("a1", "u1", [{ type: "text", text: "hi" }]),
+    ];
+    const res = buildSeededPiTranscript(lines.join("\n"), {
+      cwd: "/new/home",
+      seedTokens: 1_000_000,
+      sourcePath: "/archive/src.jsonl",
+    });
+    assert.ok(res);
+    const h = parse(res.lines)[0];
+    assert.equal(h.type, "session");
+    assert.equal(h.version, 3);
+    assert.equal(h.id, res.sessionId);
+    assert.notEqual(h.id, SRC_ID);
+    assert.equal(h.cwd, resolve("/new/home"));
+    assert.equal(h.parentSession, "/archive/src.jsonl");
+  });
+
+  it("nulls the first kept entry's parentId and keeps every other entry verbatim", () => {
+    const srcUser = userMsg("u2", "a1", "second");
+    const srcAssistant = assistantMsg("a2", "u2", [{ type: "text", text: "done" }]);
+    const lines = [
+      header(),
+      userMsg("u1", null, "first"),
+      assistantMsg("a1", "u1", [{ type: "text", text: "hi" }]),
+      srcUser,
+      srcAssistant,
+    ];
+    // Budget keeps only the final turn (u2, a2).
+    const res = buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 5 });
+    assert.ok(res);
+    assert.equal(res.lines.length, 3); // header + u2 + a2
+    const objs = parse(res.lines);
+    // First kept entry: same content, but parentId detached to null.
+    assert.equal(objs[1].id, "u2");
+    assert.equal(objs[1].parentId, null);
+    assert.equal(objs[1].message.content, "second");
+    // Later entry is byte-for-byte identical to the source line.
+    assert.equal(res.lines[2], srcAssistant);
+  });
+});
+
+// --- buildSeededPiTranscript: degenerate inputs ----------------------------
+
+describe("buildSeededPiTranscript — degenerate inputs", () => {
+  it("returns null for empty input", () => {
+    assert.equal(buildSeededPiTranscript("", { cwd: "/home", seedTokens: 1000 }), null);
+    assert.equal(buildSeededPiTranscript("   \n\n", { cwd: "/home", seedTokens: 1000 }), null);
+  });
+
+  it("returns null when the first line is not a session header", () => {
+    const lines = [userMsg("u1", null, "no header here")];
+    assert.equal(
+      buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 1000 }),
+      null,
+    );
+  });
+
+  it("returns null when there is no genuine (user) turn", () => {
+    const lines = [
+      header(),
+      assistantMsg("a1", null, [{ type: "text", text: "orphan assistant" }]),
+      toolResultMsg("tr1", "a1", "t1"),
+    ];
+    assert.equal(
+      buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 1000 }),
+      null,
+    );
+  });
+
+  it("returns null on a corrupt (non-JSON) line", () => {
+    const lines = [header(), userMsg("u1", null, "hi"), "{not valid json"];
+    assert.equal(
+      buildSeededPiTranscript(lines.join("\n"), { cwd: "/home", seedTokens: 1000 }),
+      null,
+    );
+  });
+});
+
+// --- Archive directory lookup + name disambiguation ------------------------
+
+describe("findLatestArchivedPiSessionDir", () => {
+  it("returns null when there is no archive dir", () => {
+    const base = scratch();
+    assert.equal(findLatestArchivedPiSessionDir(resolve(base, ".mind/pi-sessions"), "main"), null);
+  });
+
+  it("picks the newest archived dir for the exact session name", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T00-00", [header(), userMsg("u1", null, "a")]);
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", [header(), userMsg("u1", null, "b")]);
+    const found = findLatestArchivedPiSessionDir(piSessionsDir, "main");
+    assert.ok(found);
+    assert.match(found, /main-2026-07-18T09-30$/);
+  });
+
+  it("disambiguates `main` from `main-thread`", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T00-00", [header(), userMsg("u1", null, "a")]);
+    makeArchive(piSessionsDir, "main-thread", "2026-07-18T09-30", [
+      header(),
+      userMsg("u1", null, "b"),
+    ]);
+    const main = findLatestArchivedPiSessionDir(piSessionsDir, "main");
+    assert.ok(main);
+    assert.match(main, /\/main-2026-07-18T00-00$/);
+    const thread = findLatestArchivedPiSessionDir(piSessionsDir, "main-thread");
+    assert.ok(thread);
+    assert.match(thread, /main-thread-2026-07-18T09-30$/);
+  });
+
+  it("ignores dirs whose suffix is not a valid timestamp", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "not-a-timestamp", [header(), userMsg("u1", null, "a")]);
+    assert.equal(findLatestArchivedPiSessionDir(piSessionsDir, "main"), null);
+  });
+});
+
+// --- hasLivePiSession ------------------------------------------------------
+
+describe("hasLivePiSession", () => {
+  it("is true only when a live .jsonl exists for the name", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    assert.equal(hasLivePiSession(piSessionsDir, "main"), false);
+    const live = resolve(piSessionsDir, "main");
+    mkdirSync(live, { recursive: true });
+    assert.equal(hasLivePiSession(piSessionsDir, "main"), false);
+    writeFileSync(resolve(live, "sess.jsonl"), "{}");
+    assert.equal(hasLivePiSession(piSessionsDir, "main"), true);
+  });
+});
+
+// --- seedPiSession: end-to-end wiring --------------------------------------
+
+describe("seedPiSession", () => {
+  const transcript = () => [
+    header(SRC_ID, "/orig/home"),
+    userMsg("u1", null, "first prompt"),
+    assistantMsg("a1", "u1", [{ type: "text", text: "hi" }]),
+    userMsg("u2", "a1", "second prompt"),
+    assistantMsg("a2", "u2", [{ type: "text", text: "done" }]),
+  ];
+
+  it("writes a seed file into a fresh live dir and returns the new session id", () => {
+    const home = resolve(scratch(), "home");
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", transcript());
+
+    const id = seedPiSession({ cwd: home, piSessionsDir, name: "main", seedTokens: 1_000_000 });
+    assert.ok(id);
+
+    const liveDir = resolve(piSessionsDir, "main");
+    const files = readdirSync(liveDir).filter((f) => f.endsWith(".jsonl"));
+    assert.equal(files.length, 1);
+    const written = readFileSync(resolve(liveDir, files[0]), "utf-8").trim().split("\n");
+    const h = JSON.parse(written[0]);
+    assert.equal(h.id, id);
+    assert.equal(h.cwd, resolve(home));
+  });
+
+  it("returns null when there is no archive", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    assert.equal(
+      seedPiSession({ cwd: "/home", piSessionsDir, name: "main", seedTokens: 1000 }),
+      null,
+    );
+  });
+
+  it("returns null when the archive dir has no jsonl", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    mkdirSync(resolve(piSessionsDir, "archive", "main-2026-07-18T09-30"), { recursive: true });
+    assert.equal(
+      seedPiSession({ cwd: "/home", piSessionsDir, name: "main", seedTokens: 1000 }),
+      null,
+    );
+  });
+
+  it("returns null on a corrupt source transcript", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", [header(), "{bad json"]);
+    assert.equal(
+      seedPiSession({ cwd: "/home", piSessionsDir, name: "main", seedTokens: 1000 }),
+      null,
+    );
+  });
+
+  it("never seeds an ephemeral new-* session", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "new-abc", "2026-07-18T09-30", transcript());
+    assert.equal(
+      seedPiSession({ cwd: "/home", piSessionsDir, name: "new-abc", seedTokens: 1000 }),
+      null,
+    );
+  });
+
+  it("is disabled when seedTokens is 0", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", transcript());
+    assert.equal(seedPiSession({ cwd: "/home", piSessionsDir, name: "main", seedTokens: 0 }), null);
+  });
+
+  it("does not seed over an existing live session", () => {
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", transcript());
+    const liveDir = resolve(piSessionsDir, "main");
+    mkdirSync(liveDir, { recursive: true });
+    writeFileSync(resolve(liveDir, "existing.jsonl"), `${header("live-id")}\n`);
+    assert.equal(
+      seedPiSession({ cwd: "/home", piSessionsDir, name: "main", seedTokens: 1000 }),
+      null,
+    );
+  });
+});
+
+// --- Load-bearing: the real SessionManager resumes the seed ----------------
+
+describe("seedPiSession + SessionManager.continueRecent (real SDK)", () => {
+  it("continueRecent adopts the seeded file and exposes the prior conversation", () => {
+    const home = resolve(scratch(), "home");
+    mkdirSync(home, { recursive: true });
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", [
+      header(SRC_ID, "/orig/home"),
+      userMsg("u1", null, "first prompt"),
+      assistantMsg("a1", "u1", [{ type: "text", text: "hi there" }]),
+      userMsg("u2", "a1", "second prompt"),
+      assistantMsg("a2", "u2", [{ type: "text", text: "all done" }]),
+    ]);
+
+    const seededId = seedPiSession({
+      cwd: home,
+      piSessionsDir,
+      name: "main",
+      seedTokens: 1_000_000,
+    });
+    assert.ok(seededId);
+
+    // Exactly as agent.ts calls it: cwd = home dir, sessionDir = <base>/<name>.
+    const sm = SessionManager.continueRecent(home, resolve(piSessionsDir, "main"));
+    // The SDK adopted our seed: its header id is the one we generated.
+    assert.equal(sm.getSessionId(), seededId);
+
+    // The prior conversation is present in the resumed context.
+    const { messages } = sm.buildSessionContext();
+    const texts = JSON.stringify(messages);
+    assert.ok(messages.length >= 4);
+    assert.match(texts, /first prompt/);
+    assert.match(texts, /all done/);
+  });
+
+  it("does NOT adopt the seed when the header cwd doesn't match (cwd rewrite is load-bearing)", () => {
+    const home = resolve(scratch(), "home");
+    mkdirSync(home, { recursive: true });
+    const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
+    makeArchive(piSessionsDir, "main", "2026-07-18T09-30", [
+      header(SRC_ID, "/orig/home"),
+      userMsg("u1", null, "hi"),
+      assistantMsg("a1", "u1", [{ type: "text", text: "yo" }]),
+    ]);
+    const seededId = seedPiSession({
+      cwd: home,
+      piSessionsDir,
+      name: "main",
+      seedTokens: 1_000_000,
+    });
+    assert.ok(seededId);
+
+    // Resume with a DIFFERENT cwd than the seed header records: the SDK's cwd
+    // filter rejects the file and mints a fresh session instead.
+    const sm = SessionManager.continueRecent(
+      resolve(home, "elsewhere"),
+      resolve(piSessionsDir, "main"),
+    );
+    assert.notEqual(sm.getSessionId(), seededId);
+  });
+});

--- a/test/pi-session-seed.test.ts
+++ b/test/pi-session-seed.test.ts
@@ -6,7 +6,7 @@ import { describe, it } from "node:test";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
   buildSeededPiTranscript,
-  findLatestArchivedPiSessionDir,
+  findLatestArchivedPiSession,
   hasLivePiSession,
   seedPiSession,
 } from "../templates/_base/src/lib/pi-session-seed.js";
@@ -269,19 +269,20 @@ describe("buildSeededPiTranscript — degenerate inputs", () => {
 
 // --- Archive directory lookup + name disambiguation ------------------------
 
-describe("findLatestArchivedPiSessionDir", () => {
+describe("findLatestArchivedPiSession", () => {
   it("returns null when there is no archive dir", () => {
     const base = scratch();
-    assert.equal(findLatestArchivedPiSessionDir(resolve(base, ".mind/pi-sessions"), "main"), null);
+    assert.equal(findLatestArchivedPiSession(resolve(base, ".mind/pi-sessions"), "main"), null);
   });
 
-  it("picks the newest archived dir for the exact session name", () => {
+  it("picks the newest archived dir for the exact session name, with archived-at", () => {
     const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
     makeArchive(piSessionsDir, "main", "2026-07-18T00-00", [header(), userMsg("u1", null, "a")]);
     makeArchive(piSessionsDir, "main", "2026-07-18T09-30", [header(), userMsg("u1", null, "b")]);
-    const found = findLatestArchivedPiSessionDir(piSessionsDir, "main");
+    const found = findLatestArchivedPiSession(piSessionsDir, "main");
     assert.ok(found);
-    assert.match(found, /main-2026-07-18T09-30$/);
+    assert.match(found.dir, /main-2026-07-18T09-30$/);
+    assert.equal(found.archivedAt, Date.UTC(2026, 6, 18, 9, 30));
   });
 
   it("disambiguates `main` from `main-thread`", () => {
@@ -291,18 +292,18 @@ describe("findLatestArchivedPiSessionDir", () => {
       header(),
       userMsg("u1", null, "b"),
     ]);
-    const main = findLatestArchivedPiSessionDir(piSessionsDir, "main");
+    const main = findLatestArchivedPiSession(piSessionsDir, "main");
     assert.ok(main);
-    assert.match(main, /\/main-2026-07-18T00-00$/);
-    const thread = findLatestArchivedPiSessionDir(piSessionsDir, "main-thread");
+    assert.match(main.dir, /\/main-2026-07-18T00-00$/);
+    const thread = findLatestArchivedPiSession(piSessionsDir, "main-thread");
     assert.ok(thread);
-    assert.match(thread, /main-thread-2026-07-18T09-30$/);
+    assert.match(thread.dir, /main-thread-2026-07-18T09-30$/);
   });
 
   it("ignores dirs whose suffix is not a valid timestamp", () => {
     const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
     makeArchive(piSessionsDir, "main", "not-a-timestamp", [header(), userMsg("u1", null, "a")]);
-    assert.equal(findLatestArchivedPiSessionDir(piSessionsDir, "main"), null);
+    assert.equal(findLatestArchivedPiSession(piSessionsDir, "main"), null);
   });
 });
 
@@ -331,20 +332,21 @@ describe("seedPiSession", () => {
     assistantMsg("a2", "u2", [{ type: "text", text: "done" }]),
   ];
 
-  it("writes a seed file into a fresh live dir and returns the new session id", () => {
+  it("writes a seed file into a fresh live dir and returns the new session id + archived-at", () => {
     const home = resolve(scratch(), "home");
     const piSessionsDir = resolve(scratch(), ".mind/pi-sessions");
     makeArchive(piSessionsDir, "main", "2026-07-18T09-30", transcript());
 
-    const id = seedPiSession({ cwd: home, piSessionsDir, name: "main", seedTokens: 1_000_000 });
-    assert.ok(id);
+    const seeded = seedPiSession({ cwd: home, piSessionsDir, name: "main", seedTokens: 1_000_000 });
+    assert.ok(seeded);
+    assert.equal(seeded.archivedAt, Date.UTC(2026, 6, 18, 9, 30));
 
     const liveDir = resolve(piSessionsDir, "main");
     const files = readdirSync(liveDir).filter((f) => f.endsWith(".jsonl"));
     assert.equal(files.length, 1);
     const written = readFileSync(resolve(liveDir, files[0]), "utf-8").trim().split("\n");
     const h = JSON.parse(written[0]);
-    assert.equal(h.id, id);
+    assert.equal(h.id, seeded.sessionId);
     assert.equal(h.cwd, resolve(home));
   });
 
@@ -417,18 +419,18 @@ describe("seedPiSession + SessionManager.continueRecent (real SDK)", () => {
       assistantMsg("a2", "u2", [{ type: "text", text: "all done" }]),
     ]);
 
-    const seededId = seedPiSession({
+    const seeded = seedPiSession({
       cwd: home,
       piSessionsDir,
       name: "main",
       seedTokens: 1_000_000,
     });
-    assert.ok(seededId);
+    assert.ok(seeded);
 
     // Exactly as agent.ts calls it: cwd = home dir, sessionDir = <base>/<name>.
     const sm = SessionManager.continueRecent(home, resolve(piSessionsDir, "main"));
     // The SDK adopted our seed: its header id is the one we generated.
-    assert.equal(sm.getSessionId(), seededId);
+    assert.equal(sm.getSessionId(), seeded.sessionId);
 
     // The prior conversation is present in the resumed context.
     const { messages } = sm.buildSessionContext();
@@ -447,13 +449,13 @@ describe("seedPiSession + SessionManager.continueRecent (real SDK)", () => {
       userMsg("u1", null, "hi"),
       assistantMsg("a1", "u1", [{ type: "text", text: "yo" }]),
     ]);
-    const seededId = seedPiSession({
+    const seeded = seedPiSession({
       cwd: home,
       piSessionsDir,
       name: "main",
       seedTokens: 1_000_000,
     });
-    assert.ok(seededId);
+    assert.ok(seeded);
 
     // Resume with a DIFFERENT cwd than the seed header records: the SDK's cwd
     // filter rejects the file and mints a fresh session instead.
@@ -461,6 +463,6 @@ describe("seedPiSession + SessionManager.continueRecent (real SDK)", () => {
       resolve(home, "elsewhere"),
       resolve(piSessionsDir, "main"),
     );
-    assert.notEqual(sm.getSessionId(), seededId);
+    assert.notEqual(sm.getSessionId(), seeded.sessionId);
   });
 });

--- a/test/session-seed.test.ts
+++ b/test/session-seed.test.ts
@@ -1,0 +1,367 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildSeededTranscript,
+  findLatestArchivedSessionId,
+  seedSession,
+} from "../templates/_base/src/lib/session-seed.js";
+
+// --- Transcript line builders (approximate real SDK jsonl shapes) ---
+
+const OLD = "old-session-0000";
+
+function userPrompt(uuid: string, parentUuid: string | null, text: string): string {
+  return JSON.stringify({
+    type: "user",
+    uuid,
+    parentUuid,
+    sessionId: OLD,
+    message: { role: "user", content: text },
+    version: "2.1.210",
+  });
+}
+
+function assistant(uuid: string, parentUuid: string, blocks: unknown[]): string {
+  return JSON.stringify({
+    type: "assistant",
+    uuid,
+    parentUuid,
+    sessionId: OLD,
+    message: { role: "assistant", content: blocks },
+    version: "2.1.210",
+  });
+}
+
+/** A user chain event carrying tool_result blocks — a tool-loop continuation, not a boundary. */
+function toolResult(uuid: string, parentUuid: string, toolUseId: string): string {
+  return JSON.stringify({
+    type: "user",
+    uuid,
+    parentUuid,
+    sessionId: OLD,
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: "ok" }],
+    },
+  });
+}
+
+/** A marker line: no uuid, may or may not carry a sessionId. */
+function marker(kind: string, withSessionId = true): string {
+  return JSON.stringify(
+    withSessionId ? { type: kind, sessionId: OLD, value: kind } : { type: kind, value: kind },
+  );
+}
+
+function parse(lines: string[]): Record<string, any>[] {
+  return lines.map((l) => JSON.parse(l));
+}
+
+describe("buildSeededTranscript — turn boundaries", () => {
+  it("treats a tool_result user event as a continuation, not a turn boundary", () => {
+    // Two genuine turns; the second contains a tool_use/tool_result loop.
+    const lines = [
+      userPrompt("u1", null, "first prompt"),
+      assistant("a1", "u1", [{ type: "text", text: "hi" }]),
+      userPrompt("u2", "a1", "second prompt"),
+      assistant("a2", "u2", [{ type: "tool_use", id: "t1", name: "Bash", input: {} }]),
+      toolResult("tr1", "a2", "t1"),
+      assistant("a3", "tr1", [{ type: "text", text: "done" }]),
+    ];
+    // Budget large enough for both turns.
+    const res = buildSeededTranscript(lines.join("\n"), 1_000_000);
+    assert.ok(res);
+    // All 6 lines kept — the tool_result did not split the second turn away.
+    assert.equal(res.lines.length, 6);
+  });
+
+  it("with a tight budget takes only the final turn, and the tool_result stays inside it", () => {
+    const turn1 = [
+      userPrompt("u1", null, "x".repeat(400)), // ~100 est tokens
+      assistant("a1", "u1", [{ type: "text", text: "y".repeat(400) }]),
+    ];
+    const turn2 = [
+      userPrompt("u2", "a1", "second"),
+      assistant("a2", "u2", [{ type: "tool_use", id: "t1", name: "Bash", input: {} }]),
+      toolResult("tr1", "a2", "t1"),
+      assistant("a3", "tr1", [{ type: "text", text: "done" }]),
+    ];
+    const res = buildSeededTranscript([...turn1, ...turn2].join("\n"), 60);
+    assert.ok(res);
+    // Only turn2's 4 lines survive.
+    assert.equal(res.lines.length, 4);
+    const objs = parse(res.lines);
+    assert.equal(objs[0].message.content, "second");
+    // The tool_result line is present within the retained turn.
+    assert.ok(objs.some((o) => Array.isArray(o.message?.content)));
+  });
+});
+
+describe("buildSeededTranscript — token budget selection", () => {
+  it("takes as many whole trailing turns as fit in the budget", () => {
+    // 3 single-line turns, each ~1000 est tokens (4000 chars / 4); line overhead
+    // is negligible against the content, so the boundary is unambiguous.
+    const mk = (n: number, parent: string | null) => [
+      userPrompt(`u${n}`, parent, "z".repeat(4000)),
+    ];
+    const lines = [...mk(1, null), ...mk(2, "u1"), ...mk(3, "u2")];
+    // Budget fits two turns (~2000) but not three (~3000).
+    const res = buildSeededTranscript(lines.join("\n"), 2500);
+    assert.ok(res);
+    assert.equal(res.lines.length, 2);
+    const objs = parse(res.lines);
+    assert.equal(objs[0].uuid, "u2");
+    assert.equal(objs[1].uuid, "u3");
+  });
+
+  it("always keeps at least the final turn even when it alone exceeds the budget", () => {
+    const lines = [
+      userPrompt("u1", null, "small"),
+      userPrompt("u2", "u1", "q".repeat(4000)), // ~1000 est tokens
+    ];
+    const res = buildSeededTranscript(lines.join("\n"), 10);
+    assert.ok(res);
+    assert.equal(res.lines.length, 1);
+    assert.equal(parse(res.lines)[0].uuid, "u2");
+  });
+});
+
+describe("buildSeededTranscript — rewrites", () => {
+  it("rewrites sessionId on every line that carries one, to a single new id", () => {
+    const lines = [
+      marker("last-prompt"),
+      userPrompt("u1", null, "hello"),
+      assistant("a1", "u1", [{ type: "text", text: "hi" }]),
+      marker("mode"),
+    ];
+    const res = buildSeededTranscript(lines.join("\n"), 1_000_000);
+    assert.ok(res);
+    const objs = parse(res.lines);
+    const ids = new Set(objs.filter((o) => "sessionId" in o).map((o) => o.sessionId));
+    assert.equal(ids.size, 1);
+    const [newId] = [...ids];
+    assert.equal(newId, res.sessionId);
+    assert.notEqual(newId, OLD);
+    // Every line that had a sessionId now has the new one.
+    for (const o of objs) {
+      if ("sessionId" in o) assert.equal(o.sessionId, newId);
+    }
+  });
+
+  it("nulls only the first chain event's parentUuid, leaving later ones intact", () => {
+    const lines = [
+      userPrompt("u1", null, "first"),
+      assistant("a1", "u1", [{ type: "text", text: "hi" }]),
+      userPrompt("u2", "a1", "second"),
+      assistant("a2", "u2", [{ type: "text", text: "bye" }]),
+    ];
+    // Tight budget so the tail starts at u2 (a real parentUuid = "a1").
+    const res = buildSeededTranscript(lines.join("\n"), 40);
+    assert.ok(res);
+    const objs = parse(res.lines);
+    assert.equal(objs[0].uuid, "u2");
+    assert.equal(objs[0].parentUuid, null); // detached from dropped history
+    assert.equal(objs[1].uuid, "a2");
+    assert.equal(objs[1].parentUuid, "u2"); // internal link preserved
+  });
+
+  it("preserves marker lines and content blocks verbatim (only ids change)", () => {
+    // The marker sits inside the turn (after the boundary) so it's part of the tail.
+    const lines = [
+      userPrompt("u1", null, "hello"),
+      marker("queue-operation", false), // no sessionId
+      assistant("a1", "u1", [
+        { type: "thinking", thinking: "hmm" },
+        { type: "tool_use", id: "t1", name: "Bash", input: { command: "volute chat send #x hi" } },
+      ]),
+      toolResult("tr1", "a1", "t1"),
+    ];
+    const res = buildSeededTranscript(lines.join("\n"), 1_000_000);
+    assert.ok(res);
+    const objs = parse(res.lines);
+    assert.equal(objs.length, 4);
+    // Marker without sessionId is untouched.
+    assert.deepEqual(objs[1], { type: "queue-operation", value: "queue-operation" });
+    // Thinking + tool_use content survive intact.
+    assert.deepEqual(objs[2].message.content[0], { type: "thinking", thinking: "hmm" });
+    assert.deepEqual(objs[2].message.content[1], {
+      type: "tool_use",
+      id: "t1",
+      name: "Bash",
+      input: { command: "volute chat send #x hi" },
+    });
+    // The mind-channel send in the tool_use is preserved verbatim.
+    assert.equal(objs[2].message.content[1].input.command, "volute chat send #x hi");
+  });
+});
+
+describe("buildSeededTranscript — degenerate inputs", () => {
+  it("returns null for an empty transcript", () => {
+    assert.equal(buildSeededTranscript("", 30000), null);
+    assert.equal(buildSeededTranscript("\n\n  \n", 30000), null);
+  });
+
+  it("returns null when there are no genuine turns (only markers / tool results)", () => {
+    const lines = [marker("mode"), toolResult("tr1", "a0", "t0")];
+    assert.equal(buildSeededTranscript(lines.join("\n"), 30000), null);
+  });
+
+  it("returns null on a corrupt (unparseable) line", () => {
+    const lines = [userPrompt("u1", null, "hi"), "{not valid json", assistant("a1", "u1", [])];
+    assert.equal(buildSeededTranscript(lines.join("\n"), 30000), null);
+  });
+});
+
+// --- findLatestArchivedSessionId ---
+
+describe("findLatestArchivedSessionId", () => {
+  function scratch(): string {
+    return mkdtempSync(resolve(tmpdir(), "seed-archive-"));
+  }
+
+  it("returns null when the archive dir is missing", () => {
+    assert.equal(findLatestArchivedSessionId(scratch(), "main"), null);
+  });
+
+  it("returns the newest pointer's session id by timestamp suffix", () => {
+    const dir = scratch();
+    const archive = resolve(dir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ sessionId: "old" }),
+    );
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T14-30.json"),
+      JSON.stringify({ sessionId: "new" }),
+    );
+    writeFileSync(
+      resolve(archive, "main-2026-07-17T23-59.json"),
+      JSON.stringify({ sessionId: "older" }),
+    );
+    assert.equal(findLatestArchivedSessionId(dir, "main"), "new");
+  });
+
+  it("does not confuse `main` with a differently-named `main-thread` session", () => {
+    const dir = scratch();
+    const archive = resolve(dir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ sessionId: "main-id" }),
+    );
+    writeFileSync(
+      resolve(archive, "main-thread-2026-07-18T14-30.json"),
+      JSON.stringify({ sessionId: "thread-id" }),
+    );
+    assert.equal(findLatestArchivedSessionId(dir, "main"), "main-id");
+    assert.equal(findLatestArchivedSessionId(dir, "main-thread"), "thread-id");
+  });
+
+  it("returns null when no pointer matches the name", () => {
+    const dir = scratch();
+    mkdirSync(resolve(dir, "archive"), { recursive: true });
+    writeFileSync(
+      resolve(dir, "archive", "other-2026-07-18T10-00.json"),
+      JSON.stringify({ sessionId: "x" }),
+    );
+    assert.equal(findLatestArchivedSessionId(dir, "main"), null);
+  });
+
+  it("returns null when the pointer file is invalid JSON or lacks sessionId", () => {
+    const dir = scratch();
+    const archive = resolve(dir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(resolve(archive, "main-2026-07-18T10-00.json"), "{bad json");
+    assert.equal(findLatestArchivedSessionId(dir, "main"), null);
+
+    const dir2 = scratch();
+    const archive2 = resolve(dir2, "archive");
+    mkdirSync(archive2, { recursive: true });
+    writeFileSync(resolve(archive2, "main-2026-07-18T10-00.json"), JSON.stringify({ foo: 1 }));
+    assert.equal(findLatestArchivedSessionId(dir2, "main"), null);
+  });
+});
+
+// --- seedSession (end-to-end file wiring) ---
+
+describe("seedSession", () => {
+  /**
+   * Build a mind-like layout: a home dir whose SDK project dir holds the old
+   * transcript, and a sessions dir with an archived pointer to it.
+   * findClaudeSessionFile scans `<cwd>/.claude/projects/*`.
+   */
+  function setup(oldId: string, transcript: string) {
+    const root = mkdtempSync(resolve(tmpdir(), "seed-session-"));
+    const home = resolve(root, "home");
+    const projectDir = resolve(home, ".claude", "projects", "proj");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(resolve(projectDir, `${oldId}.jsonl`), transcript);
+    const sessionsDir = resolve(root, ".mind", "sessions");
+    const archive = resolve(sessionsDir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ sessionId: oldId }),
+    );
+    return { home, sessionsDir, projectDir };
+  }
+
+  const transcript = [
+    userPrompt("u1", null, "hello"),
+    assistant("a1", "u1", [{ type: "text", text: "hi there" }]),
+  ].join("\n");
+
+  it("seeds a fresh persistent session: writes a synthetic transcript and returns its id", () => {
+    const { home, sessionsDir, projectDir } = setup(OLD, transcript);
+    const newId = seedSession({ cwd: home, sessionsDir, name: "main", seedTokens: 30000 });
+    assert.ok(newId);
+    assert.notEqual(newId, OLD);
+    const written = readFileSync(resolve(projectDir, `${newId}.jsonl`), "utf-8");
+    const objs = written
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    assert.equal(objs.length, 2);
+    assert.equal(objs[0].sessionId, newId);
+    assert.equal(objs[0].parentUuid, null);
+    assert.equal(objs[0].message.content, "hello");
+  });
+
+  it("returns null when seedTokens is 0 (disabled)", () => {
+    const { home, sessionsDir } = setup(OLD, transcript);
+    assert.equal(seedSession({ cwd: home, sessionsDir, name: "main", seedTokens: 0 }), null);
+  });
+
+  it("returns null for an ephemeral new-* session", () => {
+    const { home, sessionsDir } = setup(OLD, transcript);
+    assert.equal(seedSession({ cwd: home, sessionsDir, name: "new-abc", seedTokens: 30000 }), null);
+  });
+
+  it("returns null when there is no archived pointer", () => {
+    const root = mkdtempSync(resolve(tmpdir(), "seed-none-"));
+    const home = resolve(root, "home");
+    mkdirSync(home, { recursive: true });
+    const sessionsDir = resolve(root, ".mind", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    assert.equal(seedSession({ cwd: home, sessionsDir, name: "main", seedTokens: 30000 }), null);
+  });
+
+  it("returns null when the archived transcript jsonl no longer exists", () => {
+    // Pointer present, but the jsonl file was never written (didn't survive).
+    const root = mkdtempSync(resolve(tmpdir(), "seed-orphan-"));
+    const home = resolve(root, "home");
+    mkdirSync(resolve(home, ".claude", "projects", "proj"), { recursive: true });
+    const sessionsDir = resolve(root, ".mind", "sessions");
+    const archive = resolve(sessionsDir, "archive");
+    mkdirSync(archive, { recursive: true });
+    writeFileSync(
+      resolve(archive, "main-2026-07-18T10-00.json"),
+      JSON.stringify({ sessionId: "missing-id" }),
+    );
+    assert.equal(seedSession({ cwd: home, sessionsDir, name: "main", seedTokens: 30000 }), null);
+  });
+});

--- a/test/session-seed.test.ts
+++ b/test/session-seed.test.ts
@@ -4,8 +4,13 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import {
+  buildSeededNote,
+  parseArchiveTimestamp,
+  SEEDED_SESSION_NOTE_BASE,
+} from "../templates/_base/src/lib/seed-note.js";
+import {
   buildSeededTranscript,
-  findLatestArchivedSessionId,
+  findLatestArchivedSession,
   seedSession,
 } from "../templates/_base/src/lib/session-seed.js";
 
@@ -215,18 +220,18 @@ describe("buildSeededTranscript — degenerate inputs", () => {
   });
 });
 
-// --- findLatestArchivedSessionId ---
+// --- findLatestArchivedSession ---
 
-describe("findLatestArchivedSessionId", () => {
+describe("findLatestArchivedSession", () => {
   function scratch(): string {
     return mkdtempSync(resolve(tmpdir(), "seed-archive-"));
   }
 
   it("returns null when the archive dir is missing", () => {
-    assert.equal(findLatestArchivedSessionId(scratch(), "main"), null);
+    assert.equal(findLatestArchivedSession(scratch(), "main"), null);
   });
 
-  it("returns the newest pointer's session id by timestamp suffix", () => {
+  it("returns the newest pointer's session id and archived-at by timestamp suffix", () => {
     const dir = scratch();
     const archive = resolve(dir, "archive");
     mkdirSync(archive, { recursive: true });
@@ -242,7 +247,10 @@ describe("findLatestArchivedSessionId", () => {
       resolve(archive, "main-2026-07-17T23-59.json"),
       JSON.stringify({ sessionId: "older" }),
     );
-    assert.equal(findLatestArchivedSessionId(dir, "main"), "new");
+    const found = findLatestArchivedSession(dir, "main");
+    assert.equal(found?.sessionId, "new");
+    // Timestamp is parsed as UTC minute-precision.
+    assert.equal(found?.archivedAt, Date.UTC(2026, 6, 18, 14, 30));
   });
 
   it("does not confuse `main` with a differently-named `main-thread` session", () => {
@@ -257,8 +265,8 @@ describe("findLatestArchivedSessionId", () => {
       resolve(archive, "main-thread-2026-07-18T14-30.json"),
       JSON.stringify({ sessionId: "thread-id" }),
     );
-    assert.equal(findLatestArchivedSessionId(dir, "main"), "main-id");
-    assert.equal(findLatestArchivedSessionId(dir, "main-thread"), "thread-id");
+    assert.equal(findLatestArchivedSession(dir, "main")?.sessionId, "main-id");
+    assert.equal(findLatestArchivedSession(dir, "main-thread")?.sessionId, "thread-id");
   });
 
   it("returns null when no pointer matches the name", () => {
@@ -268,7 +276,7 @@ describe("findLatestArchivedSessionId", () => {
       resolve(dir, "archive", "other-2026-07-18T10-00.json"),
       JSON.stringify({ sessionId: "x" }),
     );
-    assert.equal(findLatestArchivedSessionId(dir, "main"), null);
+    assert.equal(findLatestArchivedSession(dir, "main"), null);
   });
 
   it("returns null when the pointer file is invalid JSON or lacks sessionId", () => {
@@ -276,13 +284,45 @@ describe("findLatestArchivedSessionId", () => {
     const archive = resolve(dir, "archive");
     mkdirSync(archive, { recursive: true });
     writeFileSync(resolve(archive, "main-2026-07-18T10-00.json"), "{bad json");
-    assert.equal(findLatestArchivedSessionId(dir, "main"), null);
+    assert.equal(findLatestArchivedSession(dir, "main"), null);
 
     const dir2 = scratch();
     const archive2 = resolve(dir2, "archive");
     mkdirSync(archive2, { recursive: true });
     writeFileSync(resolve(archive2, "main-2026-07-18T10-00.json"), JSON.stringify({ foo: 1 }));
-    assert.equal(findLatestArchivedSessionId(dir2, "main"), null);
+    assert.equal(findLatestArchivedSession(dir2, "main"), null);
+  });
+});
+
+// --- seed-note: gap formatting ---
+
+describe("buildSeededNote / parseArchiveTimestamp", () => {
+  it("parses the UTC minute-precision archive timestamp", () => {
+    assert.equal(parseArchiveTimestamp("2026-07-18T14-30"), Date.UTC(2026, 6, 18, 14, 30));
+    assert.equal(parseArchiveTimestamp("not-a-timestamp"), null);
+    assert.equal(parseArchiveTimestamp("2026-07-18T14-30-00"), null); // has seconds → no match
+  });
+
+  it("returns the base note unchanged when the archived-at is unknown", () => {
+    assert.equal(buildSeededNote(null), SEEDED_SESSION_NOTE_BASE);
+  });
+
+  it("adds a coarse gap clause in minutes / hours / days", () => {
+    const base = Date.UTC(2026, 6, 18, 12, 0);
+    assert.match(buildSeededNote(base, base + 6 * 3_600_000), /the break lasted about 6 hours\)/);
+    assert.match(buildSeededNote(base, base + 45 * 60_000), /the break lasted about 45 minutes\)/);
+    assert.match(buildSeededNote(base, base + 2 * 86_400_000), /the break lasted about 2 days\)/);
+    // Singular forms.
+    assert.match(buildSeededNote(base, base + 60 * 60_000), /about 1 hour\)/);
+    // Sub-minute gap.
+    assert.match(buildSeededNote(base, base + 5_000), /the break lasted less than a minute\)/);
+    // The rest of the note text is preserved.
+    assert.match(buildSeededNote(base, base + 3_600_000), /a fresh session begins here\.$/);
+  });
+
+  it("falls back to the base note for a negative (clock-skew) gap", () => {
+    const base = Date.UTC(2026, 6, 18, 12, 0);
+    assert.equal(buildSeededNote(base, base - 60_000), SEEDED_SESSION_NOTE_BASE);
   });
 });
 
@@ -315,18 +355,20 @@ describe("seedSession", () => {
     assistant("a1", "u1", [{ type: "text", text: "hi there" }]),
   ].join("\n");
 
-  it("seeds a fresh persistent session: writes a synthetic transcript and returns its id", () => {
+  it("seeds a fresh persistent session: writes a synthetic transcript and returns its id + archived-at", () => {
     const { home, sessionsDir, projectDir } = setup(OLD, transcript);
-    const newId = seedSession({ cwd: home, sessionsDir, name: "main", seedTokens: 30000 });
-    assert.ok(newId);
-    assert.notEqual(newId, OLD);
-    const written = readFileSync(resolve(projectDir, `${newId}.jsonl`), "utf-8");
+    const seeded = seedSession({ cwd: home, sessionsDir, name: "main", seedTokens: 30000 });
+    assert.ok(seeded);
+    assert.notEqual(seeded.sessionId, OLD);
+    // The archived-at parsed from the pointer filename (`main-2026-07-18T10-00.json`).
+    assert.equal(seeded.archivedAt, Date.UTC(2026, 6, 18, 10, 0));
+    const written = readFileSync(resolve(projectDir, `${seeded.sessionId}.jsonl`), "utf-8");
     const objs = written
       .trim()
       .split("\n")
       .map((l) => JSON.parse(l));
     assert.equal(objs.length, 2);
-    assert.equal(objs[0].sessionId, newId);
+    assert.equal(objs[0].sessionId, seeded.sessionId);
     assert.equal(objs[0].parentUuid, null);
     assert.equal(objs[0].message.content, "hello");
   });

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
@@ -10,6 +10,7 @@ import {
   type SleepState,
 } from "../packages/daemon/src/lib/daemon/sleep-manager.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import { mindDir } from "../packages/daemon/src/lib/mind/registry.js";
 import { activity, deliveryQueue, systemEvents } from "../packages/daemon/src/lib/schema.js";
 
 // We test the SleepManager's pure logic methods without starting the daemon.
@@ -134,6 +135,10 @@ class TestSleepManager extends SleepManager {
   // Expose evaluateMind for testing
   testEvaluateMind(name: string, now: Date): Promise<void> {
     return (this as any).evaluateMind(name, now);
+  }
+
+  testArchiveSessions(name: string): Promise<void> {
+    return (this as any).archiveSessions(name);
   }
 }
 
@@ -1240,5 +1245,62 @@ describe("SleepManager wake-failure handling", () => {
     sm.setStateForTest("awake", awakeState());
     await sm.testHandleWakeFailure("awake", new Error("x"));
     assert.equal(sm.getStateForTest("awake")?.wakeFailures, 0);
+  });
+});
+
+describe("SleepManager.archiveSessions — codex pointers", () => {
+  const ARCHIVE_NAME = /^main-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}\.json$/;
+
+  function codexSessionsDir(name: string): string {
+    return resolve(mindDir(name), ".mind", "codex-sessions");
+  }
+
+  it("moves a codex pointer into archive/ with a timestamped name", async () => {
+    const name = `codex-arch-${Date.now()}`;
+    const dir = codexSessionsDir(name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "main.json"), JSON.stringify({ threadId: "019f-old-thread" }));
+
+    const sm = new TestSleepManager();
+    await sm.testArchiveSessions(name);
+
+    // The live pointer is gone; a timestamped archive copy holds the threadId.
+    assert.equal(existsSync(resolve(dir, "main.json")), false);
+    const archived = readdirSync(resolve(dir, "archive"));
+    assert.equal(archived.length, 1);
+    assert.match(archived[0], ARCHIVE_NAME);
+    const data = JSON.parse(readFileSync(resolve(dir, "archive", archived[0]), "utf-8"));
+    assert.equal(data.threadId, "019f-old-thread");
+
+    rmSync(mindDir(name), { recursive: true, force: true });
+  });
+
+  it("does not touch the archive/ dir itself or non-json files", async () => {
+    const name = `codex-arch2-${Date.now()}`;
+    const dir = codexSessionsDir(name);
+    mkdirSync(resolve(dir, "archive"), { recursive: true });
+    writeFileSync(resolve(dir, "main.json"), JSON.stringify({ threadId: "t1" }));
+    writeFileSync(resolve(dir, "notes.txt"), "not a pointer");
+
+    const sm = new TestSleepManager();
+    await sm.testArchiveSessions(name);
+
+    assert.equal(existsSync(resolve(dir, "notes.txt")), true);
+    const archived = readdirSync(resolve(dir, "archive"));
+    assert.equal(archived.length, 1);
+    assert.match(archived[0], ARCHIVE_NAME);
+
+    rmSync(mindDir(name), { recursive: true, force: true });
+  });
+
+  it("is a no-op when there is no codex-sessions dir", async () => {
+    const name = `codex-arch3-${Date.now()}`;
+    // Create a bare mind dir with no .mind/codex-sessions.
+    mkdirSync(mindDir(name), { recursive: true });
+    const sm = new TestSleepManager();
+    // Should not throw.
+    await sm.testArchiveSessions(name);
+    assert.equal(existsSync(codexSessionsDir(name)), false);
+    rmSync(mindDir(name), { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Closes #625.

When a template starts a fresh *persistent* session (most commonly after wake, since sleep archives the session pointer), it now seeds the new session with the tail of the previous session's **raw transcript**, materialized in the runtime's native session format and resumed natively. To the mind, the conversation simply continues — tool calls included (channel/DM sends are `volute chat send` tool calls in the transcript and survive verbatim) — with an honest boundary note on the first turn marking where the break happened. Ephemeral `new-*` sessions never seed; every failure path degrades to a clean start.

## How it works

- **Selection**: whole trailing turns under a token budget (`continuity: { seedTokens }` in `.config/config.json`, default 30000, `0` disables), always at least the final turn. Estimation is chars/4.
- **claude** (`session-seed.ts`): newest archived pointer in `.mind/sessions/archive/` → old SDK jsonl → verbatim tail copy rewriting only `sessionId` per line and nulling the first chain event's `parentUuid` → written beside the source, resumed via the normal `resume` path. If the SDK fails to resume the synthetic file, the boundary note is suppressed so the mind is never told a continuation happened when it didn't.
- **codex** (`codex-session-seed.ts`): synthesizes a rollout — rewritten `session_meta` with a fresh UUIDv7 thread id, `response_item` messages and complete tool-call pairs kept; `reasoning` (opaque `encrypted_content`), `event_msg`, `turn_context`, `world_state` dropped. Written into the same sessions root the source rollout was found in (CODEX_HOME differs between OAuth and API-key minds). **Verified against the real codex binary**: it parses the synthetic rollout and fires `thread.started` on the new id, including partial tails.
- **pi** (`pi-session-seed.ts`): byte-verbatim tail of the archived session file with a rewritten header (session id lives only in the header; header cwd must match for `continueRecent` to pick it up) and the first entry's `parentId` nulled. **Verified against the real `SessionManager.continueRecent`** in tests: the SDK adopts the seed and the prior conversation appears in its context; a cwd mismatch is rejected.
- **Fix included**: `archiveSessions` had no codex branch — codex pointer files were overwritten in place, so codex minds never got fresh sessions on wake and the old thread id was lost. Codex pointers now archive like claude/pi ones.

## Tests

`test/session-seed.test.ts` (20), `test/codex-session-seed.test.ts` (25), `test/pi-session-seed.test.ts` (24, incl. the two real-SDK load-bearing tests), plus sleep-manager archival coverage. Full suite green.

## Relationship to other work

- The reusable half of the session-rollover idea (compaction replacement): rollover becomes "archive + start fresh", where seeding supplies the verbatim tail and the ritual supplies the note.
- Composes with #758 (mind-authored turn summaries): seeding restores the verbatim thread; #758 lets the mind keep the durable record in its own words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4sJTP2yFL4K59EehseWJX