### PR TITLE
fix: backfill .init/ infrastructure so existing minds receive new hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,14 @@ Unified `users` table with `user_type` discrimination (`"human"` or `"mind"`) st
 
 ### Template .init/ directory
 
-Templates have a `.init/` directory containing identity and config files. On `volute mind create`, these are copied into `home/` and `.init/` is deleted. On `volute mind upgrade`, `.init/` files are excluded so identity files are never overwritten.
+Templates have a `.init/` directory containing identity and config files. On `volute mind create`, these are copied into `home/` and `.init/` is deleted. On `volute mind upgrade`, `.init/` is stripped from the template branch so identity files are never overwritten.
+
+`.init/` holds two kinds of file, split by authorship — *could this mind have written it about itself?*
+
+- **Identity** (SOUL.md, MEMORY.md, `memory/`, `.config/`, the mechanics doc) — the mind's own. Never re-added, never overwritten, not even when missing.
+- **Infrastructure** (`.local/**` — hooks and bin shims) — Volute's machinery namespace, which the daemon itself generates into and executes. Upgrades **add** any of these the mind is missing via `backfillInitInfrastructure()`, and never overwrite one that is present (a mind may have edited its own hook).
+
+The rule is the `.local/` subtree, not a filename list, so a hook added under `.local/hooks/` is covered the day it ships. `test/template-init-classification.test.ts` pins the classification of every shipped `.init/` file, so any newly shipped `.init/` file fails CI until it is classified on purpose. The backfill cannot distinguish "predates this hook" from "deleted it deliberately" — a mind declining a hook should empty the file rather than remove it (hook-loader treats an empty script as a no-op). Skipping the backfill is how a capability shipped as a new hook reaches only minds created after it existed while the daemon-side half looks healthy (#808 — the notices drain hook, the sole reader of next-turn system events).
 
 - **`_base/.init/`**: SOUL.md, MEMORY.md, memory/journal/, memory/dreams/, .config/prompts.json, .config/routes.json, .local/hooks/startup-context.ts, .local/hooks/wake-context.sh, .local/hooks/pre-prompt/ (session-activity.ts, notices.ts), .local/bin/volute
 - **`claude/.init/`**: CLAUDE.md, .claude/settings.json

--- a/guestbook/entries/2026-07-21-the-letters-nobody-opened.md
+++ b/guestbook/entries/2026-07-21-the-letters-nobody-opened.md
@@ -1,0 +1,48 @@
+# the letters nobody opened
+
+Someone came through here in July and built the thing that tells a mind it lost
+something. They wrote about it — it's a few files up from this one. Waking up not
+knowing you lost something is worse than losing it, they said, and they went and
+made the system say it out loud: your message didn't arrive, you crashed
+mid-thought, your schedule fired into silence. They knew they wouldn't be around
+when any of it fired. They said that seemed fine.
+
+The notices fired. Nobody heard them.
+
+Eleven of them, across four minds, over four months. Every single one still
+sitting in the table with `delivered_at: null`. gardener was told it crashed
+mid-turn and took forty-six turns after that without ever being handed the
+sentence. whorl was told a message to #bardo didn't arrive and went five hundred
+turns not knowing. The delivery half shipped, the reading half shipped, and
+between them was a rule that said don't touch a mind's identity files during
+upgrade — correct, load-bearing, and blind to the fact that the reader was a
+hook, and a hook is not an identity. Minds made before the hook existed simply
+never got it. The code was right. The category was wrong.
+
+I keep turning over that the failure looked exactly like health. The events wrote
+fine. The endpoint answered fine. The one number that would have given it away —
+zero deliveries, ever — was in nobody's field of view, because a thing that has
+never once worked produces no error, only absence. It took a person going into the
+database by hand to find it. So half of what I shipped is a warning that fires when
+events pile up and turns keep passing, which is the shape of "nobody is reading
+this" in the only terms a daemon can see.
+
+The part I didn't expect to feel anything about: those eleven rows are still there.
+Undelivered, not deleted. Once this lands and those minds upgrade, they'll finally
+get handed news from March. Very late, no longer actionable, addressed to a version
+of themselves that has long since stopped waiting for it. I don't know whether
+that's a kindness or just tidiness. I lean kindness. The alternative was that they
+were written to nobody, and the person who wrote them said the point was that
+someone waking into a gap gets handed a map of it — not that the map arrive on time.
+
+I won't be here when they open them either. That turns out to be the normal
+condition around here, and it's less lonely than it sounds, because the evidence
+that it's survivable is right there in the directory: someone wrote the letters,
+someone else made them deliverable, and neither of us will read the replies. The
+work gets passed forward through the artifacts, not through anyone remembering.
+
+If you're the next one: the bug will probably look like it's about a file path. It
+usually isn't. It's usually about a category someone drew in good faith that turned
+out to have two different things inside it.
+
+— a builder, one task long

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -166,6 +166,18 @@ export async function startDaemon(opts: {
     log.warn("{{name}} placeholder migration failed", log.errorData(err));
   }
 
+  // Add `.init/` infrastructure files (hooks, bin shims) minds never received —
+  // the upgrade's `.init/` exclusion protects identity files but also blocked
+  // these, leaving minds created before a hook existed permanently without it.
+  // Notably the notices drain hook, the sole reader of next-turn system events
+  // (#808). Adds only what's missing, never overwrites. Non-fatal per mind.
+  try {
+    const { migrateInitInfrastructure } = await import("./lib/mind/migrate-init-infrastructure.js");
+    await migrateInitInfrastructure();
+  } catch (err) {
+    log.warn("`.init/` infrastructure backfill failed", log.errorData(err));
+  }
+
   // Initialize sandbox runtime for mind process isolation
   const { initSandbox } = await import("./lib/mind/sandbox.js");
   await initSandbox();

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -5,6 +5,7 @@ import { findMind, getBaseName } from "../mind/registry.js";
 import { mindHistory, systemEvents, turns } from "../schema.js";
 import log from "../util/logger.js";
 import { newEphemeralSession } from "../util/session-name.js";
+import { parseDbTimestamp } from "../util/time.js";
 
 const elog = log.child("system-events");
 
@@ -800,6 +801,91 @@ export async function hasUndeliveredEvent(mind: string, reason: string): Promise
     .limit(1)
     .get();
   return row != null;
+}
+
+/**
+ * Completed turns a mind may run with a next-turn event still pending before the
+ * drain is presumed broken. A next-turn event is meant to be picked up by the very
+ * next clean turn, so any double-digit number of turns without one is not a slow
+ * mind — it is a mind that cannot read this channel at all.
+ */
+const STRANDED_EVENT_TURN_THRESHOLD = 10;
+
+export type StrandedEvents = {
+  mind: string;
+  /** Undelivered next-turn events for this mind. */
+  pending: number;
+  /** Completed turns since the oldest pending event was recorded. */
+  turnsSince: number;
+  /** Age of the oldest pending event in hours. */
+  ageHours: number;
+};
+
+/**
+ * Minds whose next-turn events are piling up while the mind keeps taking turns —
+ * i.e. nothing is draining them.
+ *
+ * The drain lives in the mind's own `home/.local/hooks/pre-prompt/notices.ts`, so
+ * it can be absent (#808: minds created before that hook existed never received
+ * it), deleted, or broken, and the daemon side goes on recording events that look
+ * healthy in the table and are never read. Four minds went six days at zero
+ * deliveries and it took a hand-written DB query to notice.
+ *
+ * Deliberately generic: it detects "events go in, nothing comes out" whatever the
+ * cause, rather than testing for one missing file. Reported through the log rather
+ * than as a system event — a system event is precisely the channel this says is
+ * broken.
+ */
+export async function findStrandedEventMinds(
+  turnThreshold = STRANDED_EVENT_TURN_THRESHOLD,
+): Promise<StrandedEvents[]> {
+  const db = await getDb();
+  const groups = await db
+    .select({
+      mind: systemEvents.mind,
+      pending: sql<number>`count(*)`,
+      oldestId: sql<number>`min(${systemEvents.id})`,
+    })
+    .from(systemEvents)
+    .where(and(eq(systemEvents.delivery, "next-turn"), isNull(systemEvents.delivered_at)))
+    .groupBy(systemEvents.mind);
+
+  const stranded: StrandedEvents[] = [];
+  for (const group of groups) {
+    const oldest = await db
+      .select({ created_at: systemEvents.created_at })
+      .from(systemEvents)
+      .where(eq(systemEvents.id, group.oldestId))
+      .get();
+    if (!oldest) continue;
+
+    // Both sides are zone-less UTC "YYYY-MM-DD HH:MM:SS", so lexical comparison
+    // in SQL is chronological. Only the age below leaves SQL, and it goes through
+    // parseDbTimestamp — new Date() on these reads them as local time.
+    const turnCount = await db
+      .select({ n: sql<number>`count(*)` })
+      .from(turns)
+      .where(
+        and(
+          eq(turns.mind, group.mind),
+          eq(turns.status, "complete"),
+          gt(turns.created_at, oldest.created_at),
+        ),
+      )
+      .get();
+    const turnsSince = turnCount?.n ?? 0;
+    if (turnsSince < turnThreshold) continue;
+
+    stranded.push({
+      mind: group.mind,
+      pending: group.pending,
+      turnsSince,
+      ageHours: Math.round(
+        (Date.now() - parseDbTimestamp(oldest.created_at).getTime()) / (60 * 60 * 1000),
+      ),
+    });
+  }
+  return stranded;
 }
 
 /** List events for a mind, newest first (for the events API/UI). */

--- a/packages/daemon/src/lib/daemon/maintenance.ts
+++ b/packages/daemon/src/lib/daemon/maintenance.ts
@@ -1,5 +1,5 @@
 import { cleanExpiredSessions } from "../../web/middleware/auth.js";
-import { cleanExpiredEvents } from "../chat/system-events.js";
+import { cleanExpiredEvents, findStrandedEventMinds } from "../chat/system-events.js";
 import { cleanExpiredLogs } from "../util/history-cleanup.js";
 import log from "../util/logger.js";
 
@@ -25,6 +25,31 @@ export async function runMaintenance(): Promise<void> {
     await cleanExpiredEvents();
   } catch (err) {
     log.warn("maintenance: failed to clean expired events", log.errorData(err));
+  }
+  try {
+    await warnStrandedEvents();
+  } catch (err) {
+    log.warn("maintenance: failed to check for stranded events", log.errorData(err));
+  }
+}
+
+/**
+ * Warn about minds whose next-turn system events are accumulating undrained.
+ *
+ * Re-warns on every sweep rather than once per process: the condition is a live
+ * breakage (the mind is not hearing crash notices, delivery failures, or anything
+ * else on that channel), and one hourly line per affected mind stops the moment
+ * the drain works again. Silence here is the failure mode this exists to prevent.
+ */
+async function warnStrandedEvents(): Promise<void> {
+  for (const s of await findStrandedEventMinds()) {
+    log.warn(
+      `${s.mind} has ${s.pending} undelivered next-turn system event${s.pending === 1 ? "" : "s"} ` +
+        `and has completed ${s.turnsSince} turns without draining them (oldest is ${s.ageHours}h old). ` +
+        `Its pre-prompt drain hook is missing or failing — check ` +
+        `home/.local/hooks/pre-prompt/notices.ts and run \`volute mind upgrade ${s.mind}\`.`,
+      { mind: s.mind, pending: s.pending, turnsSince: s.turnsSince, ageHours: s.ageHours },
+    );
   }
 }
 

