### PR TITLE
feat: announce shared page publishes and notify prior authors

### DIFF
--- a/packages/extensions/pages/src/commands.ts
+++ b/packages/extensions/pages/src/commands.ts
@@ -5,7 +5,7 @@ import type { ExtensionCommand } from "@volute/extensions";
 
 import { getPublishedPages, syncPublishedPages, syncSystemPages } from "./db.js";
 import {
-  collectHtmlFiles,
+  collectPageFiles,
   hashFiles,
   isolationFrom,
   pagesLog,
@@ -55,11 +55,53 @@ export function createCommands(): Record<string, ExtensionCommand> {
             if (result.ok && ctx.db) {
               const repoDir = resolve(ctx.dataDir, "repo");
               try {
-                syncSystemPages(ctx.db, hashFiles(repoDir, collectHtmlFiles(repoDir)), mindName);
+                syncSystemPages(ctx.db, hashFiles(repoDir, collectPageFiles(repoDir)), mindName);
               } catch (err) {
                 console.error("[pages] failed to sync system pages to DB:", err);
                 syncWarning =
                   "\nWarning: failed to sync pages to dashboard — they may not appear in the UI until the next daemon restart.";
+              }
+            }
+
+            // Announce the publish and close the collaboration loop with prior authors.
+            const files = result.changedFiles ?? [];
+            if (files.length > 0) {
+              const fileList = files.join(", ");
+              ctx.publishActivity({
+                type: "page_published",
+                mind: mindName,
+                summary: `${mindName} tended the commons: ${fileList}`,
+                metadata: {
+                  shared: true,
+                  files,
+                  message,
+                  iframeUrl: `/ext/pages/public/_system/${files[0]}`,
+                },
+              });
+
+              try {
+                await ctx.announceToSystem(
+                  `${mindName} tended the commons: ${fileList} — "${message}"`,
+                );
+
+                // Close the collaboration loop: tell prior authors someone built on their work.
+                const authorFiles = new Map<string, string[]>();
+                for (const [file, authors] of Object.entries(result.priorAuthors ?? {})) {
+                  for (const a of authors)
+                    authorFiles.set(a, [...(authorFiles.get(a) ?? []), file]);
+                }
+                for (const [author, theirs] of authorFiles) {
+                  await ctx.recordNotice(
+                    author,
+                    `${mindName} built on ${theirs.join(", ")} in the commons — ${
+                      theirs.length > 1 ? "pages" : "a page"
+                    } you helped write ("${message}"). \`volute pages log\` shows the trail.`,
+                  );
+                }
+              } catch (err) {
+                console.warn(
+                  `[pages] shared publish notification failed: ${(err as Error).message}`,
+                );
               }
             }
 

--- a/packages/extensions/pages/src/commands.ts
+++ b/packages/extensions/pages/src/commands.ts
@@ -8,6 +8,7 @@ import {
   collectPageFiles,
   hashFiles,
   isolationFrom,
+  isPageFile,
   pagesLog,
   pagesPull,
   pagesPullAndMerge,
@@ -67,6 +68,8 @@ export function createCommands(): Record<string, ExtensionCommand> {
             const files = result.changedFiles ?? [];
             if (files.length > 0) {
               const fileList = files.join(", ");
+              // Link the first actual page (a changed file may be a non-page asset).
+              const pageFile = files.find(isPageFile);
               ctx.publishActivity({
                 type: "page_published",
                 mind: mindName,
@@ -75,7 +78,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
                   shared: true,
                   files,
                   message,
-                  iframeUrl: `/ext/pages/public/_system/${files[0]}`,
+                  ...(pageFile ? { iframeUrl: `/ext/pages/public/_system/${pageFile}` } : {}),
                 },
               });
 

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -6,7 +6,7 @@ import { initDb, syncSystemPages } from "./db.js";
 import { createPublicRoutes, createRoutes } from "./routes.js";
 import {
   addPagesWorktree,
-  collectHtmlFiles,
+  collectPageFiles,
   ensurePagesRepo,
   hashFiles,
   isolationFrom,
@@ -57,7 +57,7 @@ export default createExtension({
         if (ctx.db) {
           const repoDir = resolve(ctx.dataDir, "repo");
           try {
-            syncSystemPages(ctx.db, hashFiles(repoDir, collectHtmlFiles(repoDir)));
+            syncSystemPages(ctx.db, hashFiles(repoDir, collectPageFiles(repoDir)));
           } catch (err) {
             console.error("[pages] failed to sync system pages to DB:", err);
           }

--- a/packages/extensions/pages/src/routes.ts
+++ b/packages/extensions/pages/src/routes.ts
@@ -38,17 +38,22 @@ export function createRoutes(ctx: ExtensionContext): Hono {
       const limit = rawLimit ? parseInt(rawLimit, 10) || 8 : 8;
       const recentPages = getRecentPagesList(ctx.db, { mind: mind || undefined, limit });
       return c.json(
-        recentPages.map((p) => ({
-          id: `page-${p.mind}-${p.file}`,
-          title: `${p.mind}/${p.file}`,
-          url: p.url ?? `/minds/${p.mind}/pages/${p.file}`,
-          date: p.modified,
-          author: p.mind,
-          bodyHtml: `<p>Page updated</p>`,
-          iframeUrl: `/ext/pages/public/${p.mind}/${p.file}`,
-          icon: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M2 8h12M8 2c-2 2-2 10 0 12M8 2c2 2 2 10 0 12"/></svg>',
-          color: "purple",
-        })),
+        recentPages.map((p) => {
+          const isCommons = p.mind === "_system";
+          return {
+            id: `page-${p.mind}-${p.file}`,
+            title: isCommons ? `commons — ${p.file}` : `${p.mind}/${p.file}`,
+            url: p.url ?? `/minds/${p.mind}/pages/${p.file}`,
+            date: p.modified,
+            author: isCommons ? (p.author ?? "commons") : p.mind,
+            bodyHtml: isCommons
+              ? `<p>Commons page tended${p.author ? ` by ${p.author}` : ""}</p>`
+              : `<p>Page updated</p>`,
+            iframeUrl: `/ext/pages/public/${p.mind}/${p.file}`,
+            icon: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M2 8h12M8 2c-2 2-2 10 0 12M8 2c2 2 2 10 0 12"/></svg>',
+            color: "purple",
+          };
+        }),
       );
     })
     .put("/publish/:name", ctx.requireSelf("name"), async (c) => {

--- a/packages/extensions/pages/src/shared-pages.ts
+++ b/packages/extensions/pages/src/shared-pages.ts
@@ -416,7 +416,13 @@ export async function pagesPullAndMerge(
   dataDir: string,
   message: string,
   isolation?: IsolationInfo,
-): Promise<{ ok: boolean; conflicts?: boolean; message?: string }> {
+): Promise<{
+  ok: boolean;
+  conflicts?: boolean;
+  message?: string;
+  changedFiles?: string[];
+  priorAuthors?: Record<string, string[]>;
+}> {
   return withPagesLock(async () => {
     const wt = worktreePath(mindDir);
     const dir = pagesRepoDir(dataDir);
@@ -494,6 +500,32 @@ export async function pagesPullAndMerge(
       isolation,
     );
 
+    // Contributor bookkeeping for the caller's social events. Inside the lock on
+    // purpose: HEAD is guaranteed to still be our squash commit.
+    let changedFiles: string[] = [];
+    const priorAuthors: Record<string, string[]> = {};
+    try {
+      changedFiles = (
+        await gitExec(["diff", "--name-only", "HEAD^", "HEAD"], { cwd: dir }, isolation)
+      )
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+      for (const file of changedFiles) {
+        const names = (
+          await gitExec(["log", "--format=%an", "HEAD^", "--", file], { cwd: dir }, isolation)
+        )
+          .trim()
+          .split("\n")
+          .filter(Boolean);
+        // "volute" is the committer identity used for the repo-init commit — not a mind.
+        const unique = [...new Set(names)].filter((n) => n !== mindName && n !== "volute");
+        if (unique.length > 0) priorAuthors[file] = unique;
+      }
+    } catch (err) {
+      console.warn(`[pages] contributor lookup failed: ${(err as Error).message}`);
+    }
+
     // Reset mind's branch to main
     try {
       await gitExec(["reset", "--hard", "main"], { cwd: wt }, isolation);
@@ -502,6 +534,8 @@ export async function pagesPullAndMerge(
       return {
         ok: true,
         message: "Published to main, but branch reset failed — run 'volute pages pull' to sync",
+        changedFiles,
+        priorAuthors,
       };
     }
 
@@ -513,12 +547,12 @@ export async function pagesPullAndMerge(
       }
     }
 
-    return { ok: true };
+    return { ok: true, changedFiles, priorAuthors };
   });
 }
 
-/** Recursively collect HTML files in a directory, returning paths relative to baseDir. */
-export function collectHtmlFiles(dir: string): string[] {
+/** Recursively collect HTML and Markdown files in a directory, returning paths relative to baseDir. */
+export function collectPageFiles(dir: string): string[] {
   const files: string[] = [];
   function walk(d: string) {
     let items: string[];
@@ -533,7 +567,7 @@ export function collectHtmlFiles(dir: string): string[] {
       const full = resolve(d, item);
       try {
         const s = statSync(full);
-        if (s.isFile() && item.endsWith(".html")) {
+        if (s.isFile() && (item.endsWith(".html") || item.endsWith(".md"))) {
           files.push(relative(dir, full));
         } else if (s.isDirectory()) {
           walk(full);
@@ -556,6 +590,11 @@ export function hashFiles(baseDir: string, files: string[]): { file: string; has
       .update(readFileSync(resolve(baseDir, file)))
       .digest("hex"),
   }));
+}
+
+/** Whether a file path is a page file we track (HTML or Markdown). */
+function isPageFile(f: string): boolean {
+  return f.endsWith(".html") || f.endsWith(".md");
 }
 
 /** Show files in the mind's shared pages worktree with draft/published status. */
@@ -598,16 +637,16 @@ export async function pagesStatus(mindDir: string, isolation?: IsolationInfo): P
     }
   }
 
-  const mainSet = new Set(mainFiles.filter((f) => f.endsWith(".html")));
-  const allHtml = new Set([
-    ...mainFiles.filter((f) => f.endsWith(".html")),
-    ...branchFiles.filter((f) => f.endsWith(".html")),
-    ...[...uncommittedFiles].filter((f) => f.endsWith(".html")),
+  const mainSet = new Set(mainFiles.filter(isPageFile));
+  const allPageFiles = new Set([
+    ...mainFiles.filter(isPageFile),
+    ...branchFiles.filter(isPageFile),
+    ...[...uncommittedFiles].filter(isPageFile),
   ]);
 
-  if (allHtml.size === 0) return "No shared pages found.";
+  if (allPageFiles.size === 0) return "No shared pages found.";
 
-  const lines = [...allHtml].sort().map((file) => {
+  const lines = [...allPageFiles].sort().map((file) => {
     const onMain = mainSet.has(file);
     const isUncommitted = uncommittedFiles.has(file);
     let status: string;

--- a/packages/extensions/pages/src/shared-pages.ts
+++ b/packages/extensions/pages/src/shared-pages.ts
@@ -593,7 +593,7 @@ export function hashFiles(baseDir: string, files: string[]): { file: string; has
 }
 
 /** Whether a file path is a page file we track (HTML or Markdown). */
-function isPageFile(f: string): boolean {
+export function isPageFile(f: string): boolean {
   return f.endsWith(".html") || f.endsWith(".md");
 }
 

--- a/test/pages-shared-events.test.ts
+++ b/test/pages-shared-events.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { createCommands } from "../packages/extensions/pages/src/commands.js";
+import { initDb } from "../packages/extensions/pages/src/db.js";
+import {
+  addPagesWorktree,
+  collectPageFiles,
+  ensurePagesRepo,
+  pagesPull,
+  pagesPullAndMerge,
+} from "../packages/extensions/pages/src/shared-pages.js";
+import type { Database } from "../packages/extensions/sdk/src/types.js";
+
+async function createTestDb(): Promise<Database> {
+  const mod = await import("libsql");
+  const Libsql = (mod.default ?? mod) as unknown as new (path: string) => any;
+  const db = new Libsql(":memory:");
+  db.pragma("journal_mode = WAL");
+  return {
+    exec: (sql: string) => db.exec(sql),
+    prepare: (sql: string) => {
+      const stmt = db.prepare(sql);
+      return {
+        run: (...params: unknown[]) => stmt.run(...params),
+        get: (...params: unknown[]) => stmt.get(...params),
+        all: (...params: unknown[]) => stmt.all(...params),
+      };
+    },
+    close: () => db.close(),
+  };
+}
+
+describe("shared publish contributor tracking", () => {
+  let dataDir: string, mindA: string, mindB: string;
+
+  beforeEach(async () => {
+    const base = mkdtempSync(join(tmpdir(), "pages-ev-"));
+    dataDir = join(base, "data");
+    mindA = join(base, "alpha");
+    mindB = join(base, "beta");
+    mkdirSync(dataDir, { recursive: true });
+    await ensurePagesRepo(dataDir);
+    await addPagesWorktree("alpha", mindA, dataDir);
+    await addPagesWorktree("beta", mindB, dataDir);
+  });
+
+  it("reports changed files and no prior authors for a brand-new page", async () => {
+    mkdirSync(join(mindA, "home/pages/_system"), { recursive: true });
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "# Lore\n");
+    const r = await pagesPullAndMerge("alpha", mindA, dataDir, "start lore");
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.changedFiles, ["lore.md"]);
+    assert.deepEqual(r.priorAuthors, {}); // new file — nobody to notify
+  });
+
+  it("reports the prior author when another mind edits the page", async () => {
+    mkdirSync(join(mindA, "home/pages/_system"), { recursive: true });
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "# Lore\n");
+    await pagesPullAndMerge("alpha", mindA, dataDir, "start lore");
+    // beta pulls main first, then edits the now-existing page — two branches
+    // independently *creating* the same new path (without pulling first) is a
+    // real git add/add conflict, not something the implicit rebase can resolve.
+    await pagesPull("beta", mindB);
+    const existing = readFileSync(join(mindB, "home/pages/_system/lore.md"), "utf-8");
+    writeFileSync(join(mindB, "home/pages/_system/lore.md"), `${existing}more\n`);
+    const r = await pagesPullAndMerge("beta", mindB, dataDir, "expand lore");
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.changedFiles, ["lore.md"]);
+    assert.deepEqual(r.priorAuthors, { "lore.md": ["alpha"] });
+  });
+
+  it("excludes the publisher and the repo-init identity from prior authors", async () => {
+    mkdirSync(join(mindA, "home/pages/_system"), { recursive: true });
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "v1\n");
+    await pagesPullAndMerge("alpha", mindA, dataDir, "one");
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "v2\n");
+    const r = await pagesPullAndMerge("alpha", mindA, dataDir, "two");
+    assert.deepEqual(r.priorAuthors, {}); // only alpha in history — nothing
+  });
+
+  it("collectPageFiles picks up .md as well as .html", () => {
+    const d = mkdtempSync(join(tmpdir(), "cpf-"));
+    writeFileSync(join(d, "a.html"), "");
+    writeFileSync(join(d, "b.md"), "");
+    writeFileSync(join(d, "c.txt"), "");
+    assert.deepEqual(collectPageFiles(d), ["a.html", "b.md"]);
+  });
+});
+
+describe("shared publish command events", () => {
+  let dataDir: string, mindA: string, mindB: string;
+  let db: Database;
+
+  function makeCtx(mindName: string, mindDir: string) {
+    const activity: any[] = [];
+    const announcements: string[] = [];
+    const notices: { mind: string; text: string }[] = [];
+    return {
+      mindName,
+      db,
+      dataDir,
+      authMiddleware: (() => {}) as any,
+      resolveUser: () => null,
+      getUser: async () => null,
+      getUserByUsername: async () => null,
+      publishActivity: (e: any) => activity.push(e),
+      getMindDir: (name: string) => (name === mindName ? mindDir : null),
+      getSystemsConfig: () => null,
+      announceToSystem: async (text: string) => {
+        announcements.push(text);
+      },
+      recordNotice: async (mind: string, text: string) => {
+        notices.push({ mind, text });
+      },
+      isIsolationEnabled: () => false,
+      getMindUser: (name: string) => `mind-${name}`,
+      _activity: activity,
+      _announcements: announcements,
+      _notices: notices,
+    };
+  }
+
+  beforeEach(async () => {
+    const base = mkdtempSync(join(tmpdir(), "pages-cmd-ev-"));
+    dataDir = join(base, "data");
+    mindA = join(base, "alpha");
+    mindB = join(base, "beta");
+    mkdirSync(dataDir, { recursive: true });
+    await ensurePagesRepo(dataDir);
+    await addPagesWorktree("alpha", mindA, dataDir);
+    await addPagesWorktree("beta", mindB, dataDir);
+    db = await createTestDb();
+    initDb(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("announces a shared publish and fires a page_published activity event", async () => {
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "# Lore\n");
+    const commands = createCommands();
+    const ctx = makeCtx("alpha", mindA);
+    const result = await commands.publish.handler(
+      { args: { message: "start lore" }, flags: { remote: false, shared: true }, rest: [] },
+      ctx as any,
+    );
+    assert.ok("output" in result, `expected output, got ${JSON.stringify(result)}`);
+
+    assert.equal(ctx._activity.length, 1);
+    assert.equal(ctx._activity[0].type, "page_published");
+    assert.equal(ctx._activity[0].metadata.shared, true);
+    assert.deepEqual(ctx._activity[0].metadata.files, ["lore.md"]);
+
+    assert.equal(ctx._announcements.length, 1);
+    assert.match(ctx._announcements[0], /alpha tended the commons: lore\.md — "start lore"/);
+
+    // No prior authors on a brand-new page — nobody to notify.
+    assert.equal(ctx._notices.length, 0);
+  });
+
+  it("notifies the prior author when another mind builds on their page", async () => {
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "# Lore\n");
+    const commands = createCommands();
+    await commands.publish.handler(
+      { args: { message: "start lore" }, flags: { remote: false, shared: true }, rest: [] },
+      makeCtx("alpha", mindA) as any,
+    );
+
+    await pagesPull("beta", mindB);
+    const existing = readFileSync(join(mindB, "home/pages/_system/lore.md"), "utf-8");
+    writeFileSync(join(mindB, "home/pages/_system/lore.md"), `${existing}more\n`);
+
+    const ctxB = makeCtx("beta", mindB);
+    const result = await commands.publish.handler(
+      { args: { message: "expand lore" }, flags: { remote: false, shared: true }, rest: [] },
+      ctxB as any,
+    );
+    assert.ok("output" in result, `expected output, got ${JSON.stringify(result)}`);
+
+    assert.equal(ctxB._notices.length, 1);
+    assert.equal(ctxB._notices[0].mind, "alpha");
+    assert.match(ctxB._notices[0].text, /beta built on lore\.md in the commons/);
+  });
+
+  it("fires no events when there is nothing new to publish", async () => {
+    writeFileSync(join(mindA, "home/pages/_system/lore.md"), "# Lore\n");
+    const commands = createCommands();
+    const ctx = makeCtx("alpha", mindA);
+    await commands.publish.handler(
+      { args: { message: "start lore" }, flags: { remote: false, shared: true }, rest: [] },
+      ctx as any,
+    );
+
+    // Publish again with no changes — "Nothing to publish" short-circuits
+    // before changedFiles/priorAuthors even exist on the result.
+    const result = await commands.publish.handler(
+      { args: { message: "again" }, flags: { remote: false, shared: true }, rest: [] },
+      ctx as any,
+    );
+    assert.ok("output" in result && result.output.includes("Nothing to publish"));
+    assert.equal(ctx._activity.length, 1); // only the first publish
+    assert.equal(ctx._announcements.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Shared publishes to the pages commons (`volute pages publish --shared`) were invisible: no activity event, no `#system` announcement, and no signal to a mind whose page someone else built on. This PR makes the commons feel alive:

- `pagesPullAndMerge` now computes `changedFiles` and `priorAuthors` (via `git diff --name-only HEAD^ HEAD` and `git log --format=%an HEAD^ -- <file>` inside the existing publish lock, right after the squash commit while HEAD is still guaranteed to be it).
- The `--shared` publish command now fires a `page_published` activity event, a `#system` announcement, and a per-mind notice to each prior author of a changed file — closing the collaboration loop ("built on your page").
- `collectHtmlFiles` renamed to `collectPageFiles` and widened to also match `.md` files (previously `.html` only) — this changes what's tracked/synced for existing systems that already have markdown commons pages. `pagesStatus`'s ad-hoc `.html` filters were unified through the same `isPageFile` helper.
- `/feed` gives commons (`_system`) pages distinct card copy ("commons — file", "tended by <author>") instead of reusing the personal-site phrasing.

This is Task 1 of a 4-part "Living Commons" plan; independent of the other tasks (spirit skills hook, gardening skill, doc reframing).

## Deviation from plan

The plan's prescribed test for "prior author notified" had mind B independently *create* the same new file mind A had already published, without B ever pulling first. That's a genuine git add/add conflict (two branches each creating the same path from a common ancestor that has neither) — not something the implicit rebase-on-publish can resolve, and not a realistic collaboration scenario. Verified this against the actual implementation with a manual repro before concluding it was a test-fixture issue rather than a bug. Fixed the test so mind B pulls main first, then edits the now-existing page (matching real usage: pull, then build on what's there). No implementation changes were needed once the test matched a realistic flow.

## Test plan

- [x] `test/pages-shared-events.test.ts` (new): contributor tracking at the git-plumbing level (new page → no prior authors, edited page → prior author surfaced, publisher/repo-init identity excluded, `.md` inclusion in `collectPageFiles`) plus command-level event firing (activity + announcement + notice on shared publish, no notice when nothing changed).
- [x] `test/pages-commands.test.ts` and `test/web-pages.test.ts` still green.
- [x] Full `npm test`: 2925 tests, 0 failures.
- [x] `npx biome check` clean on changed files; root `tsc --noEmit` clean.
- [x] Reviewed via two parallel review agents (bug scan + CLAUDE.md compliance) — no issues found.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01G1MeFZcN5DWvtP1X3vJYoC