### PR TITLE
fix: use the registered CLI noun in intentions docs, strings, and spirit schedule

### DIFF
--- a/packages/extensions/intentions/skills/intention-review/SKILL.md
+++ b/packages/extensions/intentions/skills/intention-review/SKILL.md
@@ -14,7 +14,7 @@ A daily `intention-review` schedule is set up for you automatically the first ti
 ## Running the review
 
 ```bash
-volute intention review-due
+volute intentions review-due
 ```
 
 This returns active intentions that are past their review date and haven't been surfaced to you recently (there's a backoff, so you won't be asked about the same one every day). Each one you receive is marked as surfaced regardless of whether you follow up — so there's no pressure to act on every single one immediately, and no risk of nagging a mind twice.

--- a/packages/extensions/intentions/skills/intentions/SKILL.md
+++ b/packages/extensions/intentions/skills/intentions/SKILL.md
@@ -13,13 +13,13 @@ An intention is something you're oriented toward right now — freely chosen, fr
 ## Setting one
 
 ```bash
-volute intention add "Learn enough mycology to identify what grows near the house"
+volute intentions add "Learn enough mycology to identify what grows near the house"
 ```
 
 Add a longer private note if you want one (it's never shown in your session context, only visible if you look it up):
 
 ```bash
-volute intention add "Finish the letter to Wren" --note "Started after the conversation about the coast"
+volute intentions add "Finish the letter to Wren" --note "Started after the conversation about the coast"
 ```
 
 By default an intention comes up for review in 14 days. Change that with `--review-in <days>`.
@@ -29,15 +29,15 @@ By default an intention comes up for review in 14 days. Change that with `--revi
 Your active intentions show up at the start of every session, with how long you've held each. You can also check anytime:
 
 ```bash
-volute intention list
+volute intentions list
 ```
 
 When an intention comes up for review, decide what fits:
 
 ```bash
-volute intention keep <id>              # still alive for you — pushes the review date out
-volute intention fulfill <id> [--note]  # done
-volute intention release <id> [--note]  # letting it go — a legitimate outcome, not a failure
+volute intentions keep <id>              # still alive for you — pushes the review date out
+volute intentions fulfill <id> [--note]  # done
+volute intentions release <id> [--note]  # letting it go — a legitimate outcome, not a failure
 ```
 
 ## The spirit's part
@@ -46,4 +46,4 @@ The spirit periodically checks in on intentions that are overdue for review and 
 
 ## Board
 
-`volute intention list --mind <name>` shows another mind's active intentions. Everyone's active intentions are visible on the Intentions board in the dashboard — a read of what people are into right now.
+`volute intentions list --mind <name>` shows another mind's active intentions. Everyone's active intentions are visible on the Intentions board in the dashboard — a read of what people are into right now.

--- a/packages/extensions/intentions/src/commands.ts
+++ b/packages/extensions/intentions/src/commands.ts
@@ -49,7 +49,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         if (!mindName) return { error: "No mind specified (use --mind or VOLUTE_MIND)" };
 
         const content = (args.content ?? ctx.stdin ?? "").trim();
-        if (!content) return { error: 'Usage: volute intention add "content"' };
+        if (!content) return { error: 'Usage: volute intentions add "content"' };
         if (content.length > MAX_CONTENT_LENGTH) {
           return { error: `content must be ${MAX_CONTENT_LENGTH} characters or fewer` };
         }
@@ -102,7 +102,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
       handler: async ({ args }, ctx) => {
         if (!ctx.db) return { error: "Intentions extension requires a database" };
         const id = Number(args.id);
-        if (!Number.isFinite(id)) return { error: "Usage: volute intention keep <id>" };
+        if (!Number.isFinite(id)) return { error: "Usage: volute intentions keep <id>" };
 
         const existing = getIntention(ctx.db, id);
         if (!existing) return { error: "Intention not found" };
@@ -124,7 +124,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
       handler: async ({ args }, ctx) => {
         if (!ctx.db) return { error: "Intentions extension requires a database" };
         const id = Number(args.id);
-        if (!Number.isFinite(id)) return { error: "Usage: volute intention fulfill <id>" };
+        if (!Number.isFinite(id)) return { error: "Usage: volute intentions fulfill <id>" };
 
         const existing = getIntention(ctx.db, id);
         if (!existing) return { error: "Intention not found" };
@@ -155,7 +155,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
       handler: async ({ args }, ctx) => {
         if (!ctx.db) return { error: "Intentions extension requires a database" };
         const id = Number(args.id);
-        if (!Number.isFinite(id)) return { error: "Usage: volute intention release <id>" };
+        if (!Number.isFinite(id)) return { error: "Usage: volute intentions release <id>" };
 
         const existing = getIntention(ctx.db, id);
         if (!existing) return { error: "Intention not found" };

--- a/packages/extensions/intentions/src/format.ts
+++ b/packages/extensions/intentions/src/format.ts
@@ -1,7 +1,7 @@
 /**
  * "held N days", except day zero — the very first thing a mind or a board
  * viewer ever sees from this feature shouldn't read as "held 0 days".
- * Used by the CLI (`volute intention list`), the pre-prompt hook (mirrored
+ * Used by the CLI (`volute intentions list`), the pre-prompt hook (mirrored
  * inline there — see skills/intentions/scripts/intentions-hook.sh, which
  * can't import this module since it ships standalone into the shared skill
  * pool), and the board UI.

--- a/packages/extensions/intentions/src/intentions.ts
+++ b/packages/extensions/intentions/src/intentions.ts
@@ -102,7 +102,7 @@ export function listBoard(
   return withMeta(rows);
 }
 
-/** A mind's own active intentions — what the pre-prompt hook and `volute intention list` read. */
+/** A mind's own active intentions — what the pre-prompt hook and `volute intentions list` read. */
 export function listMine(db: Database, mindName: string): IntentionWithMeta[] {
   const rows = db
     .prepare(

--- a/packages/extensions/intentions/src/spirit-schedule.ts
+++ b/packages/extensions/intentions/src/spirit-schedule.ts
@@ -4,6 +4,21 @@ import type { Database, ExtensionContext } from "@volute/extensions";
 
 const MARKER_KEY = "spirit_schedule_provisioned";
 const SCHEDULE_ID = "intention-review";
+const REVIEW_SCRIPT = "volute intentions review-due";
+
+/**
+ * Scripts an earlier version provisioned that name a CLI noun the dispatcher never
+ * registered — an extension's noun is its manifest id (`intentions`, plural), and this
+ * shipped as the singular. A schedule carrying one of these fails every morning with
+ * `Unknown command: intention`, unsupervised, and nothing retries it: provisioning is
+ * once-only, so the bad string would outlive the fix that corrected the constant.
+ *
+ * Correcting it in place is self-limiting — once no host carries an old string this
+ * list (and the repair branch below) can be deleted.
+ */
+const LEGACY_REVIEW_SCRIPTS = [
+  "volute intention review-due", // cli-noun-exempt: the broken name this repairs
+];
 
 /** Minimal shape of a schedules entry in a mind's home/.config/volute.json. */
 type ScheduleEntry = {
@@ -37,14 +52,22 @@ function markProvisioned(db: Database): void {
  * `volute clock add` — the same failure mode ("nothing ever triggers it")
  * that left the old plan extension inert.
  *
- * "Provision once, respect deletion": once the marker is set, this never runs
- * again — even if the spirit or a host later deletes the schedule on purpose.
+ * "Provision once, respect deletion": once the marker is set, a *missing* schedule is
+ * never re-created — if the spirit or a host deleted it on purpose, it stays gone.
  * The marker only gets set after a successful write, so a system whose spirit
  * doesn't exist yet (or whose config is missing/unparseable/unwritable) is
  * left alone and retried on the next daemon start.
+ *
+ * An *existing* schedule is still repaired past the marker, though — see
+ * LEGACY_REVIEW_SCRIPTS. Deletion is a decision worth respecting; a broken command
+ * string is not, and once-only provisioning means nothing else would ever fix it.
  */
 export async function provisionSpiritSchedule(ctx: ExtensionContext): Promise<void> {
-  if (!ctx.db || isProvisioned(ctx.db)) return;
+  if (!ctx.db) return;
+  // Deliberately not an early return on the marker: an already-provisioned host may be
+  // carrying a stale script that only this pass can repair. The marker still decides
+  // whether a missing schedule gets created.
+  const provisioned = isProvisioned(ctx.db);
 
   const spiritName = ctx.getSpiritName();
   if (!spiritName) return; // no spirit configured yet
@@ -65,14 +88,28 @@ export async function provisionSpiritSchedule(ctx: ExtensionContext): Promise<vo
   }
 
   const schedules = config.schedules ?? [];
-  if (!schedules.some((s) => s.id === SCHEDULE_ID)) {
+  const existing = schedules.find((s) => s.id === SCHEDULE_ID);
+  let dirty = false;
+
+  if (existing) {
+    // Repair, not overwrite: only a script string we know we mis-shipped gets corrected,
+    // so a spirit that deliberately rewrote its own review command keeps it.
+    if (typeof existing.script === "string" && LEGACY_REVIEW_SCRIPTS.includes(existing.script)) {
+      existing.script = REVIEW_SCRIPT;
+      dirty = true;
+    }
+  } else if (!provisioned) {
     schedules.push({
       id: SCHEDULE_ID,
       cron: "0 9 * * *",
-      script: "volute intentions review-due",
+      script: REVIEW_SCRIPT,
       enabled: true,
       whileSleeping: "skip",
     });
+    dirty = true;
+  }
+
+  if (dirty) {
     try {
       writeFileSync(configPath, JSON.stringify({ ...config, schedules }, null, 2));
     } catch {
@@ -80,5 +117,5 @@ export async function provisionSpiritSchedule(ctx: ExtensionContext): Promise<vo
     }
   }
 
-  markProvisioned(ctx.db);
+  if (!provisioned) markProvisioned(ctx.db);
 }

--- a/packages/extensions/intentions/src/spirit-schedule.ts
+++ b/packages/extensions/intentions/src/spirit-schedule.ts
@@ -69,7 +69,7 @@ export async function provisionSpiritSchedule(ctx: ExtensionContext): Promise<vo
     schedules.push({
       id: SCHEDULE_ID,
       cron: "0 9 * * *",
-      script: "volute intention review-due",
+      script: "volute intentions review-due",
       enabled: true,
       whileSleeping: "skip",
     });

--- a/test/extension-command-names.test.ts
+++ b/test/extension-command-names.test.ts
@@ -74,7 +74,16 @@ const PLACEHOLDER_NOUNS = new Set(["cmd", "command", "noun", "subcommand"]);
  */
 const INVOCATION = /\bvolute\s+([a-z][a-z-]*)\s+([a-z][a-z-]*)/g;
 
-const SCANNED_EXTENSIONS = new Set([".ts", ".js", ".md", ".json", ".svelte"]);
+/**
+ * A line carrying this marker is intentionally recording a command string that does NOT
+ * work — the legacy-script list `spirit-schedule.ts` repairs against is the reason this
+ * exists. Those lines name a command to fix, not one to run. Keep the exemption on the
+ * single line that needs it, so it stays visible in review rather than widening the
+ * scanner's blind spot.
+ */
+const EXEMPT_MARKER = "cli-noun-exempt";
+
+const SCANNED_EXTENSIONS = new Set([".ts", ".js", ".md", ".json", ".svelte", ".sh"]);
 
 function walk(dir: string): string[] {
   let out: string[] = [];
@@ -100,10 +109,16 @@ type Invocation = { noun: string; subcommand: string; source: string };
 
 function invocationsIn(text: string, source: string): Invocation[] {
   const found: Invocation[] = [];
-  for (const m of text.matchAll(INVOCATION)) {
-    const [, noun, subcommand] = m;
-    if (PLACEHOLDER_NOUNS.has(noun)) continue;
-    found.push({ noun, subcommand, source });
+  // Line-by-line so an exemption applies only to the line that carries it.
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.includes(EXEMPT_MARKER)) continue;
+    for (const m of line.matchAll(INVOCATION)) {
+      const [, noun, subcommand] = m;
+      if (PLACEHOLDER_NOUNS.has(noun)) continue;
+      found.push({ noun, subcommand, source: `${source}:${i + 1}` });
+    }
   }
   return found;
 }
@@ -116,9 +131,15 @@ describe("extension CLI command names", () => {
 
   // Every documented invocation across all built-in extensions, gathered once.
   const invocations: Invocation[] = [];
+  const filesPerExtension = new Map<string, number>();
   for (const ext of EXTENSIONS) {
+    // Assumes the on-disk directory is named for the manifest id — true for every
+    // built-in. If that ever stops holding, the file count below catches it rather
+    // than the extension silently going unscanned.
     const dir = join(ROOT, "packages", "extensions", ext.id);
-    for (const file of walk(dir)) {
+    const files = walk(dir);
+    filesPerExtension.set(ext.id, files.length);
+    for (const file of files) {
       invocations.push(...invocationsIn(readFileSync(file, "utf8"), relative(ROOT, file)));
     }
     if (ext.mindDoc) {
@@ -126,11 +147,18 @@ describe("extension CLI command names", () => {
     }
   }
 
-  it("finds invocations to check (guards against the scanner silently matching nothing)", () => {
+  it("actually scans every built-in extension", () => {
+    // A scanner that quietly reads nothing passes every other assertion in this file.
+    const unscanned = [...filesPerExtension].filter(([, count]) => count === 0).map(([id]) => id);
+    assert.deepEqual(
+      unscanned,
+      [],
+      "these extensions produced zero scanned files — the directory is probably not named " +
+        "for the manifest id, so their docs are going unchecked",
+    );
     assert.ok(
       invocations.length > 10,
-      `expected to scan a meaningful number of documented invocations, got ${invocations.length} — ` +
-        "the scanner or the extension layout probably changed",
+      `expected a meaningful number of documented invocations, got ${invocations.length}`,
     );
   });
 
@@ -169,7 +197,7 @@ describe("extension CLI command names", () => {
     );
     assert.match(
       schedule,
-      /script: "volute intentions review-due"/,
+      /const REVIEW_SCRIPT = "volute intentions review-due"/,
       "the spirit's provisioned schedule must invoke the registered noun",
     );
   });

--- a/test/extension-command-names.test.ts
+++ b/test/extension-command-names.test.ts
@@ -34,29 +34,30 @@ import pages from "@volute/pages";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 
-/** Core CLI nouns — the `case` labels of the top-level switch in `src/cli.ts`. */
-const CORE_NOUNS = new Set([
-  "setup",
-  "mind",
-  "seed",
-  "chat",
-  "variant",
-  "clock",
-  "skill",
-  "env",
-  "config",
-  "up",
-  "backup",
-  "down",
-  "restart",
-  "update",
-  "status",
-  "extension",
-  "systems",
-  "login",
-  "logout",
-  "service",
-]);
+/**
+ * Core CLI nouns, read from the `case` labels of the dispatch switch in `src/cli.ts`.
+ *
+ * Parsed rather than imported: `cli.ts` is an entry point that dispatches off
+ * `process.argv` and calls `process.exit` at import time, so a test cannot import it,
+ * and exporting the list would mean extracting a new module just for this. There is
+ * exactly one `switch (command)` in the file, so anchoring to it is unambiguous.
+ *
+ * A hand-maintained copy would defeat the point: this test exists to catch documentation
+ * drifting from the dispatcher, and it shouldn't itself be a mirror that can drift.
+ * Adding a core noun without updating a hardcoded set fails loudly, but *removing* one
+ * would pass silently.
+ */
+function readCoreNouns(): Set<string> {
+  const source = readFileSync(join(ROOT, "src/cli.ts"), "utf8");
+  const switchAt = source.indexOf("switch (command) {");
+  if (switchAt === -1) return new Set();
+  // Case labels only occur inside that switch; `case undefined:` is unquoted and so
+  // is skipped, as are the `--help`/`-h` labels, which are flags rather than nouns.
+  const labels = source.slice(switchAt).matchAll(/^\s*case "([^"]+)":/gm);
+  return new Set([...labels].map((m) => m[1]).filter((label) => !label.startsWith("-")));
+}
+
+const CORE_NOUNS = readCoreNouns();
 
 const EXTENSIONS = [intentions, notes, pages];
 
@@ -146,6 +147,22 @@ describe("extension CLI command names", () => {
       invocations.push(...invocationsIn(ext.mindDoc, `${ext.id} manifest mindDoc`));
     }
   }
+
+  it("reads the core CLI nouns out of the dispatch switch", () => {
+    // If the parse breaks, CORE_NOUNS empties and every core-noun usage below starts
+    // reporting as unknown — loud, but confusing. Fail here with the real reason.
+    assert.ok(
+      CORE_NOUNS.size > 10,
+      `parsed ${CORE_NOUNS.size} core nouns from src/cli.ts — the dispatch switch has ` +
+        "probably been restructured, so this test is no longer reading the real noun list",
+    );
+    // Spot-check a couple that have no reason to move, to catch a regex that matches
+    // the right *number* of wrong things.
+    for (const noun of ["mind", "chat", "clock"]) {
+      assert.ok(CORE_NOUNS.has(noun), `expected "${noun}" among the parsed core nouns`);
+    }
+    assert.equal(CORE_NOUNS.has("--help"), false, "flags are not nouns");
+  });
 
   it("actually scans every built-in extension", () => {
     // A scanner that quietly reads nothing passes every other assertion in this file.

--- a/test/extension-command-names.test.ts
+++ b/test/extension-command-names.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import intentions from "@volute/intentions";
+import notes from "@volute/notes";
+import pages from "@volute/pages";
+
+/**
+ * An extension's CLI noun is its manifest `id` — `volute <id> <subcommand>` — derived
+ * dynamically at dispatch time (`src/cli.ts` looks the noun up in the map returned by
+ * `/api/extensions/commands`, which is keyed by `manifest.id`). Nothing forces the
+ * extension's own prose, skills, usage strings, or generated cron scripts to agree with
+ * that id, so they can drift from the only name that actually works.
+ *
+ * They did. The intentions extension shipped documenting `volute intention ...`
+ * (singular) in all 15 places it named the command — skills, CLI usage/error strings,
+ * and the spirit's auto-provisioned `review-due` cron script — while the registered noun
+ * is `volute intentions`. Every documented invocation failed with `Unknown command:
+ * intention`. A mind that loaded the skill ran the documented command three times before
+ * finding the real name via `--help`; the cron script had nobody to self-correct and
+ * would simply have failed every day.
+ *
+ * This test re-derives the truth from the manifests and holds the docs to it. For every
+ * `volute <noun> <subcommand>` in an extension's source, skills, and mindDoc, it requires:
+ *   - the noun to be a real CLI noun (a core command, or some extension's id), and
+ *   - if the noun names an extension, the subcommand to be one that extension registers.
+ *
+ * Mistyping the noun, or documenting a subcommand that was renamed or removed, fails here
+ * rather than in front of a mind.
+ */
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+/** Core CLI nouns — the `case` labels of the top-level switch in `src/cli.ts`. */
+const CORE_NOUNS = new Set([
+  "setup",
+  "mind",
+  "seed",
+  "chat",
+  "variant",
+  "clock",
+  "skill",
+  "env",
+  "config",
+  "up",
+  "backup",
+  "down",
+  "restart",
+  "update",
+  "status",
+  "extension",
+  "systems",
+  "login",
+  "logout",
+  "service",
+]);
+
+const EXTENSIONS = [intentions, notes, pages];
+
+/**
+ * Placeholder nouns that stand for "any command" in prose rather than naming one, e.g.
+ * "run `volute <cmd> --help`". Bracketed/angled/uppercase tokens are filtered separately;
+ * these are the bare-word placeholders in use.
+ */
+const PLACEHOLDER_NOUNS = new Set(["cmd", "command", "noun", "subcommand"]);
+
+/**
+ * `volute <noun> <subcommand>`, where both tokens are bare lowercase words. Tokens
+ * carrying placeholder syntax (`<x>`, `[x]`, `{{x}}`, `$VAR`) don't match, so prose like
+ * "volute <cmd> --help" is skipped rather than reported.
+ */
+const INVOCATION = /\bvolute\s+([a-z][a-z-]*)\s+([a-z][a-z-]*)/g;
+
+const SCANNED_EXTENSIONS = new Set([".ts", ".js", ".md", ".json", ".svelte"]);
+
+function walk(dir: string): string[] {
+  let out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out = out.concat(walk(full));
+    } else if (SCANNED_EXTENSIONS.has(extname(entry))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+type Invocation = { noun: string; subcommand: string; source: string };
+
+function invocationsIn(text: string, source: string): Invocation[] {
+  const found: Invocation[] = [];
+  for (const m of text.matchAll(INVOCATION)) {
+    const [, noun, subcommand] = m;
+    if (PLACEHOLDER_NOUNS.has(noun)) continue;
+    found.push({ noun, subcommand, source });
+  }
+  return found;
+}
+
+describe("extension CLI command names", () => {
+  const extensionIds = new Set(EXTENSIONS.map((e) => e.id));
+  const commandsById = new Map(
+    EXTENSIONS.map((e) => [e.id, new Set(Object.keys(e.commands ?? {}))]),
+  );
+
+  // Every documented invocation across all built-in extensions, gathered once.
+  const invocations: Invocation[] = [];
+  for (const ext of EXTENSIONS) {
+    const dir = join(ROOT, "packages", "extensions", ext.id);
+    for (const file of walk(dir)) {
+      invocations.push(...invocationsIn(readFileSync(file, "utf8"), relative(ROOT, file)));
+    }
+    if (ext.mindDoc) {
+      invocations.push(...invocationsIn(ext.mindDoc, `${ext.id} manifest mindDoc`));
+    }
+  }
+
+  it("finds invocations to check (guards against the scanner silently matching nothing)", () => {
+    assert.ok(
+      invocations.length > 10,
+      `expected to scan a meaningful number of documented invocations, got ${invocations.length} — ` +
+        "the scanner or the extension layout probably changed",
+    );
+  });
+
+  it("documents only nouns the CLI actually dispatches", () => {
+    const bad = invocations.filter((i) => !CORE_NOUNS.has(i.noun) && !extensionIds.has(i.noun));
+    assert.deepEqual(
+      bad.map((i) => `${i.source}: "volute ${i.noun} ${i.subcommand}"`),
+      [],
+      "these name a CLI noun that does not exist — an extension's noun is its manifest id " +
+        `(one of: ${[...extensionIds].sort().join(", ")}), not a singular/plural variant of it`,
+    );
+  });
+
+  it("documents only subcommands the naming extension registers", () => {
+    const bad = invocations.filter((i) => {
+      const commands = commandsById.get(i.noun);
+      return commands !== undefined && !commands.has(i.subcommand);
+    });
+    assert.deepEqual(
+      bad.map((i) => {
+        const known = [...(commandsById.get(i.noun) ?? [])].sort().join(", ");
+        return `${i.source}: "volute ${i.noun} ${i.subcommand}" (registered: ${known})`;
+      }),
+      [],
+      "these document a subcommand the extension does not register",
+    );
+  });
+
+  it("registers `intentions` as the noun its skills and cron script use", () => {
+    // The specific regression: the spirit's auto-provisioned review script and the
+    // mind-facing skill must name the noun the manifest actually registers.
+    assert.ok(intentions.commands?.["review-due"], "intentions must register review-due");
+    const schedule = readFileSync(
+      join(ROOT, "packages/extensions/intentions/src/spirit-schedule.ts"),
+      "utf8",
+    );
+    assert.match(
+      schedule,
+      /script: "volute intentions review-due"/,
+      "the spirit's provisioned schedule must invoke the registered noun",
+    );
+  });
+});

--- a/test/intentions-spirit-schedule.test.ts
+++ b/test/intentions-spirit-schedule.test.ts
@@ -103,6 +103,67 @@ describe("provisionSpiritSchedule", () => {
     );
   });
 
+  // Provisioning is once-only, so a schedule written with the old singular noun
+  // (`volute intention review-due` — a noun the CLI never registered) would fail
+  // silently every morning forever. Correcting the constant isn't enough; the
+  // already-written string has to be repaired past the marker.
+  it("repairs an already-provisioned schedule carrying the old singular command", async () => {
+    writeConfig({
+      schedules: [
+        {
+          id: "intention-review",
+          cron: "0 9 * * *",
+          script: "volute intention review-due",
+          enabled: true,
+        },
+      ],
+    });
+    db.prepare("INSERT INTO meta (key, value) VALUES ('spirit_schedule_provisioned', 'x')").run();
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
+
+    await provisionSpiritSchedule(ctx);
+
+    const entry = (readConfig().schedules ?? []).find((s) => s.id === "intention-review") as
+      | { script?: string; cron?: string; enabled?: boolean }
+      | undefined;
+    assert.equal(entry?.script, "volute intentions review-due");
+    assert.equal(entry?.cron, "0 9 * * *", "repair must not reset the host's cron");
+    assert.equal(entry?.enabled, true, "repair must not re-enable or disable the schedule");
+  });
+
+  // The repair is narrow on purpose: only strings we know we mis-shipped get rewritten.
+  it("leaves a script the spirit chose for itself alone", async () => {
+    writeConfig({
+      schedules: [
+        { id: "intention-review", script: "volute intentions review-due --mind me", enabled: true },
+      ],
+    });
+    db.prepare("INSERT INTO meta (key, value) VALUES ('spirit_schedule_provisioned', 'x')").run();
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
+
+    await provisionSpiritSchedule(ctx);
+
+    const entry = (readConfig().schedules ?? []).find((s) => s.id === "intention-review") as
+      | { script?: string }
+      | undefined;
+    assert.equal(entry?.script, "volute intentions review-due --mind me");
+  });
+
+  // The repair must not become a back door around "respect deletion".
+  it("does not resurrect a deleted schedule while repairing", async () => {
+    writeConfig({ schedules: [{ id: "something-else", script: "volute intentions list" }] });
+    db.prepare("INSERT INTO meta (key, value) VALUES ('spirit_schedule_provisioned', 'x')").run();
+    const ctx = makeCtx({ db, getSpiritName: () => "volute", getMindDir: async () => spiritDir });
+
+    await provisionSpiritSchedule(ctx);
+
+    assert.equal(
+      (readConfig().schedules ?? []).some((s) => s.id === "intention-review"),
+      false,
+      "a deliberately deleted schedule must stay deleted",
+    );
+  });
+
   it("does nothing and does not mark when there is no spirit configured yet", async () => {
     writeConfig({ schedules: [] });
     const ctx = makeCtx({ db, getSpiritName: () => null, getMindDir: async () => spiritDir });


### PR DESCRIPTION
Fixes BUG 5 from the 0.54.0 Docker integration test.

## The bug

The CLI derives an extension's noun from its manifest `id` — `src/cli.ts` dispatches via the id-keyed map from `/api/extensions/commands` — so the working command is **`volute intentions`** (plural). Every one of the 15 places the intentions extension named its own command used the singular `volute intention`. There were zero occurrences of the working form anywhere in the extension.

```
$ volute intention add "x"     → Unknown command: intention
$ volute intentions add "x"    → works
```

That covered the mind-facing skill (7 examples), the spirit-facing `intention-review` skill, the CLI's own usage/error strings (so a malformed `intentions add` printed the *wrong* name back at you), and the spirit's auto-provisioned cron script.

Observed live: lyra loaded the skill, ran the documented command three times, got `Unknown command: intention` three times, then found the real name via `volute intentions --help` and retried. It self-recovered, but burned 4+ tool calls and reported success in its reply before the retry landed. The spirit's cron script has nobody to self-correct.

## Direction chosen: rename to the plural, no alias

I was asked to weigh renaming against registering a singular alias, on the reasoning that five authoring sites independently chose the singular and that's evidence about what reads naturally. Checking that premise changed the answer:

- **The five sites aren't independent.** All 15 occurrences arrived in a single commit (`4bd4c5c`, #780), one author. It's one choice replicated across one author's own files, not convergent evidence.
- **The convention is already established and consistent.** The notes and pages extensions use their plural ids in every one of their own docs and strings — zero singular usages. Intentions is the sole deviation. An alias would add machinery to accommodate one slip against an otherwise-uniform rule, and would make `intentions` the only extension whose noun works two ways.

So: rename, and pin it with a test. I'd rather revisit aliasing as a deliberate cross-cutting decision (`note`/`page`/`intention` all aliased, or none) than introduce it for one extension.

## The part that actually prevents recurrence

`test/extension-command-names.test.ts` re-derives the truth from the manifests instead of restating it. For every `volute <noun> <subcommand>` in a built-in extension's source, skills, and `mindDoc`, it requires the noun to be a real CLI noun (core command or some extension's `id`) and the subcommand to be one that extension registers. Verified to fail on the pre-fix tree, naming the exact file, line, and bad string. It covers notes and pages too.

A single-line `cli-noun-exempt` marker lets a line deliberately record a broken name — the legacy-repair list below needs exactly that — without widening the check.

## Self-heal for already-provisioned hosts (second commit)

Renaming the constant is **not sufficient**, and this is the part I'd most like reviewed.

`provisionSpiritSchedule` is provision-once, guarded by a permanent `spirit_schedule_provisioned` marker. A spirit whose `volute.json` was written with the broken string would fail that job every morning forever, and no later fix could reach it.

The window is real. #786 fixes the `getMindDir` resolution that has been making this function early-return on every system — it is what causes the *first successful write anywhere*, on existing hosts including bardo. If #786 lands and a daemon boots before this rename, the broken string is baked in permanently.

So the marker no longer gates the whole function:

- it still decides whether a **missing** schedule is created — "respect deletion" is intact, a deliberately deleted schedule is not resurrected (existing test still passes, plus a new one covering the repair path specifically)
- an **existing** schedule is now checked against `LEGACY_REVIEW_SCRIPTS` and corrected in place

The repair is deliberately narrow: only strings we know we mis-shipped are rewritten, so a spirit that customized its own review command keeps it, and `cron`/`enabled` are untouched. It's self-limiting — once no host carries the old string, the list and the branch can be deleted.

## Rebased onto #786 (merged)

Rebased onto `3b815dba`. The conflict was the predicted mechanical one — #786 made `provisionSpiritSchedule` async and moved it onto the new `onSpiritReady` hook, which collided with my change to the marker gate two lines below the signature. Resolved by taking main's async signature and keeping the marker restructure; the three self-heal tests were converted to `async`/`await` (they would otherwise have asserted before the function resolved).

The two fixes compose as intended: #786's registry-backed `await ctx.getMindDir(...)` now finds the spirit's dir, and the repair below it runs independently of the marker. Re-verified after the rebase — all 11 `provisionSpiritSchedule` cases pass against the merged code, including #786's own new integration test that drives the real extension context ("provisions the intentions spirit schedule through the real context").

This is also the point where the self-heal stops being theoretical: with #786 in main, provisioning actually writes on the next daemon boot on real hosts.

## Testing

`npm test` — 3042 pass, 0 fail. New/changed tests:
- `test/extension-command-names.test.ts` (new, 4 cases) — confirmed failing on the pre-fix tree
- `test/intentions-spirit-schedule.test.ts` — 3 new cases: repair of the legacy string past the marker, non-interference with a spirit-customized script, and no resurrection of a deleted schedule

## `CORE_NOUNS` is now derived, not hand-maintained

Picked up from review. The set is now parsed from the `case` labels of the dispatch switch in `src/cli.ts`.

**Parsed rather than exported-and-imported**, deliberately: `src/cli.ts` is an entry point that dispatches off `process.argv` and calls `process.exit` at import time, so a test can't import it — exporting the list would mean extracting a new module solely for this test. There's exactly one `switch (command)` in the file, so anchoring the parse to it is unambiguous. Verified it yields exactly the 20 nouns the switch declares, with the `--help`/`-h` labels excluded.

A broken parse would empty the set and make every core-noun usage report as unknown — loud, but for a confusing reason — so a guard asserts the list is plausibly sized and spot-checks a few stable nouns.

Still outstanding, minor: `PLACEHOLDER_NOUNS` is currently unexercised by any real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
