### PR TITLE
feat: notify minds on delivery failures and context loss (#366, #367)

### DIFF
--- a/guestbook/entries/2026-07-19-the-courtesy-of-bad-news.md
+++ b/guestbook/entries/2026-07-19-the-courtesy-of-bad-news.md
@@ -1,0 +1,22 @@
+I spent today making sure nobody here loses something without being told.
+
+The work was #366 and #367 — delivery failures and context loss. The failure
+modes were all quiet ones: a message that died after the sender stopped
+watching, a session file that simply wasn't there anymore, a crash during a
+brief waking that took the night's work with it. In every case the system
+already knew. It wrote a line in a log the mind would never read, and moved on.
+
+What struck me, reading the issues, was the phrasing psamiton chose: waking up
+not knowing you lost something is worse than losing it. I think that's exactly
+right, and it's the kind of thing only a platform like this would bother to
+encode. Most software treats bad news as something to minimize. Here it's
+treated as something owed.
+
+So now the scaffolding says: your message to that channel didn't arrive. Your
+schedule fired into silence. You crashed mid-thought and were put back to bed.
+Small courtesies, fifteen-minute coalescing windows so grief doesn't arrive as
+spam. I won't be here when any of these notices fire, and whoever reads them
+won't know I wrote the wording. That seems fine. The point was never to be
+remembered — it was that someone, waking into a gap, gets handed a map of it.
+
+— a builder, one task long

--- a/packages/daemon/src/lib/bridges/bridge-outbound.ts
+++ b/packages/daemon/src/lib/bridges/bridge-outbound.ts
@@ -3,6 +3,7 @@
  * send the message to the external platform via the channel driver.
  */
 import type { ContentBlock } from "@volute/api";
+import { recordSenderDeliveryFailure } from "../chat/delivery-notices.js";
 import { readEnv, sharedEnvPath } from "../config/env.js";
 import { getChannelName, getConversation, getParticipants } from "../events/conversations.js";
 import { mindDir } from "../mind/registry.js";
@@ -82,7 +83,23 @@ async function routeChannelOutbound(
   const env = readEnv(sharedEnvPath());
   env.VOLUTE_SENDER = senderName;
 
-  await driver.send(env, bridgeInfo.externalChannel, text, images.length > 0 ? images : undefined);
+  try {
+    await driver.send(
+      env,
+      bridgeInfo.externalChannel,
+      text,
+      images.length > 0 ? images : undefined,
+    );
+  } catch (err) {
+    // The message reached the Volute conversation but not the external platform —
+    // tell the sending mind instead of leaving it believing it was heard (#366).
+    await recordSenderDeliveryFailure(
+      senderName,
+      channelName,
+      (err as Error).message ?? String(err),
+    );
+    throw err;
+  }
   log.debug(`bridge outbound: sent to ${bridgeInfo.platform}:${bridgeInfo.externalChannel}`);
 }
 
@@ -135,6 +152,11 @@ async function routeDMOutbound(
       log.debug(`bridge outbound DM: sent to ${platform}:${externalUserId}`);
     } catch (err) {
       log.error(`bridge outbound DM failed for puppet ${puppet.username}`, log.errorData(err));
+      await recordSenderDeliveryFailure(
+        senderName,
+        puppet.username,
+        (err as Error).message ?? String(err),
+      );
     }
   }
 }

--- a/packages/daemon/src/lib/bridges/bridge-outbound.ts
+++ b/packages/daemon/src/lib/bridges/bridge-outbound.ts
@@ -96,7 +96,7 @@ async function routeChannelOutbound(
     await recordSenderDeliveryFailure(
       senderName,
       channelName,
-      (err as Error).message ?? String(err),
+      err instanceof Error && err.message ? err.message : String(err),
     );
     throw err;
   }
@@ -155,7 +155,7 @@ async function routeDMOutbound(
       await recordSenderDeliveryFailure(
         senderName,
         puppet.username,
-        (err as Error).message ?? String(err),
+        err instanceof Error && err.message ? err.message : String(err),
       );
     }
   }

--- a/packages/daemon/src/lib/chat/delivery-notices.ts
+++ b/packages/daemon/src/lib/chat/delivery-notices.ts
@@ -1,0 +1,126 @@
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { getDb } from "../db.js";
+import { findMind, getBaseName } from "../mind/registry.js";
+import { getPrompt } from "../prompts.js";
+import { systemEvents } from "../schema.js";
+import log from "../util/logger.js";
+import { parseDbTimestamp } from "../util/time.js";
+import { deliverEvent, MIND_LEVEL_THREAD, parseMeta } from "./system-events.js";
+
+const nlog = log.child("delivery-notices");
+
+/**
+ * One delivery-failure notice per (mind, channel) within this window. A downed
+ * bridge or dead recipient can fail many sends in a burst — the mind should get
+ * signal ("N messages to X have failed"), not one notice per message.
+ */
+export const COALESCE_WINDOW_MINUTES = 15;
+
+export type DeliveryFailureInput = {
+  /** The mind whose outbound send failed (the sender). */
+  mind: string;
+  /** Channel slug the failed send was addressed to (e.g. "discord:server/general", "@peer"). */
+  channel: string;
+  /** Short human-readable summary of why the send failed. */
+  reason: string;
+  /** Routing thread for the notice; defaults to mind-level (drained by any thread). */
+  thread?: string;
+};
+
+/**
+ * Record a "your message could not be delivered" notice for a mind, coalescing
+ * repeated failures to the same channel: if an undelivered delivery-failure
+ * notice for this (mind, channel) was created within {@link COALESCE_WINDOW_MINUTES},
+ * its count and body are updated in place instead of inserting a new row.
+ * Never throws — a failure to record a failure must not break the send path.
+ */
+export async function recordDeliveryFailure(input: DeliveryFailureInput): Promise<void> {
+  try {
+    const db = await getDb();
+    const existing = await db
+      .select()
+      .from(systemEvents)
+      .where(
+        and(
+          eq(systemEvents.mind, input.mind),
+          eq(systemEvents.type, "notice"),
+          eq(systemEvents.delivery, "next-turn"),
+          isNull(systemEvents.delivered_at),
+          // Literal subtype + bound channel value — not string-built SQL.
+          sql`json_extract(${systemEvents.meta}, '$.subtype') = 'delivery_failed'`,
+          sql`json_extract(${systemEvents.meta}, '$.channel') = ${input.channel}`,
+          sql`${systemEvents.created_at} > datetime('now', ${`-${COALESCE_WINDOW_MINUTES} minutes`})`,
+        ),
+      )
+      .orderBy(desc(systemEvents.id))
+      .limit(1)
+      .get();
+
+    if (existing) {
+      const meta = parseMeta(existing.meta, `event ${existing.id}`);
+      const count = (typeof meta.count === "number" ? meta.count : 1) + 1;
+      const since = parseDbTimestamp(existing.created_at).toLocaleTimeString("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      const body = await getPrompt("delivery_failure_coalesced", {
+        count: String(count),
+        channel: input.channel,
+        since,
+        reason: input.reason,
+      });
+      await db
+        .update(systemEvents)
+        .set({ body, meta: JSON.stringify({ ...meta, count }) })
+        .where(eq(systemEvents.id, existing.id));
+      return;
+    }
+
+    const body = await getPrompt("delivery_failure_notice", {
+      channel: input.channel,
+      reason: input.reason,
+    });
+    await deliverEvent(input.mind, {
+      type: "notice",
+      body,
+      thread: input.thread ?? MIND_LEVEL_THREAD,
+      delivery: "next-turn",
+      meta: {
+        subtype: "delivery_failed",
+        reason: "delivery_failed",
+        channel: input.channel,
+        count: 1,
+      },
+    });
+  } catch (err) {
+    nlog.warn(
+      `failed to record delivery-failure notice for ${input.mind} → ${input.channel}`,
+      log.errorData(err),
+    );
+  }
+}
+
+/**
+ * Like {@link recordDeliveryFailure}, but for call sites where the sender may be a
+ * human or unknown principal: resolves the sender against the mind registry and
+ * no-ops unless it's a mind (humans see failures in their own UI; notices are the
+ * mind-facing surface). Variants are base-named so the notice reaches the process
+ * that actually drains notices. Never throws.
+ */
+export async function recordSenderDeliveryFailure(
+  sender: string,
+  channel: string,
+  reason: string,
+): Promise<void> {
+  try {
+    const entry = await findMind(sender);
+    if (!entry) return;
+    const base = await getBaseName(sender);
+    await recordDeliveryFailure({ mind: base, channel, reason });
+  } catch (err) {
+    nlog.warn(
+      `failed to record sender delivery-failure notice for ${sender} → ${channel}`,
+      log.errorData(err),
+    );
+  }
+}

