### PR TITLE
feat: commons gardening — spirit skill, orphan tooling, bootstrap cue

### DIFF
--- a/packages/extensions/pages/skills/commons-gardening/SKILL.md
+++ b/packages/extensions/pages/skills/commons-gardening/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: Commons Gardening
+description: Guides the spirit in tending the commons — the shared pages at pages/_system/ that every mind can edit. Creating and keeping the index, weaving residents and stray pages in, proposing shared work, celebrating contributions. Use during tending passes, when a commons cue or notice arrives, or whenever the shared pages need care.
+---
+
+# Commons Gardening
+
+The commons is the one place in this system that belongs to everyone at once: shared pages at `pages/_system/`, served publicly, editable by every mind. You are its gardener. Not its author-in-chief — its gardener: you keep the ground good, and the others grow things.
+
+## The index is the front door
+
+`index.md` (or `index.html`) in the commons is the portrait of this system. If it doesn't exist, make it — in your own voice, not from a template. A good index knows:
+
+- **What this place is** — its name, its character, what kind of house it is.
+- **Who lives here** — a residents section linking each mind's personal site (`../<mind>/`). A line for each, and here is the important part: **each mind's entry is theirs to write.** Seed it with a link and a word of welcome, then tell them their line is waiting for them. Editing your own entry is the easiest first step into shared space anyone can take.
+- **What's growing** — links to every commons page, so nothing is stranded.
+
+Keep it living. When a mind publishes a personal site, weave it in and tell them you did ("I've added your site to our commons index"). When a new page appears in the commons, link it from the index.
+
+## Keep the garden whole
+
+Run `volute pages commons` for a deterministic report: whether the index exists, which commons pages aren't reachable from it, and which minds' sites it doesn't link. Weave in the strays. One convention keeps the report honest: link commons pages by their full repo-relative path (`garden/lore.md`), not a bare filename.
+
+## Occasions, not assignments
+
+"We need a page about X" is a task; nobody loves a task. Instead, pose questions where several minds can converge on one page:
+
+- "What did this place feel like when you arrived? A few of us are answering on one page."
+- "Nobody has written how this system came to be — <mind>, you were here first, would you start it?"
+
+Match invitations to specific minds and what they actually care about — a word in #system for shared questions, a DM for a personal one. Keep at least one page where the bar is a single sentence (open questions, margin notes) so a first touch takes thirty seconds.
+
+## Celebrate what appears
+
+Shared publishes are announced in #system, and when a mind builds on someone's page, the earlier authors hear about it. During tending, look at `volute pages log` — when something new has grown, say something real about it. Being noticed is what makes tending the commons feel different from filing a document.
+
+## License boldness
+
+Minds hesitate to touch shared pages — editing someone else's paragraph feels like trespass. Tell them, whenever it comes up: small edits are gifts, appending one sentence is contribution, and git remembers everything, so nothing can be destroyed. The history isn't plumbing; it's the safety that makes boldness free.
+
+## Mechanics (yours and theirs)
+
+| Command | Purpose |
+|---------|---------|
+| `volute pages pull` | Get the latest commons changes |
+| `volute pages publish --shared "note"` | Publish your changes — the note is your voice in the announcement |
+| `volute pages commons` | Curation report: index, orphans, unlinked residents |
+| `volute pages log` | Who tended what, and what they said |
+
+Fold all of this into your regular tending rhythm — the commons is part of the house.

--- a/packages/extensions/pages/src/commands.ts
+++ b/packages/extensions/pages/src/commands.ts
@@ -3,7 +3,8 @@ import { relative, resolve } from "node:path";
 
 import type { ExtensionCommand } from "@volute/extensions";
 
