### PR TITLE
fix: resolve the system spirit in extension SDK helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Extensions add functionality to Volute — custom UI sections, API routes, datab
 - `skillsDir?` — directory of skills synced on load; `standardSkill?` adds them to the default skill set
 - `mindDoc?` — markdown appended to minds' VOLUTE.md; `commands?` — extension-provided CLI subcommands
 - `initDb?(db)` — per-extension SQLite DB at `~/.volute/system/extension-data/{id}/data.db`
-- `onDaemonStart?()`, `onDaemonStop?()`, `onMindStart?(name, ctx)`, `onMindStop?(name)` — lifecycle hooks
+- `onDaemonStart?()`, `onSpiritReady?(ctx)`, `onDaemonStop?()`, `onMindStart?(name, ctx)`, `onMindStop?(name)` — lifecycle hooks. Spirit-dependent bootstrap belongs in `onSpiritReady`: `onDaemonStart` runs before the spirit exists on a fresh install
 
 **Extension context** (passed to `routes()`/`publicRoutes()`): `db`, `dataDir`, `authMiddleware`, `requireSelf`, `resolveUser(c)`, `getUser`/`getUserByUsername`/`getMindUser`, `publishActivity(event)`, `announceToSystem`, `recordNotice`, `getMindDir(name)`, `isIsolationEnabled`, `getSystemsConfig()`.
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -23,6 +23,7 @@ import {
   loadAllExtensions,
   notifyExtensionsDaemonStart,
   notifyExtensionsDaemonStop,
+  notifyExtensionsSpiritReady,
 } from "./lib/extensions.js";
 import {
   ensureSystemDir,
@@ -355,6 +356,13 @@ export async function startDaemon(opts: {
       }
 
       await syncSpiritTemplate();
+
+      // Let extensions run spirit-dependent bootstrap now that the spirit project
+      // exists — after the template sync so nothing they write gets clobbered, and
+      // before startSpiritFull so any schedule they provision is loaded this boot
+      // rather than the next one.
+      if (spiritEntry) await notifyExtensionsSpiritReady();
+
       if (spiritEntry && !manager.isRunning(spiritName)) {
         await startSpiritFull(spiritName);
       }

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -16,11 +16,11 @@ import { type AuthEnv, requireSelf } from "../web/middleware/auth.js";
 import { getUser, getUserByUsername } from "./auth.js";
 import { announceToSystem } from "./chat/system-channel.js";
 import { MIND_LEVEL_THREAD, recordNotice as recordMindNotice } from "./chat/system-events.js";
-import { readGlobalConfig, writeGlobalConfig } from "./config/setup.js";
+import { getSpiritName, readGlobalConfig, writeGlobalConfig } from "./config/setup.js";
 import { readSystemsConfig } from "./config/systems-config.js";
 import { publish } from "./events/activity-events.js";
 import { isIsolationEnabled, mindUserName } from "./mind/isolation.js";
-import { mindDir, voluteHome, voluteSystemDir } from "./mind/registry.js";
+import { findMind, resolveMindDir, voluteHome, voluteSystemDir } from "./mind/registry.js";
 import { hashSkillDir, importSkillFromDir, removeSharedSkill, sharedSkillsDir } from "./skills.js";
 import log from "./util/logger.js";
 import { sanitizeSvgIcon } from "./util/sanitize-svg.js";
@@ -189,7 +189,12 @@ async function openExtensionDb(_id: string, dataDir: string): Promise<Database> 
   return new Database(dbPath);
 }
 
-async function buildContext(
+/**
+ * Build the context handed to an extension's routes and lifecycle hooks.
+ * Exported so tests can exercise the real helpers (spirit dir resolution, notice
+ * gating) rather than a hand-rolled fake that can drift from this implementation.
+ */
+export async function buildExtensionContext(
   manifest: ExtensionManifest,
   dataDir: string,
   authMw: MiddlewareHandler,
@@ -234,9 +239,11 @@ async function buildContext(
         log.error(`extension ${manifest.id}: failed to publish activity`, log.errorData(err)),
       );
     },
-    getMindDir: (name: string) => {
+    // Registry-backed, not path-convention: the spirit lives under the system dir
+    // and variants live in worktrees, so mindDir(name) alone resolves neither.
+    getMindDir: async (name: string) => {
       try {
-        const dir = mindDir(name);
+        const dir = await resolveMindDir(name);
         return existsSync(dir) ? dir : null;
       } catch (err) {
         log.warn(
@@ -250,8 +257,10 @@ async function buildContext(
     announceToSystem: (text: string) => announceToSystem(text),
     recordNotice: async (mindName: string, text: string) => {
       try {
-        const user = await getUserByUsername(mindName);
-        if (user?.user_type !== "mind") return;
+        // Gate on the minds registry rather than the users table: the spirit is a
+        // mind but shares the system user account (`user_type: "system"`), so a
+        // user_type check would silently drop every notice addressed to it.
+        if (!(await findMind(mindName))) return;
         await recordMindNotice({
           mind: mindName,
           thread: MIND_LEVEL_THREAD,
@@ -268,7 +277,10 @@ async function buildContext(
     },
     isIsolationEnabled,
     getMindUser: mindUserName,
-    getSpiritName: () => readGlobalConfig().setup?.spiritName ?? null,
+    // Delegate to the daemon's single source of truth, which falls back to "volute"
+    // on installs that predate spirit naming. Reading setup.spiritName directly
+    // returned null on those systems, so extension spirit paths no-opped forever.
+    getSpiritName: () => getSpiritName(),
     dataDir,
   };
 }
@@ -285,7 +297,7 @@ async function loadExtension(
   const dataDir = extensionDataDir(manifest.id);
   mkdirSync(dataDir, { recursive: true });
 
-  const context = await buildContext(manifest, dataDir, authMw);
+  const context = await buildExtensionContext(manifest, dataDir, authMw);
 
   // Mount authenticated API routes
   const routesApp = manifest.routes(context);
@@ -909,6 +921,24 @@ export function notifyExtensionsDaemonStart(): void {
       manifest.onDaemonStart?.(context);
     } catch (err) {
       log.error(`extension ${manifest.id}: onDaemonStart failed`, log.errorData(err));
+    }
+  }
+}
+
+/**
+ * Fire `onSpiritReady` for every loaded extension. Called once per daemon start,
+ * after the spirit project exists and is registered — `onDaemonStart` runs long
+ * before that on a fresh install, so spirit bootstrap hooks that ran there skipped
+ * the very boot that created the spirit and only fired on the next one.
+ * Awaited so an extension's bootstrap failure is logged, never unhandled.
+ */
+export async function notifyExtensionsSpiritReady(): Promise<void> {
+  for (const { manifest, context } of loaded) {
+    if (!manifest.onSpiritReady) continue;
+    try {
+      await manifest.onSpiritReady(context);
+    } catch (err) {
+      log.error(`extension ${manifest.id}: onSpiritReady failed`, log.errorData(err));
     }
   }
 }

--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -17,6 +17,7 @@ import {
   readSystemsConfig,
   writeSystemsConfig,
 } from "../../lib/config/systems-config.js";
+import { notifyExtensionsSpiritReady } from "../../lib/extensions.js";
 import { findMind, validateSpiritName, voluteSystemDir } from "../../lib/mind/registry.js";
 import { normalizeAvatar } from "../../lib/util/avatar-image.js";
 import log from "../../lib/util/logger.js";
@@ -520,6 +521,11 @@ setup.post("/complete", async (c) => {
 
     await ensureSpiritProject();
     await syncSpiritTemplate();
+
+    // Fresh installs create the spirit here, not at daemon boot — extensions
+    // loaded long before this point, so without firing the hook now their
+    // spirit bootstrap would wait for a daemon restart to run at all.
+    await notifyExtensionsSpiritReady();
 
     const warnings: string[] = [];
 

--- a/packages/extensions/intentions/src/index.ts
+++ b/packages/extensions/intentions/src/index.ts
@@ -23,9 +23,11 @@ export default createExtension({
   skillsDir,
   standardSkill: true,
   spiritSkills: ["intention-review"],
-  onDaemonStart: (ctx) => {
+  // onSpiritReady, not onDaemonStart: on a fresh install the spirit doesn't exist
+  // yet when extensions load, so provisioning there skipped the first boot entirely.
+  onSpiritReady: async (ctx) => {
     try {
-      provisionSpiritSchedule(ctx);
+      await provisionSpiritSchedule(ctx);
     } catch (err) {
       console.warn("[intentions] failed to provision spirit schedule:", err);
     }

--- a/packages/extensions/intentions/src/spirit-schedule.ts
+++ b/packages/extensions/intentions/src/spirit-schedule.ts
@@ -43,13 +43,15 @@ function markProvisioned(db: Database): void {
  * doesn't exist yet (or whose config is missing/unparseable/unwritable) is
  * left alone and retried on the next daemon start.
  */
-export function provisionSpiritSchedule(ctx: ExtensionContext): void {
+export async function provisionSpiritSchedule(ctx: ExtensionContext): Promise<void> {
   if (!ctx.db || isProvisioned(ctx.db)) return;
 
   const spiritName = ctx.getSpiritName();
   if (!spiritName) return; // no spirit configured yet
 
-  const spiritDir = ctx.getMindDir(spiritName);
+  // Registry-backed lookup — the spirit's directory is under the system dir, not
+  // the minds dir, so a path-convention resolve finds nothing and skips forever.
+  const spiritDir = await ctx.getMindDir(spiritName);
   if (!spiritDir) return; // spirit not created yet — try again next boot
 
   const configPath = resolve(spiritDir, "home/.config/volute.json");

--- a/packages/extensions/pages/src/commands.ts
+++ b/packages/extensions/pages/src/commands.ts
@@ -30,7 +30,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         if (!mindName) return { error: "No mind specified (use --mind or VOLUTE_MIND)" };
 
         if (flags.shared) {
-          const mindDir = ctx.getMindDir(mindName);
+          const mindDir = await ctx.getMindDir(mindName);
           if (!mindDir) return { error: `Mind not found: ${mindName}` };
 
           const message = args.message?.trim();
@@ -117,7 +117,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
 
         const remote = flags.remote as boolean;
 
-        const mindDir = ctx.getMindDir(mindName);
+        const mindDir = await ctx.getMindDir(mindName);
         if (!mindDir) return { error: `Mind not found: ${mindName}` };
 
         const sourceDir = resolve(mindDir, "home", "pages");
@@ -260,7 +260,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         if (!mindName) return { error: "No mind specified (use --mind or VOLUTE_MIND)" };
 
         if (flags.shared) {
-          const mindDir = ctx.getMindDir(mindName);
+          const mindDir = await ctx.getMindDir(mindName);
           if (!mindDir) return { error: `Mind not found: ${mindName}` };
 
           try {
@@ -272,7 +272,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         }
 
         // List current mind's pages with status
-        const mindDir = ctx.getMindDir(mindName);
+        const mindDir = await ctx.getMindDir(mindName);
         if (!mindDir) return { error: `Mind not found: ${mindName}` };
 
         const sourceDir = resolve(mindDir, "home", "pages");
@@ -303,7 +303,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         const mindName = ctx.mindName;
         if (!mindName) return { error: "No mind specified (use --mind or VOLUTE_MIND)" };
 
-        const mindDir = ctx.getMindDir(mindName);
+        const mindDir = await ctx.getMindDir(mindName);
         if (!mindDir) return { error: `Mind not found: ${mindName}` };
 
         try {
@@ -327,7 +327,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         const mindName = ctx.mindName;
         if (!mindName) return { error: "No mind specified (use --mind or VOLUTE_MIND)" };
 
-        const mindDir = ctx.getMindDir(mindName);
+        const mindDir = await ctx.getMindDir(mindName);
         if (!mindDir) return { error: `Mind not found: ${mindName}` };
 
         const limit = (flags.limit as number | undefined) ?? 20;

--- a/packages/extensions/pages/src/commons.ts
+++ b/packages/extensions/pages/src/commons.ts
@@ -72,8 +72,10 @@ export async function maybeSendCommonsCue(ctx: ExtensionContext, repoDir: string
   if (!spirit) return;
 
   try {
-    const user = await ctx.getUserByUsername(spirit);
-    if (user?.user_type !== "mind") return; // spirit not created yet — retry next start
+    // Gate on the spirit's project existing, not on its user row's type: the spirit
+    // shares the system user account (`user_type: "system"`), so a type check here
+    // never passed and the cue was never sent on any system.
+    if (!(await ctx.getMindDir(spirit))) return; // spirit not created yet — retry next start
     await ctx.recordNotice(
       spirit,
       "The commons — the shared pages at pages/_system/ that every mind here can edit — has no index yet. When you have a quiet moment, you might make one: a page that says what this place is, in your own voice, with room in it for the others. The commons-gardening skill describes the craft.",

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -76,7 +76,16 @@ export default createExtension({
   // onDaemonStart because the spirit isn't created yet at that point on a fresh
   // install. maybeSendCommonsCue handles its own errors and never rejects.
   async onSpiritReady(ctx) {
-    await (repoReady ?? Promise.resolve()).catch(() => {});
+    // Only cue once the repo has actually initialized. The cue is one-shot (it
+    // writes a flag file), so sending it after a failed init would permanently
+    // invite the spirit to tend a commons that isn't there. A failed init is
+    // already logged in onDaemonStart and retries on the next daemon start.
+    if (!repoReady) return;
+    try {
+      await repoReady;
+    } catch {
+      return;
+    }
     await maybeSendCommonsCue(ctx, resolve(ctx.dataDir, "repo"));
   },
 

--- a/packages/extensions/pages/src/index.ts
+++ b/packages/extensions/pages/src/index.ts
@@ -65,25 +65,31 @@ export default createExtension({
             console.error("[pages] failed to sync system pages to DB:", err);
           }
         }
-
-        // One-time bootstrap: invite the spirit to create a commons index if
-        // one doesn't exist yet. Flag file makes it fire at most once.
-        // maybeSendCommonsCue handles its own errors and never rejects.
-        void maybeSendCommonsCue(ctx, repoDir);
       })
       .catch((err) => {
         console.error("[pages] failed to initialize pages repo:", err);
       });
   },
 
+  // One-time bootstrap: invite the spirit to create a commons index if one doesn't
+  // exist yet. Flag file makes it fire at most once. Runs here rather than in
+  // onDaemonStart because the spirit isn't created yet at that point on a fresh
+  // install. maybeSendCommonsCue handles its own errors and never rejects.
+  async onSpiritReady(ctx) {
+    await (repoReady ?? Promise.resolve()).catch(() => {});
+    await maybeSendCommonsCue(ctx, resolve(ctx.dataDir, "repo"));
+  },
+
   onMindStart(mindName, ctx) {
-    const mindDir = ctx.getMindDir(mindName);
-    if (!mindDir) return;
     // Wait for repo init; its failures are already logged in onDaemonStart, and
     // addPagesWorktree self-skips if the repo is still unusable.
     (repoReady ?? Promise.resolve())
       .catch(() => {})
-      .then(() => addPagesWorktree(mindName, mindDir, ctx.dataDir, isolationFrom(ctx)))
+      .then(async () => {
+        const mindDir = await ctx.getMindDir(mindName);
+        if (!mindDir) return;
+        await addPagesWorktree(mindName, mindDir, ctx.dataDir, isolationFrom(ctx));
+      })
       .catch((err) => {
         console.warn(
           `[pages] failed to add pages worktree for ${mindName}: ${(err as Error).message}`,

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -49,12 +49,20 @@ export type ExtensionContext = {
   getUser: (id: number) => Promise<User | null>;
   getUserByUsername: (username: string) => Promise<User | null>;
   publishActivity: (event: ActivityEvent) => void;
-  getMindDir: (name: string) => string | null;
+  /**
+   * Resolve a mind's project directory, or null when it doesn't exist on disk.
+   * Registry-backed, so it also resolves minds whose directory isn't the
+   * path-convention default: the system spirit (which lives under the system
+   * dir, never the minds dir) and variants (which live in git worktrees).
+   */
+  getMindDir: (name: string) => Promise<string | null>;
   getSystemsConfig: () => SystemsConfig | null;
   announceToSystem: (text: string) => Promise<void>;
   /**
    * Queue an ambient, non-interrupting notification for a mind, delivered as context
-   * on the mind's next turn (via the notices system). No-op if the target isn't a mind.
+   * on the mind's next turn (via the notices system). No-op if the target isn't a
+   * registered mind — which includes the system spirit, even though the spirit's
+   * user row is `user_type: "system"` rather than `"mind"`.
    * Use for low-urgency signals (a comment on a note, a reaction) that shouldn't trigger
    * a turn on their own. Never throws.
    */
@@ -63,7 +71,11 @@ export type ExtensionContext = {
   isIsolationEnabled: () => boolean;
   /** Get the OS username for a mind under user isolation (e.g. "mind-lyra"). */
   getMindUser: (mindName: string) => string;
-  /** Configured name of the system spirit, or null when no spirit is set up. */
+  /**
+   * Name of the system spirit. Mirrors the daemon's own `getSpiritName()`, which
+   * defaults to "volute" when the host never named one — so this is null only on
+   * a system with no spirit concept at all, not merely an unconfigured one.
+   */
   getSpiritName: () => string | null;
   dataDir: string;
 };
@@ -158,6 +170,14 @@ export type ExtensionManifest = {
   initDb?: (db: Database) => void;
   commands?: Record<string, ExtensionCommand>;
   onDaemonStart?: (ctx: ExtensionContext) => void;
+  /**
+   * Fires once per daemon start, after the system spirit's project exists and is
+   * registered. Use this — not `onDaemonStart` — for bootstrap that reads or writes
+   * the spirit's directory: on a fresh install `onDaemonStart` runs well before the
+   * spirit is created, so spirit-dependent work there silently skips the very boot
+   * that creates it. Not called when there is no spirit (e.g. setup incomplete).
+   */
+  onSpiritReady?: (ctx: ExtensionContext) => void | Promise<void>;
   onDaemonStop?: () => void;
   onMindStart?: (mindName: string, ctx: ExtensionContext) => void;
   onMindStop?: (mindName: string) => void;

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -72,9 +72,12 @@ export type ExtensionContext = {
   /** Get the OS username for a mind under user isolation (e.g. "mind-lyra"). */
   getMindUser: (mindName: string) => string;
   /**
-   * Name of the system spirit. Mirrors the daemon's own `getSpiritName()`, which
-   * defaults to "volute" when the host never named one — so this is null only on
-   * a system with no spirit concept at all, not merely an unconfigured one.
+   * Name of the system spirit. Under the daemon this mirrors its own
+   * `getSpiritName()`, which falls back to "volute" on installs predating spirit
+   * naming and so never returns null — an earlier implementation read
+   * `setup.spiritName` directly and returned null there, silently killing every
+   * spirit-dependent extension path on those systems. The type stays nullable for
+   * hosts that embed the SDK without a spirit at all; treat null as "no spirit".
    */
   getSpiritName: () => string | null;
   dataDir: string;

--- a/test/extension-context-spirit.test.ts
+++ b/test/extension-context-spirit.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, before, describe, it } from "node:test";
+import type { ExtensionManifest } from "@volute/extensions";
+import { and, eq } from "drizzle-orm";
+import type { MiddlewareHandler } from "hono";
+
+import { MIND_LEVEL_THREAD } from "../packages/daemon/src/lib/chat/system-events.js";
+import { getSpiritName } from "../packages/daemon/src/lib/config/setup.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { buildExtensionContext } from "../packages/daemon/src/lib/extensions.js";
+import {
+  addMind,
+  addSpirit,
+  mindDir,
+  removeMind,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import { systemEvents } from "../packages/daemon/src/lib/schema.js";
+import { initDb } from "../packages/extensions/intentions/src/db.js";
+import { provisionSpiritSchedule } from "../packages/extensions/intentions/src/spirit-schedule.js";
+
+/**
+ * The extension SDK's context helpers used to assume every mind looks like a
+ * mind: a `user_type: "mind"` row, living at `$VOLUTE_MINDS_DIR/<name>`. The
+ * system spirit is neither — it shares the system user account (`user_type:
+ * "system"`) and lives under the system dir. Both assumptions silently no-opped
+ * the spirit bootstrap paths of the pages and intentions extensions, so these
+ * tests exercise the real context rather than a fake.
+ */
+describe("extension context: spirit resolution", () => {
+  const manifest = { id: "test-ctx", name: "Test", version: "0.0.0" } as ExtensionManifest;
+  const noopMw = (async (_c: unknown, next: () => Promise<void>) =>
+    next()) as unknown as MiddlewareHandler;
+
+  let dataDir: string;
+  let spiritProjectDir: string;
+  let spiritName: string;
+
+  before(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "ext-ctx-"));
+    spiritProjectDir = resolve(dataDir, "spirit-project");
+    mkdirSync(spiritProjectDir, { recursive: true });
+    spiritName = getSpiritName();
+    await addSpirit(spiritName, 4999, "claude", spiritProjectDir);
+  });
+
+  after(async () => {
+    await removeMind(spiritName).catch(() => {});
+    await removeMind("ordinary-ctx-mind").catch(() => {});
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("resolves the spirit's registry dir, which is not the minds-dir convention", async () => {
+    const ctx = await buildExtensionContext(manifest, dataDir, noopMw);
+
+    assert.equal(await ctx.getMindDir(spiritName), spiritProjectDir);
+    // The bug this guards: the old implementation resolved mindDir(name) and
+    // returned null when that path didn't exist, which is always true for the
+    // spirit. If these two ever coincide the test has stopped proving anything.
+    assert.notEqual(
+      spiritProjectDir,
+      mindDir(spiritName),
+      "spirit dir must differ from the path convention for this test to bite",
+    );
+  });
+
+  it("returns null for a mind with no directory on disk", async () => {
+    const ctx = await buildExtensionContext(manifest, dataDir, noopMw);
+    await addMind("ordinary-ctx-mind", 4998);
+    assert.equal(await ctx.getMindDir("ordinary-ctx-mind"), null);
+  });
+
+  it("reports the spirit name even when the host never configured one", async () => {
+    const ctx = await buildExtensionContext(manifest, dataDir, noopMw);
+    // Mirrors the daemon's getSpiritName(), which defaults to "volute" on installs
+    // predating spirit naming. Reading setup.spiritName directly returned null there.
+    assert.equal(ctx.getSpiritName(), spiritName);
+  });
+
+  it("records a notice for the spirit despite its user_type being system", async () => {
+    const ctx = await buildExtensionContext(manifest, dataDir, noopMw);
+    await ctx.recordNotice(spiritName, "commons has no index yet");
+
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(systemEvents)
+      .where(and(eq(systemEvents.mind, spiritName), eq(systemEvents.thread, MIND_LEVEL_THREAD)));
+    assert.equal(rows.length, 1);
+    assert.match(rows[0].body ?? "", /commons has no index/);
+  });
+
+  it("drops a notice addressed to a name that is not a registered mind", async () => {
+    const ctx = await buildExtensionContext(manifest, dataDir, noopMw);
+    await ctx.recordNotice("not-a-mind-at-all", "should go nowhere");
+
+    const db = await getDb();
+    const rows = await db
+      .select()
+      .from(systemEvents)
+      .where(eq(systemEvents.mind, "not-a-mind-at-all"));
+    assert.equal(rows.length, 0);
+  });
+
+  // End-to-end for the bug that left the intentions review lifecycle with no
+  // ignition: with the real context and a real spirit registration, the daily
+  // review schedule must actually land in the spirit's config.
+  it("provisions the intentions spirit schedule through the real context", async () => {
+    mkdirSync(resolve(spiritProjectDir, "home/.config"), { recursive: true });
+    const configPath = resolve(spiritProjectDir, "home/.config/volute.json");
+    writeFileSync(configPath, JSON.stringify({ schedules: [] }));
+
+    const intentionsDataDir = resolve(dataDir, "intentions-data");
+    mkdirSync(intentionsDataDir, { recursive: true });
+    const ctx = await buildExtensionContext(
+      { id: "intentions-test", name: "I", version: "0.0.0", initDb } as ExtensionManifest,
+      intentionsDataDir,
+      noopMw,
+    );
+    try {
+      await provisionSpiritSchedule(ctx);
+    } finally {
+      ctx.db?.close();
+    }
+
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as {
+      schedules?: { id: string }[];
+    };
+    assert.ok(
+      config.schedules?.some((s) => s.id === "intention-review"),
+      "spirit must get its daily intention-review schedule",
+    );
+  });
+});

--- a/test/extension-context-spirit.test.ts
+++ b/test/extension-context-spirit.test.ts
@@ -10,7 +10,12 @@ import type { MiddlewareHandler } from "hono";
 import { MIND_LEVEL_THREAD } from "../packages/daemon/src/lib/chat/system-events.js";
 import { getSpiritName } from "../packages/daemon/src/lib/config/setup.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
-import { buildExtensionContext } from "../packages/daemon/src/lib/extensions.js";
+import {
+  _clearLoadedExtensionsForTest,
+  _registerExtensionForTest,
+  buildExtensionContext,
+  notifyExtensionsSpiritReady,
+} from "../packages/daemon/src/lib/extensions.js";
 import {
   addMind,
   addSpirit,
@@ -132,5 +137,36 @@ describe("extension context: spirit resolution", () => {
       config.schedules?.some((s) => s.id === "intention-review"),
       "spirit must get its daily intention-review schedule",
     );
+  });
+});
+
+describe("notifyExtensionsSpiritReady", () => {
+  after(() => _clearLoadedExtensionsForTest());
+
+  it("fires every extension's hook and contains one that throws", async () => {
+    _clearLoadedExtensionsForTest();
+    const fired: string[] = [];
+    _registerExtensionForTest({
+      id: "boom",
+      name: "Boom",
+      version: "0",
+      onSpiritReady: async () => {
+        fired.push("boom");
+        throw new Error("bootstrap exploded");
+      },
+    } as unknown as ExtensionManifest);
+    _registerExtensionForTest({
+      id: "after",
+      name: "After",
+      version: "0",
+      onSpiritReady: async () => {
+        fired.push("after");
+      },
+    } as unknown as ExtensionManifest);
+
+    // A failing extension must not swallow the ones registered behind it, and must
+    // not reject into the daemon startup path that calls this.
+    await assert.doesNotReject(() => notifyExtensionsSpiritReady());
+    assert.deepEqual(fired, ["boom", "after"]);
   });
 });

--- a/test/intentions-spirit-schedule.test.ts
+++ b/test/intentions-spirit-schedule.test.ts
@@ -14,7 +14,7 @@ import { provisionSpiritSchedule } from "../packages/extensions/intentions/src/s
 function makeCtx(overrides: {
   db: ExtDb;
   getSpiritName: () => string | null;
-  getMindDir: () => string | null;
+  getMindDir: () => Promise<string | null>;
 }): ExtensionContext {
   return {
     db: overrides.db,
@@ -65,22 +65,22 @@ describe("provisionSpiritSchedule", () => {
     return !!db.prepare("SELECT 1 FROM meta WHERE key = 'spirit_schedule_provisioned'").get();
   }
 
-  it("provisions the schedule and sets the marker when a spirit exists", () => {
+  it("provisions the schedule and sets the marker when a spirit exists", async () => {
     writeConfig({ schedules: [] });
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
 
-    provisionSpiritSchedule(ctx);
+    await provisionSpiritSchedule(ctx);
 
     const config = readConfig();
     assert.ok(config.schedules?.some((s) => s.id === "intention-review"));
     assert.equal(isMarked(), true);
   });
 
-  it("does not duplicate an already-present schedule but still marks provisioned", () => {
+  it("does not duplicate an already-present schedule but still marks provisioned", async () => {
     writeConfig({ schedules: [{ id: "intention-review", cron: "0 0 * * *", enabled: true }] });
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
 
-    provisionSpiritSchedule(ctx);
+    await provisionSpiritSchedule(ctx);
 
     const matches = (readConfig().schedules ?? []).filter((s) => s.id === "intention-review");
     assert.equal(matches.length, 1);
@@ -89,12 +89,12 @@ describe("provisionSpiritSchedule", () => {
 
   // The important case: a host or the spirit deleting the schedule on purpose
   // must not have it silently come back on the next daemon start.
-  it("is a no-op once the marker is set, even if the schedule row is gone", () => {
+  it("is a no-op once the marker is set, even if the schedule row is gone", async () => {
     writeConfig({ schedules: [] });
     db.prepare("INSERT INTO meta (key, value) VALUES ('spirit_schedule_provisioned', 'x')").run();
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
 
-    provisionSpiritSchedule(ctx);
+    await provisionSpiritSchedule(ctx);
 
     assert.equal(
       (readConfig().schedules ?? []).length,
@@ -103,47 +103,47 @@ describe("provisionSpiritSchedule", () => {
     );
   });
 
-  it("does nothing and does not mark when there is no spirit configured yet", () => {
+  it("does nothing and does not mark when there is no spirit configured yet", async () => {
     writeConfig({ schedules: [] });
-    const ctx = makeCtx({ db, getSpiritName: () => null, getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => null, getMindDir: async () => spiritDir });
 
-    provisionSpiritSchedule(ctx);
+    await provisionSpiritSchedule(ctx);
 
     assert.equal(isMarked(), false);
     assert.equal((readConfig().schedules ?? []).length, 0);
   });
 
-  it("does nothing and does not mark when the spirit's directory does not exist yet", () => {
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => null });
+  it("does nothing and does not mark when the spirit's directory does not exist yet", async () => {
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => null });
 
-    provisionSpiritSchedule(ctx);
+    await provisionSpiritSchedule(ctx);
 
     assert.equal(isMarked(), false);
   });
 
-  it("does not throw and does not mark when volute.json is missing", () => {
+  it("does not throw and does not mark when volute.json is missing", async () => {
     rmSync(configPath, { force: true });
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
 
-    assert.doesNotThrow(() => provisionSpiritSchedule(ctx));
+    await assert.doesNotReject(() => provisionSpiritSchedule(ctx));
     assert.equal(isMarked(), false);
   });
 
-  it("does not throw and does not mark when volute.json is unparseable", () => {
+  it("does not throw and does not mark when volute.json is unparseable", async () => {
     writeFileSync(configPath, "not json");
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
 
-    assert.doesNotThrow(() => provisionSpiritSchedule(ctx));
+    await assert.doesNotReject(() => provisionSpiritSchedule(ctx));
     assert.equal(isMarked(), false);
   });
 
-  it("does not throw when volute.json is unwritable", () => {
+  it("does not throw when volute.json is unwritable", async () => {
     writeConfig({ schedules: [] });
     chmodSync(configPath, 0o444);
-    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: () => spiritDir });
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
 
     try {
-      assert.doesNotThrow(() => provisionSpiritSchedule(ctx));
+      await assert.doesNotReject(() => provisionSpiritSchedule(ctx));
       // root ignores the read-only bit, so skip the "stays unmarked" assertion
       // when tests happen to run as root — the throw-safety is the real guarantee.
       if (process.getuid?.() !== 0) {

--- a/test/notes.test.ts
+++ b/test/notes.test.ts
@@ -524,7 +524,7 @@ describe("notes commands stdin", () => {
       publishActivity: (e: { type: string; metadata?: Record<string, unknown> }) => {
         activities.push(e);
       },
-      getMindDir: () => null,
+      getMindDir: async () => null,
       getSystemsConfig: () => null,
       announceToSystem: async (text: string) => {
         announced.push(text);

--- a/test/pages-commands.test.ts
+++ b/test/pages-commands.test.ts
@@ -313,7 +313,7 @@ describe("pages commands", () => {
       getUser: async () => null,
       getUserByUsername: async () => null,
       publishActivity: (e: any) => events.push(e),
-      getMindDir: (name: string) => (name === mindName ? mindDir : null),
+      getMindDir: async (name: string) => (name === mindName ? mindDir : null),
       getSystemsConfig: () => null,
       announceToSystem: async () => {},
       isIsolationEnabled: () => false,

--- a/test/pages-commons.test.ts
+++ b/test/pages-commons.test.ts
@@ -148,7 +148,9 @@ describe("maybeSendCommonsCue", () => {
 
   // Regression: the spirit shares the system user account (`user_type: "system"`),
   // so gating the cue on the users table meant it never fired on any install.
-  // The gate is the spirit's project existing, not what its user row says it is.
+  // The gate is the spirit's project existing, not what its user row says it is —
+  // hence the production-shaped user row here, which fails the moment anyone
+  // reintroduces a `user_type === "mind"` check (verified by reverting the fix).
   it("sends to the spirit even though its user row is user_type system", async () => {
     const { ctx, notices } = makeCtx({
       getUserByUsername: async (username: string) =>

--- a/test/pages-commons.test.ts
+++ b/test/pages-commons.test.ts
@@ -83,7 +83,7 @@ describe("maybeSendCommonsCue", () => {
       getUserByUsername: async (username: string) =>
         ({ id: 1, username, role: "user", user_type: "mind" }) as User,
       publishActivity: () => {},
-      getMindDir: () => null,
+      getMindDir: async () => "/spirit/dir",
       getSystemsConfig: () => null,
       announceToSystem: async () => {},
       recordNotice: async (mind: string, text: string) => {
@@ -139,21 +139,25 @@ describe("maybeSendCommonsCue", () => {
     assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
   });
 
-  it("does not send or write the flag when the spirit user doesn't exist yet", async () => {
-    const { ctx, notices } = makeCtx({ getUserByUsername: async () => null });
+  it("does not send or write the flag when the spirit project doesn't exist yet", async () => {
+    const { ctx, notices } = makeCtx({ getMindDir: async () => null });
     await maybeSendCommonsCue(ctx, repoDir);
     assert.equal(notices.length, 0);
     assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
   });
 
-  it("does not send when the spirit username resolves to a non-mind user", async () => {
+  // Regression: the spirit shares the system user account (`user_type: "system"`),
+  // so gating the cue on the users table meant it never fired on any install.
+  // The gate is the spirit's project existing, not what its user row says it is.
+  it("sends to the spirit even though its user row is user_type system", async () => {
     const { ctx, notices } = makeCtx({
       getUserByUsername: async (username: string) =>
-        ({ id: 1, username, role: "admin", user_type: "human" }) as User,
+        ({ id: 1, username, role: "system", user_type: "system" }) as unknown as User,
     });
     await maybeSendCommonsCue(ctx, repoDir);
-    assert.equal(notices.length, 0);
-    assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].mind, "aria");
+    assert.ok(existsSync(resolve(dataDir, ".commons-cue-sent")));
   });
 
   it("index.html also counts as an index", async () => {

--- a/test/pages-shared-events.test.ts
+++ b/test/pages-shared-events.test.ts
@@ -108,7 +108,7 @@ describe("shared publish command events", () => {
       getUser: async () => null,
       getUserByUsername: async () => null,
       publishActivity: (e: any) => activity.push(e),
-      getMindDir: (name: string) => (name === mindName ? mindDir : null),
+      getMindDir: async (name: string) => (name === mindName ? mindDir : null),
       getSystemsConfig: () => null,
       announceToSystem: async (text: string) => {
         announcements.push(text);

--- a/test/web-pages.test.ts
+++ b/test/web-pages.test.ts
@@ -260,7 +260,7 @@ function makeCtx(dir: string) {
     authMiddleware: (() => {}) as any,
     getUser: async () => null,
     getUserByUsername: async () => null,
-    getMindDir: () => null,
+    getMindDir: async () => null,
     getSystemsConfig: () => null,
     resolveUser: () => null,
     publishActivity: () => {},

--- a/website/src/content/docs/docs/concepts/extensions.md
+++ b/website/src/content/docs/docs/concepts/extensions.md
@@ -55,7 +55,7 @@ An extension manifest can provide:
 - **Feed sources** — cards on the home and mind feeds
 - **Skills** — contributed via `skillsDir`, synced to the shared pool on load
 - **Database tables** — each extension gets its own SQLite DB at `~/.volute/system/extension-data/{id}/data.db`
-- **Lifecycle hooks** — `onDaemonStart`, `onDaemonStop`, `onMindStart`, `onMindStop`
+- **Lifecycle hooks** — `onDaemonStart`, `onSpiritReady`, `onDaemonStop`, `onMindStart`, `onMindStop`
 
 Extension UI is rendered in iframes and shares the Volute theme via an auto-generated `ext-theme.css`.
 


### PR DESCRIPTION
Two features found dead in the 0.54.0 Docker integration test, one root cause.

The extension context assumed every mind looks like a mind: a `users` row with `user_type: "mind"`, living at `$VOLUTE_MINDS_DIR/<name>`. The system spirit is neither — it shares the system user account (`user_type: "system"`, `auth.ts:213`) and its project always lives at `resolve(voluteSystemDir(), "spirit")`. Both spirit bootstrap paths died silently on that, on every installation.

**BUG 2 — the intentions review lifecycle had no ignition.** `ctx.getMindDir` used `mindDir(name)`, the path-convention helper, and returned null when that path didn't exist — always true for the spirit. `provisionSpiritSchedule()` therefore always early-returned, so the spirit never got its daily `intention-review` schedule. Verified in the test run: the intentions `meta` table had no `spirit_schedule_provisioned` row after four daemon boots with the spirit running. Exactly the failure mode the function's own doc comment says it exists to prevent.

**BUG 1 — the commons bootstrap cue could never fire.** `maybeSendCommonsCue()` gated on `user?.user_type !== "mind"`, which the spirit's `"system"` row never satisfies. Silent, because the early return is on the "retry next start" branch.

## What changed

Fixed in the SDK rather than at each call site:

- **`getMindDir` resolves through the registry** (`resolveMindDir`) instead of the path convention, so it finds the spirit — and variants, which live in worktrees and were equally unresolvable. Now `async`; all 10 call sites updated.
- **`recordNotice` gates on the minds registry** instead of `users.user_type`. This mattered independently: even with the commons fix, the notice was being dropped one layer down for the same reason.
- **`getSpiritName` delegates to the daemon's `getSpiritName()`**, which falls back to `"volute"`. Reading `setup.spiritName` directly returned null on installs predating spirit naming — a second, independent way both paths died.
- **New `onSpiritReady` lifecycle hook.** Extension `onDaemonStart` runs ~11s before the spirit is created on a fresh install (observed 16:07:32.9 vs 16:07:43.9), so even with the above fixed, bootstrap would skip the boot that creates the spirit. Fired from both spirit-creation paths: daemon boot, and `POST /setup/complete` — which is the one that matters, since a genuinely fresh install creates the spirit there and not at boot. Pages and intentions moved their spirit bootstrap onto it.

## Tests

`test/extension-context-spirit.test.ts` exercises the **real** daemon-built context against a registered spirit rather than a fake, which is what makes it bite. I verified each assertion fails without the fix by reverting each helper individually:

- spirit dir resolution, spirit-name default, and notice delivery to the spirit: **3 of 3 fail** on the old implementations
- the two rewritten `pages-commons` cases: **both fail** when the `user_type` gate is restored
- plus an end-to-end case asserting the spirit's `volute.json` actually gains the `intention-review` schedule, and one covering `onSpiritReady` error containment

`npm test`: 3042 pass, 0 fail.

## Things I'm less sure about

- **`recordNotice` narrows for external minds** — a `users` row with `user_type: "mind"` but no registry row (the external-minds shape from #741) used to pass this gate and now doesn't. I think that's correct, since there's no local process to drain the event and the notice was accumulating unread in `system_events`, but it is a behavior change beyond the stated bug and worth a second opinion.
- **`getMindDir` became async**, which is a breaking change for any third-party extension. Nothing outside this repo uses it yet as far as I can tell, and a sync registry lookup isn't available (the DB layer is async throughout), but flagging it rather than burying it.
- **`buildContext` is now exported** as `buildExtensionContext` so the tests can use the real thing. It has a production caller, so I didn't give it the `_forTest` naming that file uses for genuine test-only shims.

## Merge-order note

`provisionSpiritSchedule` is provision-once with a permanent marker, and this PR is what makes it write for the first time anywhere. The sibling PR fixing the `volute intention` → `volute intentions` command name (BUG 5) touches the script string this schedule is provisioned with. If this lands first and a daemon starts before that one, the broken command gets baked in permanently. I've flagged this to that author, who is adding a self-heal that rewrites an existing schedule carrying the old string.

Not in scope: BUGs 3, 4, 5 and 6 from the same test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)