### PR TITLE
fix: parse active-turn timestamps as UTC in timeline headers

### DIFF
--- a/packages/web/src/ui/components/TurnTimeline.svelte
+++ b/packages/web/src/ui/components/TurnTimeline.svelte
@@ -1120,7 +1120,7 @@ function jumpToLatest() {
                   />
                 {:else}
                   {@const groups = streamingGroups.get(turn.id) ?? []}
-                  {@const startTime = new Date(turn.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  {@const startTime = new Date(normalizeTimestamp(turn.created_at)).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
                   <TimelineBranch gap={24} reach={11} noReturn>
                     {#snippet header()}
                       <div class="active-turn-header">
@@ -1170,7 +1170,7 @@ function jumpToLatest() {
                 <TimelineBranch gap={24} reach={11} noReturn>
                   {#snippet header()}
                     <div class="active-turn-header">
-                      <span class="active-turn-time">{new Date(pendingInbounds[0].created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })} – now</span>
+                      <span class="active-turn-time">{new Date(normalizeTimestamp(pendingInbounds[0].created_at)).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })} – now</span>
                     </div>
                   {/snippet}
                   {#snippet children()}


### PR DESCRIPTION
## Summary
The active-turn header and pending-inbound header in `TurnTimeline.svelte` parsed the DB's zone-less UTC `created_at` with bare `new Date()`, rendering the UTC wall-clock as local time — an open turn showed a start time hours in the future (observed on bardo: a turn started 12:30 UTC / 8:30 AM EDT displayed as "12:30 – now" at 9:20 AM local).

These were the only two render sites in the turn timeline that skipped `normalizeTimestamp()` (same bug class as #706). Wrapped both.

## Test plan
- `svelte-check`: 0 errors
- Verified all other `created_at` render sites in TurnTimeline go through `normalizeTimestamp`/`normalizeTs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)