### PR TITLE
fix: ack folded messages by identity to stop duplicate event delivery on rotation

### DIFF
--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -607,10 +607,13 @@ export function createMind(options: {
               const pending = session.channel.recover();
               const oldMessageIds = session.messageIds;
               session.channel = createMessageChannel();
+              // Starts from [] — nothing can race into this fresh channel/messageIds
+              // before the next line runs (single-threaded, no await in between).
               session.messageIds = relockstepMessageIds(
                 pending,
                 oldMessageIds,
                 session.channel.push,
+                [],
               );
               continue; // restart the stream loop on the rotated session
             }
@@ -757,18 +760,16 @@ export function createMind(options: {
       log("mind", `session "${session.name}": error reaping SDK subprocess:`, err),
     );
     // Nothing should have raced in (isSessionReapable checked isEmpty), but if it
-    // did, re-dispatch into a fresh session so no input is dropped. Same lockstep +
-    // marker treatment as the rotation path (#764) — see relockstepMessageIds above.
+    // did, re-dispatch into a fresh session so no input is dropped. Same marker
+    // treatment as the rotation path (#764) — see relockstepMessageIds above.
     // getOrCreateSession() can return a session an inbound message already raced
     // into during the reapSessionQuery() await above (it pushed its own entry into
-    // fresh.messageIds via the normal handler path) — append, don't overwrite, or
-    // that racing message's id is silently discarded.
+    // fresh.messageIds via the normal handler path) — relockstepMessageIds appends
+    // onto fresh.messageIds rather than replacing it, so that entry survives.
     const pending = session.channel.recover();
     if (pending.length > 0) {
       const fresh = getOrCreateSession(session.name);
-      fresh.messageIds.push(
-        ...relockstepMessageIds(pending, session.messageIds, fresh.channel.push),
-      );
+      relockstepMessageIds(pending, session.messageIds, fresh.channel.push, fresh.messageIds);
     }
   }
 

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -759,10 +759,16 @@ export function createMind(options: {
     // Nothing should have raced in (isSessionReapable checked isEmpty), but if it
     // did, re-dispatch into a fresh session so no input is dropped. Same lockstep +
     // marker treatment as the rotation path (#764) — see relockstepMessageIds above.
+    // getOrCreateSession() can return a session an inbound message already raced
+    // into during the reapSessionQuery() await above (it pushed its own entry into
+    // fresh.messageIds via the normal handler path) — append, don't overwrite, or
+    // that racing message's id is silently discarded.
     const pending = session.channel.recover();
     if (pending.length > 0) {
       const fresh = getOrCreateSession(session.name);
-      fresh.messageIds = relockstepMessageIds(pending, session.messageIds, fresh.channel.push);
+      fresh.messageIds.push(
+        ...relockstepMessageIds(pending, session.messageIds, fresh.channel.push),
+      );
     }
   }
 

--- a/templates/claude/src/agent.ts
+++ b/templates/claude/src/agent.ts
@@ -23,6 +23,7 @@ import { createPreCompactHook } from "./lib/hooks/pre-compact.js";
 import { createReplyInstructionsHook } from "./lib/hooks/reply-instructions.js";
 import { log } from "./lib/logger.js";
 import { createMessageChannel } from "./lib/message-channel.js";
+import { relockstepMessageIds } from "./lib/recover.js";
 import { buildSeededNote, type SeedCause } from "./lib/seed-note.js";
 import {
   isSessionReapable,
@@ -39,7 +40,7 @@ import {
 import { createSessionStore } from "./lib/session-store.js";
 import type { EffortLevel, ThinkingConfig } from "./lib/startup.js";
 import { loadPrompts, renderCompactionWarning, type SubagentConfig } from "./lib/startup.js";
-import { consumeStream } from "./lib/stream-consumer.js";
+import { consumeStream, type MessageIdEntry } from "./lib/stream-consumer.js";
 import type {
   HandlerMeta,
   HandlerResolver,
@@ -54,8 +55,9 @@ type Session = {
   name: string;
   channel: ReturnType<typeof createMessageChannel>;
   listeners: Set<Listener>;
-  messageIds: (string | undefined)[];
+  messageIds: MessageIdEntry[];
   currentMessageId?: string;
+  currentSeq?: number;
   currentQuery?: ReturnType<typeof query>;
   messageChannels: Map<string, { channel: string; sender?: string }>;
   replyInstructionsFired: boolean;
@@ -432,13 +434,13 @@ export function createMind(options: {
         const warning = compactionMessage().replaceAll("${cutoff}", cutoffLabel);
         session.rotationPhase =
           session.currentMessageId !== undefined ? "warned" : "rotateAfterTurn";
-        session.messageIds.push(undefined);
-        session.channel.push({
+        const seq = session.channel.push({
           type: "user",
           session_id: "",
           message: { role: "user", content: [{ type: "text", text: warning }] },
           parent_tool_use_id: null,
         });
+        session.messageIds.push({ id: undefined, seq });
       }
 
       // PreCompact backstop: first fire warns + pins + enters the rotation machine
@@ -457,10 +459,11 @@ export function createMind(options: {
           if (!session.name.startsWith("new-")) sessionStore.save(session.name, id);
         },
         broadcast: (event: VoluteEvent) => broadcastToSession(session, event),
+        // Identity-based ack — stream-consumer.ts calls this once per message the
+        // just-finished turn covers (its own driving message, plus any folded in
+        // mid-run) so none of them strand in the channel's in-flight set (#764).
+        ack: (seq: number) => session.channel.ack(seq),
         onTurnEnd: async () => {
-          // This turn's message is fully processed — drop it from the channel's
-          // in-flight set so a later compaction abort won't re-feed it.
-          session.channel.ack();
           session.lastActivityAt = Date.now();
           // A turn resolved — the seeded note's injection had its chance to land
           // (the pre-prompt hook ran and wasn't cancelled by an interrupt), so stop
@@ -602,8 +605,13 @@ export function createMind(options: {
               // (the wrap-up warning plus anything that arrived mid-turn) so nothing is
               // dropped when the killed subprocess takes its buffer with it.
               const pending = session.channel.recover();
+              const oldMessageIds = session.messageIds;
               session.channel = createMessageChannel();
-              for (const msg of pending) session.channel.push(msg);
+              session.messageIds = relockstepMessageIds(
+                pending,
+                oldMessageIds,
+                session.channel.push,
+              );
               continue; // restart the stream loop on the rotated session
             }
             throw err; // rethrow non-compaction errors
@@ -749,11 +757,12 @@ export function createMind(options: {
       log("mind", `session "${session.name}": error reaping SDK subprocess:`, err),
     );
     // Nothing should have raced in (isSessionReapable checked isEmpty), but if it
-    // did, re-dispatch into a fresh session so no input is dropped.
+    // did, re-dispatch into a fresh session so no input is dropped. Same lockstep +
+    // marker treatment as the rotation path (#764) — see relockstepMessageIds above.
     const pending = session.channel.recover();
     if (pending.length > 0) {
       const fresh = getOrCreateSession(session.name);
-      for (const msg of pending) fresh.channel.push(msg);
+      fresh.messageIds = relockstepMessageIds(pending, session.messageIds, fresh.channel.push);
     }
   }
 
@@ -841,13 +850,13 @@ export function createMind(options: {
 
         // Push message into SDK
         session.lastActivityAt = Date.now();
-        session.messageIds.push(meta.messageId);
-        session.channel.push({
+        const seq = session.channel.push({
           type: "user",
           session_id: "",
           message: { role: "user", content: toSDKContent(content) },
           parent_tool_use_id: null,
         });
+        session.messageIds.push({ id: meta.messageId, seq });
 
         return () => {
           if (filteredListener) session.listeners.delete(filteredListener);

--- a/templates/claude/src/lib/message-channel.ts
+++ b/templates/claude/src/lib/message-channel.ts
@@ -3,6 +3,15 @@ import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 /** A queued/in-flight message paired with the sequence number that identifies it. */
 export type ChannelEntry = { msg: SDKUserMessage; seq: number };
 
+// Module-scoped, not per-channel: rotation and the idle reaper both replace a
+// session's channel with a fresh instance while carrying seqs forward (relocking
+// old entries to new ones — see relockstepMessageIds in recover.ts). A per-instance
+// counter would restart at 0 on every fresh channel, so a seq minted by one channel
+// generation could collide with one minted by another; a single global counter makes
+// every seq unique for the process's lifetime, so a stale seq can never be mistaken
+// for a different message.
+let nextSeq = 0;
+
 export type MessageChannel = {
   /** Returns the sequence number minted for this message — the identity `ack()` needs. */
   push: (msg: SDKUserMessage) => number;
@@ -41,7 +50,6 @@ export function createMessageChannel(): MessageChannel {
   const inFlight: ChannelEntry[] = [];
   let resolve: ((value: IteratorResult<SDKUserMessage>) => void) | null = null;
   let closed = false;
-  let nextSeq = 0;
 
   function deliver(entry: ChannelEntry): IteratorResult<SDKUserMessage> {
     inFlight.push(entry);

--- a/templates/claude/src/lib/message-channel.ts
+++ b/templates/claude/src/lib/message-channel.ts
@@ -1,16 +1,25 @@
 import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 
+/** A queued/in-flight message paired with the sequence number that identifies it. */
+export type ChannelEntry = { msg: SDKUserMessage; seq: number };
+
 export type MessageChannel = {
-  push: (msg: SDKUserMessage) => void;
-  /** Acknowledge that the oldest in-flight message's turn has completed. */
-  ack: () => void;
+  /** Returns the sequence number minted for this message — the identity `ack()` needs. */
+  push: (msg: SDKUserMessage) => number;
+  /**
+   * Acknowledge that the message with this `seq` has completed its turn. Identity-based
+   * (not positional): the SDK folds messages that arrive mid-run into the active run, so
+   * a turn's `result` can cover more than just the oldest in-flight message — see the
+   * caller in stream-consumer.ts.
+   */
+  ack: (seq: number) => void;
   /**
    * Return every message that has not been fully processed — those delivered to
    * the consumer but not yet acked (their turn never finished) followed by those
-   * still queued — and reset the channel. Used to re-feed the stream after a
-   * compaction abort so in-flight input is never lost.
+   * still queued — paired with their `seq`, and reset the channel. Used to re-feed
+   * the stream after a compaction abort so in-flight input is never lost.
    */
-  recover: () => SDKUserMessage[];
+  recover: () => ChannelEntry[];
   /**
    * Terminate the input iterable: resolve any pending `next()` with `done: true`
    * and make subsequent `next()` calls return done. The SDK sees end-of-input and
@@ -23,33 +32,44 @@ export type MessageChannel = {
 };
 
 export function createMessageChannel(): MessageChannel {
-  const queue: SDKUserMessage[] = [];
+  const queue: ChannelEntry[] = [];
   // Messages handed to the consumer (the SDK's read-ahead) whose turn has not yet
   // completed. The SDK's streamInput loop pulls messages eagerly and writes them
   // to the CLI subprocess, so once delivered they no longer live in `queue`. We
   // retain them here so a compaction abort — which kills that subprocess — can
   // re-feed the unprocessed ones instead of dropping them.
-  const inFlight: SDKUserMessage[] = [];
+  const inFlight: ChannelEntry[] = [];
   let resolve: ((value: IteratorResult<SDKUserMessage>) => void) | null = null;
   let closed = false;
+  let nextSeq = 0;
 
-  function deliver(msg: SDKUserMessage): IteratorResult<SDKUserMessage> {
-    inFlight.push(msg);
-    return { value: msg, done: false };
+  function deliver(entry: ChannelEntry): IteratorResult<SDKUserMessage> {
+    inFlight.push(entry);
+    return { value: entry.msg, done: false };
   }
 
   return {
     push(msg: SDKUserMessage) {
+      const entry: ChannelEntry = { msg, seq: nextSeq++ };
       if (resolve) {
         const r = resolve;
         resolve = null;
-        r(deliver(msg));
+        r(deliver(entry));
       } else {
-        queue.push(msg);
+        queue.push(entry);
       }
+      return entry.seq;
     },
-    ack() {
-      inFlight.shift();
+    ack(seq: number) {
+      let i = inFlight.findIndex((e) => e.seq === seq);
+      if (i !== -1) {
+        inFlight.splice(i, 1);
+        return;
+      }
+      // Defensive: shouldn't normally be in the queue when acked, but remove it
+      // there too rather than leave a stranded entry if it somehow is.
+      i = queue.findIndex((e) => e.seq === seq);
+      if (i !== -1) queue.splice(i, 1);
     },
     recover() {
       // Resolve any pending iterator wait with done:true so it doesn't

--- a/templates/claude/src/lib/recover.ts
+++ b/templates/claude/src/lib/recover.ts
@@ -14,18 +14,16 @@ export const RECOVERED_MESSAGE_NOTE =
   "have handled it — check your recent work (e.g. journal, files) before repeating anything.";
 
 export function markRecovered(msg: SDKUserMessage): SDKUserMessage {
-  const marker = { type: "text" as const, text: RECOVERED_MESSAGE_NOTE };
   const content = msg.message.content;
-  return {
-    ...msg,
-    message: {
-      ...msg.message,
-      content:
-        typeof content === "string"
-          ? [marker, { type: "text" as const, text: content }]
-          : [marker, ...content],
-    },
-  };
+  const blocks = typeof content === "string" ? [{ type: "text" as const, text: content }] : content;
+  // A message can be recovered twice (consecutive rotations, up to
+  // MAX_CONSECUTIVE_ROTATIONS) — don't stack the note on each pass.
+  const first = blocks[0];
+  if (first && "type" in first && first.type === "text" && first.text === RECOVERED_MESSAGE_NOTE) {
+    return { ...msg, message: { ...msg.message, content: blocks } };
+  }
+  const marker = { type: "text" as const, text: RECOVERED_MESSAGE_NOTE };
+  return { ...msg, message: { ...msg.message, content: [marker, ...blocks] } };
 }
 
 /**
@@ -33,17 +31,11 @@ export function markRecovered(msg: SDKUserMessage): SDKUserMessage {
  * lockstep with it. Each entry's `id` carries over — matched by its *old* `seq` —
  * to the *new* seq the fresh channel mints on push, so the next turn's
  * currentMessageId/channel routing isn't corrupted by stale or missing ids (#764).
- *
- * Depends on `oldMessageIds` covering every id in `pending`: it relies on the current
- * turn (session.currentMessageId/currentSeq — not part of session.messageIds) being
- * complete and already acked by the time `recover()` runs, so its entry is absent from
- * both `pending` and `oldMessageIds` and never needs a match. That holds today because
- * the only abort site (agent.ts, in onTurnEnd) fires after the result handler has
- * cleared currentMessageId/currentSeq and acked the turn — abort never happens
- * mid-turn. If a future change (e.g. a hung-turn watchdog) aborts mid-turn, that
- * in-flight message would have no entry in oldMessageIds and would silently lose its
- * `id` here (see the `idBySeq.get` fallback to `undefined` below) — no test would catch
- * it, since the mismatch is silent misrouting, not a thrown error.
+ * A `pending` entry with no match in `oldMessageIds` gets `id: undefined` (see the
+ * `idBySeq.get` fallback below) rather than throwing — safe because `seq` is now
+ * globally unique (message-channel.ts), so this can only happen if `oldMessageIds`
+ * itself was incomplete, and losing routing info for one message beats losing the
+ * message.
  */
 export function relockstepMessageIds(
   pending: ChannelEntry[],

--- a/templates/claude/src/lib/recover.ts
+++ b/templates/claude/src/lib/recover.ts
@@ -43,12 +43,18 @@ export function markRecovered(msg: SDKUserMessage): SDKUserMessage {
  * below) rather than throwing — safe because `seq` is now globally unique
  * (message-channel.ts), so this can only happen if `oldMessageIds` itself was
  * incomplete, and losing routing info for one message beats losing the message.
+ *
+ * `existingMessageIds` has no default — deliberately. `= []` would let a call site
+ * omit it and get back a fresh array to assign over, which is exactly the #764
+ * clobber: silently discarding whatever the target array already held. Making it
+ * required turns that omission into a compile error at every call site, including
+ * ones written later.
  */
 export function relockstepMessageIds(
   pending: ChannelEntry[],
   oldMessageIds: MessageIdEntry[],
   push: (msg: SDKUserMessage) => number,
-  existingMessageIds: MessageIdEntry[] = [],
+  existingMessageIds: MessageIdEntry[],
   transform: (msg: SDKUserMessage) => SDKUserMessage = markRecovered,
 ): MessageIdEntry[] {
   const idBySeq = new Map(oldMessageIds.map((e) => [e.seq, e.id]));

--- a/templates/claude/src/lib/recover.ts
+++ b/templates/claude/src/lib/recover.ts
@@ -11,7 +11,8 @@ import type { MessageIdEntry } from "./stream-consumer.js";
  */
 export const RECOVERED_MESSAGE_NOTE =
   "Note: this message is being redelivered after a session interruption. You may already " +
-  "have handled it — check your recent work (e.g. journal, files) before repeating anything.";
+  "have handled it — check your recent work (e.g. journal, files, messages you've already " +
+  "sent) before repeating anything.";
 
 export function markRecovered(msg: SDKUserMessage): SDKUserMessage {
   const content = msg.message.content;

--- a/templates/claude/src/lib/recover.ts
+++ b/templates/claude/src/lib/recover.ts
@@ -1,0 +1,59 @@
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { ChannelEntry } from "./message-channel.js";
+import type { MessageIdEntry } from "./stream-consumer.js";
+
+/**
+ * `recover()` returns messages the channel can't prove were unprocessed — a genuinely
+ * unfinished turn looks identical to a stranded, already-completed one would have before
+ * #764's ack fix. Mark every re-pushed message so the mind can check its own record
+ * before redoing work: fail toward noise (a spurious note is cosmetic and self-correcting)
+ * rather than silence (a missing one is invisible and produces a false permanent record).
+ */
+export const RECOVERED_MESSAGE_NOTE =
+  "Note: this message is being redelivered after a session interruption. You may already " +
+  "have handled it — check your recent work (e.g. journal, files) before repeating anything.";
+
+export function markRecovered(msg: SDKUserMessage): SDKUserMessage {
+  const marker = { type: "text" as const, text: RECOVERED_MESSAGE_NOTE };
+  const content = msg.message.content;
+  return {
+    ...msg,
+    message: {
+      ...msg.message,
+      content:
+        typeof content === "string"
+          ? [marker, { type: "text" as const, text: content }]
+          : [marker, ...content],
+    },
+  };
+}
+
+/**
+ * Re-push `recover()`'s output into a fresh channel and rebuild `messageIds` in
+ * lockstep with it. Each entry's `id` carries over — matched by its *old* `seq` —
+ * to the *new* seq the fresh channel mints on push, so the next turn's
+ * currentMessageId/channel routing isn't corrupted by stale or missing ids (#764).
+ *
+ * Depends on `oldMessageIds` covering every id in `pending`: it relies on the current
+ * turn (session.currentMessageId/currentSeq — not part of session.messageIds) being
+ * complete and already acked by the time `recover()` runs, so its entry is absent from
+ * both `pending` and `oldMessageIds` and never needs a match. That holds today because
+ * the only abort site (agent.ts, in onTurnEnd) fires after the result handler has
+ * cleared currentMessageId/currentSeq and acked the turn — abort never happens
+ * mid-turn. If a future change (e.g. a hung-turn watchdog) aborts mid-turn, that
+ * in-flight message would have no entry in oldMessageIds and would silently lose its
+ * `id` here (see the `idBySeq.get` fallback to `undefined` below) — no test would catch
+ * it, since the mismatch is silent misrouting, not a thrown error.
+ */
+export function relockstepMessageIds(
+  pending: ChannelEntry[],
+  oldMessageIds: MessageIdEntry[],
+  push: (msg: SDKUserMessage) => number,
+  transform: (msg: SDKUserMessage) => SDKUserMessage = markRecovered,
+): MessageIdEntry[] {
+  const idBySeq = new Map(oldMessageIds.map((e) => [e.seq, e.id]));
+  return pending.map((entry) => ({
+    id: idBySeq.get(entry.seq),
+    seq: push(transform(entry.msg)),
+  }));
+}

--- a/templates/claude/src/lib/recover.ts
+++ b/templates/claude/src/lib/recover.ts
@@ -27,25 +27,36 @@ export function markRecovered(msg: SDKUserMessage): SDKUserMessage {
 }
 
 /**
- * Re-push `recover()`'s output into a fresh channel and rebuild `messageIds` in
- * lockstep with it. Each entry's `id` carries over — matched by its *old* `seq` —
- * to the *new* seq the fresh channel mints on push, so the next turn's
- * currentMessageId/channel routing isn't corrupted by stale or missing ids (#764).
- * A `pending` entry with no match in `oldMessageIds` gets `id: undefined` (see the
- * `idBySeq.get` fallback below) rather than throwing — safe because `seq` is now
- * globally unique (message-channel.ts), so this can only happen if `oldMessageIds`
- * itself was incomplete, and losing routing info for one message beats losing the
- * message.
+ * Re-push `recover()`'s output into a fresh channel and append the result onto
+ * `existingMessageIds` — mutated in place and returned, rather than replacing it.
+ * That's not incidental: `existingMessageIds` may already hold an entry for a
+ * message that raced in and was pushed into the SAME fresh channel/messageIds
+ * while `recover()` was still pending (the idle reaper awaits the SDK subprocess's
+ * shutdown before recovering — see agent.ts). Returning a fresh array for the
+ * caller to assign over would silently discard that entry (#764) — appending
+ * in place makes that mistake impossible at the call site.
+ *
+ * Each entry's `id` carries over — matched by its *old* `seq` — to the *new* seq
+ * the fresh channel mints on push, so the next turn's currentMessageId/channel
+ * routing isn't corrupted by stale or missing ids. A `pending` entry with no
+ * match in `oldMessageIds` gets `id: undefined` (see the `idBySeq.get` fallback
+ * below) rather than throwing — safe because `seq` is now globally unique
+ * (message-channel.ts), so this can only happen if `oldMessageIds` itself was
+ * incomplete, and losing routing info for one message beats losing the message.
  */
 export function relockstepMessageIds(
   pending: ChannelEntry[],
   oldMessageIds: MessageIdEntry[],
   push: (msg: SDKUserMessage) => number,
+  existingMessageIds: MessageIdEntry[] = [],
   transform: (msg: SDKUserMessage) => SDKUserMessage = markRecovered,
 ): MessageIdEntry[] {
   const idBySeq = new Map(oldMessageIds.map((e) => [e.seq, e.id]));
-  return pending.map((entry) => ({
-    id: idBySeq.get(entry.seq),
-    seq: push(transform(entry.msg)),
-  }));
+  existingMessageIds.push(
+    ...pending.map((entry) => ({
+      id: idBySeq.get(entry.seq),
+      seq: push(transform(entry.msg)),
+    })),
+  );
+  return existingMessageIds;
 }

--- a/templates/claude/src/lib/stream-consumer.ts
+++ b/templates/claude/src/lib/stream-consumer.ts
@@ -4,10 +4,14 @@ import { log, warn } from "./logger.js";
 import { filterEvent, loadTransparencyPreset } from "./transparency.js";
 import type { VoluteEvent } from "./types.js";
 
+/** A pending message's daemon-facing id (routing/channel key) paired with its channel `seq`. */
+export type MessageIdEntry = { id: string | undefined; seq: number };
+
 export type StreamSession = {
   name: string;
-  messageIds: (string | undefined)[];
+  messageIds: MessageIdEntry[];
   currentMessageId?: string;
+  currentSeq?: number;
   messageChannels: Map<string, { channel: string; sender?: string }>;
 };
 
@@ -16,6 +20,11 @@ export type StreamCallbacks = {
   broadcast: (event: VoluteEvent) => void;
   onTurnEnd?: () => void;
   onContextTokens?: (tokens: number) => void;
+  /**
+   * Acknowledge the message channel entry with this `seq` — its turn is done (either
+   * it drove this turn directly, or it was folded into it; see the `result` handler).
+   */
+  ack: (seq: number) => void;
 };
 
 // Loaded once at startup — mind restarts on config changes
@@ -48,7 +57,9 @@ export async function consumeStream(
   let preTurnPending = 0;
   for await (const msg of stream) {
     if (session.currentMessageId === undefined) {
-      session.currentMessageId = session.messageIds.shift();
+      const entry = session.messageIds.shift();
+      session.currentMessageId = entry?.id;
+      session.currentSeq = entry?.seq;
       preTurnPending = session.messageIds.length;
     }
     if ("session_id" in msg && msg.session_id) {
@@ -123,14 +134,20 @@ export async function consumeStream(
       if (session.currentMessageId) {
         session.messageChannels.delete(session.currentMessageId);
       }
+      // Ack this turn's driving message, identified by seq (not position — see
+      // message-channel.ts). Without this the channel's inFlight set strands an
+      // entry per turn, which gets replayed verbatim on the next rotation (#764).
+      if (session.currentSeq !== undefined) callbacks.ack(session.currentSeq);
       // Prune every id folded into this turn — the ones pushed after it started
       // — not just currentMessageId. The SDK folds mid-run arrivals into the
       // active run (they never see a result of their own), and a stranded entry
       // would be shifted in as the NEXT turn's id, tagging that turn's rows with
       // the wrong channel (#700). Ids queued before the turn started stay: each
-      // still gets a run (and result) of its own.
-      for (const id of session.messageIds.splice(preTurnPending)) {
-        if (id !== undefined) session.messageChannels.delete(id);
+      // still gets a run (and result) of its own. Ack each folded entry too — same
+      // reasoning as above, applied to every message the fold absorbed.
+      for (const entry of session.messageIds.splice(preTurnPending)) {
+        if (entry.id !== undefined) session.messageChannels.delete(entry.id);
+        callbacks.ack(entry.seq);
       }
       log("mind", `session "${session.name}": turn done`);
       // Log any error messages from the result
@@ -154,6 +171,7 @@ export async function consumeStream(
       callbacks.broadcast({ type: "done" });
       emit(session, { type: "done" });
       session.currentMessageId = undefined;
+      session.currentSeq = undefined;
       callbacks.onTurnEnd?.();
     }
   }

--- a/test/agent-rotation-lockstep.test.ts
+++ b/test/agent-rotation-lockstep.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { composeTemplate } from "../packages/daemon/src/lib/template/template.js";
+
+/**
+ * Regression guard for #764: a duplicate event delivered across an in-place session
+ * rotation.
+ *
+ * A scheduled heartbeat was fully processed by a mind, then the session rotated at
+ * the context limit — and the same event prompt was re-submitted verbatim on the new
+ * session, because a message folded into the wrap-up turn was never acked and got
+ * replayed from `channel.recover()`. Fixing the ack (see template-stale-message-
+ * channels.test.ts and message-channel.test.ts) means recover() only ever returns
+ * genuinely-unfinished messages, but agent.ts's rotation path re-pushes those into a
+ * FRESH channel — which mints its own seq numbers from zero. Without relockstepping,
+ * `session.messageIds` (the daemon-facing id per pending message, used for
+ * channel/sender routing) drifts out of sync with the new channel's identities.
+ *
+ * These tests drive `relockstepMessageIds`, the real composed function agent.ts uses
+ * at both re-push sites (rotation, idle-reap racing).
+ */
+
+const templatesRoot = resolvePath(fileURLToPath(import.meta.url), "../../templates");
+const composed: string[] = [];
+
+after(() => {
+  for (const dir of composed) rmSync(dir, { recursive: true, force: true });
+});
+
+function fakeMsg(text: string) {
+  return {
+    type: "user" as const,
+    session_id: "",
+    message: { role: "user" as const, content: [{ type: "text" as const, text }] },
+    parent_tool_use_id: null,
+  };
+}
+
+describe("claude template: relockstepMessageIds", () => {
+  let relockstepMessageIds: typeof import("../templates/claude/src/lib/recover.js")["relockstepMessageIds"];
+
+  before(async () => {
+    const dir = composeTemplate(templatesRoot, "claude").composedDir;
+    composed.push(dir);
+    ({ relockstepMessageIds } = await import(resolvePath(dir, "src/lib/recover.js")));
+  });
+
+  it("carries each entry's id over via its old seq, remapped to the new channel's seq", () => {
+    const oldMessageIds = [
+      { id: "m1", seq: 5 },
+      { id: undefined, seq: 6 }, // e.g. the rotation warning, which has no daemon id
+      { id: "m3", seq: 9 },
+    ];
+    const pending = [
+      { msg: fakeMsg("a"), seq: 5 },
+      { msg: fakeMsg("b"), seq: 6 },
+      { msg: fakeMsg("c"), seq: 9 },
+    ];
+
+    let nextSeq = 100;
+    const pushedMsgs: unknown[] = [];
+    const push = (msg: unknown) => {
+      pushedMsgs.push(msg);
+      return nextSeq++;
+    };
+
+    const result = relockstepMessageIds(pending, oldMessageIds, push, (m) => m);
+
+    assert.deepEqual(
+      result.map((e) => e.id),
+      ["m1", undefined, "m3"],
+      "ids must carry over in the original order, matched by seq (not position)",
+    );
+    assert.deepEqual(
+      result.map((e) => e.seq),
+      [100, 101, 102],
+      "each entry gets the NEW channel's seq, not the stale old one",
+    );
+    assert.equal(pushedMsgs.length, 3, "every pending message is re-pushed into the new channel");
+  });
+
+  it("matches by seq, not array position — an out-of-order oldMessageIds still resolves correctly", () => {
+    // oldMessageIds need not be in the same order recover() returns pending in (it
+    // shouldn't happen given how the two arrays are built, but the match must not
+    // silently rely on position).
+    const oldMessageIds = [
+      { id: "later", seq: 20 },
+      { id: "earlier", seq: 10 },
+    ];
+    const pending = [
+      { msg: fakeMsg("x"), seq: 10 },
+      { msg: fakeMsg("y"), seq: 20 },
+    ];
+    const push = (() => {
+      let n = 0;
+      return () => n++;
+    })();
+
+    const result = relockstepMessageIds(pending, oldMessageIds, push, (m) => m);
+    assert.deepEqual(
+      result.map((e) => e.id),
+      ["earlier", "later"],
+    );
+  });
+
+  it("defaults to undefined id for a pending entry with no matching old seq", () => {
+    // Defensive: should never happen if push sites stay in lockstep, but a missing
+    // match must not throw — it should just carry no daemon id (safe default).
+    const push = (() => {
+      let n = 0;
+      return () => n++;
+    })();
+    const result = relockstepMessageIds([{ msg: fakeMsg("orphan"), seq: 999 }], [], push, (m) => m);
+    assert.deepEqual(result, [{ id: undefined, seq: 0 }]);
+  });
+
+  it("applies the transform (recovered-message marker) to every re-pushed message", () => {
+    const oldMessageIds = [{ id: "m1", seq: 1 }];
+    const pending = [{ msg: fakeMsg("original"), seq: 1 }];
+    const pushedMsgs: { message: { content: { text: string }[] } }[] = [];
+    const push = (msg: (typeof pushedMsgs)[number]) => {
+      pushedMsgs.push(msg);
+      return 0;
+    };
+    const marker = { type: "text" as const, text: "MARKED" };
+    const transform = (m: (typeof pushedMsgs)[number]) => ({
+      ...m,
+      message: { ...m.message, content: [marker, ...m.message.content] },
+    });
+
+    relockstepMessageIds(pending, oldMessageIds, push, transform);
+
+    assert.equal(pushedMsgs.length, 1);
+    assert.deepEqual(pushedMsgs[0].message.content[0], marker);
+    assert.equal(pushedMsgs[0].message.content[1].text, "original");
+  });
+});

--- a/test/agent-rotation-lockstep.test.ts
+++ b/test/agent-rotation-lockstep.test.ts
@@ -173,7 +173,7 @@ describe("claude template: relockstepMessageIds", () => {
       return pushedMsgs.length;
     };
 
-    relockstepMessageIds(pending, oldMessageIds, push); // no transform arg — uses markRecovered
+    relockstepMessageIds(pending, oldMessageIds, push, []); // no transform arg — uses markRecovered
 
     assert.equal(pushedMsgs.length, 2);
     for (const msg of pushedMsgs) {

--- a/test/agent-rotation-lockstep.test.ts
+++ b/test/agent-rotation-lockstep.test.ts
@@ -41,11 +41,15 @@ function fakeMsg(text: string) {
 
 describe("claude template: relockstepMessageIds", () => {
   let relockstepMessageIds: typeof import("../templates/claude/src/lib/recover.js")["relockstepMessageIds"];
+  let markRecovered: typeof import("../templates/claude/src/lib/recover.js")["markRecovered"];
+  let RECOVERED_MESSAGE_NOTE: typeof import("../templates/claude/src/lib/recover.js")["RECOVERED_MESSAGE_NOTE"];
 
   before(async () => {
     const dir = composeTemplate(templatesRoot, "claude").composedDir;
     composed.push(dir);
-    ({ relockstepMessageIds } = await import(resolvePath(dir, "src/lib/recover.js")));
+    ({ relockstepMessageIds, markRecovered, RECOVERED_MESSAGE_NOTE } = await import(
+      resolvePath(dir, "src/lib/recover.js")
+    ));
   });
 
   it("carries each entry's id over via its old seq, remapped to the new channel's seq", () => {
@@ -136,5 +140,79 @@ describe("claude template: relockstepMessageIds", () => {
     assert.equal(pushedMsgs.length, 1);
     assert.deepEqual(pushedMsgs[0].message.content[0], marker);
     assert.equal(pushedMsgs[0].message.content[1].text, "original");
+  });
+
+  it("uses markRecovered as the default transform — every message production re-pushes gets it", () => {
+    // All four tests above pass an explicit transform; production never does. This
+    // drives the real default so RECOVERED_MESSAGE_NOTE is proven to actually reach
+    // a re-pushed message, for both content shapes SDKUserMessage allows.
+    const oldMessageIds = [
+      { id: "m1", seq: 1 },
+      { id: "m2", seq: 2 },
+    ];
+    const arrayContentMsg = fakeMsg("original array content");
+    const stringContentMsg = {
+      type: "user" as const,
+      session_id: "",
+      message: { role: "user" as const, content: "original string content" },
+      parent_tool_use_id: null,
+    };
+    const pending = [
+      { msg: arrayContentMsg, seq: 1 },
+      { msg: stringContentMsg, seq: 2 },
+    ];
+    const pushedMsgs: { message: { content: { type: string; text: string }[] } }[] = [];
+    const push = (msg: (typeof pushedMsgs)[number]) => {
+      pushedMsgs.push(msg);
+      return pushedMsgs.length;
+    };
+
+    relockstepMessageIds(pending, oldMessageIds, push); // no transform arg — uses markRecovered
+
+    assert.equal(pushedMsgs.length, 2);
+    for (const msg of pushedMsgs) {
+      assert.equal(msg.message.content[0].type, "text");
+      assert.equal(
+        msg.message.content[0].text,
+        RECOVERED_MESSAGE_NOTE,
+        "the note must be the first content block",
+      );
+    }
+    assert.equal(pushedMsgs[0].message.content[1].text, "original array content");
+    assert.equal(pushedMsgs[1].message.content[1].text, "original string content");
+  });
+
+  it("does not stack the note on a message recovered twice (consecutive rotations)", () => {
+    const once = markRecovered(fakeMsg("original"));
+    const twice = markRecovered(once);
+    const noteBlocks = twice.message.content.filter(
+      (b) => "type" in b && b.type === "text" && "text" in b && b.text === RECOVERED_MESSAGE_NOTE,
+    );
+    assert.equal(noteBlocks.length, 1, "the note must appear once, not once per rotation survived");
+  });
+
+  it("reap-race: appending relockstepMessageIds to an existing messageIds array preserves a racing message's entry (#764 regression)", () => {
+    // Mirrors agent.ts's idle-reap path: reapSession() deletes the session from the
+    // map, then awaits the SDK subprocess's shutdown. During that await, an inbound
+    // message can race in via getOrCreateSession(), creating a fresh session and
+    // pushing its own {id, seq} into fresh.messageIds — before reapSession ever
+    // calls relockstepMessageIds for whatever (rare) input the OLD channel recovers.
+    // fresh.messageIds must be appended to, not overwritten, or the racer's entry —
+    // and with it its channel/sender routing — is silently discarded.
+    const racerEntry = { id: "racer-msg", seq: 0 };
+    const freshMessageIds = [racerEntry]; // already populated before the recovered ones arrive
+
+    const oldMessageIds = [{ id: "recovered-msg", seq: 42 }];
+    const pending = [{ msg: fakeMsg("recovered"), seq: 42 }];
+    let nextFreshSeq = 1; // fresh channel already minted seq 0 for the racer
+    const push = () => nextFreshSeq++;
+
+    freshMessageIds.push(...relockstepMessageIds(pending, oldMessageIds, push, (m) => m));
+
+    assert.deepEqual(
+      freshMessageIds,
+      [racerEntry, { id: "recovered-msg", seq: 1 }],
+      "the racer's entry must survive alongside the relockstepped recovered entry",
+    );
   });
 });

--- a/test/agent-rotation-lockstep.test.ts
+++ b/test/agent-rotation-lockstep.test.ts
@@ -71,7 +71,7 @@ describe("claude template: relockstepMessageIds", () => {
       return nextSeq++;
     };
 
-    const result = relockstepMessageIds(pending, oldMessageIds, push, (m) => m);
+    const result = relockstepMessageIds(pending, oldMessageIds, push, [], (m) => m);
 
     assert.deepEqual(
       result.map((e) => e.id),
@@ -103,7 +103,7 @@ describe("claude template: relockstepMessageIds", () => {
       return () => n++;
     })();
 
-    const result = relockstepMessageIds(pending, oldMessageIds, push, (m) => m);
+    const result = relockstepMessageIds(pending, oldMessageIds, push, [], (m) => m);
     assert.deepEqual(
       result.map((e) => e.id),
       ["earlier", "later"],
@@ -117,7 +117,13 @@ describe("claude template: relockstepMessageIds", () => {
       let n = 0;
       return () => n++;
     })();
-    const result = relockstepMessageIds([{ msg: fakeMsg("orphan"), seq: 999 }], [], push, (m) => m);
+    const result = relockstepMessageIds(
+      [{ msg: fakeMsg("orphan"), seq: 999 }],
+      [],
+      push,
+      [],
+      (m) => m,
+    );
     assert.deepEqual(result, [{ id: undefined, seq: 0 }]);
   });
 
@@ -135,7 +141,7 @@ describe("claude template: relockstepMessageIds", () => {
       message: { ...m.message, content: [marker, ...m.message.content] },
     });
 
-    relockstepMessageIds(pending, oldMessageIds, push, transform);
+    relockstepMessageIds(pending, oldMessageIds, push, [], transform);
 
     assert.equal(pushedMsgs.length, 1);
     assert.deepEqual(pushedMsgs[0].message.content[0], marker);
@@ -191,14 +197,18 @@ describe("claude template: relockstepMessageIds", () => {
     assert.equal(noteBlocks.length, 1, "the note must appear once, not once per rotation survived");
   });
 
-  it("reap-race: appending relockstepMessageIds to an existing messageIds array preserves a racing message's entry (#764 regression)", () => {
-    // Mirrors agent.ts's idle-reap path: reapSession() deletes the session from the
-    // map, then awaits the SDK subprocess's shutdown. During that await, an inbound
-    // message can race in via getOrCreateSession(), creating a fresh session and
-    // pushing its own {id, seq} into fresh.messageIds — before reapSession ever
+  it("reap-race: a pre-existing messageIds entry survives relockstepMessageIds (#764 regression)", () => {
+    // Mirrors agent.ts's idle-reap path exactly, calling the SAME exported function
+    // agent.ts calls with the SAME argument shape: reapSession() deletes the session
+    // from the map, then awaits the SDK subprocess's shutdown. During that await, an
+    // inbound message can race in via getOrCreateSession(), creating a fresh session
+    // and pushing its own {id, seq} into fresh.messageIds — before reapSession ever
     // calls relockstepMessageIds for whatever (rare) input the OLD channel recovers.
-    // fresh.messageIds must be appended to, not overwritten, or the racer's entry —
-    // and with it its channel/sender routing — is silently discarded.
+    // relockstepMessageIds is handed fresh.messageIds directly as existingMessageIds
+    // and must append to it, in place, rather than the caller replacing it — a
+    // caller-side `x = relockstepMessageIds(...)` mistake (the actual #764 bug) would
+    // discard this racer entry, since the OLD (pre-fix) signature took no such
+    // parameter and would treat this array as the transform, throwing.
     const racerEntry = { id: "racer-msg", seq: 0 };
     const freshMessageIds = [racerEntry]; // already populated before the recovered ones arrive
 
@@ -207,8 +217,9 @@ describe("claude template: relockstepMessageIds", () => {
     let nextFreshSeq = 1; // fresh channel already minted seq 0 for the racer
     const push = () => nextFreshSeq++;
 
-    freshMessageIds.push(...relockstepMessageIds(pending, oldMessageIds, push, (m) => m));
+    const result = relockstepMessageIds(pending, oldMessageIds, push, freshMessageIds, (m) => m);
 
+    assert.equal(result, freshMessageIds, "must mutate and return the SAME array, not a fresh one");
     assert.deepEqual(
       freshMessageIds,
       [racerEntry, { id: "recovered-msg", seq: 1 }],

--- a/test/message-channel.test.ts
+++ b/test/message-channel.test.ts
@@ -45,15 +45,29 @@ describe("createMessageChannel", () => {
     assert.equal((result.value.message.content[0] as any).text, "delayed");
   });
 
+  it("push returns a monotonically increasing seq, the message's identity", () => {
+    const ch = createMessageChannel();
+    const s1 = ch.push(msg("a"));
+    const s2 = ch.push(msg("b"));
+    const s3 = ch.push(msg("c"));
+    assert.equal(typeof s1, "number");
+    assert.ok(s2 > s1);
+    assert.ok(s3 > s2);
+  });
+
   describe("recover()", () => {
-    it("returns all queued messages and empties the queue", async () => {
+    it("returns all queued messages (with seq) and empties the queue", async () => {
       const ch = createMessageChannel();
       ch.push(msg("x"));
       ch.push(msg("y"));
       ch.push(msg("z"));
 
       const recovered = ch.recover();
-      assert.deepEqual(recovered.map(text), ["x", "y", "z"]);
+      assert.deepEqual(
+        recovered.map((e) => text(e.msg)),
+        ["x", "y", "z"],
+      );
+      for (const e of recovered) assert.equal(typeof e.seq, "number");
 
       // Queue should now be empty — next push goes to a fresh queue
       ch.push(msg("after"));
@@ -75,7 +89,21 @@ describe("createMessageChannel", () => {
       ch.push(msg("after1"));
       ch.push(msg("after2"));
       const recovered2 = ch.recover();
-      assert.deepEqual(recovered2.map(text), ["after1", "after2"]);
+      assert.deepEqual(
+        recovered2.map((e) => text(e.msg)),
+        ["after1", "after2"],
+      );
+    });
+
+    it("round-trips seq: recovered entries carry the same seq push() returned", () => {
+      const ch = createMessageChannel();
+      const s1 = ch.push(msg("a"));
+      const s2 = ch.push(msg("b"));
+      const recovered = ch.recover();
+      assert.deepEqual(
+        recovered.map((e) => e.seq),
+        [s1, s2],
+      );
     });
 
     it("recovers a message consumed via the read-ahead fast-path (not lost)", async () => {
@@ -91,7 +119,10 @@ describe("createMessageChannel", () => {
 
       // Its turn never completed (no ack), so recovery must return it.
       const recovered = ch.recover();
-      assert.deepEqual(recovered.map(text), ["consumed"]);
+      assert.deepEqual(
+        recovered.map((e) => text(e.msg)),
+        ["consumed"],
+      );
     });
 
     it("returns delivered-unacked messages before still-queued ones, in order", async () => {
@@ -107,7 +138,10 @@ describe("createMessageChannel", () => {
       ch.push(msg("m2"));
       ch.push(msg("m3"));
 
-      assert.deepEqual(ch.recover().map(text), ["m1", "m2", "m3"]);
+      assert.deepEqual(
+        ch.recover().map((e) => text(e.msg)),
+        ["m1", "m2", "m3"],
+      );
     });
 
     it("recover while iterator is waiting terminates the pending iterator", async () => {
@@ -126,7 +160,49 @@ describe("createMessageChannel", () => {
 
       // Push to the same channel — goes to the queue (not the old resolve)
       ch.push(msg("new"));
-      assert.deepEqual(ch.recover().map(text), ["new"]);
+      assert.deepEqual(
+        ch.recover().map((e) => text(e.msg)),
+        ["new"],
+      );
+    });
+
+    it("does NOT return a message that was folded into a completed turn (#764)", async () => {
+      // Regression test for the duplicate-event-on-rotation bug: the SDK folds
+      // messages that arrive mid-run into the active run, so a folded message
+      // never gets a `result`/ack of its own. The mind's turn-loop is
+      // responsible for acking every message a turn covers (its driving message
+      // plus anything folded in) — this test drives the channel the way
+      // stream-consumer.ts does and checks recover() afterward.
+      const ch = createMessageChannel();
+      const iter = ch.iterable[Symbol.asyncIterator]();
+
+      // Message A starts a turn (delivered to the SDK's read-ahead consumer).
+      const pA = iter.next();
+      const seqA = ch.push(msg("A"));
+      await pA;
+
+      // Message B arrives while A's turn is still live — the SDK folds it into
+      // the running turn (delivered immediately via the read-ahead fast path,
+      // same as A).
+      const pB = iter.next();
+      const seqB = ch.push(msg("B"));
+      await pB;
+
+      // A genuinely-unprocessed message C is queued after — no turn has
+      // started for it yet.
+      ch.push(msg("C"));
+
+      // The turn resolves once: ack both A (its own driver) and B (folded in),
+      // exactly as stream-consumer.ts's result handler does by seq.
+      ch.ack(seqA);
+      ch.ack(seqB);
+
+      const recovered = ch.recover();
+      assert.deepEqual(
+        recovered.map((e) => text(e.msg)),
+        ["C"],
+        "B was folded into A's completed turn and must not be replayed; C is still owed a turn",
+      );
     });
   });
 
@@ -154,9 +230,9 @@ describe("createMessageChannel", () => {
       const ch = createMessageChannel();
       const iter = ch.iterable[Symbol.asyncIterator]();
       const pending = iter.next();
-      ch.push(msg("done"));
+      const seq = ch.push(msg("done"));
       await pending;
-      ch.ack();
+      ch.ack(seq);
       assert.equal(ch.isEmpty(), true);
     });
   });
@@ -185,7 +261,10 @@ describe("createMessageChannel", () => {
       const ch = createMessageChannel();
       ch.push(msg("raced"));
       ch.close();
-      assert.deepEqual(ch.recover().map(text), ["raced"]);
+      assert.deepEqual(
+        ch.recover().map((e) => text(e.msg)),
+        ["raced"],
+      );
     });
   });
 
@@ -195,22 +274,22 @@ describe("createMessageChannel", () => {
       const iter = ch.iterable[Symbol.asyncIterator]();
 
       const pending = iter.next();
-      ch.push(msg("done"));
+      const seq = ch.push(msg("done"));
       await pending;
 
       // The turn completed — acknowledge it.
-      ch.ack();
+      ch.ack(seq);
       assert.deepEqual(ch.recover(), []);
     });
 
-    it("acks the oldest delivered message (FIFO), recovering the rest", async () => {
+    it("is identity-based: acking one delivered message doesn't touch the others", async () => {
       // Mirrors the compaction race: m1 is mid-turn when m2 and m3 are
       // read-ahead-delivered; m1's turn completes, then compaction recovers.
       const ch = createMessageChannel();
       const iter = ch.iterable[Symbol.asyncIterator]();
 
       const p1 = iter.next();
-      ch.push(msg("m1"));
+      const seq1 = ch.push(msg("m1"));
       await p1;
       const p2 = iter.next();
       ch.push(msg("m2"));
@@ -219,14 +298,34 @@ describe("createMessageChannel", () => {
       ch.push(msg("m3"));
       await p3;
 
-      ch.ack(); // m1's turn finished
+      ch.ack(seq1); // m1's turn finished
 
-      assert.deepEqual(ch.recover().map(text), ["m2", "m3"]);
+      assert.deepEqual(
+        ch.recover().map((e) => text(e.msg)),
+        ["m2", "m3"],
+      );
     });
 
-    it("is a no-op when nothing is in flight", () => {
+    it("does not remove a pre-turn-queued message when a later seq is acked", async () => {
+      // The bug this identity-based ack replaces: a positional (shift-based) ack
+      // would wrongly consume the oldest entry regardless of which turn actually
+      // finished. Pushing m1, m2 then acking m2's seq specifically must leave m1
+      // (still genuinely unprocessed) recoverable.
       const ch = createMessageChannel();
-      assert.doesNotThrow(() => ch.ack());
+      ch.push(msg("m1"));
+      const seq2 = ch.push(msg("m2"));
+
+      ch.ack(seq2);
+
+      assert.deepEqual(
+        ch.recover().map((e) => text(e.msg)),
+        ["m1"],
+      );
+    });
+
+    it("is a no-op when the seq is not in flight or queued", () => {
+      const ch = createMessageChannel();
+      assert.doesNotThrow(() => ch.ack(999));
       assert.deepEqual(ch.recover(), []);
     });
   });

--- a/test/template-stale-message-channels.test.ts
+++ b/test/template-stale-message-channels.test.ts
@@ -41,11 +41,14 @@ describe("claude template: folded messages leave no stale messageChannels entry"
     ({ consumeStream } = await import(resolvePath(dir, "src/lib/stream-consumer.js")));
   });
 
+  type MessageIdEntry = { id: string | undefined; seq: number };
+
   function newSession() {
     return {
       name: "main",
-      messageIds: [] as (string | undefined)[],
+      messageIds: [] as MessageIdEntry[],
       currentMessageId: undefined as string | undefined,
+      currentSeq: undefined as number | undefined,
       messageChannels: new Map() as MessageChannels,
     };
   }
@@ -60,14 +63,24 @@ describe("claude template: folded messages leave no stale messageChannels entry"
     usage: { input_tokens: 1, output_tokens: 1 },
   });
 
-  const callbacks = { broadcast: () => {}, onTurnEnd: () => {} };
+  function newCallbacks() {
+    const acked: number[] = [];
+    return {
+      broadcast: () => {},
+      onTurnEnd: () => {},
+      ack: (seq: number) => acked.push(seq),
+      acked,
+    };
+  }
 
   it("a message folded into the running turn is pruned with it, and the next turn claims its own id", async () => {
     const session = newSession();
-    session.messageIds.push("m1");
+    const callbacks = newCallbacks();
+    session.messageIds.push({ id: "m1", seq: 1 });
     session.messageChannels.set("m1", { channel: "@alice", sender: "alice" });
 
-    let afterTurn1: { ids: (string | undefined)[]; channels: string[] } | undefined;
+    let afterTurn1: { ids: MessageIdEntry[]; channels: string[] } | undefined;
+    let ackedAfterTurn1: number[] | undefined;
     let claimedInTurn2: string | undefined;
 
     // The generator resumes after each yielded message has been fully processed,
@@ -76,14 +89,15 @@ describe("claude template: folded messages leave no stale messageChannels entry"
       yield assistant("replying to alice"); // turn 1 claims m1
       // A system event arrives mid-run — the SDK folds it into the active turn,
       // which will emit a single result for both messages.
-      session.messageIds.push("m2");
+      session.messageIds.push({ id: "m2", seq: 2 });
       session.messageChannels.set("m2", { channel: "event:schedule:42" });
       yield result(); // turn 1 done — must consume m1 AND the folded m2
       afterTurn1 = {
         ids: [...session.messageIds],
         channels: [...session.messageChannels.keys()],
       };
-      session.messageIds.push("m3");
+      ackedAfterTurn1 = [...callbacks.acked];
+      session.messageIds.push({ id: "m3", seq: 3 });
       session.messageChannels.set("m3", { channel: "@bob", sender: "bob" });
       yield assistant("replying to bob"); // turn 2 must claim m3, not the stale m2
       claimedInTurn2 = session.currentMessageId;
@@ -103,6 +117,11 @@ describe("claude template: folded messages leave no stale messageChannels entry"
       "the next turn must be tagged with its own message, not the stale event entry",
     );
     assert.equal(session.messageChannels.size, 0);
+    // Regression guard for #764: the driving message AND the folded one must both
+    // be acked by the time turn 1's result is fully handled — a stranded
+    // (never-acked) entry is what got replayed verbatim on the next session
+    // rotation.
+    assert.deepEqual(ackedAfterTurn1, [1, 2], "both m1 and the folded m2 must be acked");
   });
 
   it("messages queued before the turn started keep their entries — each still gets its own run", async () => {
@@ -111,11 +130,12 @@ describe("claude template: folded messages leave no stale messageChannels entry"
     // second message's entry at the first result, or its turn would lose its
     // channel (and a first-of-session message its reply instructions).
     const session = newSession();
-    session.messageIds.push("m1", "m2");
+    const callbacks = newCallbacks();
+    session.messageIds.push({ id: "m1", seq: 1 }, { id: "m2", seq: 2 });
     session.messageChannels.set("m1", { channel: "@alice", sender: "alice" });
     session.messageChannels.set("m2", { channel: "@bob", sender: "bob" });
 
-    let afterRun1: { ids: (string | undefined)[]; channels: string[] } | undefined;
+    let afterRun1: { ids: MessageIdEntry[]; channels: string[] } | undefined;
     let claimedInRun2: string | undefined;
 
     async function* stream() {
@@ -134,11 +154,13 @@ describe("claude template: folded messages leave no stale messageChannels entry"
 
     assert.deepEqual(
       afterRun1,
-      { ids: ["m2"], channels: ["m2"] },
+      { ids: [{ id: "m2", seq: 2 }], channels: ["m2"] },
       "a pre-turn queued message keeps its entry until its own run completes",
     );
     assert.equal(claimedInRun2, "m2");
     assert.equal(session.messageChannels.size, 0);
+    // Each run acks only its own driving message — not the other, still-pending one.
+    assert.deepEqual(callbacks.acked, [1, 2]);
   });
 });
 


### PR DESCRIPTION
## Production repro

Mind `mimsy`, 2026-07-20: a scheduled heartbeat event was delivered once by the daemon and fully processed by the mind (camera frame captured, journal entry written, file committed). The session then hit the 150k context limit and rotated in place. Immediately after rotation, **the same event prompt was re-submitted verbatim**, and the mind began re-running the heartbeat — it only avoided writing a duplicate journal entry because it happened to grep its own journal first.

Severity is about false records, not wasted tokens: a mind that simply does the job correctly a second time fabricates a permanent record of an event that happened once.

## Root cause

An accounting asymmetry between two parallel bookkeeping systems:

- `message-channel.ts`'s `ack()` was blind positional FIFO (`inFlight.shift()`).
- The SDK folds messages that arrive mid-run into the active run — **folded messages never produce a `result` of their own** (this is what #700 already worked around on `session.messageIds`, but there was no matching fix on the channel's `inFlight` set).
- Result: every folded message strands a permanent extra entry in `inFlight`.
- On rotation, `channel.recover()` returns `[...inFlight, ...queue]` and everything gets re-pushed into the fresh channel — replaying the stranded event.

The daemon is not at fault here — it delivers each event exactly once and stamps `delivered_at` on ack.

## Fix

Message identity is now explicit instead of positional:

- `message-channel.ts`: `push()` mints a monotonic `seq` and returns it; `ack(seq)` removes by identity; `recover()` returns `{msg, seq}` pairs.
- `stream-consumer.ts`: `session.messageIds` becomes `{id, seq}[]`; the turn-end `result` handler now acks **both** the driving message's seq **and** every folded message's seq, at the same point the folded ids are already spliced out of `messageIds` (the #700 fix site).
- `agent.ts`: wires the new `ack` callback; both `channel.recover()` call sites (rotation, and the idle-reap "shouldn't race but if it did" path) now use `relockstepMessageIds` (new file `lib/recover.ts`) to rebuild `messageIds` in lockstep with the fresh channel, matching old entries to new by `seq` rather than position — the naive "just ack N more times" approach doesn't work because `inFlight` order is `[current, ...pre-turn-queued, ...folded]` and pre-turn-queued messages each still deserve their own run.
- Every message `recover()` re-pushes is marked with a short note ("you may have already seen this — check before redoing work"), since `recover()` can never prove a replayed message was unprocessed. Fail toward noise, not silence: a spurious note is cosmetic and self-correcting; a missing one is invisible and produces a false permanent record.

`relockstepMessageIds` depends on one currently-true invariant — abort only ever happens at a turn boundary, after the current turn is already acked — documented at its definition in `lib/recover.ts` so a future mid-turn abort site (e.g. a hung-turn watchdog) doesn't silently reintroduce misrouting.

## Scope

Confined to `templates/claude/` — verified `templates/pi/` and `templates/codex/` don't share this message-channel code (no `createMessageChannel`/`inFlight` hits outside the claude template).

## Tests

- `test/message-channel.test.ts`: extended with identity-based ack tests, including the exact regression scenario (push A, deliver, push B mid-turn as a fold, single ack cycle, `recover()` must not return B while a genuinely-queued C is still returned).
- `test/template-stale-message-channels.test.ts`: the existing #700 regression test (drives the real composed `consumeStream`) updated for the new `{id, seq}` entry shape — every original assertion preserved, plus new assertions that both the driving and folded message get acked.
- `test/agent-rotation-lockstep.test.ts` (new): drives the real composed `relockstepMessageIds`, covering seq-based (not positional) matching, the transform hook, and the safe-default when no match exists.

`npm test`: 3000 pass, 0 fail. Template typecheck and biome clean. Pre-commit and pre-push hooks both ran clean (no `--no-verify`).