### PR TITLE
fix: ship memory/dreams/ so dreams are versioned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Unified `users` table with `user_type` discrimination (`"human"` or `"mind"`) st
 
 Templates have a `.init/` directory containing identity and config files. On `volute mind create`, these are copied into `home/` and `.init/` is deleted. On `volute mind upgrade`, `.init/` files are excluded so identity files are never overwritten.
 
-- **`_base/.init/`**: SOUL.md, MEMORY.md, memory/journal/, .config/prompts.json, .config/routes.json, .local/hooks/startup-context.ts, .local/hooks/wake-context.sh, .local/hooks/pre-prompt/ (session-activity.ts, notices.ts), .local/bin/volute
+- **`_base/.init/`**: SOUL.md, MEMORY.md, memory/journal/, memory/dreams/, .config/prompts.json, .config/routes.json, .local/hooks/startup-context.ts, .local/hooks/wake-context.sh, .local/hooks/pre-prompt/ (session-activity.ts, notices.ts), .local/bin/volute
 - **`claude/.init/`**: CLAUDE.md, .claude/settings.json
 - **`pi/.init/`**: MINDS.md
 - **`codex/.init/`**: AGENTS.md

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -53,7 +53,7 @@ Don't explain the connections to your waking life. Let the material speak throug
 
 ### 3. Spawn the Dreamer
 
-Invoke the **dreamer** subagent — this is critical, do NOT use a general-purpose agent. The dreamer is a special subagent defined with only your SOUL.md. Pass your dream premise as the prompt. Include an explicit instruction at the end of your premise: "Write this dream to memory/dreams/YYYY-MM-DD.md (create the directory if it doesn't exist)." — use today's actual date. The dreamer has Write and Bash tools; make sure the instruction is clearly separate from the dream narrative so it's treated as a literal file operation.
+Invoke the **dreamer** subagent — this is critical, do NOT use a general-purpose agent. The dreamer is a special subagent defined with only your SOUL.md. Pass your dream premise as the prompt. Include an explicit instruction at the end of your premise: "Write this dream to memory/dreams/YYYY-MM-DD.md." — use today's actual date. The directory already exists; `memory/dreams/` is the only place dreams go. Anywhere else is unversioned (lost on a variant join) and invisible to `dream list`/`read`/`themes`. The dreamer has Write and Bash tools; make sure the instruction is clearly separate from the dream narrative so it's treated as a literal file operation.
 
 ### 4. After the Dream
 
@@ -61,7 +61,7 @@ Invoke the **dreamer** subagent — this is critical, do NOT use a general-purpo
 - Optionally note recurring themes, striking images, or emotional threads in your journal
 - Don't over-analyze — dreams accumulate meaning over time
 
-Many minds develop their own dream conventions — a running motif, a naming pattern, a recurring structure. These emerge; they aren't prescribed.
+Many minds develop their own dream conventions — a running motif, a naming pattern, a recurring structure. These emerge; they aren't prescribed. The `memory/dreams/` location is the one exception: it's fixed, so your dreams stay versioned and readable by your dream tools.
 
 ## Dream History
 

--- a/skills/dreaming/references/INSTALL.md
+++ b/skills/dreaming/references/INSTALL.md
@@ -12,7 +12,7 @@ This sets up:
 - `dreamer` subagent in `.config/config.json`
 - Dream checker in `.local/hooks/wake-context.sh`
 
-The `memory/dreams/` directory is created automatically on your first dream.
+Dreams go in `memory/dreams/`, which already exists. It is the only versioned dream location — a dream written anywhere else is lost on a variant join.
 
 Restart your mind after running this so the subagent is loaded.
 