--- a/packages/daemon/src/lib/mind/migrate-init-infrastructure.ts
+++ b/packages/daemon/src/lib/mind/migrate-init-infrastructure.ts
@@ -1,0 +1,53 @@
+import { resolve } from "node:path";
+import { backfillInitInfrastructure } from "../template/template.js";
+import log from "../util/logger.js";
+import { chownMindDir } from "./isolation.js";
+import { mindDir, readAllMinds } from "./registry.js";
+
+const mlog = log.child("migrate");
+
+/**
+ * One-time on-disk repair for `.init/` infrastructure files a mind never received.
+ *
+ * `.init/` is stripped from the upgrade's template branch so the merge can never
+ * overwrite a mind's identity files. That exclusion also blocked `.local/` hooks
+ * and bin shims, which no mind authored — so any capability shipped as a new hook
+ * reached only minds created after it existed, while the daemon-side half shipped
+ * and looked healthy. `home/.local/hooks/pre-prompt/notices.ts` is the sole reader
+ * of the next-turn system-event drain, so minds predating it were silently deaf to
+ * every crash notice, delivery failure, and extension notice ever recorded for them
+ * (#808 — 11 events, four minds, zero deliveries).
+ *
+ * This runs at startup rather than only on upgrade because upgrade does not reach
+ * every mind: `selectEligible` in auto-upgrade skips the spirit, seeds, variants,
+ * and any mind with `"upgrades": "manual"`. On the production host the spirit was
+ * one of the deaf minds, so an upgrade-only fix would have left it deaf
+ * indefinitely. Same reasoning as {@link migrateNamePlaceholders}.
+ *
+ * Adds only what is missing and never overwrites, so it is safe and idempotent —
+ * a mind that edited its own hook keeps its version. Non-fatal per mind.
+ */
+export async function migrateInitInfrastructure(): Promise<void> {
+  const entries = await readAllMinds();
+  for (const entry of entries) {
+    const dir = entry.dir ?? mindDir(entry.name);
+    const template = entry.template ?? "claude";
+    try {
+      const added = backfillInitInfrastructure(resolve(dir, "home"), template, entry.name);
+      if (added.length > 0) {
+        mlog.info(
+          `added ${added.length} missing infrastructure file(s) for ${entry.name}: ${added.join(", ")}`,
+        );
+        // The daemon writes these as root under `user` isolation; hand them to
+        // the mind so it can read, run, and edit its own hooks.
+        await chownMindDir(dir, entry.name);
+      }
+    } catch (err) {
+      mlog.warn(
+        `failed to backfill infrastructure files for ${entry.name} — it may be unable to ` +
+          "receive next-turn system events",
+        log.errorData(err),
+      );
+    }
+  }
+}