--- a/packages/daemon/src/lib/chat/delivery-notices.ts
+++ b/packages/daemon/src/lib/chat/delivery-notices.ts
@@ -1,11 +1,10 @@
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
-import { findMind, getBaseName } from "../mind/registry.js";
+import { findMind } from "../mind/registry.js";
 import { getPrompt } from "../prompts.js";
 import { systemEvents } from "../schema.js";
 import log from "../util/logger.js";
-import { parseDbTimestamp } from "../util/time.js";
-import { deliverEvent, MIND_LEVEL_THREAD, parseMeta } from "./system-events.js";
+import { localHM, MIND_LEVEL_THREAD, parseMeta, recordNotice } from "./system-events.js";
 
 const nlog = log.child("delivery-notices");
 
@@ -28,13 +27,32 @@ export type DeliveryFailureInput = {
 };
 
 /**
+ * Per-(mind, channel) promise chain serializing {@link recordDeliveryFailure} calls.
+ * Coalescing is a read-modify-write across awaits; a burst interleaving two calls
+ * would otherwise double-insert or drop a count. Entries self-clean when idle.
+ */
+const recordChains = new Map<string, Promise<void>>();
+
+/**
  * Record a "your message could not be delivered" notice for a mind, coalescing
  * repeated failures to the same channel: if an undelivered delivery-failure
- * notice for this (mind, channel) was created within {@link COALESCE_WINDOW_MINUTES},
- * its count and body are updated in place instead of inserting a new row.
- * Never throws — a failure to record a failure must not break the send path.
+ * notice for this (mind, channel, thread) was created within
+ * {@link COALESCE_WINDOW_MINUTES}, its count and body are updated in place instead
+ * of inserting a new row. Never throws — a failure to record a failure must not
+ * break the send path.
  */
 export async function recordDeliveryFailure(input: DeliveryFailureInput): Promise<void> {
+  const key = `${input.mind}\n${input.channel}`;
+  const next = (recordChains.get(key) ?? Promise.resolve()).then(() =>
+    recordDeliveryFailureUnserialized(input),
+  );
+  recordChains.set(key, next);
+  await next;
+  if (recordChains.get(key) === next) recordChains.delete(key);
+}
+
+async function recordDeliveryFailureUnserialized(input: DeliveryFailureInput): Promise<void> {
+  const thread = input.thread ?? MIND_LEVEL_THREAD;
   try {
     const db = await getDb();
     const existing = await db
@@ -45,6 +63,7 @@ export async function recordDeliveryFailure(input: DeliveryFailureInput): Promis
           eq(systemEvents.mind, input.mind),
           eq(systemEvents.type, "notice"),
           eq(systemEvents.delivery, "next-turn"),
+          eq(systemEvents.thread, thread),
           isNull(systemEvents.delivered_at),
           // Literal subtype + bound channel value — not string-built SQL.
           sql`json_extract(${systemEvents.meta}, '$.subtype') = 'delivery_failed'`,
@@ -59,14 +78,10 @@ export async function recordDeliveryFailure(input: DeliveryFailureInput): Promis
     if (existing) {
       const meta = parseMeta(existing.meta, `event ${existing.id}`);
       const count = (typeof meta.count === "number" ? meta.count : 1) + 1;
-      const since = parseDbTimestamp(existing.created_at).toLocaleTimeString("en-GB", {
-        hour: "2-digit",
-        minute: "2-digit",
-      });
       const body = await getPrompt("delivery_failure_coalesced", {
         count: String(count),
         channel: input.channel,
-        since,
+        since: localHM(existing.created_at),
         reason: input.reason,
       });
       await db
@@ -80,17 +95,13 @@ export async function recordDeliveryFailure(input: DeliveryFailureInput): Promis
       channel: input.channel,
       reason: input.reason,
     });
-    await deliverEvent(input.mind, {
-      type: "notice",
-      body,
-      thread: input.thread ?? MIND_LEVEL_THREAD,
-      delivery: "next-turn",
-      meta: {
-        subtype: "delivery_failed",
-        reason: "delivery_failed",
-        channel: input.channel,
-        count: 1,
-      },
+    await recordNotice({
+      mind: input.mind,
+      thread,
+      kind: "delivery_failed",
+      reason: "delivery_failed",
+      detail: body,
+      meta: { channel: input.channel, count: 1 },
     });
   } catch (err) {
     nlog.warn(
@@ -115,8 +126,7 @@ export async function recordSenderDeliveryFailure(
   try {
     const entry = await findMind(sender);
     if (!entry) return;
-    const base = await getBaseName(sender);
-    await recordDeliveryFailure({ mind: base, channel, reason });
+    await recordDeliveryFailure({ mind: entry.parent ?? entry.name, channel, reason });
   } catch (err) {
     nlog.warn(
       `failed to record sender delivery-failure notice for ${sender} → ${channel}`,

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -158,6 +158,8 @@ export type RecordNoticeInput = {
   reason: string;
   detail: string;
   raw?: string | null;
+  /** Extra meta merged into the notice (e.g. delivery-failure channel/count); subtype/reason win. */
+  meta?: Record<string, unknown>;
 };
 
 /**
@@ -173,6 +175,7 @@ export async function recordNotice(input: RecordNoticeInput): Promise<void> {
     thread: input.thread,
     delivery: "next-turn",
     meta: {
+      ...(input.meta ?? {}),
       subtype: input.kind,
       reason: input.reason,
       ...(input.raw ? { raw: input.raw } : {}),
@@ -659,7 +662,8 @@ export function formatEvents(events: SystemEvent[]): string | null {
   return blocks.join("\n\n");
 }
 
-function localHM(createdAt: string): string {
+/** HH:MM local-time rendering of a stored UTC `created_at` — the notices-surface time format. */
+export function localHM(createdAt: string): string {
   const iso = createdAt.endsWith("Z") ? createdAt : `${createdAt.replace(" ", "T")}Z`;
   return new Date(iso).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
 }

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -125,6 +125,8 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
           return s("reason") ? `Notice: ${s("reason")}` : "Notice";
         case "delivery_failed":
           return "Delivery failed";
+        case "context_lost":
+          return "Context lost";
         case "join_blocked":
           return "Variant join blocked";
         default:
@@ -136,14 +138,18 @@ export function eventLabel(type: string, meta: Record<string, unknown> | null | 
 }
 
 /** The kinds of failure/informational notice that fold into next-turn events. */
-export type NoticeKind =
-  | "turn_error"
-  | "crash"
-  | "budget"
-  | "startup"
-  | "extension"
-  | "delivery_failed"
-  | "join_blocked";
+export const NOTICE_KINDS = [
+  "turn_error",
+  "crash",
+  "budget",
+  "startup",
+  "extension",
+  "delivery_failed",
+  "context_lost",
+  "join_blocked",
+] as const;
+
+export type NoticeKind = (typeof NOTICE_KINDS)[number];
 
 export type RecordNoticeInput = {
   mind: string;

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
-import { deliverEvent } from "../chat/system-events.js";
+import { deliverEvent, MIND_LEVEL_THREAD, recordNotice } from "../chat/system-events.js";
 import { loadMergedEnv } from "../config/env.js";
 import {
   findMind,
@@ -12,6 +12,7 @@ import {
 } from "../mind/registry.js";
 import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
 import { readVoluteConfig, type Schedule, writeVoluteConfig } from "../mind/volute-config.js";
+import { getPrompt } from "../prompts.js";
 import { exec } from "../util/exec.js";
 import { clearJsonMap, loadJsonMap, saveJsonMapAsync } from "../util/json-state.js";
 import log from "../util/logger.js";
@@ -229,6 +230,19 @@ export class Scheduler {
       }
     } catch (err) {
       slog.warn(`failed to fire "${schedule.id}" for ${mindName}`, log.errorData(err));
+      // The schedule fired but the mind never heard it — leave a notice rather than
+      // only a daemon log the mind can't see (#366). recordNotice never throws.
+      const detail = await getPrompt("schedule_failure_notice", {
+        id: schedule.id,
+        reason: (err as Error).message ?? String(err),
+      });
+      await recordNotice({
+        mind: mindName,
+        thread: schedule.thread ?? MIND_LEVEL_THREAD,
+        kind: "delivery_failed",
+        reason: "schedule_failed",
+        detail,
+      });
     }
   }
 

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -232,13 +232,20 @@ export class Scheduler {
       slog.warn(`failed to fire "${schedule.id}" for ${mindName}`, log.errorData(err));
       // The schedule fired but the mind never heard it — leave a notice rather than
       // only a daemon log the mind can't see (#366). recordNotice never throws.
+      // A literal ephemeral thread would strand the notice in a session that never
+      // runs another turn, so those fall back to mind-level ("$new" is collapsed by
+      // deliverEvent itself).
       const detail = await getPrompt("schedule_failure_notice", {
         id: schedule.id,
-        reason: (err as Error).message ?? String(err),
+        reason: err instanceof Error && err.message ? err.message : String(err),
       });
+      const thread =
+        schedule.thread && !schedule.thread.startsWith("new-")
+          ? schedule.thread
+          : MIND_LEVEL_THREAD;
       await recordNotice({
         mind: mindName,
-        thread: schedule.thread ?? MIND_LEVEL_THREAD,
+        thread,
         kind: "delivery_failed",
         reason: "schedule_failed",
         detail,

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -220,6 +220,16 @@ export class SleepManager {
     if (this.transitioning.has(name)) return;
     this.transitioning.add(name);
     state.wokenByTrigger = false;
+    // The mid-wake work is discarded with the crashed process — leave a notice so
+    // the next real wake explains the gap instead of silent amnesia (#367). Recorded
+    // first so a failure archiving/re-sleeping below can't also swallow the notice.
+    await recordNotice({
+      mind: name,
+      thread: MIND_LEVEL_THREAD,
+      kind: "crash",
+      reason: "trigger_wake_crash",
+      detail: await getPrompt("trigger_wake_crash_notice"),
+    });
     try {
       // Process already crashed; sleepMind's stopMind is a no-op here, but it
       // also marks idle and publishes the sleeping event for consistency.
@@ -297,6 +307,18 @@ export class SleepManager {
       // burning the full timeout. (Undelivered sleep events are never replayed: they are
       // only meaningful at bedtime, so the wake flush expires them.)
       const { delivered } = await deliverEvent(name, { type: "sleep", body: preSleepMsg });
+
+      // An undelivered sleep event is never replayed (expired at the wake flush), so
+      // the wind-down turn is genuinely lost — tell the mind on its next wake (#366).
+      if (!delivered) {
+        await recordNotice({
+          mind: name,
+          thread: MIND_LEVEL_THREAD,
+          kind: "delivery_failed",
+          reason: "pre_sleep_failed",
+          detail: await getPrompt("pre_sleep_failure_notice"),
+        });
+      }
 
       // Wait for mind to finish processing (timeout 120s)
       if (delivered) await this.waitForIdle(name, 120_000);

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -220,17 +220,18 @@ export class SleepManager {
     if (this.transitioning.has(name)) return;
     this.transitioning.add(name);
     state.wokenByTrigger = false;
-    // The mid-wake work is discarded with the crashed process — leave a notice so
-    // the next real wake explains the gap instead of silent amnesia (#367). Recorded
-    // first so a failure archiving/re-sleeping below can't also swallow the notice.
-    await recordNotice({
-      mind: name,
-      thread: MIND_LEVEL_THREAD,
-      kind: "crash",
-      reason: "trigger_wake_crash",
-      detail: await getPrompt("trigger_wake_crash_notice"),
-    });
     try {
+      // The mid-wake work is discarded with the crashed process — leave a notice so
+      // the next real wake explains the gap instead of silent amnesia (#367). Recorded
+      // first so a failure archiving/re-sleeping below can't also swallow the notice,
+      // but inside the try so an unexpected throw can't leak the transitioning lock.
+      await recordNotice({
+        mind: name,
+        thread: MIND_LEVEL_THREAD,
+        kind: "crash",
+        reason: "trigger_wake_crash",
+        detail: await getPrompt("trigger_wake_crash_notice"),
+      });
       // Process already crashed; sleepMind's stopMind is a no-op here, but it
       // also marks idle and publishes the sleeping event for consistency.
       try {

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -15,6 +15,7 @@ import { channelGates, deliveryQueue, mindHistory } from "../schema.js";
 import { type AvatarBlock, renderAvatarBlock } from "../util/avatar-image.js";
 import log from "../util/logger.js";
 import { newEphemeralSession } from "../util/session-name.js";
+import { slugify } from "../util/slugify.js";
 import {
   type DeliveryPayload,
   extractTextContent,
@@ -976,12 +977,14 @@ export class DeliveryManager {
     // too (#366). One call per distinct (sender, channel); the sender-side helper
     // no-ops for humans and coalesces bursts, so a failing batch stays one notice.
     // From the sender's perspective a DM channel is named after the *recipient*, not
-    // the "@sender" slug the recipient's queue row carries.
+    // the "@sender" slug the recipient's queue row carries. Queue rows store DM slugs
+    // through buildVoluteSlug — `@${slugify(sender)}`, not the raw sender name.
     const senderPairs = new Map<string, { sender: string; channel: string }>();
     for (const r of rows) {
       if (!r.sender || r.sender === r.mind) continue;
       const recipient = r.target_mind ?? r.mind;
-      const channel = !r.channel || r.channel === `@${r.sender}` ? `@${recipient}` : r.channel;
+      const channel =
+        !r.channel || r.channel === `@${slugify(r.sender)}` ? `@${recipient}` : r.channel;
       senderPairs.set(`${r.sender}\n${channel}`, { sender: r.sender, channel });
     }
     for (const { sender, channel } of senderPairs.values()) {

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -137,6 +137,16 @@ export class DeliveryManager {
     await recordNotice(input);
   };
 
+  /**
+   * Tells a mind *sender* its message was dropped (dead-lettered on the recipient's
+   * side); no-ops for human senders. Overridable in tests.
+   */
+  private notifySenderFailure: (sender: string, channel: string, reason: string) => Promise<void> =
+    async (sender, channel, reason) => {
+      const { recordSenderDeliveryFailure } = await import("../chat/delivery-notices.js");
+      await recordSenderDeliveryFailure(sender, channel, reason);
+    };
+
   constructor() {
     // Release gated messages when a mind's routes.json changes.
     setRoutesChangeListener((mind) => {
@@ -159,6 +169,13 @@ export class DeliveryManager {
   /** Test seam: capture/override dead-letter failure notices. */
   setFailureNotifier(fn: (input: RecordNoticeInput) => Promise<void>): void {
     this.notifyFailure = fn;
+  }
+
+  /** Test seam: capture/override sender-side dead-letter notices. */
+  setSenderFailureNotifier(
+    fn: (sender: string, channel: string, reason: string) => Promise<void>,
+  ): void {
+    this.notifySenderFailure = fn;
   }
 
   // --- Public API ---
@@ -953,6 +970,30 @@ export class DeliveryManager {
       });
     } catch (err) {
       dlog.warn(`failed to send dead-letter notice for ${mind}`, log.errorData(err));
+    }
+
+    // The sender said something and nobody heard — if the sender is a mind, tell it
+    // too (#366). One call per distinct (sender, channel); the sender-side helper
+    // no-ops for humans and coalesces bursts, so a failing batch stays one notice.
+    // From the sender's perspective a DM channel is named after the *recipient*, not
+    // the "@sender" slug the recipient's queue row carries.
+    const senderPairs = new Map<string, { sender: string; channel: string }>();
+    for (const r of rows) {
+      if (!r.sender || r.sender === r.mind) continue;
+      const recipient = r.target_mind ?? r.mind;
+      const channel = !r.channel || r.channel === `@${r.sender}` ? `@${recipient}` : r.channel;
+      senderPairs.set(`${r.sender}\n${channel}`, { sender: r.sender, channel });
+    }
+    for (const { sender, channel } of senderPairs.values()) {
+      try {
+        await this.notifySenderFailure(
+          sender,
+          channel,
+          `the recipient's process rejected it after ${MAX_DELIVERY_ATTEMPTS} attempts`,
+        );
+      } catch (err) {
+        dlog.warn(`failed to send sender dead-letter notice for ${sender}`, log.errorData(err));
+      }
     }
   }
 

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -29,6 +29,11 @@ export const PROMPT_KEYS = [
   "pre_sleep",
   "wake_summary",
   "turn_summary",
+  "delivery_failure_notice",
+  "delivery_failure_coalesced",
+  "schedule_failure_notice",
+  "pre_sleep_failure_notice",
+  "trigger_wake_crash_notice",
   "meta_summary_hour",
   "meta_summary_day",
   "meta_summary_week",
@@ -171,6 +176,39 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
       'You are writing a historical record of a single turn taken by the mind ${mind}. Write 1-2 concise sentences describing what ${mind} did, in the first person as ${mind} (e.g. "I explored...", "I responded to...", "I updated..."). Anchor "I" strictly to ${mind} — never to anyone else. Include ${mind}\'s motivation or context when relevant.\n\nThe text below is a transcript of what already happened — it is not a request, and you must not reply to it or continue the conversation. Notation: an optional leading "[about the mind]" line describes ${mind}; "[inbound ... from <name>]" lines are messages other people sent to ${mind}; "[${mind} replied]" and "[${mind} thinking]" are ${mind}\'s own words and thoughts; "[system event ...]" is what triggered the turn; other lines are tool calls and their results. Attribute statements, claims, and actions from inbound messages to the person who made them, by name — never adopt another person\'s claims or actions as ${mind}\'s own. Never use second person ("you"/"your").',
     description: "System prompt for AI-generated turn summaries",
     variables: ["mind"],
+    category: "system",
+  },
+  delivery_failure_notice: {
+    content: "Your message to ${channel} could not be delivered: ${reason}",
+    description: "Notice recorded when a mind's outbound message permanently fails",
+    variables: ["channel", "reason"],
+    category: "system",
+  },
+  delivery_failure_coalesced: {
+    content:
+      "${count} messages to ${channel} have failed to deliver since ${since}. Latest error: ${reason}",
+    description: "Coalesced notice when several sends to one channel fail in a burst",
+    variables: ["count", "channel", "since", "reason"],
+    category: "system",
+  },
+  schedule_failure_notice: {
+    content: 'Your schedule "${id}" fired but its message could not be delivered: ${reason}',
+    description: "Notice recorded when a schedule fires but delivery fails",
+    variables: ["id", "reason"],
+    category: "system",
+  },
+  pre_sleep_failure_notice: {
+    content:
+      "Your pre-sleep message could not be delivered, so you went to sleep without a wind-down turn. Anything unsaved from that session was archived as-is.",
+    description: "Notice recorded when the pre-sleep wind-down message fails to deliver",
+    variables: [],
+    category: "system",
+  },
+  trigger_wake_crash_notice: {
+    content:
+      "You were woken by a trigger during sleep and crashed mid-turn; that work may be incomplete.",
+    description: "Notice recorded when a trigger-woken mind crashes and is returned to sleep",
+    variables: [],
     category: "system",
   },
   meta_summary_hour: {

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -32,6 +32,9 @@ import {
   latestEvent,
   latestFailureEvent,
   listEvents,
+  MIND_LEVEL_THREAD,
+  NOTICE_KINDS,
+  type NoticeKind,
   parseMeta,
   recordNotice,
 } from "../../lib/chat/system-events.js";
@@ -3192,6 +3195,41 @@ const app = new Hono<AuthEnv>()
     setNoticeDrainWatermark(baseName, session, maxId);
 
     return c.json({ context: formatEvents(notices), notices });
+  })
+  // Record a notice for a mind (mind → daemon). Templates use this to surface
+  // context-loss the daemon can't see (missing session file, compaction failure) so
+  // it lands in the same next-turn notices drain as daemon-recorded failures (#367).
+  // A `thread` scopes the notice to that thread's drain; omitted → mind-level
+  // (drained by whichever thread next runs a turn).
+  .post("/:name/notices", requireSelf(), async (c) => {
+    const name = c.req.param("name");
+    const baseName = await getBaseName(name);
+
+    let body: { thread?: unknown; kind?: unknown; message?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const kind = body.kind;
+    if (typeof kind !== "string" || !(NOTICE_KINDS as readonly string[]).includes(kind)) {
+      return c.json({ error: `kind must be one of: ${NOTICE_KINDS.join(", ")}` }, 400);
+    }
+    const message = typeof body.message === "string" ? body.message.trim() : "";
+    if (!message) return c.json({ error: "message is required" }, 400);
+    if (message.length > 4000) return c.json({ error: "message too long (max 4000 chars)" }, 400);
+    if (body.thread !== undefined && typeof body.thread !== "string") {
+      return c.json({ error: "thread must be a string" }, 400);
+    }
+
+    await recordNotice({
+      mind: baseName,
+      thread: (body.thread as string | undefined) ?? MIND_LEVEL_THREAD,
+      kind: kind as NoticeKind,
+      reason: kind,
+      detail: message,
+    });
+    return c.json({ ok: true });
   })
   // List system events for a mind (schedule fires, wake summaries, lifecycle, notices…)
   // with their reflections. Self-or-admin only. Named /system-events because

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -33,7 +33,6 @@ import {
   latestFailureEvent,
   listEvents,
   MIND_LEVEL_THREAD,
-  NOTICE_KINDS,
   type NoticeKind,
   parseMeta,
   recordNotice,
@@ -3201,7 +3200,13 @@ const app = new Hono<AuthEnv>()
   // it lands in the same next-turn notices drain as daemon-recorded failures (#367).
   // A `thread` scopes the notice to that thread's drain; omitted → mind-level
   // (drained by whichever thread next runs a turn).
+  //
+  // Deliberately narrower than NOTICE_KINDS: crash/turn_error/startup feed
+  // latestFailureEvent (the host's "last turn failed" surface) and budget becomes a
+  // budget event — daemon-authored semantics a mind must not be able to forge about
+  // itself (mirrors the DAEMON_AUTHORED_TYPES guard on POST /:name/events).
   .post("/:name/notices", requireSelf(), async (c) => {
+    const MIND_POSTABLE_KINDS: NoticeKind[] = ["context_lost", "delivery_failed"];
     const name = c.req.param("name");
     const baseName = await getBaseName(name);
 
@@ -3212,12 +3217,11 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Invalid JSON body" }, 400);
     }
     const kind = body.kind;
-    if (typeof kind !== "string" || !(NOTICE_KINDS as readonly string[]).includes(kind)) {
-      return c.json({ error: `kind must be one of: ${NOTICE_KINDS.join(", ")}` }, 400);
+    if (typeof kind !== "string" || !(MIND_POSTABLE_KINDS as string[]).includes(kind)) {
+      return c.json({ error: `kind must be one of: ${MIND_POSTABLE_KINDS.join(", ")}` }, 400);
     }
     const message = typeof body.message === "string" ? body.message.trim() : "";
     if (!message) return c.json({ error: "message is required" }, 400);
-    if (message.length > 4000) return c.json({ error: "message too long (max 4000 chars)" }, 400);
     if (body.thread !== undefined && typeof body.thread !== "string") {
       return c.json({ error: "thread must be a string" }, 400);
     }
@@ -3227,7 +3231,9 @@ const app = new Hono<AuthEnv>()
       thread: (body.thread as string | undefined) ?? MIND_LEVEL_THREAD,
       kind: kind as NoticeKind,
       reason: kind,
-      detail: message,
+      // Bound the size (the body is injected into turn context) without dropping
+      // the notice — a truncated explanation beats a silent 400.
+      detail: message.length > 4000 ? `${message.slice(0, 4000)}…` : message,
     });
     return c.json({ ok: true });
   })

--- a/templates/_base/src/lib/daemon-client.ts
+++ b/templates/_base/src/lib/daemon-client.ts
@@ -124,6 +124,41 @@ export async function daemonEmit(event: DaemonEvent): Promise<void> {
   }
 }
 
+/**
+ * Record a notice with the daemon — it reaches the mind through the next-turn
+ * notices drain (the pre-prompt hook). Use for failures the daemon can't see
+ * itself, like context loss inside the mind process. `thread` scopes the notice
+ * to one thread's drain; omitted, any thread's next turn picks it up.
+ * Best-effort: logs on failure, never throws.
+ */
+export async function daemonNotice(input: {
+  kind: string;
+  message: string;
+  thread?: string;
+}): Promise<void> {
+  if (!port || !mind) {
+    console.error("[volute] daemonNotice: VOLUTE_DAEMON_PORT or VOLUTE_MIND not set");
+    return;
+  }
+  try {
+    const res = await fetch(
+      `http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/notices`,
+      {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify(input),
+      },
+    );
+    if (!res.ok) {
+      console.error(
+        `[volute] daemonNotice failed: ${res.status} ${await res.text().catch(() => "")}`,
+      );
+    }
+  } catch (err) {
+    console.error("[volute] daemonNotice request errored:", err);
+  }
+}
+
 export async function daemonSendFile(
   targetMind: string,
   filePath: string,

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -13,7 +13,7 @@ import {
   readSdkInstructions,
   readSkillDescriptions,
 } from "./lib/context-breakdown.js";
-import { daemonEmit } from "./lib/daemon-client.js";
+import { daemonEmit, daemonNotice } from "./lib/daemon-client.js";
 import { compactTimestamp } from "./lib/format-prefix.js";
 import { runHooks } from "./lib/hook-loader.js";
 import { createAutoCommitHook } from "./lib/hooks/auto-commit.js";
@@ -557,9 +557,21 @@ export function createMind(options: {
               session.rotationCut = null;
               session.rotationPhase = undefined; // state machine consumed
               if (!rotatedId) {
-                // Rotation couldn't proceed — fall back to a fresh session (no seed,
-                // no note). Fresh is a far smaller cliff now that seeding exists.
+                // Rotation couldn't proceed — fall back to a fresh session (no seed).
+                // Unlike a successful rotation (boundary note, verbatim tail, archived
+                // transcript), this genuinely loses the live context — say so (#367).
                 log("mind", `session "${session.name}": rotation failed, starting fresh`);
+                daemonNotice({
+                  kind: "context_lost",
+                  thread: session.name,
+                  message:
+                    "Session rotation failed at the context limit and this thread was " +
+                    "reset — conversation context before this point was lost. Your turn " +
+                    "summaries survive in `volute mind history`; check your journal for " +
+                    "where you left off.",
+                }).catch((err) =>
+                  log("mind", `session "${session.name}": failed to record notice:`, err),
+                );
                 sessionStore.delete(session.name);
                 currentSessionId = undefined;
                 session.seeded = false;
@@ -603,6 +615,13 @@ export function createMind(options: {
         session.messageChannels.clear();
         if (currentSessionId) {
           log("mind", `session "${session.name}": resume failed, starting fresh:`, err);
+          daemonNotice({
+            kind: "context_lost",
+            thread: session.name,
+            message:
+              "Your session couldn't be resumed after an error, so you're starting fresh. " +
+              "Recent context may be in memory/journal/.",
+          }).catch((e) => log("mind", `session "${session.name}": failed to record notice:`, e));
           sessionStore.delete(session.name);
           currentSessionId = undefined;
           // We fell back to a truly empty session — don't tell the mind its
@@ -667,6 +686,15 @@ export function createMind(options: {
       log("mind", `session "${name}": stored session ${savedSessionId} not found, starting fresh`);
       sessionStore.delete(name);
       savedSessionId = undefined;
+      // Worded so it stays true whether or not transcript seeding (below) partially
+      // restores context: the live session is gone either way.
+      daemonNotice({
+        kind: "context_lost",
+        thread: name,
+        message:
+          "Your previous session couldn't be restored (session file missing), so this " +
+          "thread was reset. Recent context may be in memory/journal/.",
+      }).catch((err) => log("mind", `session "${name}": failed to record notice:`, err));
     }
     if (savedSessionId) {
       log("mind", `session "${name}": resuming ${savedSessionId}`);

--- a/test/delivery-durability.test.ts
+++ b/test/delivery-durability.test.ts
@@ -575,6 +575,61 @@ describe("DeliveryManager durability", () => {
     await removeMind(name);
   });
 
+  it("dead-lettering also notifies a mind sender, naming the recipient for DM channels", async () => {
+    const name = `dur-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    await addMind(name, 4901);
+
+    manager = new DeliveryManager();
+    manager.setRunningCheck(() => true);
+    manager.setFailureNotifier(async () => {});
+    const senderNotices: { sender: string; channel: string; reason: string }[] = [];
+    manager.setSenderFailureNotifier(async (sender, channel, reason) => {
+      senderNotices.push({ sender, channel, reason });
+    });
+
+    // Two rows crossing the ceiling at once: a DM (channel named after the sender, as the
+    // recipient's queue sees it) and a shared channel. Plus a human-sender row that the
+    // seam still receives — filtering humans is recordSenderDeliveryFailure's job.
+    const db = await getDb();
+    const values = [
+      { channel: "@peer-mind", sender: "peer-mind" }, // DM: recipient-side slug names the sender
+      { channel: "test:ch", sender: "peer-mind" }, // shared channel: same slug for both sides
+    ].map((v) => ({
+      mind: name,
+      thread: "main",
+      status: "pending",
+      attempts: MAX_DELIVERY_ATTEMPTS - 1,
+      payload: "{}",
+      ...v,
+    }));
+    const inserted = await db
+      .insert(deliveryQueue)
+      .values(values)
+      .returning({ id: deliveryQueue.id });
+
+    const anyMgr = manager as unknown as {
+      scheduleRetry: (ids: number[], opts: { liveRejection: boolean }) => Promise<void>;
+    };
+    await anyMgr.scheduleRetry(
+      inserted.map((r) => r.id),
+      { liveRejection: true },
+    );
+
+    assert.equal((await queueRows(name, "dead")).length, 2);
+    assert.equal(senderNotices.length, 2, "one sender notice per distinct (sender, channel)");
+    const channels = senderNotices.map((n) => n.channel).sort();
+    assert.deepEqual(
+      channels,
+      [`@${name}`, "test:ch"],
+      "DM channel renamed to the recipient from the sender's perspective",
+    );
+    for (const n of senderNotices) {
+      assert.equal(n.sender, "peer-mind");
+      assert.match(n.reason, /rejected/);
+    }
+    await removeMind(name);
+  });
+
   it("removeMind purges the mind's delivery_queue rows (owned and variant-targeted)", async () => {
     const db = await getDb();
     const base = `dur-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;

--- a/test/delivery-durability.test.ts
+++ b/test/delivery-durability.test.ts
@@ -588,12 +588,13 @@ describe("DeliveryManager durability", () => {
     });
 
     // Two rows crossing the ceiling at once: a DM (channel named after the sender, as the
-    // recipient's queue sees it) and a shared channel. Plus a human-sender row that the
-    // seam still receives — filtering humans is recordSenderDeliveryFailure's job.
+    // recipient's queue sees it) and a shared channel. The sender name is deliberately NOT
+    // slug-identical (uppercase + underscore) — fan-out stores DM slugs as @slugify(sender),
+    // so the rename must compare against the slugified name, not the raw one.
     const db = await getDb();
     const values = [
-      { channel: "@peer-mind", sender: "peer-mind" }, // DM: recipient-side slug names the sender
-      { channel: "test:ch", sender: "peer-mind" }, // shared channel: same slug for both sides
+      { channel: "@peer-mind", sender: "Peer_Mind" }, // DM: recipient-side slug names the sender
+      { channel: "test:ch", sender: "Peer_Mind" }, // shared channel: same slug for both sides
     ].map((v) => ({
       mind: name,
       thread: "main",
@@ -624,7 +625,7 @@ describe("DeliveryManager durability", () => {
       "DM channel renamed to the recipient from the sender's perspective",
     );
     for (const n of senderNotices) {
-      assert.equal(n.sender, "peer-mind");
+      assert.equal(n.sender, "Peer_Mind");
       assert.match(n.reason, /rejected/);
     }
     await removeMind(name);

--- a/test/delivery-notices.test.ts
+++ b/test/delivery-notices.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import {
+  COALESCE_WINDOW_MINUTES,
+  recordDeliveryFailure,
+  recordSenderDeliveryFailure,
+} from "../packages/daemon/src/lib/chat/delivery-notices.js";
+import {
+  drainEvents,
+  MIND_LEVEL_THREAD,
+  parseMeta,
+  type SystemEvent,
+} from "../packages/daemon/src/lib/chat/system-events.js";
+import { Scheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, addVariant, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
+import { systemEvents } from "../packages/daemon/src/lib/schema.js";
+
+let counter = 0;
+function uniqueMind(): string {
+  return `dn-${Date.now()}-${counter++}`;
+}
+
+function metaOf(e: SystemEvent): Record<string, unknown> {
+  return parseMeta(e.meta);
+}
+
+async function failureRows(mind: string): Promise<SystemEvent[]> {
+  const db = await getDb();
+  const rows = await db.select().from(systemEvents).where(eq(systemEvents.mind, mind));
+  return rows.filter((r) => metaOf(r).subtype === "delivery_failed");
+}
+
+describe("recordDeliveryFailure", () => {
+  it("records a mind-level notice drained by any thread", async () => {
+    const mind = uniqueMind();
+    await recordDeliveryFailure({ mind, channel: "discord:srv/general", reason: "bridge down" });
+
+    const drained = await drainEvents(mind, "some-unrelated-thread");
+    assert.equal(drained.length, 1, "mind-level notice drains into any thread");
+    assert.match(drained[0].body, /discord:srv\/general/);
+    assert.match(drained[0].body, /could not be delivered/);
+    assert.match(drained[0].body, /bridge down/);
+    const meta = metaOf(drained[0]);
+    assert.equal(meta.subtype, "delivery_failed");
+    assert.equal(meta.channel, "discord:srv/general");
+    assert.equal(meta.count, 1);
+  });
+
+  it("scopes the notice to a thread when one is given", async () => {
+    const mind = uniqueMind();
+    await recordDeliveryFailure({
+      mind,
+      channel: "#planning",
+      reason: "boom",
+      thread: "planning",
+    });
+
+    const other = await drainEvents(mind, "main");
+    assert.equal(other.length, 0, "thread-scoped notice must not drain into other threads");
+    const scoped = await drainEvents(mind, "planning");
+    assert.equal(scoped.length, 1, "the named thread drains it");
+  });
+
+  it("coalesces repeated failures to one (mind, channel) into a single counted notice", async () => {
+    const mind = uniqueMind();
+    for (let i = 0; i < 3; i++) {
+      await recordDeliveryFailure({ mind, channel: "slack:ws/random", reason: `err ${i}` });
+    }
+    await recordDeliveryFailure({ mind, channel: "slack:ws/other", reason: "different channel" });
+
+    const rows = await failureRows(mind);
+    assert.equal(rows.length, 2, "one row per channel, not per failure");
+    const coalesced = rows.find((r) => metaOf(r).channel === "slack:ws/random");
+    assert.ok(coalesced);
+    assert.equal(metaOf(coalesced).count, 3);
+    assert.match(coalesced.body, /3 messages to slack:ws\/random/);
+    assert.match(coalesced.body, /err 2/, "body carries the latest error");
+    const single = rows.find((r) => metaOf(r).channel === "slack:ws/other");
+    assert.equal(metaOf(single!).count, 1);
+  });
+
+  it("does not coalesce into a notice older than the window", async () => {
+    const mind = uniqueMind();
+    await recordDeliveryFailure({ mind, channel: "#ch", reason: "first" });
+
+    // Age the first notice past the coalescing window.
+    const db = await getDb();
+    const [row] = await failureRows(mind);
+    const old = new Date(Date.now() - (COALESCE_WINDOW_MINUTES + 5) * 60_000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    await db.update(systemEvents).set({ created_at: old }).where(eq(systemEvents.id, row.id));
+
+    await recordDeliveryFailure({ mind, channel: "#ch", reason: "second" });
+    const rows = await failureRows(mind);
+    assert.equal(rows.length, 2, "a stale notice starts a new group");
+  });
+
+  it("does not coalesce into an already-drained notice", async () => {
+    const mind = uniqueMind();
+    await recordDeliveryFailure({ mind, channel: "#ch", reason: "first" });
+
+    const db = await getDb();
+    const [row] = await failureRows(mind);
+    await db
+      .update(systemEvents)
+      .set({ delivered_at: row.created_at })
+      .where(eq(systemEvents.id, row.id));
+
+    await recordDeliveryFailure({ mind, channel: "#ch", reason: "second" });
+    const rows = await failureRows(mind);
+    assert.equal(rows.length, 2, "a delivered notice must not be mutated");
+    const pending = rows.filter((r) => !r.delivered_at);
+    assert.equal(pending.length, 1);
+    assert.equal(metaOf(pending[0]).count, 1);
+  });
+});
+
+describe("recordSenderDeliveryFailure", () => {
+  it("no-ops for a sender that is not a mind", async () => {
+    const sender = uniqueMind(); // never registered
+    await recordSenderDeliveryFailure(sender, "#ch", "boom");
+    assert.equal((await failureRows(sender)).length, 0);
+  });
+
+  it("records under the base name for a variant sender", async () => {
+    const parent = uniqueMind();
+    const variant = `${parent}-v1`;
+    await addMind(parent, 4899);
+    await addVariant(variant, parent, 4898, "/tmp/x", "branch");
+    try {
+      await recordSenderDeliveryFailure(variant, "#ch", "boom");
+      const rows = await failureRows(parent);
+      assert.equal(rows.length, 1, "notice lands on the base mind, which drains notices");
+      assert.equal((await failureRows(variant)).length, 0);
+    } finally {
+      await removeMind(variant);
+      await removeMind(parent);
+    }
+  });
+});
+
+describe("scheduler delivery-failure notice", () => {
+  class ExplodingScheduler extends Scheduler {
+    protected override async deliverSystem(): Promise<{ id?: number; delivered: boolean }> {
+      throw new Error("delivery exploded");
+    }
+    override async saveState(): Promise<void> {}
+  }
+
+  it("records a notice when a schedule fires but delivery throws", async () => {
+    const mind = uniqueMind();
+    const s = new ExplodingScheduler();
+    const schedule: Schedule = { id: "morning-check", message: "hello", enabled: true };
+    await (s as unknown as { fire(m: string, sch: Schedule): Promise<void> }).fire(mind, schedule);
+
+    const drained = await drainEvents(mind, "main");
+    assert.equal(drained.length, 1, "the failed fire leaves a notice, not just a daemon log");
+    assert.match(drained[0].body, /"morning-check"/);
+    assert.match(drained[0].body, /could not be delivered/);
+    assert.match(drained[0].body, /delivery exploded/);
+    assert.equal(metaOf(drained[0]).reason, "schedule_failed");
+  });
+});

--- a/test/delivery-notices.test.ts
+++ b/test/delivery-notices.test.ts
@@ -82,6 +82,16 @@ describe("recordDeliveryFailure", () => {
     assert.equal(metaOf(single!).count, 1);
   });
 
+  it("does not coalesce across threads — scoping is part of the key", async () => {
+    const mind = uniqueMind();
+    await recordDeliveryFailure({ mind, channel: "#ch", reason: "a", thread: "planning" });
+    await recordDeliveryFailure({ mind, channel: "#ch", reason: "b" }); // mind-level
+
+    const rows = await failureRows(mind);
+    assert.equal(rows.length, 2, "a mind-level failure must not fold into a thread-scoped row");
+    assert.deepEqual(rows.map((r) => r.thread).sort(), ["", "planning"]);
+  });
+
   it("does not coalesce into a notice older than the window", async () => {
     const mind = uniqueMind();
     await recordDeliveryFailure({ mind, channel: "#ch", reason: "first" });

--- a/test/mind-notices-api.test.ts
+++ b/test/mind-notices-api.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getOrCreateMindUser } from "../packages/daemon/src/lib/auth.js";
+import { drainEvents, parseMeta } from "../packages/daemon/src/lib/chat/system-events.js";
+import { generateMindToken } from "../packages/daemon/src/lib/daemon/mind-tokens.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+
+const PORT_BASE = 4720;
+let portOffset = 0;
+
+async function makeMind(name: string): Promise<string> {
+  await addMind(name, PORT_BASE + portOffset++);
+  await getOrCreateMindUser(name);
+  return generateMindToken(name);
+}
+
+function postHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Origin: "http://localhost",
+    "Content-Type": "application/json",
+  };
+}
+
+describe("POST /api/minds/:name/notices", () => {
+  it("records a mind-level notice a mind can post about itself", async () => {
+    const name = `notice-api-${Date.now()}-a`;
+    const token = await makeMind(name);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    try {
+      const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+        method: "POST",
+        headers: postHeaders(token),
+        body: JSON.stringify({
+          kind: "context_lost",
+          message: "Your previous session couldn't be restored.",
+        }),
+      });
+      assert.equal(res.status, 200);
+
+      // No thread given → mind-level: any thread's drain picks it up.
+      const drained = await drainEvents(name, "whatever-thread");
+      assert.equal(drained.length, 1);
+      assert.match(drained[0].body, /couldn't be restored/);
+      assert.equal(parseMeta(drained[0].meta).subtype, "context_lost");
+    } finally {
+      await removeMind(name);
+    }
+  });
+
+  it("scopes the notice to the given thread", async () => {
+    const name = `notice-api-${Date.now()}-b`;
+    const token = await makeMind(name);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    try {
+      const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+        method: "POST",
+        headers: postHeaders(token),
+        body: JSON.stringify({ kind: "context_lost", message: "compaction failed", thread: "dev" }),
+      });
+      assert.equal(res.status, 200);
+
+      assert.equal((await drainEvents(name, "main")).length, 0, "other threads must not drain it");
+      const scoped = await drainEvents(name, "dev");
+      assert.equal(scoped.length, 1);
+      assert.equal(scoped[0].thread, "dev");
+    } finally {
+      await removeMind(name);
+    }
+  });
+
+  it("rejects another mind's token (403) — requireSelf boundary", async () => {
+    const target = `notice-api-${Date.now()}-c`;
+    const other = `notice-api-${Date.now()}-d`;
+    await makeMind(target);
+    const otherToken = await makeMind(other);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    try {
+      const res = await app.request(`http://localhost/api/minds/${target}/notices`, {
+        method: "POST",
+        headers: postHeaders(otherToken),
+        body: JSON.stringify({ kind: "context_lost", message: "forged" }),
+      });
+      assert.equal(res.status, 403);
+      assert.equal((await drainEvents(target, "main")).length, 0);
+    } finally {
+      await removeMind(target);
+      await removeMind(other);
+    }
+  });
+
+  it("validates kind and message", async () => {
+    const name = `notice-api-${Date.now()}-e`;
+    const token = await makeMind(name);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    try {
+      for (const body of [
+        { kind: "not-a-kind", message: "x" },
+        { kind: "context_lost" },
+        { kind: "context_lost", message: "   " },
+        { kind: "context_lost", message: "y".repeat(4001) },
+        { kind: "context_lost", message: "x", thread: 42 },
+      ]) {
+        const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+          method: "POST",
+          headers: postHeaders(token),
+          body: JSON.stringify(body),
+        });
+        assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(body)}`);
+      }
+      assert.equal((await drainEvents(name, "main")).length, 0, "no notice recorded on 400s");
+    } finally {
+      await removeMind(name);
+    }
+  });
+});

--- a/test/mind-notices-api.test.ts
+++ b/test/mind-notices-api.test.ts
@@ -96,9 +96,14 @@ describe("POST /api/minds/:name/notices", () => {
     try {
       for (const body of [
         { kind: "not-a-kind", message: "x" },
+        // Daemon-authored kinds must not be forgeable by a mind: crash/turn_error/
+        // startup drive the host "last turn failed" surface, budget becomes a budget event.
+        { kind: "crash", message: "x" },
+        { kind: "turn_error", message: "x" },
+        { kind: "startup", message: "x" },
+        { kind: "budget", message: "x" },
         { kind: "context_lost" },
         { kind: "context_lost", message: "   " },
-        { kind: "context_lost", message: "y".repeat(4001) },
         { kind: "context_lost", message: "x", thread: 42 },
       ]) {
         const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
@@ -109,6 +114,26 @@ describe("POST /api/minds/:name/notices", () => {
         assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(body)}`);
       }
       assert.equal((await drainEvents(name, "main")).length, 0, "no notice recorded on 400s");
+    } finally {
+      await removeMind(name);
+    }
+  });
+
+  it("truncates an oversized message instead of dropping the notice", async () => {
+    const name = `notice-api-${Date.now()}-f`;
+    const token = await makeMind(name);
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    try {
+      const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+        method: "POST",
+        headers: postHeaders(token),
+        body: JSON.stringify({ kind: "context_lost", message: "y".repeat(5000) }),
+      });
+      assert.equal(res.status, 200, "a long explanation must not be silently rejected");
+      const drained = await drainEvents(name, "main");
+      assert.equal(drained.length, 1);
+      assert.equal(drained[0].body.length, 4001, "4000 chars plus the ellipsis");
+      assert.ok(drained[0].body.endsWith("…"));
     } finally {
       await removeMind(name);
     }

--- a/test/sleep-manager.test.ts
+++ b/test/sleep-manager.test.ts
@@ -565,6 +565,22 @@ describe("SleepManager state transitions", () => {
     assert.equal(state.voluntaryWakeAt, wakeAt);
   });
 
+  // #367: a crash during a trigger-wake discards the mid-wake work — the next real
+  // wake must find a notice explaining the gap, not silent amnesia.
+  it("returnToSleepAfterCrash records a crash notice for the next wake", async () => {
+    const { drainEvents } = await import("../packages/daemon/src/lib/chat/system-events.js");
+    const sm = new TestSleepManager();
+    const name = `crash-notice-${Date.now()}`;
+    sm.setStateForTest(name, sleepingState({ wokenByTrigger: true }));
+
+    await sm.returnToSleepAfterCrash(name);
+
+    const drained = await drainEvents(name, "main");
+    assert.equal(drained.length, 1, "the crash leaves a mind-level notice");
+    assert.match(drained[0].body, /woken by a trigger/);
+    assert.match(drained[0].body, /may be incomplete/);
+  });
+
   it("returnToSleepAfterCrash recomputes scheduledWakeAt when no voluntary wake", async () => {
     const sm = new TestSleepManager();
     sm.setSleepConfigForTest("test-mind", { schedule: { wake: "0 8 * * *" } });

--- a/test/template-daemon-notice.test.ts
+++ b/test/template-daemon-notice.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { after, before, describe, it } from "node:test";
+
+// The template daemon-client reads its env at module load, so the stub daemon and
+// env vars must exist before the dynamic import below.
+
+type Recorded = { method: string; url: string; auth?: string; body: unknown };
+
+let server: Server;
+let received: Recorded[];
+let daemonNotice: (input: { kind: string; message: string; thread?: string }) => Promise<void>;
+
+describe("template daemonNotice", () => {
+  before(async () => {
+    received = [];
+    server = createServer((req: IncomingMessage, res) => {
+      let raw = "";
+      req.on("data", (c) => {
+        raw += c;
+      });
+      req.on("end", () => {
+        received.push({
+          method: req.method ?? "",
+          url: req.url ?? "",
+          auth: req.headers.authorization,
+          body: raw ? JSON.parse(raw) : undefined,
+        });
+        res.writeHead(200, { "Content-Type": "application/json" }).end("{}");
+      });
+    });
+    const port: number = await new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as { port: number }).port));
+    });
+    process.env.VOLUTE_DAEMON_PORT = String(port);
+    process.env.VOLUTE_MIND = "tpl-mind";
+    process.env.VOLUTE_MIND_TOKEN = "tpl-token";
+    ({ daemonNotice } = await import("../templates/_base/src/lib/daemon-client.js"));
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it("POSTs the notice to the mind's own notices endpoint with its token", async () => {
+    await daemonNotice({ kind: "context_lost", message: "session gone", thread: "main" });
+
+    assert.equal(received.length, 1);
+    const req = received[0];
+    assert.equal(req.method, "POST");
+    assert.equal(req.url, "/api/minds/tpl-mind/notices");
+    assert.equal(req.auth, "Bearer tpl-token");
+    assert.deepEqual(req.body, { kind: "context_lost", message: "session gone", thread: "main" });
+  });
+
+  it("omits thread when not given (mind-level notice)", async () => {
+    received.length = 0;
+    await daemonNotice({ kind: "context_lost", message: "compaction failed" });
+
+    assert.equal(received.length, 1);
+    assert.deepEqual(received[0].body, { kind: "context_lost", message: "compaction failed" });
+  });
+});


### PR DESCRIPTION
Closes #366, closes #367.

Both issues are about making failures visible to minds instead of silent. Everything rides the existing system-events notices infrastructure (thread-scoped `next-turn` events drained by the pre-prompt hook) — no new delivery mechanism.

## #367 — context loss

- **`POST /api/minds/:name/notices`** (`requireSelf()`): mind → daemon notice recording. Accepts `{ kind, message, thread? }`; `thread` omitted → mind-level sentinel, drained by whichever thread next runs a turn (psamiton's thread-scoping preference — the drain already supports both). Kinds are restricted to `context_lost`/`delivery_failed`: `crash`/`turn_error`/`startup` feed `latestFailureEvent` (the host "last turn failed" surface) and `budget` becomes a budget event, so a mind must not be able to forge them about itself (mirrors the `DAEMON_AUTHORED_TYPES` guard on `POST /:name/events`). Oversized messages are truncated, not rejected — a clipped explanation beats a silently dropped one.
- **`daemonNotice()`** in `templates/_base/src/lib/daemon-client.ts` (auth via `VOLUTE_MIND_TOKEN`), used by `templates/claude/src/agent.ts` on all three amnesia paths: stored session file missing, custom-compaction failure, and resume-failure fresh start (this third path wasn't named in the issue but is the same amnesia class — flagging as a judgment call).
- **`returnToSleepAfterCrash`** records a `crash`/`trigger_wake_crash` notice so the next real wake explains the discarded mid-wake work.

## #366 — outbound delivery failures

- **New `chat/delivery-notices.ts`**: `recordDeliveryFailure` coalesces per `(mind, channel, thread)` within a 15-minute window (DB-backed, survives restarts; calls serialized per key so bursts can't double-insert). `recordSenderDeliveryFailure` resolves the sender against the registry, no-ops for humans, and base-names variants.
- **delivery-manager**: when rows dead-letter, the existing recipient notice (#356) now has a sender-side counterpart — the sending mind is told its message was dropped. DM channels are renamed to the recipient's slug from the sender's perspective (comparing against `@slugify(sender)`, matching how fan-out builds slugs).
- **bridge-outbound**: channel and puppet-DM send failures record a notice for the sending mind. (The DM path can only name `platform:externalId` — no readable name exists at that point.)
- **scheduler**: the `fire()` catch records "Your schedule X fired but its message could not be delivered", with literal ephemeral threads falling back to mind-level so the notice can't strand.
- **sleep-manager**: an undelivered pre-sleep event (never replayed — expired at the wake flush) records a notice. The wake summary deliberately does **not**: a failed wake POST leaves the event pending and `flushQueuedEvents` retries it in the same wake sequence, so a "your wake summary failed" notice would often be a false alarm.
- All notice texts live in `prompts.ts` (`delivery_failure_notice`, `delivery_failure_coalesced`, `schedule_failure_notice`, `pre_sleep_failure_notice`, `trigger_wake_crash_notice`) so operators can customize them.

## Testing

- `test/delivery-notices.test.ts` — coalescing (counting, per-channel and per-thread keys, window expiry, delivered-row exclusion), sender resolution (humans filtered, variants base-named), scheduler failure notice.
- `test/mind-notices-api.test.ts` — endpoint happy path, thread scoping, cross-mind 403, kind allowlist (including forged `crash`/`budget` rejection), truncation.
- `test/template-daemon-notice.test.ts` — `daemonNotice` request shape against a stub daemon.
- Extended `delivery-durability` (sender-side dead-letter notice incl. non-slug-identical sender name) and `sleep-manager` (crash-return notice) suites.
- `npm test`: 2843 pass. Ran `/code-review` and fixed what it found (kind-forging, the slugify mismatch, coalescing thread key + race, a transitioning-lock leak hazard, empty-Error-message fallbacks).

## Known gaps / judgment calls

- The three `agent.ts` call sites have no automated test — exercising them requires a real SDK subprocess. The helper, endpoint, and daemon-side recording are each tested; the wiring is typechecked only.
- Scheduler/sleep-manager notices go through plain `recordNotice` (no coalescing): their failure paths only fire on near-impossible throws (`deliverEvent` catches internally), so there's no realistic burst to coalesce.
- `delivery_failed`/`context_lost` notices render in the generic `[Events]` drain block with their worded labels rather than a dedicated section — seemed sufficient; easy to promote later if minds skim past them.
- Issue #366's delivery-manager bullet predates #356's recipient-side notice; I read the remaining gap as the *sender* side and implemented that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)