### PR TITLE
fix: deliveries no longer interrupt minds mid-turn by default

### DIFF
--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -1340,6 +1340,7 @@ export class DeliveryManager {
         ...enrichedPayload,
         session,
         instructions: sessionConfig.instructions,
+        interrupt: sessionConfig.interrupt,
       });
 
       try {
@@ -1460,6 +1461,7 @@ export class DeliveryManager {
         session,
         batch: { channels },
         instructions: sessionConfig.instructions,
+        interrupt: sessionConfig.interrupt,
       });
 
       try {

--- a/packages/daemon/src/lib/delivery/delivery-router.ts
+++ b/packages/daemon/src/lib/delivery/delivery-router.ts
@@ -27,6 +27,7 @@ export type BatchConfig = {
 export type SessionConfig = {
   instructions?: string;
   delivery?: DeliveryMode;
+  interrupt?: boolean;
 };
 
 export type DeliveryMode =
@@ -58,6 +59,7 @@ export type ResolvedDeliveryMode =
 export type ResolvedSessionConfig = {
   delivery: ResolvedDeliveryMode;
   instructions?: string;
+  interrupt: boolean;
 };
 
 export type MatchMeta = {
@@ -340,6 +342,7 @@ export function resolveDeliveryMode(
   const ruleBatch = rule?.batch;
   const defaults: ResolvedSessionConfig = {
     delivery: { mode: "immediate" },
+    interrupt: false,
   };
 
   if (!config.threads) {
@@ -352,6 +355,7 @@ export function resolveDeliveryMode(
           maxWait: batch.maxWait ?? DEFAULT_BATCH_MAX_WAIT,
           triggers: batch.triggers,
         },
+        interrupt: false,
       };
     }
     return defaults;
@@ -381,6 +385,7 @@ export function resolveDeliveryMode(
       return {
         delivery,
         instructions: sessionConfig.instructions,
+        interrupt: sessionConfig.interrupt ?? false,
       };
     }
   }
@@ -395,6 +400,7 @@ export function resolveDeliveryMode(
         maxWait: batch.maxWait ?? DEFAULT_BATCH_MAX_WAIT,
         triggers: batch.triggers,
       },
+      interrupt: false,
     };
   }
 

--- a/packages/daemon/src/lib/delivery/message-delivery.ts
+++ b/packages/daemon/src/lib/delivery/message-delivery.ts
@@ -387,7 +387,7 @@ export async function deliverBatch(
     const res = await fetch(`http://127.0.0.1:${entry.port}/message`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ session, batch: { channels } }),
+      body: JSON.stringify({ session, batch: { channels }, interrupt: false }),
     });
     return res.ok;
   } catch (err) {

--- a/skills/volute-mind/references/routing.md
+++ b/skills/volute-mind/references/routing.md
@@ -15,7 +15,8 @@ Messages are routed to threads based on rules in `.config/routes.json`. Rules ar
     { "channel": "discord:logs", "destination": "file", "path": "notes/log.md" }
   ],
   "threads": {
-    "discord": { "delivery": { "mode": "batch", "debounce": 20, "maxWait": 120, "triggers": ["@mymind"] }, "interrupt": false, "instructions": "Brief responses only." }
+    "discord": { "delivery": { "mode": "batch", "debounce": 20, "maxWait": 120, "triggers": ["@mymind"] }, "instructions": "Brief responses only." },
+    "urgent": { "interrupt": true }
   },
   "default": "main",
   "gateUnmatched": true
@@ -47,7 +48,7 @@ The `threads` section configures behavior per thread. Keys are glob patterns mat
 | Field | Description |
 |-------|-------------|
 | `delivery` | `"immediate"` (default), `"batch"`, or `{ "mode": "batch", "debounce": N, "maxWait": N, "triggers": [...] }` |
-| `interrupt` | Whether a new message may interrupt an in-progress turn (default: `true`) |
+| `interrupt` | Whether a new message may interrupt an in-progress turn (default: `false`) |
 | `instructions` | Instructions prepended to messages for this thread (e.g. `"Brief responses only."`) |
 
 ## Batch config