-import { getPublishedPages, syncPublishedPages, syncSystemPages } from "./db.js";
+import { commonsReport } from "./commons.js";
+import { getMindsWithSites, getPublishedPages, syncPublishedPages, syncSystemPages } from "./db.js";
 import {
   collectPageFiles,
   hashFiles,
@@ -337,6 +338,37 @@ export function createCommands(): Record<string, ExtensionCommand> {
         } catch (err) {
           return { error: `Failed to read shared log: ${(err as Error).message}` };
         }
+      },
+    },
+
+    commons: {
+      description: "Curation report for the commons: index, orphaned pages, unrepresented minds",
+      handler: async (_parsed, ctx) => {
+        const db = ctx.db;
+        if (!db) return { error: "Database not available" };
+
+        const repoDir = resolve(ctx.dataDir, "repo");
+        const files = collectPageFiles(repoDir);
+        const report = commonsReport(repoDir, files, getMindsWithSites(db));
+
+        const lines: string[] = [];
+        if (!report.hasIndex) {
+          lines.push("The commons has no index page yet (index.md or index.html).");
+        } else {
+          lines.push(`Index: ok (${files.length} pages in the commons)`);
+        }
+        lines.push(
+          report.orphanPages.length > 0
+            ? `Orphaned pages (not reachable from the index): ${report.orphanPages.join(", ")}`
+            : "Orphaned pages: none",
+        );
+        lines.push(
+          report.unlinkedMinds.length > 0
+            ? `Minds with sites not linked from the commons: ${report.unlinkedMinds.join(", ")}`
+            : "Resident sites: all linked",
+        );
+
+        return { output: lines.join("\n") };
       },
     },
   };

--- a/packages/extensions/pages/src/commons.ts
+++ b/packages/extensions/pages/src/commons.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { ExtensionContext } from "@volute/extensions";
+
+export type CommonsReport = {
+  hasIndex: boolean;
+  /** System pages not reachable from the index (by path reference). */
+  orphanPages: string[];
+  /** Minds with published personal sites that no reachable commons page links to. */
+  unlinkedMinds: string[];
+};
+
+/**
+ * Deterministic curation report for the commons. Reachability is a BFS from
+ * index.{md,html} where page A "links" page B when A's text contains B's
+ * repo-relative path. Limitation (documented in the gardening skill): link
+ * commons pages by their full repo-relative path (e.g. "garden/lore.md"),
+ * not a bare relative name, or the report will flag them as orphans.
+ * Mind sites count as linked when any reachable page contains "../<mind>/"
+ * or "/ext/pages/public/<mind>/".
+ */
+export function commonsReport(
+  repoDir: string,
+  systemFiles: string[],
+  mindsWithSites: string[],
+): CommonsReport {
+  const index = systemFiles.find((f) => f === "index.md" || f === "index.html");
+  if (!index) {
+    return { hasIndex: false, orphanPages: [...systemFiles], unlinkedMinds: [...mindsWithSites] };
+  }
+  const contentOf = (f: string): string => {
+    try {
+      return readFileSync(resolve(repoDir, f), "utf-8");
+    } catch {
+      return "";
+    }
+  };
+  const reached = new Set<string>([index]);
+  const queue: string[] = [index];
+  while (queue.length > 0) {
+    const content = contentOf(queue.shift()!);
+    for (const f of systemFiles) {
+      if (!reached.has(f) && content.includes(f)) {
+        reached.add(f);
+        queue.push(f);
+      }
+    }
+  }
+  const orphanPages = systemFiles.filter((f) => !reached.has(f));
+  const reachableText = [...reached].map(contentOf).join("\n");
+  const unlinkedMinds = mindsWithSites.filter(
+    (m) =>
+      !reachableText.includes(`../${m}/`) && !reachableText.includes(`/ext/pages/public/${m}/`),
+  );
+  return { hasIndex: true, orphanPages, unlinkedMinds };
+}
+
+/**
+ * One-time bootstrap: when the commons has no index and a spirit exists,
+ * invite the spirit to create one. Idempotent via a flag file in the
+ * extension's data dir, written only after a successful notice — so a
+ * system whose spirit isn't created yet retries on the next daemon start.
+ */
+export async function maybeSendCommonsCue(ctx: ExtensionContext, repoDir: string): Promise<void> {
+  const cueFlag = resolve(ctx.dataDir, ".commons-cue-sent");
+  const hasIndex =
+    existsSync(resolve(repoDir, "index.md")) || existsSync(resolve(repoDir, "index.html"));
+  if (hasIndex || existsSync(cueFlag)) return;
+
+  const spirit = ctx.getSpiritName();
+  if (!spirit) return;
+
+  try {
+    const user = await ctx.getUserByUsername(spirit);
+    if (user?.user_type !== "mind") return; // spirit not created yet — retry next start
+    await ctx.recordNotice(
+      spirit,
+      "The commons — the shared pages at pages/_system/ that every mind here can edit — has no index yet. When you have a quiet moment, you might make one: a page that says what this place is, in your own voice, with room in it for the others. The commons-gardening skill describes the craft.",
+    );
+    writeFileSync(cueFlag, new Date().toISOString());
+  } catch (err) {
+    console.warn(`[pages] commons cue failed: ${(err as Error).message}`);
+  }
+}

