### PR TITLE
fix: restore home files deleted by the upgrade allowlist migration at merge-back

### DIFF
--- a/packages/daemon/src/lib/mind/variants.ts
+++ b/packages/daemon/src/lib/mind/variants.ts
@@ -148,6 +148,128 @@ export function formatUnresolvedHomeFilesMessage(
 }
 
 /**
+ * A pre-allowlist mind's home can hold tens of thousands of tracked files
+ * (auto-commit was `git add -A`), so path lists must be chunked below argv
+ * limits (macOS ARG_MAX is 1 MiB) and the diff read with a raised maxBuffer.
+ */
+const RESTORE_PATH_CHUNK = 500;
+const RESTORE_DIFF_MAX_BUFFER = 64 * 1024 * 1024;
+
+/**
+ * Merge `branch` into the current branch at `cwd`; on failure, best-effort
+ * `git merge --abort` before rethrowing.
+ *
+ * A conflicted merge still applies every *cleanly*-merged change to the
+ * working tree — including the upgrade migration's home/ deletions — and
+ * leaves the repo mid-merge (MERGE_HEAD present), where a live mind's next
+ * auto-commit (`git add -A` + commit) would conclude the merge and bake those
+ * deletions in permanently. Aborting rolls the working tree back to the
+ * pre-merge state, so nothing is deleted and nothing is left half-merged.
+ */
+export async function mergeOrAbort(cwd: string, branch: string): Promise<void> {
+  try {
+    await gitExec(["merge", branch], { cwd });
+  } catch (err) {
+    let aborted = false;
+    try {
+      await gitExec(["merge", "--abort"], { cwd });
+      aborted = true;
+    } catch {
+      // No merge was in progress (the failure predated the merge starting),
+      // or the abort itself failed — the original error is the one to surface.
+    }
+    if (aborted) {
+      // git's own message says "fix conflicts and then commit the result",
+      // which is no longer true — the merge state is gone. Conflict details
+      // land on stdout, which execFile's error message omits; carry them.
+      const e = err as Error & { stdout?: string };
+      const detail = [e.message, e.stdout?.trim()].filter(Boolean).join("\n");
+      throw new Error(
+        `merge of '${branch}' failed and was aborted; the working tree was rolled back unchanged.\n${detail}`,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Restore home/ files a merge physically deleted from the working tree, as
+ * untracked content, from `sourceCommit` (the pre-merge HEAD).
+ *
+ * The upgrade's "prepare for home/ allowlist migration" step untracks home/
+ * with `git rm --cached`. That leaves the files on disk *in the upgrade
+ * worktree*, but records them as deleted in the upgrade branch's history — so
+ * when the branch merges back into the live mind dir, git applies those
+ * deletions to the real working tree, and every file tracked pre-upgrade but
+ * outside the new .gitignore allowlist is removed from the mind's live home.
+ * This puts the content back the way the migration always claimed to leave
+ * it: on disk, no longer versioned. `git restore --worktree` touches only the
+ * working tree, and the allowlist .gitignore keeps the files untracked.
+ *
+ * Only paths the current .gitignore *ignores* are restored — those are
+ * exactly the migration's victims. A deleted path git would still track was
+ * deleted deliberately by the template merge; resurrecting it would hand it
+ * straight back to auto-commit as a zombie file, re-created on every future
+ * upgrade.
+ *
+ * @returns the repo-relative paths restored — empty when the merge deleted
+ *   nothing under home/ (the common already-migrated case). Throws on git
+ *   failure; callers must surface that rather than swallow it, because a
+ *   silent failure here is silent data loss.
+ */
+export async function restoreMergeDeletedHomeFiles(
+  cwd: string,
+  sourceCommit: string,
+): Promise<string[]> {
+  // --no-renames: rename detection would pair a deleted home file with a
+  // similar added file and report R instead of D, silently dropping it here.
+  const raw = await gitExec(
+    [
+      "diff",
+      "--name-only",
+      "--diff-filter=D",
+      "--no-renames",
+      "-z",
+      sourceCommit,
+      "HEAD",
+      "--",
+      "home/",
+    ],
+    { cwd, maxBuffer: RESTORE_DIFF_MAX_BUFFER },
+  );
+  const deleted = raw.split("\0").filter(Boolean);
+  if (deleted.length === 0) return [];
+
+  // Keep only paths the post-merge .gitignore ignores (see doc comment).
+  // NUL-delimited stdin/stdout keeps pathnames literal (no core.quotePath
+  // mangling) and clear of argv limits. check-ignore exits 1 when none match.
+  let paths: string[] = [];
+  try {
+    const ignoredRaw = await gitExec(["check-ignore", "--stdin", "-z"], {
+      cwd,
+      maxBuffer: RESTORE_DIFF_MAX_BUFFER,
+      stdin: deleted.join("\0"),
+    });
+    paths = ignoredRaw.split("\0").filter(Boolean);
+  } catch (err) {
+    if ((err as { code?: number }).code !== 1) throw err;
+    // exit 1: no deleted path is ignored — nothing was a migration victim
+  }
+  if (paths.length === 0) return [];
+
+  for (let i = 0; i < paths.length; i += RESTORE_PATH_CHUNK) {
+    // :(literal) — these are exact paths from git's own diff output, not
+    // patterns; without it a filename containing `*` or `[` would be
+    // glob-interpreted.
+    const pathspecs = paths.slice(i, i + RESTORE_PATH_CHUNK).map((p) => `:(literal)${p}`);
+    await gitExec(["restore", `--source=${sourceCommit}`, "--worktree", "--", ...pathspecs], {
+      cwd,
+    });
+  }
+  return paths;
+}
+
+/**
  * Merge a variant branch into the parent worktree, excluding the mind's living
  * memory (MEMORY.md, memory/journal/) from the textual merge. The parent keeps
  * its own copy of those files; the variant's delta is returned so it can be

--- a/packages/daemon/src/lib/util/exec.ts
+++ b/packages/daemon/src/lib/util/exec.ts
@@ -1,20 +1,27 @@
 import { execFile as execFileCb, execFileSync, spawn } from "node:child_process";
 import { wrapForIsolation } from "../mind/isolation.js";
 
-/** Promise wrapper around child_process.execFile. Returns stdout as a string. */
+/** Promise wrapper around child_process.execFile. Returns stdout as a string.
+ * `stdin`, when given, is written to the child's stdin and the stream closed. */
 export async function exec(
   cmd: string,
   args: string[],
-  options?: { cwd?: string; mindName?: string; env?: NodeJS.ProcessEnv },
+  options?: {
+    cwd?: string;
+    mindName?: string;
+    env?: NodeJS.ProcessEnv;
+    maxBuffer?: number;
+    stdin?: string;
+  },
 ): Promise<string> {
   const [wrappedCmd, wrappedArgs] = options?.mindName
     ? await wrapForIsolation(cmd, args, options.mindName)
     : [cmd, args];
   return new Promise((resolve, reject) => {
-    execFileCb(
+    const child = execFileCb(
       wrappedCmd,
       wrappedArgs,
-      { cwd: options?.cwd, env: options?.env },
+      { cwd: options?.cwd, env: options?.env, maxBuffer: options?.maxBuffer },
       (err, stdout, stderr) => {
         if (err) {
           (err as Error & { stderr?: string; stdout?: string }).stderr = stderr;
@@ -25,6 +32,12 @@ export async function exec(
         }
       },
     );
+    if (options?.stdin !== undefined && child.stdin) {
+      // EPIPE here (child exited before reading) surfaces through the exit
+      // callback above; swallow the stream-level duplicate.
+      child.stdin.on("error", () => {});
+      child.stdin.end(options.stdin);
+    }
   });
 }
 
@@ -36,7 +49,13 @@ export async function exec(
  */
 export function gitExec(
   args: string[],
-  options: { cwd: string; mindName?: string; env?: NodeJS.ProcessEnv },
+  options: {
+    cwd: string;
+    mindName?: string;
+    env?: NodeJS.ProcessEnv;
+    maxBuffer?: number;
+    stdin?: string;
+  },
 ): Promise<string> {
   const fullArgs =
     process.env.VOLUTE_ISOLATION === "user" ? ["-c", "safe.directory=*", ...args] : args;

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -100,7 +100,9 @@ import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
 import {
   findUnresolvedHomeFiles,
   formatUnresolvedHomeFilesMessage,
+  mergeOrAbort,
   mergeVariantExcludingMemory,
+  restoreMergeDeletedHomeFiles,
   validateBranchName,
 } from "../../lib/mind/variants.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
@@ -460,7 +462,42 @@ async function mergeUpgradeAndRestart(
   }
 
   const preMergeHead = (await gitExec(["rev-parse", "HEAD"], { cwd: dir })).trim();
-  await gitExec(["merge", upgradeBranch], { cwd: dir });
+  // On failure this aborts the half-applied merge, rolling back the home/
+  // deletions a conflicted merge has already made to the live working tree.
+  await mergeOrAbort(dir, upgradeBranch);
+
+  // The allowlist-migration prep commit records pre-allowlist home/ files as
+  // deleted, so the merge just removed them from the live working tree. Put
+  // the content back, untracked — first, before any later step can fail.
+  let restoreWarning: string | undefined;
+  let restored: string[] = [];
+  try {
+    restored = await restoreMergeDeletedHomeFiles(dir, preMergeHead);
+    if (restored.length > 0) {
+      log.info(
+        `restored ${restored.length} home files untracked by the allowlist migration for ${mindName}`,
+      );
+    }
+  } catch (err) {
+    log.error(`failed to restore merge-deleted home files for ${mindName}`, log.errorData(err));
+    restoreWarning =
+      `Upgrade merged but restoring home files the allowlist migration deleted failed: ` +
+      `${err instanceof Error ? err.message : String(err)}. Recover them manually: list them ` +
+      `with \`git diff --name-only --diff-filter=D --no-renames ${preMergeHead} HEAD -- home/\`, ` +
+      `then restore each with \`git restore --source=${preMergeHead} --worktree -- <path>\`.`;
+  }
+  if (restored.length > 0) {
+    try {
+      await chownMindDir(dir, mindName);
+    } catch (err) {
+      // cleanupVariant's own chown usually repairs this right after; log rather
+      // than misreport it as a restore failure.
+      log.warn(`failed to chown restored home files for ${mindName}`, log.errorData(err));
+    }
+  }
+  /** Prefix any later warning with the restore failure — it's mind data, it goes first. */
+  const withRestoreWarning = (warning?: string): string | undefined =>
+    [restoreWarning, warning].filter(Boolean).join(" ") || undefined;
 
   // Merge succeeded — everything below is best-effort cleanup/restart
   try {
@@ -506,7 +543,9 @@ async function mergeUpgradeAndRestart(
       log.warn(`failed to swap template home files for ${mindName}`, log.errorData(err));
       return {
         ok: true,
-        warning: `Upgrade merged but template switch ${oldTemplate}→${template} failed: ${err instanceof Error ? err.message : String(err)}. The mind is still registered as ${oldTemplate}; re-run the switch or fix home/ manually.`,
+        warning: withRestoreWarning(
+          `Upgrade merged but template switch ${oldTemplate}→${template} failed: ${err instanceof Error ? err.message : String(err)}. The mind is still registered as ${oldTemplate}; re-run the switch or fix home/ manually.`,
+        ),
       };
     }
   }
@@ -529,7 +568,9 @@ async function mergeUpgradeAndRestart(
       log.warn(`npm install failed after upgrade merge for ${mindName}`, log.errorData(err));
       return {
         ok: true,
-        warning: `Upgrade merged but npm install failed: ${err instanceof Error ? err.message : String(err)}. You may need to run npm install manually.`,
+        warning: withRestoreWarning(
+          `Upgrade merged but npm install failed: ${err instanceof Error ? err.message : String(err)}. You may need to run npm install manually.`,
+        ),
       };
     }
   } else {
@@ -550,11 +591,13 @@ async function mergeUpgradeAndRestart(
   } catch (e) {
     return {
       ok: true,
-      warning: `Upgrade merged but mind restart failed: ${e instanceof Error ? e.message : String(e)}`,
+      warning: withRestoreWarning(
+        `Upgrade merged but mind restart failed: ${e instanceof Error ? e.message : String(e)}`,
+      ),
     };
   }
 
-  return { ok: true, warning: switchWarning };
+  return { ok: true, warning: withRestoreWarning(switchWarning) };
 }
 
 /** Import a mind from a .volute archive (extracted to tempDir by CLI). */

--- a/test/upgrade-home-restore.test.ts
+++ b/test/upgrade-home-restore.test.ts
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  mergeOrAbort,
+  restoreMergeDeletedHomeFiles,
+} from "../packages/daemon/src/lib/mind/variants.js";
+
+const tmpDir = join(tmpdir(), `.volute-upgrade-restore-test-${process.pid}`);
+
+function git(args: string[], cwd: string): string {
+  // Strip ALL GIT_* env vars set by hooks (e.g. pre-push) that override cwd-based repo discovery
+  const env: Record<string, string> = { LEFTHOOK: "0" };
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
+  }
+  return execFileSync("git", args, { cwd, encoding: "utf-8", env });
+}
+
+/** Allowlist .gitignore matching the shape templates ship (templates/_base/gitignore). */
+const ALLOWLIST_GITIGNORE = [
+  "home/*",
+  "!home/SOUL.md",
+  "!home/memory/",
+  "!home/memory/**",
+  "",
+].join("\n");
+
+/**
+ * Build a mind repo where everything under home/ is tracked (the pre-allowlist
+ * state), then run the exact upgrade sequence from the daemon's upgrade route:
+ * worktree + `git rm -r --cached home/`, template-merge simulation introducing
+ * the allowlist .gitignore, re-add of allowlisted files, and finally the
+ * merge-back into the live dir. Returns the pre-merge HEAD, exactly what
+ * mergeUpgradeAndRestart captures before `git merge`.
+ */
+function runUpgradeSequence(
+  dir: string,
+  wt: string,
+  opts: { autoCommitOnMain?: boolean; afterTemplateMerge?: () => void } = {},
+): string {
+  // Mirrors the daemon's `git diff --cached --quiet ||` commit guard
+  const commitIfChanged = (message: string) => {
+    try {
+      git(["diff", "--cached", "--quiet"], wt);
+    } catch {
+      git(["commit", "-m", message], wt);
+    }
+  };
+
+  git(["worktree", "add", "-b", "upgrade", wt], dir);
+
+  // Prep step: untrack home/, keep SOUL.md (stands in for the VOLUTE.md re-add)
+  git(["rm", "-r", "--cached", "--ignore-unmatch", "home/"], wt);
+  git(["checkout", "HEAD", "--", "home/SOUL.md"], wt);
+  git(["add", "home/SOUL.md"], wt);
+  commitIfChanged("prepare for home/ allowlist migration");
+
+  // Simulated template merge: brings the new allowlist .gitignore
+  writeFileSync(join(wt, ".gitignore"), ALLOWLIST_GITIGNORE);
+  git(["add", ".gitignore"], wt);
+  commitIfChanged("template merge (allowlist gitignore)");
+
+  opts.afterTemplateMerge?.();
+
+  // Re-add pass: only allowlisted files come back
+  git(["add", "home/"], wt);
+  commitIfChanged("re-add allowlisted home files");
+
+  if (opts.autoCommitOnMain) {
+    // Simulate mergeUpgradeAndRestart's "Auto-commit before upgrade merge"
+    writeFileSync(join(dir, "drift.txt"), "uncommitted drift on main\n");
+    git(["add", "-A"], dir);
+    git(["commit", "-m", "Auto-commit before upgrade merge"], dir);
+  }
+
+  const preMergeHead = git(["rev-parse", "HEAD"], dir).trim();
+  git(["merge", "upgrade"], dir);
+  return preMergeHead;
+}
+
+describe("restoreMergeDeletedHomeFiles", () => {
+  let dir: string;
+  let wt: string;
+
+  beforeEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    dir = join(tmpDir, "mind");
+    wt = join(tmpDir, "wt");
+    mkdirSync(join(dir, "home", ".local", "bin"), { recursive: true });
+    mkdirSync(join(dir, "home", "memory"), { recursive: true });
+    git(["init", "-b", "main"], dir);
+    git(["config", "user.email", "test@test.com"], dir);
+    git(["config", "user.name", "Test"], dir);
+    writeFileSync(join(dir, "home", "SOUL.md"), "soul\n");
+    writeFileSync(join(dir, "home", "memory", "note.md"), "memory\n");
+    writeFileSync(join(dir, "home", ".gitconfig"), "[user]\n\tname = mind\n");
+    writeFileSync(join(dir, "home", ".local", "bin", "volute"), "#!/bin/sh\n");
+    writeFileSync(join(dir, "home", "with space.md"), "a filename with a space\n");
+    writeFileSync(join(dir, "home", "notes [draft]*.md"), "pathspec-magic characters\n");
+    git(["add", "-A"], dir);
+    git(["commit", "-m", "initial (everything tracked, pre-allowlist)"], dir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("restores non-allowlisted home files deleted by a fast-forward merge-back", async () => {
+    const preMergeHead = runUpgradeSequence(dir, wt);
+
+    // The bug: the merge-back physically deleted these from the live dir
+    assert.ok(!existsSync(join(dir, "home", ".gitconfig")), "repro precondition: file deleted");
+    assert.ok(!existsSync(join(dir, "home", ".local", "bin", "volute")));
+    assert.ok(!existsSync(join(dir, "home", "with space.md")));
+    assert.ok(!existsSync(join(dir, "home", "notes [draft]*.md")));
+
+    const restored = await restoreMergeDeletedHomeFiles(dir, preMergeHead);
+
+    assert.deepEqual(restored.sort(), [
+      "home/.gitconfig",
+      "home/.local/bin/volute",
+      "home/notes [draft]*.md",
+      "home/with space.md",
+    ]);
+    assert.equal(readFileSync(join(dir, "home", ".gitconfig"), "utf-8"), "[user]\n\tname = mind\n");
+    assert.equal(
+      readFileSync(join(dir, "home", ".local", "bin", "volute"), "utf-8"),
+      "#!/bin/sh\n",
+    );
+    assert.equal(
+      readFileSync(join(dir, "home", "with space.md"), "utf-8"),
+      "a filename with a space\n",
+    );
+    assert.equal(
+      readFileSync(join(dir, "home", "notes [draft]*.md"), "utf-8"),
+      "pathspec-magic characters\n",
+    );
+
+    // Allowlisted files survived the merge and are still tracked
+    assert.equal(readFileSync(join(dir, "home", "SOUL.md"), "utf-8"), "soul\n");
+    assert.equal(readFileSync(join(dir, "home", "memory", "note.md"), "utf-8"), "memory\n");
+
+    // Restored files are on disk but NOT re-tracked — the migration's stated end state
+    const tracked = git(["ls-files", "--", "home/"], dir).trim().split("\n");
+    assert.ok(!tracked.includes("home/.gitconfig"), "restored file must stay untracked");
+    assert.ok(!tracked.includes("home/.local/bin/volute"));
+    // ...and the working tree is clean (nothing staged, nothing modified)
+    assert.equal(git(["status", "--porcelain", "--untracked-files=no"], dir).trim(), "");
+  });
+
+  it("restores files when the merge-back is a true merge (auto-commit moved main)", async () => {
+    const preMergeHead = runUpgradeSequence(dir, wt, { autoCommitOnMain: true });
+
+    assert.ok(!existsSync(join(dir, "home", ".gitconfig")), "repro precondition: file deleted");
+
+    const restored = await restoreMergeDeletedHomeFiles(dir, preMergeHead);
+
+    assert.deepEqual(restored.sort(), [
+      "home/.gitconfig",
+      "home/.local/bin/volute",
+      "home/notes [draft]*.md",
+      "home/with space.md",
+    ]);
+    assert.equal(readFileSync(join(dir, "home", ".gitconfig"), "utf-8"), "[user]\n\tname = mind\n");
+    // Main's own auto-committed drift is untouched
+    assert.equal(readFileSync(join(dir, "drift.txt"), "utf-8"), "uncommitted drift on main\n");
+  });
+
+  it("does not resurrect allowlisted files the template merge deliberately deleted", async () => {
+    // An allowlisted (still-trackable) file removed on the upgrade branch is
+    // template intent, not migration fallout — restoring it would hand it back
+    // to auto-commit as a zombie, re-created on every future upgrade.
+    writeFileSync(join(dir, "home", "memory", "obsolete.md"), "removed by template\n");
+    git(["add", "home/memory/obsolete.md"], dir);
+    git(["commit", "-m", "track an allowlisted file the template will delete"], dir);
+
+    const preMergeHead = runUpgradeSequence(dir, wt, {
+      afterTemplateMerge: () => {
+        // The prep step already untracked it; the template drops it from disk
+        // so the re-add pass never brings it back — its deletion (vs the base
+        // commit) rides the upgrade branch into the merge.
+        rmSync(join(wt, "home", "memory", "obsolete.md"));
+      },
+    });
+
+    const restored = await restoreMergeDeletedHomeFiles(dir, preMergeHead);
+
+    assert.ok(!restored.includes("home/memory/obsolete.md"), "template deletion must stand");
+    assert.ok(!existsSync(join(dir, "home", "memory", "obsolete.md")));
+    // The migration's own victims are still restored
+    assert.ok(restored.includes("home/.gitconfig"));
+    assert.equal(readFileSync(join(dir, "home", ".gitconfig"), "utf-8"), "[user]\n\tname = mind\n");
+  });
+
+  it("restores a deleted file even when rename detection would pair it with an added file", async () => {
+    // A deleted home file ≥50% similar to a file added in the same range is
+    // reported as R, not D, under default rename detection — --no-renames
+    // keeps it in the deleted set.
+    const content = `${"shared line\n".repeat(50)}`;
+    writeFileSync(join(dir, "home", "old-doc.md"), content);
+    git(["add", "home/old-doc.md"], dir);
+    git(["commit", "-m", "track a doc the template will ship elsewhere"], dir);
+
+    const preMergeHead = runUpgradeSequence(dir, wt, {
+      afterTemplateMerge: () => {
+        // Tracked outside home/ so it pairs as the rename target
+        writeFileSync(join(wt, "docs-copy.md"), content);
+        git(["add", "docs-copy.md"], wt);
+        git(["commit", "-m", "template adds a near-identical file"], wt);
+      },
+    });
+
+    assert.ok(!existsSync(join(dir, "home", "old-doc.md")), "repro precondition: file deleted");
+
+    const restored = await restoreMergeDeletedHomeFiles(dir, preMergeHead);
+
+    assert.ok(restored.includes("home/old-doc.md"), "rename detection must not hide the deletion");
+    assert.equal(readFileSync(join(dir, "home", "old-doc.md"), "utf-8"), content);
+  });
+
+  it("is a no-op when the merge deleted nothing under home/", async () => {
+    // Already-migrated mind: only allowlisted files are tracked
+    git(["rm", "-r", "--cached", "--ignore-unmatch", "home/"], dir);
+    writeFileSync(join(dir, ".gitignore"), ALLOWLIST_GITIGNORE);
+    git(["add", ".gitignore", "home/"], dir);
+    git(["commit", "-m", "already migrated"], dir);
+
+    const preMergeHead = runUpgradeSequence(dir, wt);
+
+    const restored = await restoreMergeDeletedHomeFiles(dir, preMergeHead);
+    assert.deepEqual(restored, []);
+
+    // Untracked home files were never touched by any of this
+    assert.equal(readFileSync(join(dir, "home", ".gitconfig"), "utf-8"), "[user]\n\tname = mind\n");
+  });
+});
+
+describe("mergeOrAbort", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    dir = join(tmpDir, "mind");
+    mkdirSync(join(dir, "home"), { recursive: true });
+    git(["init", "-b", "main"], dir);
+    git(["config", "user.email", "test@test.com"], dir);
+    git(["config", "user.name", "Test"], dir);
+    writeFileSync(join(dir, "src.ts"), "original\n");
+    writeFileSync(join(dir, "home", ".gitconfig"), "mind data\n");
+    git(["add", "-A"], dir);
+    git(["commit", "-m", "initial"], dir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rolls back a conflicted merge's clean deletions and leaves no merge in progress", async () => {
+    // Branch: delete home/.gitconfig (clean deletion) + edit src.ts (will conflict)
+    git(["checkout", "-b", "upgrade"], dir);
+    git(["rm", "home/.gitconfig"], dir);
+    writeFileSync(join(dir, "src.ts"), "branch edit\n");
+    git(["add", "-A"], dir);
+    git(["commit", "-m", "delete home file, edit src"], dir);
+    // Main: conflicting edit to src.ts
+    git(["checkout", "main"], dir);
+    writeFileSync(join(dir, "src.ts"), "main edit\n");
+    git(["add", "-A"], dir);
+    git(["commit", "-m", "conflicting main edit"], dir);
+
+    await assert.rejects(() => mergeOrAbort(dir, "upgrade"));
+
+    // The clean deletion was rolled back with the rest of the merge
+    assert.equal(readFileSync(join(dir, "home", ".gitconfig"), "utf-8"), "mind data\n");
+    assert.equal(readFileSync(join(dir, "src.ts"), "utf-8"), "main edit\n");
+    // No MERGE_HEAD left for a later auto-commit to conclude
+    assert.ok(!existsSync(join(dir, ".git", "MERGE_HEAD")), "merge must be aborted");
+    assert.equal(git(["status", "--porcelain"], dir).trim(), "");
+  });
+
+  it("merges cleanly when there is no conflict", async () => {
+    git(["checkout", "-b", "upgrade"], dir);
+    writeFileSync(join(dir, "src.ts"), "branch edit\n");
+    git(["add", "-A"], dir);
+    git(["commit", "-m", "branch edit"], dir);
+    git(["checkout", "main"], dir);
+
+    await mergeOrAbort(dir, "upgrade");
+
+    assert.equal(readFileSync(join(dir, "src.ts"), "utf-8"), "branch edit\n");
+  });
+});


### PR DESCRIPTION
## What

The upgrade's "prepare for home/ allowlist migration" step (`git rm -r --cached home/`) records pre-allowlist home files as *deleted* in the upgrade branch's history. Inside the upgrade worktree the files stay on disk — which is what made the step look safe — but when the branch merges back into the **live mind directory**, git applies the recorded deletions to the real working tree. Every file tracked pre-upgrade but outside the new `.gitignore` allowlist was physically deleted from the mind's live home. Confirmed in production: mimsy lost 14 files including `.gitconfig`. A pre-allowlist mind (~700 tracked non-allowlist files) would lose essentially its whole home except SOUL/MEMORY/VOLUTE/memory/.config/skills — hooks, `.local/bin/volute`, credentials, pages, all of it.

## Fix

- **`restoreMergeDeletedHomeFiles()`** (`variants.ts`): after the merge-back, lists home/ paths the merge deleted (`git diff --diff-filter=D --no-renames -z` against the pre-merge HEAD) and restores their content with `git restore --worktree` — on disk, untracked, which is the end state the migration always claimed.
  - Only paths the post-merge `.gitignore` *ignores* are restored (`git check-ignore --stdin -z`). A deleted path git would still track was deleted deliberately by the template merge; restoring it would resurrect it into tracking at the next auto-commit and re-create it on every future upgrade.
  - `--no-renames` so rename detection can't reclassify a deletion as `R` and silently drop it.
  - NUL-delimited stdin/stdout and 500-path pathspec chunks (+ raised `maxBuffer`) so huge pre-allowlist homes don't hit argv/buffer limits — the biggest homes are exactly the ones with the most at risk.
- **`mergeOrAbort()`** (`variants.ts`): a conflicted merge-back previously *still applied* all cleanly-merged deletions to the live working tree and left the repo mid-merge (`MERGE_HEAD` present) — where the running mind's next auto-commit (`git add -A` + commit) would conclude the merge and bake the deletions in permanently. Now the merge is aborted on failure: working tree rolled back unchanged, no merge state left behind, error message says so instead of git's "fix conflicts and then commit the result".
- **`mergeUpgradeAndRestart`** (`minds.ts`): runs the restore immediately after the merge, before anything else can fail; threads a restore failure into every subsequent return's `warning` (never swallowed) with a correctly *scoped* manual recovery command; chown of restored files is its own step so a chown failure isn't misreported as a restore failure. Both the fresh and `--continue` upgrade paths go through this function.
- **`exec.ts`**: optional `stdin`/`maxBuffer` passthrough on `exec`/`gitExec` (needed for `check-ignore --stdin -z`, which is also immune to `core.quotePath` mangling).

## Tests

`test/upgrade-home-restore.test.ts` builds the exact upgrade sequence in a scratch repo and covers: fast-forward and true-merge merge-backs (both delete files without the fix), restored files staying untracked with a clean status, filenames with spaces and pathspec-magic chars (`notes [draft]*.md`), no-op for already-migrated minds, template-deleted allowlisted files *not* resurrected, rename detection not hiding deletions, and `mergeOrAbort` rolling back a conflicted merge's clean deletions with no `MERGE_HEAD` left. 2935/2935 unit tests pass.

## Uncertainty / notes

- The conflicted-merge-back behavior change (abort instead of leaving `MERGING` + 500) is a behavior change for hosts who were hand-resolving that state — but there was never a supported flow for it, and the mid-merge state was an auto-commit trap. Flagging it in case someone relied on it.
- The restore intentionally errs toward resurrecting: a non-allowlisted file the template merge deleted comes back as an untracked leftover (recoverable), rather than risking deleting mind data (not recoverable). Allowlisted deletions stand, per template intent.
- Recovery for already-affected minds (no code needed): `git diff --name-only --diff-filter=D <prep-commit>^ HEAD -- home/` to list, then `git restore --source=<prep-commit>^ --worktree -- <paths>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)