--- a/templates/_base/src/lib/routing.ts
+++ b/templates/_base/src/lib/routing.ts
@@ -156,7 +156,7 @@ export function resolveSessionConfig(
   config: RoutingConfig,
   sessionName: string,
 ): ResolvedSessionConfig {
-  const defaults: ResolvedSessionConfig = { interrupt: true, replyInstructions: "once" };
+  const defaults: ResolvedSessionConfig = { interrupt: false, replyInstructions: "once" };
 
   if (!config.threads) return defaults;
 
@@ -165,7 +165,7 @@ export function resolveSessionConfig(
       const batch = sessionConfig.batch != null ? normalizeBatch(sessionConfig.batch) : undefined;
       return {
         batch,
-        interrupt: sessionConfig.interrupt ?? true,
+        interrupt: sessionConfig.interrupt ?? false,
         instructions: sessionConfig.instructions,
         replyInstructions: sessionConfig.replyInstructions ?? "once",
       };

--- a/test/delivery-durability.test.ts
+++ b/test/delivery-durability.test.ts
@@ -679,4 +679,68 @@ describe("DeliveryManager durability", () => {
     assert.deepEqual(texts, ["one", "two"], "messages delivered in submission order");
     await removeMind(name);
   });
+
+  describe("interrupt field on delivery POSTs", () => {
+    it("sends interrupt: false by default (no threads config)", async () => {
+      const srv = await startMindServer();
+      servers.push(srv.server);
+      const name = await registerMind(srv.port, IMMEDIATE);
+
+      manager = new DeliveryManager();
+      manager.setRunningCheck(() => true);
+
+      await manager.routeAndDeliver(name, { channel: "test:ch", sender: "alice", content: "hi" });
+
+      assert.equal(srv.received.length, 1);
+      assert.equal((srv.received[0] as { interrupt?: boolean }).interrupt, false);
+      await removeMind(name);
+    });
+
+    it("sends interrupt: true when the mind's routes.json thread config opts in", async () => {
+      const srv = await startMindServer();
+      servers.push(srv.server);
+      const name = await registerMind(srv.port, {
+        rules: [{ channel: "*", thread: "main" }],
+        threads: { main: { interrupt: true } },
+        gateUnmatched: false,
+      });
+
+      manager = new DeliveryManager();
+      manager.setRunningCheck(() => true);
+
+      await manager.routeAndDeliver(name, { channel: "test:ch", sender: "alice", content: "hi" });
+
+      assert.equal(srv.received.length, 1);
+      assert.equal((srv.received[0] as { interrupt?: boolean }).interrupt, true);
+      await removeMind(name);
+    });
+
+    it("sends interrupt: false on a batch delivery POST", async () => {
+      const srv = await startMindServer();
+      servers.push(srv.server);
+      const name = await registerMind(srv.port, {
+        rules: [{ channel: "test:*", thread: "group" }],
+        threads: { group: { delivery: { mode: "batch", debounce: 0, maxWait: 0 } } },
+        gateUnmatched: false,
+      });
+
+      manager = new DeliveryManager();
+      manager.setRunningCheck(() => true);
+
+      const msg = (sender: string, content: string) => ({
+        payload: { channel: "test:ch", sender, content },
+        channel: "test:ch",
+        sender,
+        createdAt: Date.now(),
+      });
+      await (manager as any).deliverBatchToMind(name, "group", [msg("alice", "one")], {
+        delivery: { mode: "immediate" },
+        interrupt: false,
+      });
+
+      assert.equal(srv.received.length, 1);
+      assert.equal((srv.received[0] as { interrupt?: boolean }).interrupt, false);
+      await removeMind(name);
+    });
+  });
 });

--- a/test/delivery-router.test.ts
+++ b/test/delivery-router.test.ts
@@ -216,4 +216,25 @@ describe("resolveDeliveryMode", () => {
     const r = resolveDeliveryMode(config, "main");
     assert.equal(r.instructions, "Be brief.");
   });