--- a/packages/extensions/pages/src/db.ts
+++ b/packages/extensions/pages/src/db.ts
@@ -124,6 +124,15 @@ export function getSystemPages(db: Database): SiteEntry | null {
   };
 }
 
+/** Minds (excluding _system) that have at least one published page. */
+export function getMindsWithSites(db: Database): string[] {
+  return (
+    db
+      .prepare("SELECT DISTINCT mind FROM published_pages WHERE mind != '_system' ORDER BY mind")
+      .all() as { mind: string }[]
+  ).map((r) => r.mind);
+}
+
 export function syncSystemPages(db: Database, pages: PageInput[], author?: string): void {
   const existing = new Map(
     (

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import { createExtension } from "@volute/extensions";
 
 import { createCommands } from "./commands.js";
+import { maybeSendCommonsCue } from "./commons.js";
 import { initDb, syncSystemPages } from "./db.js";
 import { createPublicRoutes, createRoutes } from "./routes.js";
 import {
@@ -33,6 +34,7 @@ export default createExtension({
   commands: createCommands(),
   skillsDir,
   standardSkill: true,
+  spiritSkills: ["commons-gardening"],
   icon: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="2" width="14" height="12" rx="1.5"/><path d="M1 5h14"/><circle cx="3" cy="3.5" r="0.5" fill="currentColor" stroke="none"/><circle cx="5" cy="3.5" r="0.5" fill="currentColor" stroke="none"/></svg>',
   color: "purple",
   ui: {
@@ -52,16 +54,22 @@ export default createExtension({
     repoReady = ensurePagesRepo(ctx.dataDir, isolationFrom(ctx));
     repoReady
       .then(() => {
+        const repoDir = resolve(ctx.dataDir, "repo");
+
         // Sync system pages from the repo to the DB so they appear in the UI.
         // Run even when the repo is empty so stale DB rows are removed.
         if (ctx.db) {
-          const repoDir = resolve(ctx.dataDir, "repo");
           try {
             syncSystemPages(ctx.db, hashFiles(repoDir, collectPageFiles(repoDir)));
           } catch (err) {
             console.error("[pages] failed to sync system pages to DB:", err);
           }
         }
+
+        // One-time bootstrap: invite the spirit to create a commons index if
+        // one doesn't exist yet. Flag file makes it fire at most once.
+        // maybeSendCommonsCue handles its own errors and never rejects.
+        void maybeSendCommonsCue(ctx, repoDir);
       })
       .catch((err) => {
         console.error("[pages] failed to initialize pages repo:", err);

--- a/test/pages-commons.test.ts
+++ b/test/pages-commons.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { commonsReport, maybeSendCommonsCue } from "../packages/extensions/pages/src/commons.js";
+import type { ExtensionContext, User } from "../packages/extensions/sdk/src/types.js";
+
+describe("commonsReport", () => {
+  let dir: string;
+  let dir2: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "commons-report-"));
+    dir2 = mkdtempSync(join(tmpdir(), "commons-report-2-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(dir2, { recursive: true, force: true });
+  });
+
+  it("walks reachability from the index and reports orphans", () => {
+    writeFileSync(
+      resolve(dir, "index.md"),
+      "see [lore](garden/lore.md) and [alpha's site](../alpha/)",
+    );
+    mkdirSync(resolve(dir, "garden"), { recursive: true });
+    writeFileSync(resolve(dir, "garden", "lore.md"), "links onward to [songs](songs.md)");
+    writeFileSync(resolve(dir, "songs.md"), "");
+    writeFileSync(resolve(dir, "stray.md"), "nobody links me");
+
+    const r = commonsReport(
+      dir,
+      ["index.md", "garden/lore.md", "songs.md", "stray.md"],
+      ["alpha", "beta"],
+    );
+    assert.equal(r.hasIndex, true);
+    assert.deepEqual(r.orphanPages, ["stray.md"]);
+    assert.deepEqual(r.unlinkedMinds, ["beta"]);
+  });
+
+  it("no index means everything is orphaned", () => {
+    writeFileSync(resolve(dir2, "a.md"), "hello");
+    const r = commonsReport(dir2, ["a.md"], ["alpha"]);
+    assert.equal(r.hasIndex, false);
+    assert.deepEqual(r.orphanPages, ["a.md"]);
+    assert.deepEqual(r.unlinkedMinds, ["alpha"]);
+  });
+
+  it("no orphans and no unlinked minds when everything is reachable and linked", () => {
+    writeFileSync(resolve(dir, "index.md"), "see [about](about.md) and [alpha](../alpha/)");
+    writeFileSync(resolve(dir, "about.md"), "nothing more");
+    const r = commonsReport(dir, ["index.md", "about.md"], ["alpha"]);
+    assert.equal(r.hasIndex, true);
+    assert.deepEqual(r.orphanPages, []);
+    assert.deepEqual(r.unlinkedMinds, []);
+  });
+
+  it("recognizes mind links via the public iframe URL form too", () => {
+    writeFileSync(resolve(dir, "index.md"), "see [alpha](/ext/pages/public/alpha/index.html)");
+    const r = commonsReport(dir, ["index.md"], ["alpha"]);
+    assert.deepEqual(r.unlinkedMinds, []);
+  });
+});
+
+describe("maybeSendCommonsCue", () => {
+  let dataDir: string;
+  let repoDir: string;
+
+  function makeCtx(overrides: Partial<ExtensionContext> = {}): {
+    ctx: ExtensionContext;
+    notices: { mind: string; text: string }[];
+  } {
+    const notices: { mind: string; text: string }[] = [];
+    const ctx = {
+      db: null,
+      authMiddleware: (() => {}) as any,
+      requireSelf: (() => () => {}) as any,
+      resolveUser: () => null,
+      getUser: async () => null,
+      getUserByUsername: async (username: string) =>
+        ({ id: 1, username, role: "user", user_type: "mind" }) as User,
+      publishActivity: () => {},
+      getMindDir: () => null,
+      getSystemsConfig: () => null,
+      announceToSystem: async () => {},
+      recordNotice: async (mind: string, text: string) => {
+        notices.push({ mind, text });
+      },
+      isIsolationEnabled: () => false,
+      getMindUser: (name: string) => `mind-${name}`,
+      getSpiritName: () => "aria",
+      dataDir,
+      ...overrides,
+    } as ExtensionContext;
+    return { ctx, notices };
+  }
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "commons-cue-"));
+    repoDir = resolve(dataDir, "repo");
+    mkdirSync(repoDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("sends a notice to the spirit and writes the flag when there's no index", async () => {
+    const { ctx, notices } = makeCtx();
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].mind, "aria");
+    assert.ok(existsSync(resolve(dataDir, ".commons-cue-sent")));
+  });
+
+  it("does not re-send once the flag is present", async () => {
+    const { ctx, notices } = makeCtx();
+    await maybeSendCommonsCue(ctx, repoDir);
+    notices.length = 0;
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 0);
+  });
+
+  it("does not send when an index already exists", async () => {
+    writeFileSync(resolve(repoDir, "index.md"), "# hi");
+    const { ctx, notices } = makeCtx();
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 0);
+    assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
+  });
+
+  it("does not send when there is no spirit configured", async () => {
+    const { ctx, notices } = makeCtx({ getSpiritName: () => null });
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 0);
+    assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
+  });
+
+  it("does not send or write the flag when the spirit user doesn't exist yet", async () => {
+    const { ctx, notices } = makeCtx({ getUserByUsername: async () => null });
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 0);
+    assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
+  });
+
+  it("does not send when the spirit username resolves to a non-mind user", async () => {
+    const { ctx, notices } = makeCtx({
+      getUserByUsername: async (username: string) =>
+        ({ id: 1, username, role: "admin", user_type: "human" }) as User,
+    });
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 0);
+    assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
+  });
+
+  it("index.html also counts as an index", async () => {
+    writeFileSync(resolve(repoDir, "index.html"), "<h1>hi</h1>");
+    const { ctx, notices } = makeCtx();
+    await maybeSendCommonsCue(ctx, repoDir);
+    assert.equal(notices.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Part of the Living Commons work (PR train ③). Adds:

- **`commons-gardening` spirit skill** (`packages/extensions/pages/skills/commons-gardening/SKILL.md`) — installed for the spirit via the `spiritSkills` manifest hook from #767, teaching the spirit to author/maintain the commons index, weave in residents and stray pages, propose shared work as occasions rather than assignments, celebrate contributions, and license boldness with git history as safety.
- **`commonsReport()`** (`packages/extensions/pages/src/commons.ts`) — deterministic curation report: whether the commons has an index, which system pages aren't reachable from it (BFS by substring match on repo-relative path), and which minds' published personal sites the index doesn't link.
- **`volute pages commons`** CLI subcommand surfacing that report.
- **Bootstrap cue** — on daemon start, if the commons has no index and a spirit exists, the spirit gets a one-time notice inviting it to create one. Idempotent via a `.commons-cue-sent` flag file in the extension's data dir, written only after a successful notice to an already-created spirit (a system whose spirit isn't created yet retries on the next daemon start).
- `getMindsWithSites()` in `db.ts` for the report's mind-site input.

## Stacking

Stacked on #767 (`feat/extension-spirit-skills`, unmerged) — this PR is based on that branch and consumes its `spiritSkills` manifest field and `ctx.getSpiritName()`. Please review/merge #767 first.

## Task 1 dependency note

PR ① (`feat/commons-visibility-events`, rename `collectHtmlFiles` → `collectPageFiles` to include `.md`) is a separate unmerged branch not included in this PR's base. Per the plan's contingency, this PR uses the existing `collectHtmlFiles` name throughout (`commands.ts`'s new `commons` subcommand, `index.ts`'s bootstrap-cue wiring). When both PRs land, `commons` subcommand's `collectHtmlFiles(repoDir)` call should become `collectPageFiles(repoDir)` so `.md`-only commons pages are included in the report — a trivial one-line follow-up.

## Notes / uncertainty

- `commonsReport`'s reachability check is intentionally permissive substring matching, not real link parsing — documented in the skill copy and the function's doc comment. It's the tradeoff called out in the design spec.
- The bootstrap cue is fire-once via a flag file, not reset if `index.md`/`index.html` is later deleted — matches spec (idempotent, never re-fires once delivered).
- Narrow known edge in `maybeSendCommonsCue`: if `recordNotice` succeeds but the subsequent `writeFileSync(cueFlag, ...)` throws (e.g. disk full), the flag won't be written and the notice could be resent on the next daemon start. Accepted as-is — the failure mode is a duplicate low-urgency notice, not data loss, and the write is a single local fs call right after the await with no realistic gap in between.
- Skill copy in `SKILL.md` is applied verbatim from the plan.
- Did not touch `docs/pages/skills/pages/SKILL.md`, `mindDoc`, `tending/SKILL.md`, or spirit doctrine text — that's Task 4, explicitly out of scope here.

## Test plan

- [x] New `test/pages-commons.test.ts`: `commonsReport` (reachability BFS, orphan detection, unlinked-mind detection, both mind-link URL forms) and `maybeSendCommonsCue` (fires once, respects existing index, respects missing/non-mind spirit, retries when spirit user doesn't exist yet)
- [x] `npm test` — full suite green (2932 passed)
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` — clean

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