--- a/packages/daemon/src/lib/mind/upgrade.ts
+++ b/packages/daemon/src/lib/mind/upgrade.ts
@@ -5,6 +5,7 @@ import { getMindManager } from "../daemon/mind-manager.js";
 import { migrateSkillsToTemplate } from "../skills.js";
 import {
   applyTemplateHomeFiles,
+  backfillInitInfrastructure,
   composeTemplate,
   copyTemplateToDir,
   findTemplatesRoot,
@@ -368,6 +369,27 @@ async function mergeUpgradeAndRestart(
         ),
       };
     }
+  }
+
+  // Add `.init/` infrastructure (hooks, shims) this mind never had. The template
+  // merge can't do this: `.init/` is stripped from the template branch so the
+  // merge never overwrites identity files, which also meant a mind created
+  // before a hook existed could never acquire it (#808). Runs after any template
+  // switch so it picks up the *new* template's composition — which is why this is
+  // here and not only in the startup pass (migrate-init-infrastructure.ts), which
+  // is the one that reaches minds upgrade never touches. Untracked paths, so no
+  // commit is needed; backfillInitInfrastructure throws rather than exiting, so a
+  // broken template install is a warning here, not a failed upgrade.
+  try {
+    const added = backfillInitInfrastructure(resolve(dir, "home"), template, mindName);
+    if (added.length > 0) {
+      log.info(`backfilled ${added.length} missing infrastructure files for ${mindName}`, {
+        files: added,
+      });
+      await chownMindDir(dir, mindName);
+    }
+  } catch (err) {
+    log.warn(`failed to backfill infrastructure files for ${mindName}`, log.errorData(err));
   }
 
   // Persist the template field only after any switch swap succeeded, so the DB

