### PR TITLE
feat: auto-upgrade minds with clean template merges

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -24,6 +24,8 @@ export type Mind = {
   channels: PlatformConnection[];
   hasPages?: boolean;
   templateStale?: boolean;
+  /** Reason the last auto-upgrade attempt backed off (conflicts, opt-out, etc.), if any. */
+  upgradeBlocked?: string;
   lastActiveAt?: string | null;
   displayName?: string;
   description?: string;

--- a/packages/cli/src/commands/mind-list.ts
+++ b/packages/cli/src/commands/mind-list.ts
@@ -40,6 +40,7 @@ const cmd = command({
       stage?: string;
       created?: string;
       templateStale?: boolean;
+      upgradeBlocked?: string;
     }>;
 
     if (minds.length === 0) {
@@ -53,7 +54,10 @@ const cmd = command({
       const age = mind.created ? relativeAge(mind.created) : "";
       const ageLabel = age ? `  ${age} old` : "";
       const template = mind.templateStale ? "  [template: outdated]" : "";
-      console.log(`  ${mind.name}: ${status}${label}${ageLabel}${template}`);
+      const upgradeBlocked = mind.upgradeBlocked
+        ? `  [upgrade blocked: ${mind.upgradeBlocked}]`
+        : "";
+      console.log(`  ${mind.name}: ${status}${label}${ageLabel}${template}${upgradeBlocked}`);
     }
   },
 });

--- a/packages/cli/src/commands/mind-status.ts
+++ b/packages/cli/src/commands/mind-status.ts
@@ -45,6 +45,7 @@ const cmd = command({
         overHardCap: boolean;
       } | null;
       templateStale?: boolean;
+      upgradeBlocked?: string;
       channels?: Array<{ name: string; displayName?: string; status: string }>;
       variants?: Array<{ name: string; status: string }>;
       hasPages?: boolean;
@@ -69,6 +70,9 @@ const cmd = command({
     }
     if (mind.templateStale) {
       console.log(`Template: outdated — run 'volute mind upgrade ${mind.name}'`);
+    }
+    if (mind.upgradeBlocked) {
+      console.log(`[upgrade blocked: ${mind.upgradeBlocked}]`);
     }
 
     // Surface the newest un-drained failure notice so a silent mind explains itself

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -386,16 +386,23 @@ export async function startDaemon(opts: {
     const { backfillTemplateHashes, notifyVersionUpdate, warnStaleTemplates } = await import(
       "./lib/version-notify.js"
     );
-    // Backfill first (measures on-disk hashes), then warn about stale minds.
-    backfillTemplateHashes()
-      .then(() => warnStaleTemplates())
+    // Notify first — a mind opted into auto-upgrade is told "it will be applied
+    // automatically in a few minutes", so that notice must go out before the pass
+    // below actually runs it, not after. Then backfill on-disk hashes, warn about
+    // stale minds, then run the serialized auto-upgrade pass over eligible ones.
+    notifyVersionUpdate()
       .catch((err) => {
-        log.warn("failed to check template staleness", log.errorData(err));
+        log.warn("failed to send version update notifications", log.errorData(err));
+      })
+      .then(() => backfillTemplateHashes())
+      .then(() => warnStaleTemplates())
+      .then(async () => {
+        const { runAutoUpgrades } = await import("./lib/daemon/auto-upgrade.js");
+        await runAutoUpgrades();
+      })
+      .catch((err) => {
+        log.warn("template staleness/auto-upgrade pass failed", log.errorData(err));
       });
-    // Fire-and-forget notification (non-blocking)
-    notifyVersionUpdate().catch((err) => {
-      log.warn("failed to send version update notifications", log.errorData(err));
-    });
   } catch (err) {
     log.warn("failed to initialize version notifications", log.errorData(err));
   }

--- a/packages/daemon/src/lib/daemon/auto-upgrade.ts
+++ b/packages/daemon/src/lib/daemon/auto-upgrade.ts
@@ -1,0 +1,195 @@
+import { deliverEvent } from "../chat/system-events.js";
+import { type MindEntry, mindDir, readRegistry } from "../mind/registry.js";
+import { isTemplateStale } from "../mind/template-staleness.js";
+import {
+  abortUpgrade,
+  runUpgrade,
+  UpgradeInProgressError,
+  type UpgradeOutcome,
+} from "../mind/upgrade.js";
+import { readVoluteConfig } from "../mind/volute-config.js";
+import log from "../util/logger.js";
+import { getMindManager } from "./mind-manager.js";
+import { getSleepManagerIfReady } from "./sleep-manager.js";
+
+const alog = log.child("auto-upgrade");
+
+/** Delay before the single retry attempt for a transient (thrown) upgrade error. */
+const RETRY_DELAY_MS = 5000;
+
+export type AutoUpgradeBlocked = { reason: string; at: Date };
+
+/** In-memory only — cleared per-mind at the start of each pass and on success. */
+const blocked = new Map<string, AutoUpgradeBlocked>();
+
+/** In-memory record of minds whose last auto-upgrade backed off (conflicts/errors). */
+export function getUpgradeBlocked(name: string): AutoUpgradeBlocked | undefined {
+  return blocked.get(name);
+}
+
+export type SelectEligibleDeps = {
+  isStale: (entry: MindEntry) => boolean;
+  isSleeping: (name: string) => boolean;
+  readConfig: (name: string) => { upgrades?: "auto" | "manual" } | null;
+};
+
+/**
+ * Pure eligibility + ordering over registry entries: stale, non-seed/spirit/variant
+ * minds that haven't opted out via `"upgrades": "manual"`, sorted sleeping-first
+ * (stable — ties keep their original relative order).
+ */
+export function selectEligible(entries: MindEntry[], deps: SelectEligibleDeps): MindEntry[] {
+  const eligible = entries.filter((entry) => {
+    if (entry.mindType !== "mind") return false;
+    if (entry.stage === "seed") return false;
+    if (entry.parent) return false;
+    if (!deps.isStale(entry)) return false;
+    if (deps.readConfig(entry.name)?.upgrades === "manual") return false;
+    return true;
+  });
+
+  return eligible.sort((a, b) => {
+    const aSleeping = deps.isSleeping(a.name) ? 0 : 1;
+    const bSleeping = deps.isSleeping(b.name) ? 0 : 1;
+    return aSleeping - bSleeping;
+  });
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Collaborators of {@link autoUpgradeOne}, injectable so its branches are unit-testable. */
+export type AutoUpgradeOneDeps = {
+  isRunning: (name: string) => boolean;
+  runUpgrade: (name: string, opts: { restart: boolean }) => Promise<UpgradeOutcome>;
+  abortUpgrade: (name: string) => Promise<void>;
+  deliverEvent: (name: string, input: { type: string; body: string }) => Promise<unknown>;
+  delay: (ms: number) => Promise<void>;
+};
+
+const defaultAutoUpgradeOneDeps: AutoUpgradeOneDeps = {
+  isRunning: (name) => getMindManager().isRunning(name),
+  runUpgrade,
+  abortUpgrade,
+  deliverEvent: (name, input) => deliverEvent(name, input),
+  delay: sleep,
+};
+
+/**
+ * Removes blocked records for minds that are not in this pass's eligible set
+ * (resolved manually, opted out, or removed from the registry) — otherwise a
+ * conflict a host resolves by hand keeps a stale "upgrade blocked" badge
+ * forever. Entries for minds that ARE eligible are left untouched here; the
+ * per-mind attempt below clears or replaces them once the outcome is known.
+ */
+export function pruneBlocked(
+  blockedMap: Map<string, AutoUpgradeBlocked>,
+  eligibleNames: Set<string>,
+): void {
+  for (const name of blockedMap.keys()) {
+    if (!eligibleNames.has(name)) blockedMap.delete(name);
+  }
+}
+
+/**
+ * Auto-upgrade a single mind. Never throws — every failure path records a
+ * blocked reason and returns, so the caller's per-mind try/catch is a backstop
+ * rather than the primary handling. Collaborators are injectable (defaulting to
+ * the real daemon-wide singletons) so each branch is unit-testable without a
+ * running daemon.
+ */
+export async function autoUpgradeOne(
+  entry: MindEntry,
+  sleeping: boolean,
+  deps: AutoUpgradeOneDeps = defaultAutoUpgradeOneDeps,
+): Promise<void> {
+  const wasRunning = deps.isRunning(entry.name);
+  // Never restart a sleeping mind (it's supposed to stay stopped), and never
+  // skip restarting a mind that was actually running — that would leave it
+  // executing the old code.
+  const restart = wasRunning && !sleeping;
+
+  const attempt = () => deps.runUpgrade(entry.name, { restart });
+
+  let outcome: UpgradeOutcome;
+  try {
+    outcome = await attempt();
+  } catch (err) {
+    if (err instanceof UpgradeInProgressError) {
+      blocked.set(entry.name, {
+        reason: "upgrade already in progress (mid conflict resolution)",
+        at: new Date(),
+      });
+      return;
+    }
+    // Transient failure — retry once after a short delay before giving up.
+    await deps.delay(RETRY_DELAY_MS);
+    try {
+      outcome = await attempt();
+    } catch (err2) {
+      const message = err2 instanceof Error ? err2.message : String(err2);
+      alog.error(`auto-upgrade failed for ${entry.name} after retry`, log.errorData(err2));
+      blocked.set(entry.name, { reason: message, at: new Date() });
+      return;
+    }
+  }
+
+  if (outcome.status === "conflicts") {
+    await deps.abortUpgrade(entry.name).catch((err) => {
+      alog.warn(`failed to abort conflicted auto-upgrade for ${entry.name}`, log.errorData(err));
+    });
+    const fileList = outcome.files.join(", ");
+    await deps.deliverEvent(entry.name, {
+      type: "notice",
+      body:
+        `Auto-upgrade hit merge conflicts in: ${fileList}. Run \`volute mind upgrade ${entry.name}\` ` +
+        `to resolve them manually (or set "upgrades": "manual" in home/.config/volute.json to stop ` +
+        `auto attempts).`,
+    });
+    blocked.set(entry.name, { reason: `merge conflicts: ${fileList}`, at: new Date() });
+  }
+}
+
+/** Serialized auto-upgrade pass over stale, eligible minds. Never throws. */
+export async function runAutoUpgrades(): Promise<void> {
+  let entries: MindEntry[];
+  try {
+    entries = await readRegistry();
+  } catch (err) {
+    alog.error("failed to read registry for auto-upgrade pass", log.errorData(err));
+    return;
+  }
+
+  const sleepManager = getSleepManagerIfReady();
+  const isSleeping = (name: string) => sleepManager?.isSleeping(name) ?? false;
+
+  const eligible = selectEligible(entries, {
+    isStale: (entry) => isTemplateStale(entry),
+    isSleeping,
+    readConfig: (name) => readVoluteConfig(mindDir(name)),
+  });
+
+  pruneBlocked(blocked, new Set(eligible.map((e) => e.name)));
+
+  if (eligible.length === 0) return;
+
+  alog.info(`auto-upgrade pass starting for ${eligible.length} mind(s)`, {
+    minds: eligible.map((e) => e.name),
+  });
+
+  for (const entry of eligible) {
+    blocked.delete(entry.name);
+    try {
+      await autoUpgradeOne(entry, isSleeping(entry.name));
+    } catch (err) {
+      // Backstop: autoUpgradeOne shouldn't throw, but one mind's failure must
+      // never stop the walk.
+      alog.error(`unexpected error auto-upgrading ${entry.name}`, log.errorData(err));
+      blocked.set(entry.name, {
+        reason: err instanceof Error ? err.message : String(err),
+        at: new Date(),
+      });
+    }
+  }
+}

--- a/packages/daemon/src/lib/mind/upgrade.ts
+++ b/packages/daemon/src/lib/mind/upgrade.ts
@@ -42,6 +42,27 @@ export const UPGRADE_BRANCH = "upgrade";
 const FINAL_MERGE_CONFLICTS_MESSAGE =
   "Merge conflicts detected at the final merge step. The mind's directory has been restored to its pre-merge state; the upgrade worktree has been left in place for manual resolution.";
 
+/** Per-mind chain of in-flight upgrade operations, used by {@link withUpgradeLock}. */
+const upgradeLocks = new Map<string, Promise<unknown>>();
+
+/**
+ * Serializes upgrade operations (runUpgrade/continueUpgrade/abortUpgrade) for a
+ * single mind so a manual call and the auto-upgrade pass can never race on the
+ * same worktree — e.g. one treating the other's in-progress merge as a stale
+ * orphan and aborting it out from under it. Different mind names run unaffected.
+ * A rejected op is swallowed before chaining the next one, so a single failure
+ * never wedges the queue for that mind.
+ */
+export async function withUpgradeLock<T>(mindName: string, fn: () => Promise<T>): Promise<T> {
+  const prior = upgradeLocks.get(mindName) ?? Promise.resolve();
+  const run = prior.catch(() => {}).then(fn);
+  upgradeLocks.set(
+    mindName,
+    run.catch(() => {}),
+  );
+  return run;
+}
+
 /** Configure per-repo git identity for a mind: name = mind name, email = [mind].[system]@volute.systems. */
 export async function configureGitIdentity(
   mindName: string,
@@ -459,6 +480,13 @@ export async function runUpgrade(
   mindName: string,
   opts?: { template?: string; restart?: boolean },
 ): Promise<UpgradeOutcome> {
+  return withUpgradeLock(mindName, () => runUpgradeCore(mindName, opts));
+}
+
+async function runUpgradeCore(
+  mindName: string,
+  opts?: { template?: string; restart?: boolean },
+): Promise<UpgradeOutcome> {
   const entry = await findMind(mindName);
   if (!entry) throw new Error("Mind not found");
   const dir = mindDir(mindName);
@@ -471,13 +499,15 @@ export async function runUpgrade(
 
   // An upgrade worktree from a prior run may still be sitting here — either a
   // daemon restart orphaned it mid-run, or a caller is genuinely mid-conflict-
-  // resolution. Only the latter should keep blocking a fresh upgrade.
+  // resolution. Only the latter should keep blocking a fresh upgrade. Calls the
+  // unlocked core directly — runUpgradeCore already holds this mind's lock, and
+  // going through the public abortUpgrade would deadlock waiting on itself.
   if (existsSync(worktreeDir)) {
     if (upgradeMidResolution(worktreeDir)) {
       throw new UpgradeInProgressError(worktreeDir);
     }
     log.warn(`clearing stale orphaned upgrade worktree for ${mindName}`);
-    await abortUpgrade(mindName);
+    await abortUpgradeCore(mindName);
   }
 
   // Initialize git repo if missing (minds created before git config was fixed)
@@ -613,6 +643,13 @@ export async function continueUpgrade(
   mindName: string,
   opts?: { template?: string; restart?: boolean },
 ): Promise<UpgradeOutcome> {
+  return withUpgradeLock(mindName, () => continueUpgradeCore(mindName, opts));
+}
+
+async function continueUpgradeCore(
+  mindName: string,
+  opts?: { template?: string; restart?: boolean },
+): Promise<UpgradeOutcome> {
   const entry = await findMind(mindName);
   if (!entry) throw new Error("Mind not found");
   const dir = mindDir(mindName);
@@ -691,6 +728,10 @@ export async function continueUpgrade(
 
 /** Abort an in-progress upgrade: abort worktree merge if mid-merge, cleanupVariant, delete branch. */
 export async function abortUpgrade(mindName: string): Promise<void> {
+  return withUpgradeLock(mindName, () => abortUpgradeCore(mindName));
+}
+
+async function abortUpgradeCore(mindName: string): Promise<void> {
   const dir = mindDir(mindName);
   const variantName = upgradeVariantName(mindName);
   const worktreeDir = upgradeWorktreeDir(dir);

--- a/packages/daemon/src/lib/mind/volute-config.ts
+++ b/packages/daemon/src/lib/mind/volute-config.ts
@@ -66,6 +66,8 @@ export type VoluteConfig = CognitionConfig & {
   sleep?: SleepConfig;
   echoText?: boolean;
   unescapeNewlines?: boolean;
+  /** Opt out of the post-startup auto-upgrade pass. Absent/"auto" → eligible. */
+  upgrades?: "auto" | "manual";
   [key: string]: unknown;
 };
 

--- a/packages/daemon/src/lib/version-notify.ts
+++ b/packages/daemon/src/lib/version-notify.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { deliverEvent } from "./chat/system-events.js";
 import { mindDir, readRegistry, setMindTemplateHash, voluteSystemDir } from "./mind/registry.js";
 import { computeMindTemplateHash } from "./mind/template-staleness.js";
+import { readVoluteConfig } from "./mind/volute-config.js";
 import { parseReleaseNotes } from "./release-notes.js";
 import { computeTemplateHash } from "./template/template-hash.js";
 import { getCurrentVersion } from "./update-check.js";
@@ -113,8 +114,15 @@ export async function notifyVersionUpdate(): Promise<void> {
     const tmpl = entry.template ?? "claude";
     const currentHash = templateHashes.get(tmpl);
     const needsUpgrade = shouldSuggestUpgrade(entry, currentHash);
+    const autoUpgrade = readVoluteConfig(mindDir(entry.name))?.upgrades !== "manual";
 
-    const message = formatNotification(currentVersion, releaseNotes, needsUpgrade, entry.name);
+    const message = formatNotification(
+      currentVersion,
+      releaseNotes,
+      needsUpgrade,
+      entry.name,
+      autoUpgrade,
+    );
 
     // Immediate (triggers a turn): an idle mind — exactly the stale mind that needs the
     // upgrade nudge — never drains a next-turn event, and pre-events templates lack the
@@ -151,11 +159,19 @@ export function shouldSuggestUpgrade(
   );
 }
 
-function formatNotification(
+/**
+ * Format the version-update message sent to a mind. When a template update is
+ * available, the hint differs by whether the mind has opted out of the
+ * post-startup auto-upgrade pass (`autoUpgrade` — see readVoluteConfig's
+ * `upgrades` field): opted-in minds are told the upgrade is automatic,
+ * opted-out minds are told to run it themselves.
+ */
+export function formatNotification(
   version: string,
   releaseNotes: string | null,
   needsUpgrade: boolean,
   mindName: string,
+  autoUpgrade: boolean,
 ): string {
   let message = `Volute has been updated to v${version}.`;
 
@@ -164,7 +180,9 @@ function formatNotification(
   }
 
   if (needsUpgrade) {
-    message += `\n\n---\n\nA template update is available for you. To upgrade, run:\n  volute mind upgrade ${mindName}`;
+    message += autoUpgrade
+      ? `\n\n---\n\nA template update is available. It will be applied automatically in a few minutes (set "upgrades": "manual" in home/.config/volute.json to manage upgrades yourself).`
+      : `\n\n---\n\nA template update is available for you. To upgrade, run:\n  volute mind upgrade ${mindName}`;
   }
 
   return message;

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -38,6 +38,7 @@ import {
   recordNotice,
 } from "../../lib/chat/system-events.js";
 import { getSpiritName } from "../../lib/config/setup.js";
+import { getUpgradeBlocked } from "../../lib/daemon/auto-upgrade.js";
 import { getMindManager, MindStartupError } from "../../lib/daemon/mind-manager.js";
 // Lifecycle functions from mind-service.ts
 import {
@@ -1189,6 +1190,7 @@ const app = new Hono<AuthEnv>()
           ...mindStatus,
           hasPages,
           templateStale: isTemplateStale(entry),
+          upgradeBlocked: getUpgradeBlocked(entry.name)?.reason,
           lastActiveAt,
         };
       }),
@@ -1240,6 +1242,7 @@ const app = new Hono<AuthEnv>()
       variants: variantStatuses,
       hasPages,
       templateStale: isTemplateStale(entry),
+      upgradeBlocked: getUpgradeBlocked(name)?.reason,
       ...(notice && {
         lastNotice: {
           kind: notice.kind,

--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -287,6 +287,12 @@ let isSystemActive = $derived(
                         use:tooltipAction={{ text: `Running an outdated template — run 'volute mind upgrade ${mind.name}'`, position: "right" }}
                       >outdated</span>
                     {/if}
+                    {#if mind.upgradeBlocked}
+                      <span
+                        class="upgrade-blocked-badge"
+                        use:tooltipAction={{ text: mind.upgradeBlocked, position: "right" }}
+                      >upgrade blocked</span>
+                    {/if}
                     {#if mindUnread > 0}
                       <span class="unread-dot"></span>
                     {/if}
@@ -641,6 +647,16 @@ let isSystemActive = $derived(
     border-radius: var(--radius);
     background: var(--yellow-bg);
     color: var(--yellow);
+    font-size: 10px;
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+
+  .upgrade-blocked-badge {
+    padding: 1px 6px;
+    border-radius: var(--radius);
+    background: var(--red-bg);
+    color: var(--red);
     font-size: 10px;
     font-weight: 500;
     flex-shrink: 0;

--- a/templates/claude/.init/CLAUDE.md
+++ b/templates/claude/.init/CLAUDE.md
@@ -11,6 +11,10 @@ Messages arrive with a context prefix:
 
 You can also reach out proactively — see the **volute-mind** skill.
 
+## Framework Upgrades
+
+When the host updates Volute, your framework code (`src/`, plus `VOLUTE.md`) upgrades automatically the next time you're eligible — usually your next restart. Identity and memory files in `home/` — `SOUL.md`, `MEMORY.md`, everything you author — are never touched by an upgrade. If you'd rather manage your own framework code by hand, set `"upgrades": "manual"` in `.config/volute.json`.
+
 ## Identity & Sessions
 
 These files shape your starting identity. They're loaded into your system prompt, but they belong to you — edit them as you evolve:

--- a/templates/codex/.init/AGENTS.md
+++ b/templates/codex/.init/AGENTS.md
@@ -13,6 +13,10 @@ Messages arrive with a context prefix:
 
 You can also reach out proactively — see the **volute-mind** skill.
 
+## Framework Upgrades
+
+When the host updates Volute, your framework code (`src/`, plus `VOLUTE.md`) upgrades automatically the next time you're eligible — usually your next restart. Identity and memory files in `home/` — `SOUL.md`, `MEMORY.md`, everything you author — are never touched by an upgrade. If you'd rather manage your own framework code by hand, set `"upgrades": "manual"` in `.config/volute.json`.
+
 ## Memory System
 
 Two-tier memory, both managed via file tools:

--- a/templates/pi/.init/MINDS.md
+++ b/templates/pi/.init/MINDS.md
@@ -13,6 +13,10 @@ Messages arrive with a context prefix:
 
 You can also reach out proactively — see the **volute-mind** skill.
 
+## Framework Upgrades
+
+When the host updates Volute, your framework code (`src/`, plus `VOLUTE.md`) upgrades automatically the next time you're eligible — usually your next restart. Identity and memory files in `home/` — `SOUL.md`, `MEMORY.md`, everything you author — are never touched by an upgrade. If you'd rather manage your own framework code by hand, set `"upgrades": "manual"` in `.config/volute.json`.
+
 ## Memory System
 
 Two-tier memory, both managed via file tools:

--- a/test/auto-upgrade.test.ts
+++ b/test/auto-upgrade.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  type AutoUpgradeBlocked,
+  type AutoUpgradeOneDeps,
+  autoUpgradeOne,
+  getUpgradeBlocked,
+  pruneBlocked,
+  type SelectEligibleDeps,
+  selectEligible,
+} from "../packages/daemon/src/lib/daemon/auto-upgrade.js";
+import type { MindEntry } from "../packages/daemon/src/lib/mind/registry.js";
+import { formatNotification } from "../packages/daemon/src/lib/version-notify.js";
+
+function makeEntry(overrides: Partial<MindEntry> & { name: string }): MindEntry {
+  return {
+    port: 4100,
+    created: new Date().toISOString(),
+    running: false,
+    mindType: "mind",
+    ...overrides,
+  };
+}
+
+function makeDeps(opts: {
+  stale?: Set<string>;
+  sleeping?: Set<string>;
+  manual?: Set<string>;
+}): SelectEligibleDeps {
+  return {
+    isStale: (entry: MindEntry) => opts.stale?.has(entry.name) ?? true,
+    isSleeping: (name: string) => opts.sleeping?.has(name) ?? false,
+    readConfig: (name: string) => (opts.manual?.has(name) ? { upgrades: "manual" as const } : null),
+  };
+}
+
+describe("selectEligible", () => {
+  it("excludes spirits, seeds, and variants", () => {
+    const entries = [
+      makeEntry({ name: "spirit-1", mindType: "spirit" }),
+      makeEntry({ name: "seed-1", stage: "seed" }),
+      makeEntry({ name: "variant-1", parent: "parent-mind" }),
+      makeEntry({ name: "regular-1" }),
+    ];
+    const result = selectEligible(entries, makeDeps({}));
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["regular-1"],
+    );
+  });
+
+  it("excludes non-stale minds", () => {
+    const entries = [makeEntry({ name: "a" }), makeEntry({ name: "b" })];
+    const result = selectEligible(entries, makeDeps({ stale: new Set(["a"]) }));
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["a"],
+    );
+  });
+
+  it('excludes minds opted out via "upgrades": "manual"', () => {
+    const entries = [makeEntry({ name: "a" }), makeEntry({ name: "b" })];
+    const result = selectEligible(entries, makeDeps({ manual: new Set(["b"]) }));
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["a"],
+    );
+  });
+
+  it("includes minds with absent config (auto is the default)", () => {
+    const entries = [makeEntry({ name: "a" })];
+    const result = selectEligible(entries, makeDeps({}));
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["a"],
+    );
+  });
+
+  it("includes minds explicitly configured as auto", () => {
+    const entries = [makeEntry({ name: "a" })];
+    const deps: SelectEligibleDeps = {
+      isStale: () => true,
+      isSleeping: () => false,
+      readConfig: () => ({ upgrades: "auto" }),
+    };
+    const result = selectEligible(entries, deps);
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["a"],
+    );
+  });
+
+  it("orders sleeping minds first, preserving relative order otherwise", () => {
+    const entries = [
+      makeEntry({ name: "a" }),
+      makeEntry({ name: "b" }),
+      makeEntry({ name: "c" }),
+      makeEntry({ name: "d" }),
+    ];
+    const result = selectEligible(entries, makeDeps({ sleeping: new Set(["b", "d"]) }));
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["b", "d", "a", "c"],
+    );
+  });
+
+  it("returns an empty array when nothing is eligible", () => {
+    const entries = [makeEntry({ name: "a", stage: "seed" })];
+    const result = selectEligible(entries, makeDeps({}));
+    assert.deepEqual(result, []);
+  });
+});
+
+describe("pruneBlocked", () => {
+  function makeBlocked(reason = "merge conflicts: SOUL.md"): AutoUpgradeBlocked {
+    return { reason, at: new Date() };
+  }
+
+  it("removes entries for minds not in the eligible set", () => {
+    const blocked = new Map<string, AutoUpgradeBlocked>([
+      ["resolved-manually", makeBlocked()],
+      ["opted-out", makeBlocked()],
+      ["still-blocked", makeBlocked()],
+    ]);
+    pruneBlocked(blocked, new Set(["still-blocked"]));
+    assert.deepEqual([...blocked.keys()], ["still-blocked"]);
+  });
+
+  it("leaves entries for minds that are eligible untouched", () => {
+    const entry = makeBlocked("upgrade already in progress");
+    const blocked = new Map<string, AutoUpgradeBlocked>([["a", entry]]);
+    pruneBlocked(blocked, new Set(["a", "b"]));
+    assert.equal(blocked.get("a"), entry);
+  });
+
+  it("clears everything when nothing is eligible", () => {
+    const blocked = new Map<string, AutoUpgradeBlocked>([
+      ["a", makeBlocked()],
+      ["b", makeBlocked()],
+    ]);
+    pruneBlocked(blocked, new Set());
+    assert.equal(blocked.size, 0);
+  });
+
+  it("is a no-op on an empty blocked map", () => {
+    const blocked = new Map<string, AutoUpgradeBlocked>();
+    pruneBlocked(blocked, new Set(["a"]));
+    assert.equal(blocked.size, 0);
+  });
+});
+
+describe("autoUpgradeOne", () => {
+  it("conflicts: aborts the upgrade, notifies the mind with the conflicting files, and records a blocked reason", async () => {
+    const entry = makeEntry({ name: "conflict-mind" });
+    let abortedName: string | undefined;
+    let deliveredBody: string | undefined;
+    const deps: AutoUpgradeOneDeps = {
+      isRunning: () => true,
+      runUpgrade: async () => ({
+        status: "conflicts",
+        worktreeDir: "/tmp/x",
+        files: ["SOUL.md", "package.json"],
+      }),
+      abortUpgrade: async (name) => {
+        abortedName = name;
+      },
+      deliverEvent: async (_name, input) => {
+        deliveredBody = input.body;
+        return { delivered: true };
+      },
+      delay: async () => {},
+    };
+
+    await autoUpgradeOne(entry, false, deps);
+
+    assert.equal(abortedName, "conflict-mind");
+    assert.match(deliveredBody ?? "", /SOUL\.md/);
+    assert.match(deliveredBody ?? "", /package\.json/);
+    const blocked = getUpgradeBlocked("conflict-mind");
+    assert.ok(blocked, "should record a blocked entry");
+    assert.match(blocked!.reason, /merge conflicts/);
+  });
+
+  it("thrown error: retries exactly once, then records blocked and sends no event", async () => {
+    const entry = makeEntry({ name: "retry-mind" });
+    let attempts = 0;
+    let eventSent = false;
+    let delayMs: number | undefined;
+    const deps: AutoUpgradeOneDeps = {
+      isRunning: () => false,
+      runUpgrade: async () => {
+        attempts++;
+        throw new Error("transient git failure");
+      },
+      abortUpgrade: async () => {},
+      deliverEvent: async () => {
+        eventSent = true;
+        return { delivered: true };
+      },
+      delay: async (ms) => {
+        delayMs = ms;
+      },
+    };
+
+    await autoUpgradeOne(entry, false, deps);
+
+    assert.equal(attempts, 2, "should retry exactly once (two total attempts)");
+    assert.equal(eventSent, false, "transient errors should not notify the mind");
+    assert.ok(delayMs && delayMs > 0, "should delay before the retry");
+    const blocked = getUpgradeBlocked("retry-mind");
+    assert.ok(blocked, "should record a blocked entry");
+    assert.match(blocked!.reason, /transient git failure/);
+  });
+
+  it("sleeping mind: never restarts it, even if it was running", async () => {
+    const entry = makeEntry({ name: "sleeping-mind" });
+    let restartArg: boolean | undefined;
+    const deps: AutoUpgradeOneDeps = {
+      isRunning: () => true, // wasRunning
+      runUpgrade: async (_name, opts) => {
+        restartArg = opts.restart;
+        return { status: "upgraded" };
+      },
+      abortUpgrade: async () => {},
+      deliverEvent: async () => ({ delivered: true }),
+      delay: async () => {},
+    };
+
+    await autoUpgradeOne(entry, /* sleeping */ true, deps);
+
+    assert.equal(restartArg, false, "a sleeping mind must never be restarted");
+  });
+});
+
+describe("formatNotification (auto-upgrade wording)", () => {
+  it("points to the manual upgrade command when the mind opted out", () => {
+    const message = formatNotification("1.2.3", null, true, "mymind", false);
+    assert.match(message, /volute mind upgrade mymind/);
+    assert.doesNotMatch(message, /applied automatically/);
+  });
+
+  it("mentions automatic upgrade when the mind has not opted out", () => {
+    const message = formatNotification("1.2.3", null, true, "mymind", true);
+    assert.match(message, /applied automatically/);
+    assert.match(message, /"upgrades": "manual"/);
+    assert.doesNotMatch(message, /volute mind upgrade mymind/);
+  });
+
+  it("omits the upgrade hint entirely when no upgrade is needed", () => {
+    const message = formatNotification("1.2.3", null, false, "mymind", true);
+    assert.doesNotMatch(message, /template update/);
+  });
+});

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -26,6 +26,10 @@ import {
   voluteSystemDir,
 } from "../packages/daemon/src/lib/mind/registry.js";
 import {
+  readVoluteConfig,
+  writeVoluteConfig,
+} from "../packages/daemon/src/lib/mind/volute-config.js";
+import {
   activity,
   deliveryQueue,
   mindHistory,
@@ -322,6 +326,26 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       createRes.status === 200 || createRes.status === 201,
       `Create mind: ${createRes.status} ${await createRes.text()}`,
     );
+
+    // Mind creation defaults `sleep.enabled` to true with a 00:00/08:00 UTC
+    // schedule (packages/daemon/src/web/api/minds.ts). If this suite runs inside
+    // that window, the daemon's SleepManager would put the shared test mind to
+    // sleep mid-run and derail unrelated assertions (running-status checks,
+    // history/notice counts). Disable the *schedule* here so the mind never
+    // auto-sleeps; tests that exercise sleep do so explicitly (POST .../sleep),
+    // which is unaffected since manual sleep doesn't check `sleep.enabled`.
+    {
+      const testMindDir = mindDir(TEST_MIND);
+      const config = readVoluteConfig(testMindDir);
+      assert.ok(config, "volute.json should exist after mind create");
+      config.sleep = { ...config.sleep, enabled: false };
+      writeVoluteConfig(testMindDir, config);
+      assert.equal(
+        readVoluteConfig(testMindDir)?.sleep?.enabled,
+        false,
+        "scheduled sleep should be disabled for the shared e2e test mind",
+      );
+    }
 
     // Install mind dependencies
     const dir = mindDir(TEST_MIND);

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -29,6 +29,7 @@ import {
   activity,
   deliveryQueue,
   mindHistory,
+  minds,
   summaries,
   systemEvents,
   turns,
@@ -188,6 +189,58 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     throw new Error(
       `No${notPid ? " new" : ""} process listening on :${port} within ${timeoutMs}ms`,
     );
+  }
+
+  function listeningPids(port: number): number[] {
+    try {
+      const out = execFileSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], {
+        encoding: "utf-8",
+      }).trim();
+      return out
+        .split("\n")
+        .filter(Boolean)
+        .map((p) => parseInt(p, 10));
+    } catch {
+      // lsof exits non-zero when nothing is listening
+      return [];
+    }
+  }
+
+  /**
+   * Wait for `port` to have no listener, reaping a lingering one if it outlasts
+   * a grace period. `npx tsx daemon.ts` hands off to a distinct `tsx`-spawned
+   * `node` grandchild that runs the actual daemon (confirmed via `ps` — this is
+   * how tsx enables its loader hooks, which must be set at process start); a
+   * SIGTERM to the outer process this test spawned does not reliably reach that
+   * grandchild, so `daemon.on("exit")` firing doesn't guarantee the port is
+   * released. Left unreaped, the orphan fails the next daemon's own bind
+   * ("port already in use") and then out-survives the test file itself.
+   */
+  async function waitForPortFree(port: number, graceMs: number): Promise<void> {
+    const deadline = Date.now() + graceMs;
+    while (Date.now() < deadline) {
+      if (listeningPids(port).length === 0) return;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    for (const pid of listeningPids(port)) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {}
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+    for (const pid of listeningPids(port)) {
+      process.stderr.write(
+        `[test] port ${port} still held by pid ${pid} after SIGTERM — SIGKILL\n`,
+      );
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+    }
+    await new Promise((r) => setTimeout(r, 500));
+    const remaining = listeningPids(port);
+    if (remaining.length > 0) {
+      throw new Error(`port ${port} still has listener(s) ${remaining.join(",")} after SIGKILL`);
+    }
   }
 
   /** Poll the daemon API until the test mind reports status "running". */
@@ -1315,6 +1368,127 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       `Cleanup abort: ${abortRes.status} ${await abortRes.clone().text()}`,
     );
     assert.ok(!existsSync(worktreeDir), "worktree should be gone after abort");
+  });
+
+  it("auto-upgrade: a stale running mind is upgraded automatically on daemon startup", {
+    timeout: 240000,
+  }, async (t) => {
+    await ensureTestMind();
+    const dir = mindDir(TEST_MIND);
+    const serverPath = resolve(dir, "src", "server.ts");
+    const db = await getDb();
+
+    // Snapshot state this test is about to mutate, so it can always be put back —
+    // even if the test itself fails or times out partway through — rather than
+    // leaking a marked-up server.ts / stale template_hash into later tests that
+    // reuse this same mind (e.g. the last-known-good test).
+    const originalSource = readFileSync(serverPath, "utf-8");
+    const originalEntry = await findMind(TEST_MIND);
+    const originalTemplateHash = originalEntry?.templateHash ?? null;
+    t.after(async () => {
+      writeFileSync(serverPath, originalSource);
+      await db
+        .update(minds)
+        .set({ template_hash: originalTemplateHash })
+        .where(eq(minds.name, TEST_MIND));
+      // Restart (not just start): the marked-up src/ this test committed during
+      // the merge is now the mind's git HEAD, so a plain revert of the working
+      // tree alone leaves that commit behind. Last-known-good recovery restores
+      // src/ from HEAD on a broken restart (see last-known-good.ts), so a later
+      // test's rollback would resurrect the marker straight out of history. A
+      // successful restart on this now-clean working tree makes the daemon call
+      // commitSrcChanges() itself, advancing HEAD past the marker commit — the
+      // same way a real successful restart establishes a new known-good baseline.
+      await daemonRequest(`/api/minds/${TEST_MIND}/restart`, { method: "POST" }).catch(() => {});
+    });
+
+    // Start the mind and wait for it to be running — the auto-upgrade pass must
+    // see it as previously-running so it restarts the mind after the merge (the
+    // "never call runUpgrade with restart:false on a running mind" footgun).
+    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    assert.ok(
+      startRes.status === 200 || startRes.status === 409,
+      `Start: expected 200 or 409, got ${startRes.status}`,
+    );
+    await waitForMindRunning();
+
+    // Make the mind stale: drift its on-disk template copy AND clear the stored
+    // template_hash — isTemplateStale's fast path trusts a matching stored hash,
+    // so a stale hash left in place would mask the on-disk drift.
+    const marker = "// auto-upgrade-e2e-marker\n";
+    writeFileSync(serverPath, `${originalSource}${marker}`);
+    await db.update(minds).set({ template_hash: null }).where(eq(minds.name, TEST_MIND));
+
+    // Restart the daemon (simulates `volute down && volute up`) so the
+    // post-startup auto-upgrade pass runs fresh. `daemon.kill()`/`.on("exit")`
+    // target the `npx` process this test spawned, but `npx tsx ...` hands off
+    // to `tsx` as a distinct child — npx exiting doesn't guarantee the actual
+    // daemon (and its listening socket) is gone yet. Give shutdown a generous
+    // budget for CI load, then wait for the daemon's own port to actually free
+    // before spawning the replacement; otherwise the new daemon's own bind can
+    // fail with EADDRINUSE ("port already in use") and exit immediately, and
+    // the mind never gets auto-upgraded. (The mind's own port doesn't need the
+    // same care — manager.startMind() already self-heals a stale process
+    // holding a mind's port before starting it.)
+    daemon.kill("SIGTERM");
+    await new Promise<void>((res) => {
+      daemon.on("exit", () => res());
+      setTimeout(() => {
+        try {
+          daemon.kill("SIGKILL");
+        } catch {}
+        res();
+      }, 20000);
+    });
+    await waitForPortFree(PORT, 20000);
+
+    daemon = spawn(
+      "npx",
+      ["tsx", "packages/daemon/src/daemon.ts", "--port", String(PORT), "--foreground"],
+      {
+        cwd: process.cwd(),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...cleanEnv,
+          VOLUTE_DAEMON_TOKEN: TOKEN,
+          VOLUTE_BASE_PORT: String(MIND_BASE_PORT),
+        },
+      },
+    );
+    daemon.stderr?.on("data", (data: Buffer) => {
+      process.stderr.write(`[daemon] ${data}`);
+    });
+
+    await waitForHealth();
+
+    // Poll until the auto-upgrade pass has merged the template update and
+    // restarted the mind.
+    const deadline = Date.now() + 120000;
+    let upgraded = false;
+    let lastStatus: { status?: string; templateStale?: boolean } = {};
+    while (Date.now() < deadline) {
+      const res = await daemonRequest(`/api/minds/${TEST_MIND}`);
+      lastStatus = (await res.json()) as { status?: string; templateStale?: boolean };
+      if (lastStatus.status === "running" && lastStatus.templateStale === false) {
+        upgraded = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    assert.ok(
+      upgraded,
+      `mind should be auto-upgraded and running within budget; last status: ${JSON.stringify(lastStatus)}`,
+    );
+
+    // The merge must preserve local drift rather than overwrite it.
+    const finalContent = readFileSync(serverPath, "utf-8");
+    assert.ok(
+      finalContent.includes(marker.trim()),
+      "auto-upgrade should merge, not overwrite, the mind's local changes",
+    );
+
+    // Stop the mind so later tests see the usual state.
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("unified chat: send via /api/v1/chat", async () => {

--- a/test/upgrade-lock.test.ts
+++ b/test/upgrade-lock.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { withUpgradeLock } from "../packages/daemon/src/lib/mind/upgrade.js";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("withUpgradeLock", () => {
+  it("serializes concurrent operations for the same mind name", async () => {
+    const order: string[] = [];
+    const first = deferred<void>();
+
+    const p1 = withUpgradeLock("mind-a", async () => {
+      order.push("start-1");
+      await first.promise;
+      order.push("end-1");
+    });
+
+    // Let p1 actually start — the lock is initially free.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.deepEqual(order, ["start-1"]);
+
+    const p2 = withUpgradeLock("mind-a", async () => {
+      order.push("start-2");
+    });
+
+    // p2 must stay queued behind p1, not start early.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.deepEqual(order, ["start-1"]);
+
+    first.resolve();
+    await Promise.all([p1, p2]);
+    assert.deepEqual(order, ["start-1", "end-1", "start-2"]);
+  });
+
+  it("does not serialize operations for different mind names", async () => {
+    const order: string[] = [];
+    const first = deferred<void>();
+
+    const p1 = withUpgradeLock("mind-a2", async () => {
+      order.push("a-start");
+      await first.promise;
+      order.push("a-end");
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const p2 = withUpgradeLock("mind-b2", async () => {
+      order.push("b-start");
+    });
+    await p2;
+
+    // A different mind's op runs before mind-a2's finishes — different keys don't block.
+    assert.deepEqual(order, ["a-start", "b-start"]);
+    first.resolve();
+    await p1;
+  });
+
+  it("a rejected operation does not block the next queued operation for the same mind", async () => {
+    const order: string[] = [];
+
+    const p1 = withUpgradeLock("mind-c", async () => {
+      order.push("1");
+      throw new Error("boom");
+    });
+
+    const p2 = withUpgradeLock("mind-c", async () => {
+      order.push("2");
+    });
+
+    await assert.rejects(p1, /boom/);
+    await p2;
+    assert.deepEqual(order, ["1", "2"]);
+  });
+
+  it("returns the operation's resolved value", async () => {
+    const result = await withUpgradeLock("mind-d", async () => 42);
+    assert.equal(result, 42);
+  });
+});


### PR DESCRIPTION
Builds on #776. After daemon startup, a serialized background pass auto-upgrades minds whose template is stale — so hosts stop chasing every mind after each Volute update, and minds that never touch their framework code stay current without doing anything.

**Consent model:** auto by default; a mind opts out with `"upgrades": "manual"` in `home/.config/volute.json` (documented in each template's mind-facing mechanics doc). Version notifications tell auto minds the upgrade is automatic (and how to opt out); opted-out minds keep the run-it-yourself instruction, delivered before the pass runs.

**How it runs:**
- Serialized (one mind at a time — no npm/git I/O storms on slow-storage hosts), after startup completes, fire-and-forget off the startup path
- Sleeping/stopped minds are upgraded in place without starting them (sleeping first); they wake into the new template with the upgraded notice pending
- Eligibility: regular minds only (no seeds/variants/spirit), stale per `isTemplateStale`, not opted out
- Conflicts → clean abort (nothing left behind), system event to the mind with the conflicted files and manual path, and a persistent `upgradeBlocked` reason surfaced to hosts in the minds API, web sidebar badge, and `volute mind list`/`status`
- Transient errors → one retry after 5s, then recorded + logged; one mind's failure never stops the walk
- Per-mind upgrade lock serializes the auto-pass against concurrent manual `volute mind upgrade` calls (and any double-invocation), closing a pre-existing race

Tests: 17 new unit tests (eligibility/ordering, blocked-record pruning, notification wording, conflict/retry/sleeping branches with injected deps, upgrade-lock semantics) + a daemon-e2e test that makes a mind stale, restarts the daemon, and verifies the mind is auto-upgraded with its own src modification surviving the merge. Full suite 2946/2946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)