+
+  it("defaults interrupt to false with no threads config", () => {
+    const r = resolveDeliveryMode({}, "main");
+    assert.equal(r.interrupt, false);
+  });
+
+  it("defaults interrupt to false when a thread config matches but doesn't set it", () => {
+    const config: RoutingConfig = {
+      threads: { main: { delivery: "batch" } },
+    };
+    const r = resolveDeliveryMode(config, "main");
+    assert.equal(r.interrupt, false);
+  });
+
+  it("honors an explicit interrupt: true in the matched thread config", () => {
+    const config: RoutingConfig = {
+      threads: { main: { interrupt: true } },
+    };
+    const r = resolveDeliveryMode(config, "main");
+    assert.equal(r.interrupt, true);
+  });
 });

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -461,36 +461,36 @@ describe("resolveRoute", () => {
 describe("resolveSessionConfig", () => {
   it("returns defaults when no sessions configured", () => {
     const r = resolveSessionConfig({}, "main");
-    assert.equal(r.interrupt, true);
+    assert.equal(r.interrupt, false);
     assert.equal(r.batch, undefined);
     assert.equal(r.instructions, undefined);
   });
 
   it("matches exact session name", () => {
     const config: RoutingConfig = {
-      threads: { discord: { interrupt: false } },
+      threads: { discord: { interrupt: true } },
     };
     const r = resolveSessionConfig(config, "discord");
-    assert.equal(r.interrupt, false);
+    assert.equal(r.interrupt, true);
   });
 
   it("matches glob pattern", () => {
     const config: RoutingConfig = {
-      threads: { "@*": { interrupt: false } },
+      threads: { "@*": { interrupt: true } },
     };
     const r = resolveSessionConfig(config, "@conv-abc");
-    assert.equal(r.interrupt, false);
+    assert.equal(r.interrupt, true);
   });
 
   it("first match wins", () => {
     const config: RoutingConfig = {
       threads: {
-        "discord:*": { interrupt: false },
-        "*": { interrupt: true },
+        "discord:*": { interrupt: true },
+        "*": { interrupt: false },
       },
     };
     const r = resolveSessionConfig(config, "discord:general");
-    assert.equal(r.interrupt, false);
+    assert.equal(r.interrupt, true);
   });
 
   it("normalizes batch number (minutes) to BatchConfig", () => {
@@ -521,10 +521,10 @@ describe("resolveSessionConfig", () => {
 
   it("returns defaults for unmatched session", () => {
     const config: RoutingConfig = {
-      threads: { discord: { interrupt: false } },
+      threads: { discord: { interrupt: true } },
     };
     const r = resolveSessionConfig(config, "slack");
-    assert.equal(r.interrupt, true);
+    assert.equal(r.interrupt, false);
     assert.equal(r.batch, undefined);
   });
 


### PR DESCRIPTION
## Problem

PR #387 intended to stop chat deliveries from interrupting minds mid-turn: it dropped the daemon's hardcoded `interrupt: true` from delivery POSTs, with the stated goal that "the mind-side `interrupt()` is gated on `meta.interrupt` → now always false → never fires... fixes all minds on daemon restart, no template upgrade needed."

That analysis missed the mind-side template's fallback (`templates/_base/src/lib/router.ts`):

```ts
const interrupt = meta.interrupt ?? sessionConfig.interrupt;
```

An **absent** `interrupt` field is `undefined`, not `false` — so it fell through to `resolveSessionConfig`'s mind-side default, which was `interrupt: true`. Every mid-turn delivery kept calling `query.interrupt()`, aborting the mind's in-flight turn. Confirmed on bardo: 553 `interrupting current turn` log lines, five during a single recent multi-mind conversation (#783).

## Fix

Resolve `interrupt` **daemon-side**, in `resolveDeliveryMode()` (`packages/daemon/src/lib/delivery/delivery-router.ts`):
- Default `false` on every return path (no threads config, unmatched thread, rule-level-batch fallback).
- When a thread config in `routes.json` matches, honor an explicit `"interrupt": true`; otherwise `false`.

Send the resolved boolean explicitly in every delivery POST body:
- `delivery-manager.ts`: `deliverToMind()` and `deliverBatchToMind()`.
- `message-delivery.ts`: the wake-flush `deliverBatch()` path sends `interrupt: false` (a just-woken idle mind never needs to interrupt itself).

Because an **explicit boolean always wins** over the template's `??` fallback, this heals every mind on daemon restart with no template upgrade required — the fix #387 originally promised.

For minds that do upgrade, `templates/_base/src/lib/routing.ts`'s own default flips from `interrupt: true` to `interrupt: false` (`resolveSessionConfig`'s defaults object and its `sessionConfig.interrupt ?? true` fallback), and `skills/volute-mind/references/routing.md` is updated to document the new default, with the example config showing the opt-in lever (`"interrupt": true` on a thread) instead of the now-redundant explicit `false`.

## Interplay with #782

#782 (wedged-turn `activeCount` leak) is caused by rapid deliveries folding into one `done` while a turn is busy — the same busy-turn condition that used to trigger destructive interrupts. This fix doesn't touch #782's counter logic, but by ensuring interrupts default off *everywhere in the daemon*, not just in the intent of #387, it removes one path where deliveries could still cut a turn short mid-tool. No changes to `sweepWedgedTurns`/`reconcileWedgedTurns` are included here.

## Test plan

- `test/delivery-router.test.ts`: `resolveDeliveryMode` returns `interrupt: false` with no threads config, `interrupt: false` when a matched thread config doesn't set it, and `interrupt: true` when it explicitly opts in.
- `test/delivery-durability.test.ts`: new `interrupt field on delivery POSTs` suite — asserts the actual POST body sent to a mock mind server carries `interrupt: false` by default, `interrupt: true` when routes.json opts in, and `interrupt: false` on a batch delivery.
- `test/routing.test.ts`: flipped the mind-side `resolveSessionConfig` default-value assertions from `true`→`false` to match the new default (and inverted a couple of fixture configs so they still exercise both branches).
- Full suite: `npm test` — 3035/3035 passing (run twice, once pre-push via the lefthook hook).
- `npm run typecheck:templates` — claude/pi/codex templates all pass.

Refs #783, #387, #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)