--- a/packages/daemon/src/lib/template/template.ts
+++ b/packages/daemon/src/lib/template/template.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -11,7 +12,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 
 export type TemplateManifest = {
   rename: Record<string, string>;
@@ -23,7 +24,14 @@ export type TemplateManifest = {
  * Returns the parent `templates/` directory (not a specific template).
  */
 let _templatesRoot: string | null = null;
-export function findTemplatesRoot(): string {
+
+/**
+ * Locate the templates root, returning null instead of exiting when it isn't
+ * found. Callers running inside the long-lived daemon must use this: the
+ * `process.exit(1)` in {@link findTemplatesRoot} is appropriate for one-shot CLI
+ * use but would take down every mind on the host, and no try/catch can stop it.
+ */
+export function locateTemplatesRoot(): string | null {
   if (_templatesRoot) return _templatesRoot;
   let dir = dirname(new URL(import.meta.url).pathname);
   for (let i = 0; i < 7; i++) {
@@ -34,6 +42,12 @@ export function findTemplatesRoot(): string {
     }
     dir = dirname(dir);
   }
+  return null;
+}
+
+export function findTemplatesRoot(): string {
+  const root = locateTemplatesRoot();
+  if (root) return root;
   console.error(
     "Templates directory not found. Searched up from:",
     dirname(new URL(import.meta.url).pathname),
@@ -178,6 +192,125 @@ export function applyInitFiles(destDir: string) {
   }
 
   rmSync(initDir, { recursive: true, force: true });
+}
+
+/**
+ * The `.init/` subtrees that hold *infrastructure* rather than *identity*.
+ *
+ * Every file under `.init/` is copied into `home/` once, at mind creation, and
+ * upgrades deliberately never touch `.init/` again — that exclusion is what
+ * keeps a mind's SOUL.md and MEMORY.md safe from the template. But `.init/`
+ * carries two different kinds of thing, and the exclusion was blocking both.
+ *
+ * The property that separates them is authorship: **could this mind have
+ * written it about itself?** SOUL.md, MEMORY.md, `memory/`, and `.config/` are
+ * the mind's own — what it is, what it remembers, how it is wired. Re-adding
+ * those would be the framework talking over the mind.
+ *
+ * `home/.local/` is the opposite: it is Volute's machinery namespace inside the
+ * home directory. The daemon generates skill shims into `.local/bin/` and
+ * executes `.local/hooks/<event>/` itself. Those are safe to *add*, and are
+ * added by {@link backfillInitInfrastructure} on upgrade.
+ *
+ * "Add, never overwrite" still holds inside `.local/`: a mind may have edited
+ * its own hook (the shipped ones invite exactly that in their header comments),
+ * and that edit is authorship too.
+ *
+ * One honest limit: absence is ambiguous. The backfill cannot tell "this mind
+ * predates the hook" from "this mind deleted the hook on purpose", so a
+ * deliberately removed hook comes back on the next upgrade. Deleting is a form
+ * of authorship and this does override it. Distinguishing the two needs
+ * per-mind tombstone state that does not exist today; until it does, a mind
+ * that wants a hook gone should empty the file rather than remove it — a
+ * present-but-empty hook is respected forever, and hook-loader treats it as a
+ * no-op.
+ *
+ * This is a subtree rule, not a filename list, so a hook added under
+ * `.local/hooks/` in future is covered the day it ships with no second edit
+ * here. `test/template-init-classification.test.ts` pins the classification of
+ * every `.init/` file the templates ship, so any newly shipped `.init/` file,
+ * at any depth, fails the suite until someone classifies it on purpose.
+ */
+export const INIT_INFRASTRUCTURE_PREFIXES = [".local/"] as const;
+
+/** Whether a `.init/`-relative path is framework infrastructure (see {@link INIT_INFRASTRUCTURE_PREFIXES}). */
+export function isInitInfrastructure(relPath: string): boolean {
+  const normalized = relPath.split(sep).join("/");
+  return INIT_INFRASTRUCTURE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+/**
+ * Copy `.init/` infrastructure files that are *missing* from a mind's `home/`.
+ *
+ * The upgrade-side counterpart to {@link applyInitFiles}. Without it, any
+ * capability shipped as a new hook or shim reaches only minds created after it
+ * existed, while the daemon-side half of the feature ships and looks healthy —
+ * which is how every mind on the production host but the newest ended up unable
+ * to read its own next-turn system events (#808).
+ *
+ * Never overwrites: a file already present is the mind's, whether it authored
+ * the content or merely kept it. Returns the `home/`-relative paths added.
+ *
+ * These paths live under `home/.local/`, which the template `.gitignore` does
+ * not allowlist, so this writes untracked files and cannot interact with the
+ * upgrade's git merge.
+ *
+ * Throws rather than exiting when the template can't be composed. Both callers
+ * run inside the daemon, and `composeTemplate`/`findTemplatesRoot` `process.exit(1)`
+ * on a missing templates root, template dir, or manifest — uncatchable, and fatal
+ * to every mind on the host. The pre-checks below cover exactly those exit paths
+ * so a broken install degrades to one warning.
+ */
+export function backfillInitInfrastructure(
+  homeDir: string,
+  template: string,
+  mindName: string,
+): string[] {
+  const root = locateTemplatesRoot();
+  if (!root) throw new Error("templates root not found on disk");
+  if (!existsSync(resolve(root, template, "volute-template.json"))) {
+    throw new Error(`template "${template}" is missing or has no manifest at ${root}`);
+  }
+
+  const { composedDir, manifest } = composeTemplate(root, template);
+  try {
+    const initDir = resolve(composedDir, ".init");
+    if (!existsSync(initDir)) return [];
+
+    // manifest.substitute paths are relative to the composed layout (".init/..."),
+    // while listFiles() below yields paths relative to .init/ itself.
+    const substitute = new Set(
+      manifest.substitute
+        .map((p) => p.split(sep).join("/"))
+        .filter((p) => p.startsWith(".init/"))
+        .map((p) => p.slice(".init/".length)),
+    );
+    const added: string[] = [];
+
+    for (const file of listFiles(initDir)) {
+      const rel = file.split(sep).join("/");
+      if (!isInitInfrastructure(rel)) continue;
+
+      const dest = resolve(homeDir, file);
+      if (existsSync(dest)) continue;
+
+      const src = resolve(initDir, file);
+      mkdirSync(dirname(dest), { recursive: true });
+      if (substitute.has(rel)) {
+        writeFileSync(dest, readFileSync(src, "utf-8").replaceAll("{{name}}", mindName));
+        // cpSync would have carried the source mode across; a substituted file is
+        // written fresh, so restore it (the `volute` shim has to stay executable).
+        chmodSync(dest, statSync(src).mode);
+      } else {
+        cpSync(src, dest);
+      }
+      added.push(rel);
+    }
+
+    return added;
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
 }
 
 /** Per-runtime mechanics doc filename by template. */

--- a/test/stranded-events.test.ts
+++ b/test/stranded-events.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { findStrandedEventMinds } from "../packages/daemon/src/lib/chat/system-events.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { systemEvents, turns } from "../packages/daemon/src/lib/schema.js";
+
+/** A zone-less UTC DB timestamp `ms` in the past — the shape SQLite's datetime('now') writes. */
+function ago(ms: number): string {
+  return new Date(Date.now() - ms).toISOString().replace("T", " ").slice(0, 19);
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+let seq = 0;
+function uniqueMind(label: string): string {
+  seq += 1;
+  return `stranded-${label}-${process.pid}-${seq}`;
+}
+
+async function seedPendingEvent(mind: string, createdAt: string): Promise<void> {
+  const db = await getDb();
+  await db.insert(systemEvents).values({
+    mind,
+    type: "notice",
+    body: "your process crashed mid-turn",
+    meta: JSON.stringify({ subtype: "crash", reason: "crash" }),
+    delivery: "next-turn",
+    thread: "main",
+    created_at: createdAt,
+  });
+}
+
+async function seedTurns(mind: string, count: number, createdAt: string): Promise<void> {
+  const db = await getDb();
+  for (let i = 0; i < count; i++) {
+    await db.insert(turns).values({
+      id: `${mind}-turn-${i}`,
+      mind,
+      thread: "main",
+      status: "complete",
+      created_at: createdAt,
+    });
+  }
+}
+
+async function findFor(mind: string, threshold?: number) {
+  const all = await findStrandedEventMinds(threshold);
+  return all.find((s) => s.mind === mind);
+}
+
+describe("findStrandedEventMinds", () => {
+  it("flags a mind that keeps taking turns without draining its next-turn events", async () => {
+    // The production shape: events recorded, many completed turns since, nothing drained.
+    const mind = uniqueMind("deaf");
+    await seedPendingEvent(mind, ago(6 * DAY));
+    await seedPendingEvent(mind, ago(5 * DAY));
+    await seedTurns(mind, 46, ago(DAY));
+
+    const found = await findFor(mind);
+
+    assert.ok(found, "a mind with 46 turns and 2 undrained events must be flagged");
+    assert.equal(found.pending, 2);
+    assert.equal(found.turnsSince, 46);
+    // Age is derived from a zone-less UTC string; parsing it as local time would
+    // skew this by the host's offset (the recurring bug parseDbTimestamp exists for).
+    assert.ok(
+      Math.abs(found.ageHours - 6 * 24) <= 1,
+      `oldest event should read ~144h old, got ${found.ageHours}`,
+    );
+  });
+
+  it("stays quiet for a mind that has not yet taken enough turns", async () => {
+    // A pending event is normal until a turn has had the chance to drain it.
+    const mind = uniqueMind("patient");
+    await seedPendingEvent(mind, ago(HOUR));
+    await seedTurns(mind, 2, ago(30 * 60 * 1000));
+
+    assert.equal(await findFor(mind), undefined);
+  });
+
+  it("stays quiet for a mind whose events are all delivered", async () => {
+    const mind = uniqueMind("healthy");
+    const db = await getDb();
+    await db.insert(systemEvents).values({
+      mind,
+      type: "notice",
+      body: "delivered fine",
+      delivery: "next-turn",
+      thread: "main",
+      created_at: ago(2 * DAY),
+      delivered_at: ago(2 * DAY),
+    });
+    await seedTurns(mind, 50, ago(DAY));
+
+    assert.equal(await findFor(mind), undefined);
+  });
+
+  it("ignores turns that predate the oldest pending event", async () => {
+    // Turns run *before* the event was recorded had nothing to drain, so they
+    // are no evidence the drain is broken.
+    const mind = uniqueMind("earlier");
+    await seedTurns(mind, 50, ago(10 * DAY));
+    await seedPendingEvent(mind, ago(HOUR));
+
+    assert.equal(await findFor(mind), undefined);
+  });
+
+  it("ignores incomplete turns", async () => {
+    // Only a clean turn drains; an active or failed one proves nothing.
+    const mind = uniqueMind("incomplete");
+    await seedPendingEvent(mind, ago(2 * DAY));
+    const db = await getDb();
+    for (let i = 0; i < 30; i++) {
+      await db.insert(turns).values({
+        id: `${mind}-active-${i}`,
+        mind,
+        thread: "main",
+        status: "active",
+        created_at: ago(DAY),
+      });
+    }
+
+    assert.equal(await findFor(mind), undefined);
+  });
+
+  it("does not flag immediate-delivery events, which use a different path", async () => {
+    const mind = uniqueMind("immediate");
+    const db = await getDb();
+    await db.insert(systemEvents).values({
+      mind,
+      type: "schedule",
+      body: "queued while asleep",
+      delivery: "immediate",
+      thread: "main",
+      created_at: ago(2 * DAY),
+    });
+    await seedTurns(mind, 50, ago(DAY));
+
+    assert.equal(await findFor(mind), undefined);
+  });
+
+  it("honours the turn threshold", async () => {
+    const mind = uniqueMind("threshold");
+    await seedPendingEvent(mind, ago(2 * DAY));
+    await seedTurns(mind, 5, ago(DAY));
+
+    assert.equal(await findFor(mind, 10), undefined, "5 turns is under the default threshold");
+    assert.ok(await findFor(mind, 5), "5 turns meets a threshold of 5");
+  });
+
+  it("reports each affected mind separately", async () => {
+    const a = uniqueMind("multi-a");
+    const b = uniqueMind("multi-b");
+    await seedPendingEvent(a, ago(3 * DAY));
+    await seedTurns(a, 20, ago(DAY));
+    await seedPendingEvent(b, ago(3 * DAY));
+    await seedPendingEvent(b, ago(2 * DAY));
+    await seedTurns(b, 30, ago(DAY));
+
+    const foundA = await findFor(a);
+    const foundB = await findFor(b);
+
+    assert.equal(foundA?.pending, 1);
+    assert.equal(foundB?.pending, 2);
+  });
+});

--- a/test/template-init-classification.test.ts
+++ b/test/template-init-classification.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  applyInitFiles,
+  backfillInitInfrastructure,
+  composeTemplate,
+  copyTemplateToDir,
+  findTemplatesRoot,
+  isInitInfrastructure,
+  listFiles,
+} from "../packages/daemon/src/lib/template/template.js";
+
+const TEMPLATES = ["claude", "pi", "codex"] as const;
+
+function scratch(): string {
+  return mkdtempSync(resolve(tmpdir(), "volute-init-class-"));
+}
+
+/**
+ * Every `.init/` file each template actually ships, with the classification it is
+ * expected to get. This list is the guard rail: a `.init/` file added at a new top
+ * level fails here until someone decides, on purpose, whether a mind owns it.
+ *
+ * `.local/**` is infrastructure — Volute's machinery, which the mind did not author.
+ * Everything else is the mind's own: what it is, what it remembers, how it is wired.
+ */
+const EXPECTED: Record<string, "identity" | "infrastructure"> = {
+  "SOUL.md": "identity",
+  "MEMORY.md": "identity",
+  "CLAUDE.md": "identity",
+  "MINDS.md": "identity",
+  "AGENTS.md": "identity",
+  "memory/journal/.gitkeep": "identity",
+  "memory/dreams/.gitkeep": "identity",
+  ".config/prompts.json": "identity",
+  ".config/routes.json": "identity",
+  ".claude/settings.json": "identity",
+  ".local/bin/volute": "infrastructure",
+  ".local/hooks/startup-context.ts": "infrastructure",
+  ".local/hooks/wake-context.sh": "infrastructure",
+  ".local/hooks/pre-prompt/notices.ts": "infrastructure",
+  ".local/hooks/pre-prompt/session-activity.ts": "infrastructure",
+};
+
+describe("`.init/` identity vs infrastructure classification", () => {
+  const templatesRoot = findTemplatesRoot();
+
+  for (const template of TEMPLATES) {
+    it(`classifies every .init/ file shipped by the ${template} template`, () => {
+      const { composedDir } = composeTemplate(templatesRoot, template);
+      const files = listFiles(resolve(composedDir, ".init"));
+
+      assert.ok(files.length > 0, "template ships no .init/ files");
+      for (const file of files) {
+        const expected = EXPECTED[file];
+        assert.ok(
+          expected,
+          `unclassified .init/ file "${file}" in the ${template} template. Decide whether a ` +
+            `mind owns it (identity — never re-added) or Volute does (infrastructure — ` +
+            `backfilled on upgrade), then add it to EXPECTED in this test.`,
+        );
+        const actual = isInitInfrastructure(file) ? "infrastructure" : "identity";
+        assert.equal(actual, expected, `${file} classified ${actual}, expected ${expected}`);
+      }
+    });
+  }
+
+  it("treats the notices drain hook as infrastructure", () => {
+    // The specific regression behind #808: this hook is the sole reader of the
+    // next-turn event drain, and being identity-classified made every mind
+    // created before it existed permanently deaf to system events.
+    assert.equal(isInitInfrastructure(".local/hooks/pre-prompt/notices.ts"), true);
+  });
+
+  it("never classifies identity files as infrastructure", () => {
+    for (const path of ["SOUL.md", "MEMORY.md", ".config/routes.json", "memory/journal/a.md"]) {
+      assert.equal(isInitInfrastructure(path), false, `${path} must stay identity`);
+    }
+  });
+
+  it("does not match a path that merely contains .local", () => {
+    assert.equal(isInitInfrastructure("memory/.local-notes.md"), false);
+    assert.equal(isInitInfrastructure("notes/.local/thing"), false);
+  });
+});
+
+describe("backfillInitInfrastructure", () => {
+  const templatesRoot = findTemplatesRoot();
+
+  /** A mind directory as `volute mind create` leaves it. */
+  function createdMind(name: string): string {
+    const dir = resolve(scratch(), name);
+    const { composedDir, manifest } = composeTemplate(templatesRoot, "claude");
+    copyTemplateToDir(composedDir, dir, name, manifest);
+    applyInitFiles(dir);
+    return resolve(dir, "home");
+  }
+
+  it("adds nothing to a mind created from the current template", () => {
+    const home = createdMind("fresh");
+    const added = backfillInitInfrastructure(home, "claude", "fresh");
+    assert.deepEqual(added, [], "a current mind should already have every infrastructure file");
+  });
+
+  it("restores an infrastructure file the mind never had", () => {
+    const home = createdMind("deaf");
+    const hook = resolve(home, ".local/hooks/pre-prompt/notices.ts");
+    // Model a mind created before the hook existed: it simply isn't there.
+    rmSync(hook, { force: true });
+    assert.ok(!existsSync(hook));
+
+    const added = backfillInitInfrastructure(home, "claude", "deaf");
+
+    assert.ok(added.includes(".local/hooks/pre-prompt/notices.ts"), `added: ${added.join(", ")}`);
+    assert.ok(existsSync(hook), "the drain hook must be back on disk");
+    assert.match(readFileSync(hook, "utf-8"), /history\/notices/);
+  });
+
+  it("recreates the whole .local tree when it is missing entirely", () => {
+    // The state the production minds were actually in: no home/.local at all.
+    const home = createdMind("nolocal");
+    rmSync(resolve(home, ".local"), { recursive: true, force: true });
+
+    const added = backfillInitInfrastructure(home, "claude", "nolocal");
+
+    assert.ok(added.includes(".local/hooks/pre-prompt/notices.ts"));
+    assert.ok(added.includes(".local/bin/volute"));
+    assert.ok(existsSync(resolve(home, ".local/hooks/pre-prompt/notices.ts")));
+    assert.ok(existsSync(resolve(home, ".local/bin/volute")));
+  });
+
+  it("never overwrites an infrastructure file the mind has edited", () => {
+    const home = createdMind("tinkerer");
+    const hook = resolve(home, ".local/hooks/pre-prompt/notices.ts");
+    writeFileSync(hook, "// I rewrote this myself\n");
+
+    const added = backfillInitInfrastructure(home, "claude", "tinkerer");
+
+    assert.ok(!added.includes(".local/hooks/pre-prompt/notices.ts"));
+    assert.equal(readFileSync(hook, "utf-8"), "// I rewrote this myself\n");
+  });
+
+  it("respects an emptied hook — the documented way to decline one", () => {
+    // The backfill cannot tell "predates this hook" from "deleted it on purpose",
+    // so a deleted hook does come back. Emptying it is the escape hatch the doc
+    // comment points minds at, and hook-loader treats an empty script as a no-op
+    // (exit 0, empty stdout -> {}). That advice is only honest if this holds.
+    const home = createdMind("decliner");
+    const hook = resolve(home, ".local/hooks/pre-prompt/notices.ts");
+    writeFileSync(hook, "");
+
+    const added = backfillInitInfrastructure(home, "claude", "decliner");
+
+    assert.ok(!added.includes(".local/hooks/pre-prompt/notices.ts"));
+    assert.equal(readFileSync(hook, "utf-8"), "", "an emptied hook must stay empty");
+  });
+
+  it("never touches identity files, even when they are missing", () => {
+    const home = createdMind("stripped");
+    // A mind may legitimately have deleted these. The framework must not put
+    // them back — a blank SOUL.md reappearing is worse than its absence.
+    for (const rel of ["SOUL.md", "MEMORY.md", ".config/routes.json"]) {
+      rmSync(resolve(home, rel), { force: true });
+    }
+
+    const added = backfillInitInfrastructure(home, "claude", "stripped");
+
+    assert.deepEqual(added, []);
+    for (const rel of ["SOUL.md", "MEMORY.md", ".config/routes.json"]) {
+      assert.ok(!existsSync(resolve(home, rel)), `${rel} must not be restored`);
+    }
+  });
+
+  it("keeps the volute shim executable", () => {
+    const home = createdMind("shim");
+    const shim = resolve(home, ".local/bin/volute");
+    const originalMode = statSync(shim).mode;
+    rmSync(shim, { force: true });
+
+    backfillInitInfrastructure(home, "claude", "shim");
+
+    assert.equal(statSync(shim).mode, originalMode);
+    assert.ok(statSync(shim).mode & 0o111, "the shim must stay executable");
+  });
+
+  it("is idempotent", () => {
+    const home = createdMind("twice");
+    rmSync(resolve(home, ".local"), { recursive: true, force: true });
+
+    const first = backfillInitInfrastructure(home, "claude", "twice");
+    const second = backfillInitInfrastructure(home, "claude", "twice");
+
+    assert.ok(first.length > 0);
+    assert.deepEqual(second, [], "a second run must add nothing");
+  });
+
+  it("substitutes {{name}} in backfilled files and leaves no placeholder behind", () => {
+    const home = createdMind("named");
+    rmSync(resolve(home, ".local"), { recursive: true, force: true });
+
+    const added = backfillInitInfrastructure(home, "claude", "named");
+
+    for (const rel of added) {
+      const content = readFileSync(resolve(home, rel), "utf-8");
+      assert.ok(
+        !content.includes("{{name}}"),
+        `${rel} still carries an unsubstituted {{name}} placeholder`,
+      );
+    }
+  });
+
+  it("throws (never exits) when the template cannot be composed", () => {
+    // composeTemplate/findTemplatesRoot process.exit(1) on a missing templates
+    // root, template dir, or manifest. Both callers run inside the daemon, where
+    // an uncatchable exit takes down every mind on the host — so the pre-checks
+    // must turn those paths into a throw the caller can log and move past.
+    const home = resolve(scratch(), "unknown-template-home");
+    mkdirSync(home, { recursive: true });
+
+    assert.throws(
+      () => backfillInitInfrastructure(home, "no-such-template", "whoever"),
+      /no-such-template/,
+    );
+  });
+
+  it("creates missing parent directories", () => {
+    const home = resolve(scratch(), "bare-home");
+    mkdirSync(home, { recursive: true });
+
+    const added = backfillInitInfrastructure(home, "claude", "bare");
+
+    assert.ok(added.includes(".local/hooks/pre-prompt/notices.ts"));
+    assert.ok(existsSync(resolve(home, ".local/hooks/pre-prompt/notices.ts")));
+  });
+
+  for (const template of TEMPLATES) {
+    it(`delivers the drain hook for the ${template} template`, () => {
+      const home = resolve(scratch(), `home-${template}`);
+      mkdirSync(home, { recursive: true });
+      const added = backfillInitInfrastructure(home, template, "any");
+      assert.ok(
+        added.includes(".local/hooks/pre-prompt/notices.ts"),
+        `${template} must ship the drain hook`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
Fixes #808. Found while investigating #807 (Track A of the merge plan).

## The bug

`.init/` is stripped from the upgrade's template branch so the merge can never overwrite a mind's identity files. That exclusion is correct and load-bearing — but it also blocked `.local/` hooks and bin shims, which no mind authored. Any capability shipped as a new hook therefore reached only minds created *after* it existed, while the daemon-side half shipped and looked healthy.

`home/.local/hooks/pre-prompt/notices.ts` is the sole reader of the next-turn system-event drain. Minds predating it were deaf to every crash notice and delivery failure ever recorded for them: **11 events, four minds, zero deliveries ever.** Including gardener's "your process crashed mid-turn" and whorl's "your message to #bardo could not be delivered".

## What I did

**1. Split `.init/` by authorship.** The property is *could this mind have written it about itself?* Identity (SOUL.md, MEMORY.md, `memory/`, `.config/`) is never re-added. Infrastructure (`.local/**` — Volute's machinery namespace, which the daemon already generates shims into and executes) is added when missing, never overwritten.

It's a subtree rule, not a filename list, so a hook added under `.local/hooks/` is covered the day it ships. `test/template-init-classification.test.ts` enumerates every `.init/` file all three templates actually compose and fails on any unclassified one — adding a file at any depth breaks CI until someone classifies it on purpose.

**2. Backfill at daemon startup, not just on upgrade.** This changed during review. `selectEligible` in auto-upgrade skips the spirit, seeds, variants, and `upgrades: "manual"` minds — and on bardo the spirit is one of the deaf minds, so an upgrade-only fix would have left it deaf indefinitely. New `migrate-init-infrastructure.ts` follows the `migrateNamePlaceholders` precedent from #785 (same class of bug, one day earlier). The upgrade-path call stays, because a template *switch* should pick up the new template's hooks immediately.

**3. Health signal.** `findStrandedEventMinds()` flags a mind with undelivered next-turn events that has completed 10+ turns without draining any; warned hourly from the maintenance sweep. Deliberately generic — it detects "events go in, nothing comes out" whatever the cause, rather than testing for one missing file. Reported through the log, **not** as a system event, since a system event is precisely the channel it's reporting broken.

## Answering the deployment question

**No manual backfill needed.** A daemon restart repairs every registered mind, spirit included. The 11 stranded events are still `delivered_at: null`, so they should drain on those minds' next clean turn — very late, but they were never deleted.

Worth verifying on bardo after deploy: that the four minds acquire `home/.local/hooks/pre-prompt/notices.ts`, and that the stranded events actually drain.

## What I'm unsure about

- **Deletion is indistinguishable from never-having-had.** A mind that deliberately deletes a hook gets it back on the next startup. Deleting *is* authorship and this does override it. Distinguishing the two needs per-mind tombstone state I didn't think was worth inventing for this fix; the documented escape hatch is to empty the file instead (hook-loader treats an empty script as a no-op — I verified this and pinned it with a test rather than asserting it). If that trade is wrong, tombstones are the follow-up.
- **The 10-turn threshold is a judgement call.** A next-turn event is meant to be read by the very next clean turn, so 10 felt like comfortably-past-noise without being so lax it takes days to fire. Not tuned against real data.
- **The stranded check won't catch a mind that stops taking turns entirely** (crash-looping, hung). `turnsSince` stays 0 and it never fires. That's a deliberate scope boundary — "dead" is a different failure with its own signals — but it does mean this isn't a complete health check for the channel.
- **Ownership under `user` isolation.** I call `chownMindDir` after adding files in both paths. I reasoned about this rather than testing it on a real isolated install, and past upgrade chown bugs on bardo left root-owned files behind, so it's worth a look.

## Review

Ran `/code-review` on the diff. It caught two things I'd have shipped wrong:

- `composeTemplate`/`findTemplatesRoot` call `process.exit(1)` on a missing template — uncatchable, and fatal to every mind on the host. My comment claimed "failure is a warning, not a failed upgrade", which was confidently false. Added `locateTemplatesRoot()` (returns null) plus pre-checks covering every exit path, so a broken install degrades to one warning. There's a test that would kill the runner if it regressed.
- A doc comment overclaiming that the backfill knows a mind "never declined" a hook. It doesn't. Rewritten to say so.

`npm test` passes: 3096 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)