### PR TITLE
fix: fire extension mind-start hooks for the spirit

### DIFF
--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -221,6 +221,16 @@ export async function startSpiritFull(name: string): Promise<void> {
   // Load spirit schedules with explicit dir (spirit lives outside ~/.volute/minds/)
   getScheduler().loadSchedules(name, entry?.dir ?? spiritDir());
 
+  // The spirit is a mind as far as extensions are concerned — it has a registry
+  // row, a directory, and its own pages/notes/intentions. Skipping this left it
+  // with no pages worktree, so the mind whose job is tending the commons was the
+  // one mind that could never publish to it (#795).
+  try {
+    notifyExtensionsMindStart(name);
+  } catch (err) {
+    log.error(`failed to notify extensions of spirit start for ${name}`, log.errorData(err));
+  }
+
   publishActivity({
     type: "mind_started",
     mind: name,
@@ -232,6 +242,7 @@ export async function startSpiritFull(name: string): Promise<void> {
  * Stop a spirit process.
  */
 export async function stopSpiritFull(name: string): Promise<void> {
+  notifyExtensionsMindStop(name);
   markIdle(name);
   getScheduler().unloadSchedules(name);
   await getMindManager().stopMind(name);

--- a/packages/extensions/pages/src/shared-pages.ts
+++ b/packages/extensions/pages/src/shared-pages.ts
@@ -178,7 +178,18 @@ export async function addPagesWorktree(
   }
 
   const wt = worktreePath(mindDir);
-  if (existsSync(wt)) return;
+  if (existsSync(wt)) {
+    // A real worktree has a `.git` file. A plain directory here is what a mind
+    // creates by hand when publishing failed for lack of a worktree (#795) — say
+    // so, because git then refuses to provision over it and every later publish
+    // fails with an opaque `invalid upstream` deep inside the rebase.
+    if (!existsSync(resolve(wt, ".git"))) {
+      console.warn(
+        `[pages] ${wt} exists but is not a worktree — shared publishing will fail for ${mindName}. Move it aside and restart the mind to provision one.`,
+      );
+    }
+    return;
+  }
 
   // Ensure parent pages/ directory exists
   mkdirSync(resolve(mindDir, "home", "pages"), { recursive: true });

--- a/test/spirit-extension-hooks.test.ts
+++ b/test/spirit-extension-hooks.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, before, describe, it } from "node:test";
+import type { ExtensionManifest } from "@volute/extensions";
+
+import {
+  initMindManager,
+  tryGetMindManager,
+} from "../packages/daemon/src/lib/daemon/mind-manager.js";
+import { startSpiritFull, stopSpiritFull } from "../packages/daemon/src/lib/daemon/mind-service.js";
+import { initScheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
+import {
+  _clearLoadedExtensionsForTest,
+  _registerExtensionForTest,
+} from "../packages/daemon/src/lib/extensions.js";
+import { addSpirit, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+
+/**
+ * The spirit is a mind: a registry row with a directory, its own pages, notes and
+ * intentions. But it starts through startSpiritFull, which for a long time skipped
+ * `notifyExtensionsMindStart` entirely — so the spirit received *no* extension
+ * mind-start hook of any kind. The visible casualty was the pages extension, which
+ * provisions each mind's shared-pages git worktree in `onMindStart`: the spirit
+ * never got one, so `volute pages publish --shared` could never succeed for the one
+ * mind whose job is tending the commons (#795).
+ */
+describe("spirit lifecycle fires extension mind hooks", () => {
+  const spiritName = "spirit-hooks-test";
+  let dataDir: string;
+  const started: string[] = [];
+  const stopped: string[] = [];
+
+  before(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "spirit-hooks-"));
+    mkdirSync(resolve(dataDir, "home/.config"), { recursive: true });
+    await addSpirit(spiritName, 4997, "claude", dataDir);
+
+    initScheduler();
+    const manager = tryGetMindManager() ?? initMindManager();
+    // Spawning a real mind process is e2e territory; this test is about what the
+    // lifecycle notifies, not what it spawns.
+    manager.startMind = async () => {};
+    manager.stopMind = async () => {};
+
+    _clearLoadedExtensionsForTest();
+    _registerExtensionForTest({
+      id: "hook-spy",
+      name: "Hook Spy",
+      version: "0",
+      onMindStart: (name: string) => {
+        started.push(name);
+      },
+      onMindStop: (name: string) => {
+        stopped.push(name);
+      },
+    } as unknown as ExtensionManifest);
+  });
+
+  after(async () => {
+    _clearLoadedExtensionsForTest();
+    await removeMind(spiritName).catch(() => {});
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("notifies extensions when the spirit starts", async () => {
+    await startSpiritFull(spiritName);
+    assert.deepEqual(started, [spiritName]);
+  });
+
+  it("notifies extensions when the spirit stops", async () => {
+    await stopSpiritFull(spiritName);
+    assert.deepEqual(stopped, [spiritName]);
+  });
+});


### PR DESCRIPTION
Fixes #795.

## Which fix, and why

**(a) — route the spirit through the same start notification.** `startSpiritFull()` now calls `notifyExtensionsMindStart(name)`, exactly as `startMindFull()` does.

The alternative — provisioning the pages worktree from the pages extension's `onSpiritReady` — fixes today's symptom and leaves the class of bug intact. As the issue notes, this is the third time in one release cycle that extension plumbing forgot the spirit is a mind (`user_type: "system"` early-return on the commons cue; `getMindDir` using path convention over the registry; this). The spirit *is* a row in the `minds` table with a `dir`; every extension hook is written against "a mind started". Making the lifecycle honest is the smaller and more durable change: the next extension that implements `onMindStart` gets the spirit for free instead of discovering the gap in production.

## Extension `onMindStart` audit

Every loaded extension, per `discoverBuiltinExtensions` (`packages/daemon/src/lib/extensions.ts:506`):

| Extension | `onMindStart` | Verdict for the spirit |
|---|---|---|
| **notes** (`@volute/notes`) | none | Safe — no hook, nothing changes. |
| **intentions** (`@volute/intentions`) | none (only `onSpiritReady`) | Safe — no hook. Its spirit bootstrap stays in `onSpiritReady`, which is the right home for spirit-*only* work. |
| **pages** (`@volute/pages`) | `addPagesWorktree` | Safe and *desired* — this is the bug. `ctx.getMindDir(spirit)` resolves via the registry (#786), so it provisions at the spirit's real dir. |

Third-party/local extensions can't be enumerated, but the contract they're written against is "a mind started", and the spirit is a mind with a directory and its own pages/notes/intentions. Nothing spirit-specific (sleep, token budget, mail) lives behind this hook — those stay where they are in `startMindFull`, which the spirit still does not go through.

**No flag or spirit-ness signal was needed.** If a future extension genuinely must skip the spirit, `ctx.getSpiritName()` already exists on the extension context.

### Double-fire / idempotency

`onSpiritReady` and `onMindStart` now both run for the spirit. For pages they do different things: `onSpiritReady` sends the one-shot commons cue (guarded by a flag file) and provisions nothing; `onMindStart` provisions the worktree and sends nothing. No overlap, no ordering hazard — `onSpiritReady` fires before `startSpiritFull` at daemon boot.

`addPagesWorktree` is genuinely self-skipping, verified rather than trusted: it returns early on `existsSync(worktreePath)` (`shared-pages.ts:180`) and on an unusable repo. Repeat spirit starts/restarts are no-ops.

## Also fixed: the stop-side gap

`stopSpiritFull()` had the mirror-image hole — no `notifyExtensionsMindStop()`. No built-in extension implements `onMindStop` today, so nothing was visibly broken, but it's the same bug waiting for its first consumer. Now fires. (`stopSpiritFull` currently has no callers in-tree; the fix is on the exported path regardless.)

## Also: making the field failure legible

The fix provisions correctly on a fresh install, but on a system that already hit this bug the spirit hand-`mkdir`'d `home/pages/_system` when publishing failed — and `addPagesWorktree`'s `existsSync` guard then skips it *silently, forever*. `git` won't provision over the non-empty directory either. So a plain directory where a worktree belongs now warns with what to do about it, rather than leaving the host with only an opaque `invalid upstream 'main'` from inside a rebase. Existing deployments still need the stale directory moved aside by hand; this at least says so.

## Regression test

`test/spirit-extension-hooks.test.ts` registers a spy extension, starts and stops a registered spirit with the process spawn stubbed, and asserts both hooks fire with the spirit's name.

```ts
it("notifies extensions when the spirit starts", async () => {
  await startSpiritFull(spiritName);
  assert.deepEqual(started, [spiritName]);
});

it("notifies extensions when the spirit stops", async () => {
  await stopSpiritFull(spiritName);
  assert.deepEqual(stopped, [spiritName]);
});
```

Confirmed it bites — with the two `notifyExtensions*` calls removed from `mind-service.ts`, both fail:

```
  ✖ notifies extensions when the spirit starts (3.537542ms)
  ✖ notifies extensions when the spirit stops (0.917292ms)
ℹ fail 2
```

## Verification

`npm test` — full suite:

```
ℹ tests 3070
ℹ suites 609
ℹ pass 3070
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 78503.546417
```

`npx tsc --noEmit` — clean, no output.

Spirit gets a *real* worktree (scratch script against a spirit-shaped dir outside the minds dir, since that path convention was the previous bug):

```
.../data/repo                                  4e526a5 [main]
.../system/spirit/home/pages/_system           4e526a5 [volute]

spirit .git present: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
