### PR TITLE
fix: load the pi template's mechanics doc into the system prompt

### DIFF
--- a/templates/_base/src/lib/context-breakdown.ts
+++ b/templates/_base/src/lib/context-breakdown.ts
@@ -451,9 +451,17 @@ export async function processPiSession(
 
 // --- Preamble text readers ---
 
-/** Read the SDK instruction file content (CLAUDE.md, MINDS.md, or AGENTS.md). */
+/**
+ * Read the instruction file the runtime loads on its own (CLAUDE.md for the
+ * Claude Agent SDK, AGENTS.md for codex).
+ *
+ * MINDS.md is deliberately absent: pi does not auto-load it, so the pi template
+ * appends it to the system prompt instead (see pi's `withMechanicsDoc`). Listing
+ * it here would count those tokens twice — once under `systemPrompt` and again
+ * under `sdkInstructions`.
+ */
 export function readSdkInstructions(cwd: string): string {
-  for (const name of ["CLAUDE.md", "MINDS.md", "AGENTS.md"]) {
+  for (const name of ["CLAUDE.md", "AGENTS.md"]) {
     try {
       return readFileSync(resolve(cwd, name), "utf-8");
     } catch (err: any) {
@@ -497,7 +505,7 @@ export function countSystemPromptTokens(systemPrompt: string): number {
   return countTokens(systemPrompt);
 }
 
-/** Count tokens in the SDK instruction file (CLAUDE.md, MINDS.md, or AGENTS.md). */
+/** Count tokens in the runtime-loaded instruction file (CLAUDE.md or AGENTS.md). */
 export function countSdkInstructionTokens(cwd: string): number {
   const content = readSdkInstructions(cwd);
   return content ? countTokens(content) : 0;

--- a/templates/pi/src/lib/mechanics-doc.ts
+++ b/templates/pi/src/lib/mechanics-doc.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** This template's mechanics doc, relative to the mind's home/. */
+export const MECHANICS_DOC = "MINDS.md";
+
+/**
+ * Append the mechanics doc to the system prompt.
+ *
+ * pi-coding-agent only auto-loads a project context file named AGENTS.md or
+ * CLAUDE.md (see @earendil-works/pi-coding-agent `core/resource-loader.js`), so
+ * MINDS.md never reaches the model on its own — pi minds would run with no
+ * mechanics doc at all. The claude and codex templates get theirs for free
+ * because their runtimes read CLAUDE.md / AGENTS.md natively; pi has to be
+ * handed its doc by hand.
+ *
+ * Kept in the system prompt (rather than injected as a context file) so it is
+ * counted once, under `systemPrompt`, by the context breakdown.
+ */
+export function withMechanicsDoc(systemPrompt: string, homeDir: string): string {
+  const path = resolve(homeDir, MECHANICS_DOC);
+  let doc: string;
+  try {
+    doc = readFileSync(path, "utf-8").trim();
+  } catch (err: any) {
+    if (err?.code !== "ENOENT") throw err;
+    return systemPrompt;
+  }
+  return doc ? `${systemPrompt}\n\n---\n\n${doc}` : systemPrompt;
+}

--- a/templates/pi/src/server.ts
+++ b/templates/pi/src/server.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import { createMind } from "./agent.js";
 import { createFileHandlerResolver } from "./lib/file-handler.js";
 import { log, setLevel } from "./lib/logger.js";
+import { withMechanicsDoc } from "./lib/mechanics-doc.js";
 import { createRouter } from "./lib/router.js";
 import {
   loadConfig,
@@ -18,7 +19,8 @@ if (config.logLevel) setLevel(config.logLevel);
 if (config.model) log("server", `using model: ${config.model}`);
 if (config.thinkingLevel) log("server", `thinking level: ${config.thinkingLevel}`);
 
-const systemPrompt = loadSystemPrompt(config);
+// pi does not auto-load MINDS.md, so the mechanics doc is appended by hand.
+const systemPrompt = withMechanicsDoc(loadSystemPrompt(config), resolve("home"));
 const pkg = loadPackageInfo();
 
 const mindDir = resolve(".");

--- a/test/pi-mechanics-doc.test.ts
+++ b/test/pi-mechanics-doc.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
+import { mindSkillsDir } from "../packages/daemon/src/lib/skills.js";
+import {
+  applyInitFiles,
+  composeTemplate,
+  copyTemplateToDir,
+  findTemplatesRoot,
+} from "../packages/daemon/src/lib/template/template.js";
+import {
+  countSdkInstructionTokens,
+  readSdkInstructions,
+} from "../templates/_base/src/lib/context-breakdown.js";
+import { MECHANICS_DOC, withMechanicsDoc } from "../templates/pi/src/lib/mechanics-doc.js";
+
+/**
+ * Build a mind directory from a real template exactly as `mind create` does
+ * (compose _base + template, copy with {{name}} substitution, apply .init/).
+ * Returns the mind dir; every assertion below therefore runs against the files
+ * a freshly-created mind actually has on disk.
+ */
+const scratch: string[] = [];
+function createMindDir(template: string): string {
+  const dest = mkdtempSync(resolve(tmpdir(), `volute-mind-${template}-`));
+  scratch.push(dest);
+  const { composedDir, manifest } = composeTemplate(findTemplatesRoot(), template);
+  try {
+    copyTemplateToDir(composedDir, dest, "testmind", manifest);
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+  applyInitFiles(dest);
+  return dest;
+}
+
+after(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("pi mechanics doc reaches the system prompt", () => {
+  it("appends the mind's MINDS.md to the system prompt", () => {
+    const home = resolve(createMindDir("pi"), "home");
+    const doc = readFileSync(resolve(home, MECHANICS_DOC), "utf-8");
+    assert.ok(doc.trim().length > 0, "pi template must ship a non-empty mechanics doc");
+
+    const prompt = withMechanicsDoc("SOUL", home);
+    assert.notEqual(prompt, "SOUL", "mechanics doc was not appended");
+    assert.ok(prompt.startsWith("SOUL"), "base system prompt must be preserved");
+    assert.ok(prompt.includes(doc.trim()), "full mechanics doc must be in the system prompt");
+  });
+
+  it("wires the mechanics doc into the prompt pi is actually started with", () => {
+    // The helper above is only useful if server.ts applies it. A source-level
+    // check is crude, but the wiring is exactly what was missing (#801) and
+    // importing server.ts would boot a real HTTP server.
+    const dir = createMindDir("pi");
+    assert.ok(existsSync(resolve(dir, "src/lib/mechanics-doc.ts")), "helper must ship in template");
+    const server = readFileSync(resolve(dir, "src/server.ts"), "utf-8");
+    assert.match(server, /withMechanicsDoc\(\s*loadSystemPrompt\(/);
+  });
+
+  it("is a no-op when the mind has no mechanics doc", () => {
+    const home = mkdtempSync(resolve(tmpdir(), "volute-empty-home-"));
+    scratch.push(home);
+    assert.equal(withMechanicsDoc("SOUL", home), "SOUL");
+  });
+
+  it("pi ships no runtime-auto-loaded instruction file, so the doc is not double-counted", () => {
+    // pi only auto-loads AGENTS.md/CLAUDE.md. If either ever appears in the pi
+    // template, MINDS.md becomes dead weight and this accounting is wrong.
+    const home = resolve(createMindDir("pi"), "home");
+    assert.ok(!existsSync(resolve(home, "AGENTS.md")));
+    assert.ok(!existsSync(resolve(home, "CLAUDE.md")));
+    assert.equal(readSdkInstructions(home), "");
+    assert.equal(countSdkInstructionTokens(home), 0);
+  });
+
+  it("claude and codex minds still report their runtime-loaded instruction file", () => {
+    for (const [template, file] of [
+      ["claude", "CLAUDE.md"],
+      ["codex", "AGENTS.md"],
+    ] as const) {
+      const home = resolve(createMindDir(template), "home");
+      assert.ok(existsSync(resolve(home, file)), `${template} must ship ${file}`);
+      assert.ok(readSdkInstructions(home).length > 0, `${template} instructions must be read`);
+      assert.ok(countSdkInstructionTokens(home) > 0, `${template} instructions must be counted`);
+    }
+  });
+});
+
+describe("template skills directory resolves from real template output", () => {
+  // The discriminator in skills.ts probes mechanics-doc filenames. These cases
+  // run it against freshly-created minds rather than synthetic marker files, so
+  // renaming a template's mechanics doc fails here instead of silently pointing
+  // a mind at a skills directory its runtime never reads.
+  const expected: Record<string, string> = {
+    claude: join("home", ".claude", "skills"),
+    pi: join("home", ".pi", "skills"),
+    codex: join("home", ".agents", "skills"),
+  };
+
+  for (const [template, suffix] of Object.entries(expected)) {
+    it(`${template} mind resolves to ${suffix}`, () => {
+      const dir = createMindDir(template);
+      assert.equal(mindSkillsDir(dir), resolve(dir, suffix));
+    });
+  }
+
+  it("gives each template a distinct skills directory", () => {
+    const dirs = Object.keys(expected).map((t) => mindSkillsDir(createMindDir(t)).split("home")[1]);
+    assert.equal(new Set(dirs).size, dirs.length, "templates must not collide on a skills dir");
+  });
+});


### PR DESCRIPTION
Fixes #801.

pi-coding-agent only auto-loads a project context file named `AGENTS.md`/`CLAUDE.md` (`core/resource-loader.js:31`), so the pi template's `MINDS.md` never reached the model. Every pi mind has been running with **no mechanics doc at all** — never told that `MEMORY.md` is its core memory or that journal entries live in `memory/journal/`.

## Which option, and why

The issue offered two directions. **I took option 2** — keep `MINDS.md`, load it explicitly — for three reasons:

1. **Option 1 breaks the discriminator and offers nothing in return.** Renaming to `AGENTS.md` makes pi and codex ship the same marker file, collapsing `mindSkillsDir()`'s probe (`skills.ts:266-278`). pi minds would resolve to `.agents/skills` and their skills would silently vanish. Fixing that properly means moving `mindSkillsDir(dir: string)` to a registry lookup — which needs a mind *name*, not a path, and an async DB read — rippling through `skills.ts` (7 call sites), `spirit.ts`, `default-autonomy.ts`, and `seed-sprout.ts`. That's a large, risky refactor whose only payoff is enabling the rename.
2. **Option 1 strands every existing pi mind.** `mind upgrade` excludes `.init/`, so a renamed mechanics doc would never land on minds that already exist. They'd keep a `MINDS.md` nothing reads, and need a migration. Option 2 repairs them with a plain upgrade (details below).
3. **The stated downside of option 2 — "depends on template-side loading code staying correct" — is testable**, and now tested. See the regression tests.

This satisfies the requirement verbatim: pi works, and pi/codex stay distinguishable.

### On the discriminator

Since `MINDS.md` stays, the filename probe remains correct and I left it alone — no site infers template-by-filename incorrectly today. I did **strengthen** its test coverage: the existing tests in `test/skills.test.ts` assert against hand-written marker files, so a template rename would pass them while breaking real minds. The new tests run `mindSkillsDir()` against directories built by the *actual* create path (`composeTemplate` → `copyTemplateToDir` → `applyInitFiles`), so the invariant is now anchored to what the templates really ship.

I still think the probe is the wrong source of truth long-term — a claude mind that authors its own `AGENTS.md` flips to `.agents/skills` — but that's an independent bug and out of scope here. Worth a follow-up issue if you want it.

## Changes

- **`templates/pi/src/lib/mechanics-doc.ts`** (new) — `withMechanicsDoc(systemPrompt, homeDir)` appends `MINDS.md` to the system prompt. ENOENT is a no-op; other read errors throw rather than silently dropping the doc.
- **`templates/pi/src/server.ts`** — `withMechanicsDoc(loadSystemPrompt(config), resolve("home"))`.
- **`templates/_base/src/lib/context-breakdown.ts`** — `readSdkInstructions()` now looks only for `CLAUDE.md`/`AGENTS.md`, the files a runtime actually auto-loads. `MINDS.md` is deliberately absent: it's now inside the system prompt, so listing it here would count those tokens **twice** (once under `systemPrompt`, again under `sdkInstructions`). Accounting now reflects what is really loaded, in both directions — before this PR it reported tokens the mind didn't have; the naive fix would have reported them twice.

Kept in the system prompt rather than injected as a pi context file so there's exactly one accounting path.

## Regression tests

New `test/pi-mechanics-doc.test.ts` (9 cases). Every case builds a mind directory through the real creation path, so template drift fails the suite:

- pi's `MINDS.md` is non-empty and its full text lands in the system prompt.
- `server.ts` actually wires `withMechanicsDoc(loadSystemPrompt(...))` — a source-level assertion, deliberately, because the missing *wiring* was the bug and importing `server.ts` would boot an HTTP server.
- pi ships no `AGENTS.md`/`CLAUDE.md`, so `countSdkInstructionTokens` is 0 (no double count).
- claude and codex still read and count their runtime-loaded instruction file.
- claude/pi/codex each resolve to `.claude/skills` / `.pi/skills` / `.agents/skills`, and the three are mutually distinct.

**Confirmed these fail without the fix** (reverted the two source files on a scratch checkout — no `git stash`):

```
✔ appends the mind's MINDS.md to the system prompt
✖ wires the mechanics doc into the prompt pi is actually started with
✔ is a no-op when the mind has no mechanics doc
✖ pi ships no runtime-auto-loaded instruction file, so the doc is not double-counted
✔ claude and codex minds still report their runtime-loaded instruction file
✔ claude mind resolves to home/.claude/skills
✔ pi mind resolves to home/.pi/skills
✔ codex mind resolves to home/.agents/skills
✔ gives each template a distinct skills directory
```

## Verification

`npm test` — **3079 pass, 0 fail** (611 suites).

`npx tsc --noEmit` — clean. `npm run typecheck:templates` — claude, pi, codex all pass.

**Live check on a freshly-created pi mind** (real template composition, then executing server.ts's exact prompt composition in that directory):

```
base prompt chars: 6966
final prompt chars: 9345
grew by mechanics doc: true
mentions MEMORY.md: true
mentions memory/journal: true
sdkInstruction tokens (0 == no double count): 0
```

The delta is exactly the mechanics doc: `MINDS.md` is 2397 bytes, 2372 trimmed, + 7 for the `\n\n---\n\n` separator = 2379 = 9345 − 6966. The mind's `home/` contains no `AGENTS.md` or `CLAUDE.md`, confirming pi minds previously received nothing.

Skills resolution on real created minds — pi → `home/.pi/skills`, codex → `home/.agents/skills`, claude → `home/.claude/skills`. **The codex regression that option 1 risked does not exist here**, since no filename changed.

## Existing minds: repaired by upgrade, no migration needed

No file is renamed or moved. Existing pi minds already have `MINDS.md` in `home/` and keep it untouched. The fix lives entirely in `src/`, which `mind upgrade` *does* update (the template branch strips `home/` but not `src/`), so **`volute mind upgrade <name>` + restart repairs an existing pi mind** — it picks up the new `src/lib/mechanics-doc.ts` and the `server.ts` wiring, and the doc it already has on disk starts reaching the prompt. No migration script, no manual steps, nothing to clean up.

Had this gone the rename route, existing minds would have been left behind — `.init/` is excluded from upgrades — which is a large part of why it didn't.

## Note on PR #800

I touched `templates/_base/src/lib/context-breakdown.ts`, which #800 may also touch — a small conflict is possible in `readSdkInstructions`. I did **not** touch `templates/_base/gitignore` (the `!home/MINDS.md` allowlist stays correct), and nothing here overlaps the `_base/.init/memory/dreams/` work being kept from #800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)