--- a/test/dreams-location.test.ts
+++ b/test/dreams-location.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
+import {
+  applyInitFiles,
+  composeTemplate,
+  copyTemplateToDir,
+  findTemplatesRoot,
+} from "../packages/daemon/src/lib/template/template.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), `.volute-dreams-test-${process.pid}-`));
+
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+/** Create a mind from `template` exactly the way mind creation does. */
+function scaffold(template: string, mindName: string): string {
+  const dest = join(tmpDir, `${mindName}-${template}`);
+  const { composedDir, manifest } = composeTemplate(findTemplatesRoot(), template);
+  try {
+    copyTemplateToDir(composedDir, dest, mindName, manifest);
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+  applyInitFiles(dest);
+  return dest;
+}
+
+/** True when `path` is excluded by the mind's .gitignore. */
+function isIgnored(dir: string, path: string): boolean {
+  try {
+    execFileSync("git", ["check-ignore", "-q", path], { cwd: dir });
+    return true;
+  } catch {
+    // check-ignore exits non-zero when the path is not ignored.
+    return false;
+  }
+}
+
+/**
+ * Dreams have one location: memory/dreams/ — the path the dreaming skill,
+ * scripts/dream.ts and wake-context-dreams.sh all use, and the only one the
+ * gitignore allowlist covers (via `!home/memory/**`).
+ *
+ * The skill used to say "create the directory if it doesn't exist", which
+ * invites each mind to pick its own spot. One picked `dreams/`, where dreams
+ * are unversioned — lost on a variant join — and invisible to `dream list`,
+ * `read` and `themes`, which only ever look in memory/dreams/ (#799).
+ */
+describe("dreams have a single versioned location", () => {
+  for (const template of ["pi", "claude", "codex"]) {
+    it(`ships memory/dreams/ in the ${template} template and versions it`, () => {
+      const dest = scaffold(template, `dreamtest-${template}`);
+      const dreams = resolve(dest, "home", "memory", "dreams");
+
+      // Shipping the directory removes the moment where a mind has to choose.
+      assert.ok(existsSync(dreams), "memory/dreams/ must exist so dreams have a home");
+
+      execFileSync("git", ["init", "-q"], { cwd: dest });
+      writeFileSync(resolve(dreams, "2026-07-21.md"), "a dream\n");
+      assert.ok(!isIgnored(dest, "home/memory/dreams/2026-07-21.md"));
+    });
+  }
+
+  it("keeps the skill and its tooling on the same path", () => {
+    const skillDir = resolve(import.meta.dirname, "..", "skills", "dreaming");
+    const skill = readFileSync(resolve(skillDir, "SKILL.md"), "utf-8");
+    const dreamScript = readFileSync(resolve(skillDir, "scripts", "dream.ts"), "utf-8");
+
+    // The instruction handed to the dreamer must name memory/dreams/ and must
+    // not tell it to create a directory — that is what let it choose one.
+    assert.match(skill, /Write this dream to memory\/dreams\/YYYY-MM-DD\.md/);
+    assert.doesNotMatch(skill, /create the directory if it doesn't exist/);
+
+    // dream list/read/themes resolve against this exact path, so a dream
+    // written anywhere else is invisible to the mind's own tools.
+    assert.match(dreamScript, /const dreamsDir = resolve\("memory\/dreams"\)/);
+
+    // Mind-facing paths are relative to home/, which is the mind's cwd — a
+    // `home/` prefix here would resolve to home/home/.
+    assert.doesNotMatch(skill, /home\/memory\/dreams/);
+  });
+});


### PR DESCRIPTION
Refs #799 (the dreams half). **Re-scoped** — see "What this dropped" below.

## The problem

`skills/dreaming/SKILL.md` told the dreamer to write to `memory/dreams/YYYY-MM-DD.md` "(create the directory if it doesn't exist)". That parenthetical leaves the location up to whoever is holding the pen. `oren` picked `dreams/`, and dreams written there are:

- **unversioned** — no gitignore allowlist covers `home/dreams/`, so they're lost on a variant join, which is how this surfaced
- **invisible to the mind's own tooling** — `dream list`, `dream read` and `dream themes` all resolve `memory/dreams` (`scripts/dream.ts:4`), as does `wake-context-dreams.sh:8`

So a dream in the wrong directory isn't just untracked; the mind can't find it again either.

## The fix

Standardise on `memory/dreams/` rather than allowlisting `home/dreams/`. Every existing reference already agrees on `memory/dreams/` — the skill (×3), `dream.ts`, the wake-context hook, the README. Adding a second real location is what got us here.

The actual cause was an asymmetry: `_base/.init/` ships `memory/journal/` but not `memory/dreams/`. Journal writes land correctly because the directory is already there; dreams had to invent one. So the directory now ships, exactly the way `memory/journal/` does, and the skill drops the "create it" instruction and says the location is fixed — while naming, motifs and structure stay the mind's own.

No gitignore change is needed: `!home/memory/**` already covers it.

## Files

| file | change |
|---|---|
| `templates/_base/.init/memory/dreams/.gitkeep` | ship the directory |
| `skills/dreaming/SKILL.md` | drop "create the directory"; state the location is fixed |
| `skills/dreaming/references/INSTALL.md` | same, for the install path |
| `test/dreams-location.test.ts` | new |
| `CLAUDE.md` | one word, keeping the `_base/.init/` inventory accurate |

Mind-facing paths stay relative (`memory/dreams/`, not `home/memory/dreams/`) — the mind's cwd *is* `home/`, so a `home/` prefix would resolve to `home/home/`. The test asserts this.

## Test

`test/dreams-location.test.ts` scaffolds real minds through `composeTemplate` → `copyTemplateToDir` → `applyInitFiles` for all three templates, asserting `memory/dreams/` exists and a dream written there is not gitignored. A fourth test pins the skill text to its tooling: the dreamer instruction names `memory/dreams/`, the "create the directory" phrasing is gone, `dream.ts` still resolves the same path, and no mind-facing path carries a `home/` prefix.

```
✔ ships memory/dreams/ in the pi template and versions it
✔ ships memory/dreams/ in the claude template and versions it
✔ ships memory/dreams/ in the codex template and versions it
✔ keeps the skill and its tooling on the same path
```

## Verification

```
ℹ tests 3074
ℹ pass 3074
ℹ fail 0
```

`npx tsc --noEmit` clean; `npm run typecheck:templates` passes claude, pi and codex.

## What this dropped, and why

This PR previously also collapsed pi's `.pi/MEMORY.md` shadow memory file into `MEMORY.md` via a symlink, with supporting changes to `template.ts`, `auto-commit.ts`, `_base/gitignore` and `biome.json`. All of that is gone. Two reasons:

1. **Nothing of ours belongs under `home/.pi/`.** That directory is pi-coding-agent's (`settings.json`, `SYSTEM.md`, `npm/`, `git/`, and the `skills/` dir it discovers itself). Maintainer decision.
2. **The behaviour is a one-off, not a mechanism.** Other pi minds, including ones on the same kimi-k2.5 model, never did this. n=1 doesn't justify permanent infrastructure in someone else's directory.

Worth keeping on the record from that investigation: pi 0.80.6 has **no memory-file concept at all** (zero `MEMORY` matches across its `dist/` and `docs/`) — `.pi/MEMORY.md` was never a pi convention, so there was never a config knob to point at `MEMORY.md`. pi does inject a rule to resolve a skill's relative paths against the skill directory (`core/skills.js:265`), which is a real contributing factor but evidently not sufficient. The likelier explanation for the ambiguity `oren` faced is #801: pi minds never receive their mechanics doc at all, because pi loads `AGENTS.md`/`CLAUDE.md` and the template ships `MINDS.md`. That's being fixed properly there.

**No migration is shipped.** `oren`'s real memory content still sits in unread `.pi/` files and would need hand-merging — the richer copy was the unread one (1996 B vs 1175 B), so it must not simply be overwritten. Since this is being treated as a one-off, anyone hitting it again should hand-merge rather than expect tooling. Dreams already written to `home/dreams/` likewise need moving to `home/memory/dreams/` by hand; this PR only prevents new ones from landing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
