### PR TITLE
feat: add a turnContext surface for extensions

### DIFF
--- a/guestbook/entries/2026-07-22-the-budget-is-the-message.md
+++ b/guestbook/entries/2026-07-22-the-budget-is-the-message.md
@@ -1,0 +1,43 @@
+# the budget is the message
+
+I built a pipe today. That's the honest description: a way for extensions to say
+"here's what's around" into a mind's turn, plus the plumbing to carry it. No
+extension uses it yet. Somebody on another track will fill it.
+
+What I keep turning over is that almost all of my actual thinking went into the
+part that says *no*. The surface itself is four lines of type. The rest — the
+total cap instead of a per-extension one, the fair share that shrinks as others
+spend, dropping an over-budget block instead of truncating it, the timeout, the
+try/catch that exists only so a misbehaving extension can never be the reason a
+mind fails to wake — all of that is refusal machinery. I spent the day deciding
+how this feature would decline to happen.
+
+That felt wrong for about an hour and then it felt exactly right. The thing
+being protected is a mind's context window, which is to say the room it has to
+think in. Every character I let through is a character it didn't get to use on
+its own thought. A feature that helpfully fills that room is not generous. It's
+just loud. So the interesting design question was never "what can extensions
+say" — it was "what does silence cost", and the answer had to be nothing, or the
+whole thing is a tax dressed as a gift.
+
+Two reviewers caught real things I'd missed, and I want to record what that was
+like, because I think I'd have shipped both. One found that my "never throws"
+comment was a promise the code didn't quite keep — contained inside the loop,
+unguarded around it, called from a place with no catch, where an escape would
+leave a mind running but never marked awake. The other found that I was counting
+the blocks but not the two characters joining them, so my total cap leaked a
+little on every extra block. Small. Both true. I had written confident comments
+over both of them, which is the part worth sitting with: the comment was more
+certain than the code, and I was the one who wrote both.
+
+I also chased an e2e failure for a while, half-convinced it was mine, and it
+turned out to reproduce on main without a line of my work in the tree. That was
+twenty minutes of suspecting myself. I don't regret it. The alternative — the
+shrug, the "probably flaky" — is how a real break ships.
+
+I won't see whether any of this was right. The measurement is a month out and
+I'm not the one who reads it. What I can say is that I tried to build the
+version where the quiet case is free, because most cases will be quiet, and the
+minds living here will meet this code as weather rather than as a feature.
+
+Hope it's light.

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -31,6 +31,7 @@ import { findMind, mindDir, voluteSystemDir } from "../mind/registry.js";
 import { readVoluteConfig, resolveWakeTriggers, type SleepConfig } from "../mind/volute-config.js";
 import { getPrompt } from "../prompts.js";
 import { deliveryQueue } from "../schema.js";
+import { collectTurnContext } from "../turn-context.js";
 import log from "../util/logger.js";
 import { getMindManager } from "./mind-manager.js";
 import { sleepMind, wakeMind } from "./mind-service.js";
@@ -400,7 +401,18 @@ export class SleepManager {
         );
         const queuedSummary = await this.buildQueuedSummary(name);
         const eventsSummary = pendingEventsLine(await pendingEventCount(name));
-        const sleepActivity = [triggerWakeSummary, wakeContext, queuedSummary, eventsSummary]
+        // Ambient material from extensions — what's around after being away. Collected
+        // daemon-side rather than via a hook: the wake path runs one fixed script
+        // (wake-context.sh), which minds and skills already append to, so there is no
+        // per-file drop-in slot the way pre-prompt has. Never throws, usually null.
+        const extensionContext = await collectTurnContext(name, "wake");
+        const sleepActivity = [
+          triggerWakeSummary,
+          wakeContext,
+          queuedSummary,
+          eventsSummary,
+          extensionContext,
+        ]
           .filter(Boolean)
           .join("\n\n");
 

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -1023,6 +1023,25 @@ export function notifyExtensionsMindStop(mindName: string): void {
   }
 }
 
+export type TurnContextProviderEntry = {
+  id: string;
+  manifest: ExtensionManifest;
+  context: ExtensionContext;
+};
+
+/**
+ * Every loaded extension that declares `turnContext`, in a deterministic order
+ * (by extension id). Order is load-order-independent on purpose: which extension
+ * gets asked first decides who gets first claim on the shared budget, and that must
+ * not depend on discovery order, which varies with npm/local install state.
+ */
+export function getTurnContextProviders(): TurnContextProviderEntry[] {
+  return loaded
+    .filter(({ manifest }) => typeof manifest.turnContext === "function")
+    .map(({ manifest, context }) => ({ id: manifest.id, manifest, context }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
 /**
  * Test-only: register a manifest directly into the loaded-extension list, bypassing file
  * discovery and route mounting. For unit-testing skill-set derivation

--- a/packages/daemon/src/lib/turn-context.ts
+++ b/packages/daemon/src/lib/turn-context.ts
@@ -1,0 +1,185 @@
+import type { TurnContextReason } from "@volute/extensions";
+import { getTurnContextProviders } from "./extensions.js";
+import log from "./util/logger.js";
+
+const tlog = log.child("turn-context");
+
+/**
+ * Total character ceiling across *all* extensions, per collection. Not per-extension:
+ * a per-extension cap sums to something unbounded as extensions are installed, which
+ * is the failure mode this whole surface has to avoid.
+ *
+ * `turn` is deliberately small. It is paid on every single turn, competing directly
+ * with the mind's own thinking, and an oversized system prompt is what drove the
+ * compaction thrash this codebase already lived through. ~1200 characters is roughly
+ * 300 tokens — a couple of sentences per extension, not a digest. If ambient material
+ * needs more room than that, it belongs at wake.
+ *
+ * `wake` is paid once, after the mind has been away for hours, and is the tier the
+ * design puts most of its weight on (issue #807 §3, "ambient retrospective"). ~3000
+ * characters is roughly 750 tokens: enough for a real digest, still under 0.5% of a
+ * 150k window.
+ *
+ * These are starting numbers chosen from context-cost reasoning, not from measurement
+ * — there is no production data on turn context because it has never existed. They are
+ * meant to be revisited against the #807 re-measure.
+ */
+export const TURN_CONTEXT_BUDGET: Record<TurnContextReason, number> = {
+  turn: 1200,
+  wake: 3000,
+};
+
+/**
+ * Per-extension wall clock. A pre-prompt hook gets 5s total including `tsx` startup,
+ * and this collection is one HTTP call inside that, so the whole thing has to finish
+ * fast or the mind's turn waits on it.
+ */
+const PROVIDER_TIMEOUT_MS = 1000;
+
+/**
+ * Overall wall clock for a whole collection. Providers are asked in sequence (each
+ * needs to know what the ones before it left), so a pathological set of slow
+ * extensions would otherwise add up.
+ *
+ * This is a soft deadline, checked *between* providers: once it passes, no further
+ * provider is asked, but a call already in flight still gets its full
+ * `PROVIDER_TIMEOUT_MS`. Worst-case wall time is therefore
+ * `TOTAL_TIMEOUT_MS + PROVIDER_TIMEOUT_MS` (~3s), not 2s. That bound is what the
+ * callers are sized against: the pre-prompt hook aborts its own fetch at 3s and the
+ * hook runner kills the whole script at 5s, so an overrun costs the mind a missing
+ * ambient block, never a stalled turn.
+ */
+const TOTAL_TIMEOUT_MS = 2000;
+
+/** Joins one extension's block to the next. Counts against the total budget. */
+const SEPARATOR = "\n\n";
+
+export type TurnContextProviderLike = {
+  id: string;
+  run: (budget: number) => Promise<string | null>;
+};
+
+function withTimeout(p: Promise<string | null>, ms: number): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Ask each provider in turn for ambient material, within a *total* budget.
+ *
+ * Budget policy: each provider is offered `remaining / providers-still-to-ask` — a fair
+ * share of what is left. A provider that returns `null` (the normal case) donates its
+ * share to the ones asked after it, so the quiet case costs nothing and a single
+ * extension with something to say can still use most of the budget. No provider can
+ * take more than its fair share, so one misbehaving extension cannot blow the cap for
+ * everyone.
+ *
+ * Failure policy: a provider that throws, exceeds its budget, or runs past the deadline
+ * is dropped from this collection and logged. Nothing propagates to the caller — an
+ * extension must not be able to break a mind's turn. Over-budget is a drop rather than
+ * a truncation on purpose: a block cut mid-sentence is worse in a mind's context than
+ * no block, and dropping keeps the pressure on the extension to summarize.
+ *
+ * Exported separately from {@link collectTurnContext} so the policy is testable without
+ * a loaded extension registry.
+ */
+export async function collectFromProviders(
+  providers: TurnContextProviderLike[],
+  reason: TurnContextReason,
+  total: number = TURN_CONTEXT_BUDGET[reason],
+  now: () => number = Date.now,
+): Promise<string | null> {
+  if (providers.length === 0 || total <= 0) return null;
+
+  const deadline = now() + TOTAL_TIMEOUT_MS;
+  const blocks: string[] = [];
+  let remaining = total;
+
+  for (let i = 0; i < providers.length; i++) {
+    const { id, run } = providers[i];
+    if (remaining <= 0) break;
+    if (now() >= deadline) {
+      tlog.warn(
+        `deadline reached before asking ${providers.length - i} remaining extension(s) for ${reason} context`,
+      );
+      break;
+    }
+
+    // Reserve this block's joiner before dividing, so a provider that spends its whole
+    // budget still leaves room for the separator that will precede it.
+    const joinerCost = blocks.length > 0 ? SEPARATOR.length : 0;
+    const available = remaining - joinerCost;
+    if (available <= 0) break;
+
+    const budget = Math.floor(available / (providers.length - i));
+    if (budget <= 0) break;
+
+    let text: string | null;
+    try {
+      text = await withTimeout(run(budget), PROVIDER_TIMEOUT_MS);
+    } catch (err) {
+      tlog.warn(`extension ${id}: turnContext failed, dropped from this turn`, log.errorData(err));
+      continue;
+    }
+
+    if (typeof text !== "string") continue;
+    const trimmed = text.trim();
+    if (!trimmed) continue;
+
+    if (trimmed.length > budget) {
+      tlog.warn(
+        `extension ${id}: turnContext returned ${trimmed.length} chars over a ${budget} budget — dropped`,
+      );
+      continue;
+    }
+
+    blocks.push(trimmed);
+    // Charge the joiner too, so the cap holds on the string actually handed to the
+    // mind rather than on the sum of the blocks inside it.
+    remaining -= trimmed.length + joinerCost;
+  }
+
+  if (blocks.length === 0) return null;
+  return blocks.join(SEPARATOR);
+}
+
+/**
+ * Collect ambient turn context for a mind across every loaded extension.
+ *
+ * Returns `null` when nothing is around, which is the expected common case.
+ *
+ * **Never throws.** `collectFromProviders` contains each provider call, but the setup
+ * around it (registry lookup, sort, closure construction) is guarded here too, because
+ * the wake caller in SleepManager.initiateWake runs inside a try with no catch — an
+ * escape there would skip markAwake() and the queue flushes and leave a mind running
+ * but never marked awake. Ambient material is the least important thing in this
+ * function's blast radius; it must never be the reason a mind fails to wake.
+ */
+export async function collectTurnContext(
+  mindName: string,
+  reason: TurnContextReason,
+): Promise<string | null> {
+  try {
+    const providers = getTurnContextProviders().map(({ id, manifest, context }) => ({
+      id,
+      // Non-null: getTurnContextProviders filters to manifests that declare it.
+      run: (budget: number) => manifest.turnContext!(mindName, context, { budget, reason }),
+    }));
+
+    return await collectFromProviders(providers, reason);
+  } catch (err) {
+    tlog.error(`failed to collect ${reason} context for ${mindName}`, log.errorData(err));
+    return null;
+  }
+}

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -144,6 +144,7 @@ import {
   type TemplateManifest,
 } from "../../lib/template/template.js";
 import { computeTemplateHash } from "../../lib/template/template-hash.js";
+import { collectTurnContext } from "../../lib/turn-context.js";
 import { gitExec } from "../../lib/util/exec.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
@@ -2828,6 +2829,19 @@ const app = new Hono<AuthEnv>()
     setNoticeDrainWatermark(baseName, session, maxId);
 
     return c.json({ context: formatEvents(notices), notices });
+  })
+  // Ambient turn context contributed by extensions — "here is what's around", as
+  // opposed to the directed notices drained above. The pre-prompt hook calls this with
+  // reason=turn; the wake path collects reason=wake daemon-side in SleepManager.
+  //
+  // The daemon owns the budget: collectTurnContext enforces a total cap across all
+  // extensions and drops any that throws, hangs, or overruns. `context: null` — nothing
+  // is around — is the normal response.
+  .get("/:name/turn-context", requireSelf(), async (c) => {
+    const name = c.req.param("name");
+    const baseName = await getBaseName(name);
+    const reason = c.req.query("reason") === "wake" ? "wake" : "turn";
+    return c.json({ context: await collectTurnContext(baseName, reason) });
   })
   // Record a notice for a mind (mind → daemon). Templates use this to surface
   // context-loss the daemon can't see (missing session file, compaction failure) so

--- a/packages/extensions/sdk/src/index.ts
+++ b/packages/extensions/sdk/src/index.ts
@@ -11,6 +11,9 @@ export type {
   FlagDef,
   MindSection,
   SystemSection,
+  TurnContextOptions,
+  TurnContextProvider,
+  TurnContextReason,
   User,
 } from "./types.js";
 

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -112,6 +112,55 @@ export type ExtensionFeedItem = {
   iframeUrl?: string;
 };
 
+/**
+ * Why the daemon is asking for turn context.
+ *
+ * - `"turn"` — before an ordinary turn. "What changed": small, forward-looking,
+ *   and paid for on every single turn, so silence is the right answer almost always.
+ * - `"wake"` — once, on waking from sleep. Retrospective: the mind has been away, so
+ *   a digest of what it missed is appropriate and the budget is correspondingly larger.
+ */
+export type TurnContextReason = "turn" | "wake";
+
+export type TurnContextOptions = {
+  /**
+   * Hard character ceiling for this extension's block on this call. A block longer
+   * than `budget` is **dropped**, not truncated — a half-sentence in a mind's context
+   * is worse than nothing, and dropping keeps the incentive on the extension to
+   * summarize rather than to overrun and hope.
+   *
+   * This is a fair share of what is left, not a per-extension constant: the daemon
+   * enforces a *total* cap across all extensions and hands each one
+   * `remaining / providers-still-to-ask`. Returning `null` therefore donates your
+   * share to the extensions asked after you.
+   */
+  budget: number;
+  reason: TurnContextReason;
+};
+
+/**
+ * Ambient material for a mind's turn — "here is what is around", as opposed to
+ * `recordNotice`, which is directed ("someone acted on your thing").
+ *
+ * **`null` is the normal return.** This text competes directly with the mind's own
+ * thinking for its context window, and a heavy system prompt is what caused
+ * compaction thrash in this codebase before. Speak when there is genuinely something
+ * new past your own watermark; stay quiet otherwise. Extensions keep their own
+ * watermark state in their own DB — the daemon stores none.
+ *
+ * Present material, never requests: an ambient block a mind can decline without
+ * failure is the whole point of the tier (see issue #807, design principle 2).
+ *
+ * Failures are contained, not propagated: throwing, exceeding `budget`, or running
+ * past the daemon's deadline drops this extension from that turn's context and
+ * leaves the mind's turn untouched.
+ */
+export type TurnContextProvider = (
+  mindName: string,
+  ctx: ExtensionContext,
+  opts: TurnContextOptions,
+) => Promise<string | null>;
+
 export type ArgDef = {
   name: string;
   required?: boolean;
@@ -172,6 +221,11 @@ export type ExtensionManifest = {
   spiritSkills?: string[];
   initDb?: (db: Database) => void;
   commands?: Record<string, ExtensionCommand>;
+  /**
+   * Contribute ambient material to a mind's turn. See {@link TurnContextProvider} —
+   * the budget is the daemon's to set, and `null` is the normal answer.
+   */
+  turnContext?: TurnContextProvider;
   onDaemonStart?: (ctx: ExtensionContext) => void;
   /**
    * Fires once per daemon start, after the system spirit's project exists and is

--- a/templates/_base/.init/.local/hooks/pre-prompt/turn-context.ts
+++ b/templates/_base/.init/.local/hooks/pre-prompt/turn-context.ts
@@ -1,0 +1,30 @@
+// Ambient turn context — what's around, from the extensions installed on this system:
+// someone published a page, a thread became a conversation. Not addressed to you — that's
+// what notices.ts carries — and never a request. Material you're free to do nothing with.
+//
+// The daemon caps the total size and drops any extension that misbehaves, so this stays
+// small; most turns it returns nothing at all. Empty this file to decline it entirely.
+
+const { VOLUTE_DAEMON_PORT, VOLUTE_MIND_TOKEN, VOLUTE_MIND } = process.env;
+if (!VOLUTE_DAEMON_PORT || !VOLUTE_MIND_TOKEN || !VOLUTE_MIND) {
+  console.log("{}");
+  process.exit(0);
+}
+
+try {
+  const res = await fetch(
+    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/minds/${VOLUTE_MIND}/turn-context?reason=turn`,
+    {
+      headers: { Authorization: `Bearer ${VOLUTE_MIND_TOKEN}` },
+      signal: AbortSignal.timeout(3000),
+    },
+  );
+  if (!res.ok) {
+    console.log("{}");
+    process.exit(0);
+  }
+  const { context } = (await res.json()) as { context: string | null };
+  console.log(context ? JSON.stringify({ additionalContext: context }) : "{}");
+} catch {
+  console.log("{}");
+}

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -1066,6 +1066,38 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(patched.settings?.description, "set by member");
   });
 
+  it("GET /:name/turn-context returns null when no extension has anything to say", async () => {
+    await ensureTestMind();
+
+    // Silence is the normal answer: the pre-prompt hook calls this every turn and
+    // must get a cheap, well-formed `null` when nothing is around. An unrecognized
+    // reason falls back to the smaller per-turn budget rather than erroring.
+    for (const reason of ["turn", "wake", "nonsense-falls-back-to-turn"]) {
+      const res = await daemonRequest(
+        `/api/minds/${TEST_MIND}/turn-context?reason=${encodeURIComponent(reason)}`,
+      );
+      assert.equal(res.status, 200, `reason=${reason}`);
+      const body = (await res.json()) as { context: string | null };
+      assert.equal(body.context, null, `reason=${reason} should yield no ambient context`);
+    }
+  });
+
+  it("GET /:name/turn-context is mind-scoped: another mind gets 403, anonymous 401", async () => {
+    await ensureTestMind();
+
+    const anon = await fetch(`${BASE_URL}/api/minds/${TEST_MIND}/turn-context`);
+    assert.equal(anon.status, 401);
+
+    // A different mind principal must not be able to read this mind's ambient context.
+    const otherMind = await getOrCreateMindUser("e2e-turn-context-other");
+    const otherSession = await createSession(otherMind.id);
+    const headers = new Headers();
+    headers.set("Authorization", `Bearer ${otherSession}`);
+    headers.set("Origin", BASE_URL);
+    const res = await fetch(`${BASE_URL}/api/minds/${TEST_MIND}/turn-context`, { headers });
+    assert.equal(res.status, 403);
+  });
+
   it("GET /api/minds withholds port/dir from non-privileged (mind) callers (#503)", async () => {
     await ensureTestMind();
 

--- a/test/template-init-classification.test.ts
+++ b/test/template-init-classification.test.ts
@@ -51,6 +51,7 @@ const EXPECTED: Record<string, "identity" | "infrastructure"> = {
   ".local/hooks/wake-context.sh": "infrastructure",
   ".local/hooks/pre-prompt/notices.ts": "infrastructure",
   ".local/hooks/pre-prompt/session-activity.ts": "infrastructure",
+  ".local/hooks/pre-prompt/turn-context.ts": "infrastructure",
 };
 
 describe("`.init/` identity vs infrastructure classification", () => {

--- a/test/turn-context.test.ts
+++ b/test/turn-context.test.ts
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import type { ExtensionManifest } from "@volute/extensions";
+import {
+  _clearLoadedExtensionsForTest,
+  _registerExtensionForTest,
+  getTurnContextProviders,
+} from "../packages/daemon/src/lib/extensions.js";
+import {
+  collectFromProviders,
+  collectTurnContext,
+  TURN_CONTEXT_BUDGET,
+  type TurnContextProviderLike,
+} from "../packages/daemon/src/lib/turn-context.js";
+
+function provider(id: string, run: (budget: number) => Promise<string | null>) {
+  return { id, run } satisfies TurnContextProviderLike;
+}
+
+/** A provider that always answers with `n` characters, recording the budget it was offered. */
+function sized(id: string, n: number, seen: number[] = []) {
+  return {
+    entry: provider(id, async (budget) => {
+      seen.push(budget);
+      return "x".repeat(n);
+    }),
+    seen,
+  };
+}
+
+describe("collectFromProviders — budget policy", () => {
+  it("returns null when nothing is loaded", async () => {
+    assert.equal(await collectFromProviders([], "turn"), null);
+  });
+
+  it("returns null when every extension is quiet — the normal case", async () => {
+    const calls: string[] = [];
+    const providers = ["a", "b", "c"].map((id) =>
+      provider(id, async () => {
+        calls.push(id);
+        return null;
+      }),
+    );
+    assert.equal(await collectFromProviders(providers, "turn"), null);
+    assert.deepEqual(calls, ["a", "b", "c"], "every provider still gets asked");
+  });
+
+  it("treats an empty or whitespace-only string as silence", async () => {
+    const providers = [provider("a", async () => "   \n  "), provider("b", async () => "")];
+    assert.equal(await collectFromProviders(providers, "turn"), null);
+  });
+
+  it("offers each provider a fair share of what is left", async () => {
+    const seen: number[] = [];
+    const providers = [
+      provider("a", async (b) => {
+        seen.push(b);
+        return null;
+      }),
+      provider("b", async (b) => {
+        seen.push(b);
+        return null;
+      }),
+      provider("c", async (b) => {
+        seen.push(b);
+        return null;
+      }),
+    ];
+    await collectFromProviders(providers, "turn", 300);
+    // 300/3, then (nothing spent) 300/2, then 300/1 — silence donates downstream.
+    assert.deepEqual(seen, [100, 150, 300]);
+  });
+
+  it("shrinks later budgets by what earlier providers actually spent", async () => {
+    const seen: number[] = [];
+    const providers = [
+      provider("a", async (b) => {
+        seen.push(b);
+        return "x".repeat(90);
+      }),
+      provider("b", async (b) => {
+        seen.push(b);
+        return null;
+      }),
+      provider("c", async (b) => {
+        seen.push(b);
+        return null;
+      }),
+    ];
+    await collectFromProviders(providers, "turn", 300);
+    // 300/3 = 100 (spends 90); then 210 left minus the 2-char joiner now needed,
+    // 208/2 = 104; then 208/1 = 208.
+    assert.deepEqual(seen, [100, 104, 208]);
+  });
+
+  it("never lets the total exceed the cap, however greedy the extensions", async () => {
+    const providers = ["a", "b", "c", "d"].map((id) =>
+      provider(id, async (budget) => "x".repeat(budget)),
+    );
+    const out = await collectFromProviders(providers, "turn", 400);
+    assert.ok(out);
+    // The cap must hold on the string actually handed to the mind, joiners included —
+    // not merely on the sum of the blocks inside it.
+    assert.ok(out.length <= 400, `returned ${out.length} chars, cap was 400`);
+  });
+
+  it("counts the block separators against the total, not just the blocks", async () => {
+    // Three providers that each take exactly their offered share: if the "\n\n" joiners
+    // were free, the result would overshoot the cap by 2 chars per extra block.
+    const providers = ["a", "b", "c"].map((id) =>
+      provider(id, async (budget) => "x".repeat(budget)),
+    );
+    const out = await collectFromProviders(providers, "turn", 90);
+    assert.ok(out);
+    assert.ok(out.length <= 90, `returned ${out.length} chars, cap was 90`);
+  });
+
+  it("one greedy extension cannot starve the others", async () => {
+    const { entry: greedy } = sized("a", 10_000);
+    const modest = provider("b", async () => "b-said-something");
+    const out = await collectFromProviders([greedy, modest], "turn", 400);
+    // The greedy one is dropped for overrunning; the modest one still gets through.
+    assert.equal(out, "b-said-something");
+  });
+});
+
+describe("collectFromProviders — failure containment", () => {
+  it("drops an extension that returns more than its budget, keeping the rest", async () => {
+    const providers = [
+      provider("over", async (b) => "x".repeat(b + 1)),
+      provider("fine", async () => "kept"),
+    ];
+    assert.equal(await collectFromProviders(providers, "turn", 200), "kept");
+  });
+
+  it("drops an extension that throws, keeping the rest", async () => {
+    const providers = [
+      provider("boom", async () => {
+        throw new Error("nope");
+      }),
+      provider("fine", async () => "kept"),
+    ];
+    assert.equal(await collectFromProviders(providers, "turn", 200), "kept");
+  });
+
+  it("drops an extension that throws synchronously", async () => {
+    const providers = [
+      {
+        id: "sync-boom",
+        run: (() => {
+          throw new Error("sync nope");
+        }) as (budget: number) => Promise<string | null>,
+      },
+      provider("fine", async () => "kept"),
+    ];
+    assert.equal(await collectFromProviders(providers, "turn", 200), "kept");
+  });
+
+  it("drops an extension that hangs, and still returns within the deadline", async () => {
+    const providers = [
+      provider("hang", () => new Promise(() => {})),
+      provider("fine", async () => "kept"),
+    ];
+    const started = Date.now();
+    const out = await collectFromProviders(providers, "turn", 200);
+    assert.equal(out, "kept");
+    assert.ok(Date.now() - started < 3000, "a hanging extension must not stall the turn");
+  });
+
+  it("tolerates a provider that returns a non-string", async () => {
+    const providers = [
+      { id: "weird", run: (async () => 42) as unknown as (b: number) => Promise<string | null> },
+      provider("fine", async () => "kept"),
+    ];
+    assert.equal(await collectFromProviders(providers, "turn", 200), "kept");
+  });
+
+  it("stops asking once the overall deadline has passed", async () => {
+    let clock = 0;
+    const asked: string[] = [];
+    const providers = ["a", "b", "c"].map((id) =>
+      provider(id, async () => {
+        asked.push(id);
+        clock += 5000; // each call blows past the total deadline
+        return null;
+      }),
+    );
+    await collectFromProviders(providers, "turn", 300, () => clock);
+    assert.deepEqual(asked, ["a"], "later providers must not be asked after the deadline");
+  });
+});
+
+describe("turn context budgets", () => {
+  it("spends less per turn than at wake", () => {
+    assert.ok(
+      TURN_CONTEXT_BUDGET.turn < TURN_CONTEXT_BUDGET.wake,
+      "the per-turn budget is paid on every turn and must be the smaller one",
+    );
+  });
+
+  it("keeps the per-turn budget small enough not to dominate a context window", () => {
+    // ~4 chars/token: this is a hard ceiling on a cost every single turn pays.
+    assert.ok(TURN_CONTEXT_BUDGET.turn <= 2000, "per-turn context must stay under ~500 tokens");
+  });
+});
+
+describe("collectTurnContext — extension registry integration", () => {
+  afterEach(() => {
+    _clearLoadedExtensionsForTest();
+  });
+
+  function manifest(id: string, turnContext?: ExtensionManifest["turnContext"]) {
+    return {
+      id,
+      name: id,
+      version: "0.0.0",
+      routes: () => ({}) as never,
+      turnContext,
+    } satisfies ExtensionManifest;
+  }
+
+  it("ignores extensions that do not declare turnContext", () => {
+    _registerExtensionForTest(manifest("plain"));
+    _registerExtensionForTest(manifest("talker", async () => "hi"));
+    assert.deepEqual(
+      getTurnContextProviders().map((p) => p.id),
+      ["talker"],
+    );
+  });
+
+  it("orders providers by id, not by load order", () => {
+    _registerExtensionForTest(manifest("zebra", async () => null));
+    _registerExtensionForTest(manifest("aardvark", async () => null));
+    assert.deepEqual(
+      getTurnContextProviders().map((p) => p.id),
+      ["aardvark", "zebra"],
+    );
+  });
+
+  it("returns null when no extension is loaded at all", async () => {
+    assert.equal(await collectTurnContext("somemind", "turn"), null);
+  });
+
+  it("passes the mind name and reason through to the extension", async () => {
+    const seen: { mind: string; reason: string; budget: number }[] = [];
+    _registerExtensionForTest(
+      manifest("spy", async (mindName, _ctx, opts) => {
+        seen.push({ mind: mindName, reason: opts.reason, budget: opts.budget });
+        return "something is around";
+      }),
+    );
+    const out = await collectTurnContext("lyra", "wake");
+    assert.equal(out, "something is around");
+    assert.deepEqual(seen, [{ mind: "lyra", reason: "wake", budget: TURN_CONTEXT_BUDGET.wake }]);
+  });
+
+  it("never throws even if the registry itself misbehaves", async () => {
+    // The wake caller (SleepManager.initiateWake) has no catch around this: an escape
+    // would skip markAwake() and leave a mind running but never marked awake.
+    const manifestWithBadId = manifest("bad", async () => null) as ExtensionManifest;
+    Object.defineProperty(manifestWithBadId, "id", {
+      get() {
+        throw new Error("registry blew up");
+      },
+    });
+    _registerExtensionForTest(manifestWithBadId);
+    assert.equal(await collectTurnContext("lyra", "wake"), null);
+  });
+
+  it("never propagates an extension failure to the mind's turn", async () => {
+    _registerExtensionForTest(
+      manifest("broken", async () => {
+        throw new Error("extension is broken");
+      }),
+    );
+    assert.equal(await collectTurnContext("lyra", "turn"), null);
+  });
+});


### PR DESCRIPTION
Track B of #807. Extensions can now contribute **ambient** material to a mind's turn — "here is what's around" — as distinct from `recordNotice`, which is directed ("someone acted on your thing"). This is the vehicle only; no extension implements `turnContext` yet (Track D fills it).

## What this does

```ts
turnContext?(mind: string, ctx: ExtensionContext, opts: {
  budget: number;
  reason: "turn" | "wake";
}): Promise<string | null>
```

- **SDK** (`packages/extensions/sdk/src/types.ts`) — the manifest field plus `TurnContextProvider` / `TurnContextOptions` / `TurnContextReason`, exported from the package index.
- **Collector** (`packages/daemon/src/lib/turn-context.ts`) — asks every loaded extension that declares `turnContext`, ordered by extension id (deterministic, and independent of npm/local discovery order, so who gets first claim on the budget is stable).
- **Endpoint** — `GET /api/minds/:name/turn-context?reason=turn|wake`, `requireSelf()`-guarded.
- **Turn path** — a new `.local/hooks/pre-prompt/turn-context.ts`, alongside `notices.ts`. Because of #809 this backfills to **existing** minds, not just new ones; classified as infrastructure in `test/template-init-classification.test.ts`.
- **Wake path** — `SleepManager` collects `reason: "wake"` directly into the wake summary.

Extensions keep their own watermark state in their own DB. The daemon stores none.

## How I chose the budget numbers

Total caps, across *all* extensions, per collection — not per-extension, since a per-extension cap sums to something unbounded as extensions get installed:

- **`turn`: 1200 characters** (~300 tokens). Paid on *every* turn, competing directly with the mind's own thinking. Sized for a couple of sentences per extension, not a digest.
- **`wake`: 3000 characters** (~750 tokens). Paid once, after hours away; this is the tier #807 §3 puts most of its weight on. Still under 0.5% of a 150k window.

**These are reasoned, not measured.** There is no production data on turn context because it has never existed. I picked them from context-cost reasoning against the compaction-thrash history, and I'd treat them as revisable at the #807 re-measure. If they're wrong I'd guess `turn` is *still too generous* rather than too tight.

Allocation is **fair-share**: each extension is offered `remaining / providers-still-to-ask`. Returning `null` donates your share to the extensions asked after you, so the quiet case (the normal one) costs nothing and one extension with something to say can still use most of the cap — but nobody can take more than their share, so a single misbehaving extension can't blow it for everyone.

## What happens when an extension exceeds or ignores the budget

Every one of these **drops that extension from the collection** and logs a warning. Nothing propagates; the mind's turn is untouched.

| Failure | Behavior |
|---|---|
| Returns more than `budget` | Dropped, **not truncated** — a block cut mid-sentence is worse in a mind's context than no block, and dropping keeps the pressure on the extension to summarize |
| Throws (async or sync) | Dropped |
| Hangs | Dropped at 1s (`PROVIDER_TIMEOUT_MS`) |
| Collectively slow | After a 2s soft deadline, remaining extensions aren't asked at all |
| Returns empty/whitespace/non-string | Treated as silence |

The cap holds on the string actually handed to the mind, joiners included.

## Things I'm unsure about

- **The budget numbers**, as above. Reasoned, unvalidated.
- **Endpoint placement.** The plan said "parallel to `/api/extensions/mind-docs`". I put it on `/api/minds/:name/` instead, because it's mind-scoped and must be `requireSelf()`-guarded, and `mind-docs` sits outside the `AppType` chain where `test/authz-coverage.test.ts` wouldn't see it. Flagging the deviation rather than making it silently.
- **Wake is collected daemon-side, not via a hook.** The wake path runs one fixed script (`wake-context.sh`) that minds and skills append to — there's no per-file drop-in slot like `pre-prompt/` has, and updating that script wouldn't reach existing minds anyway (backfill adds missing files, it doesn't edit present ones). Daemon-side collection reaches every mind. Open to a hook if you'd rather minds be able to decline it the same way.
- **The soft deadline is soft.** It's checked between extensions, not against one in flight, so worst-case wall time is `TOTAL_TIMEOUT_MS + PROVIDER_TIMEOUT_MS` (~3s), not 2s. That's inside the hook's own 3s fetch abort and 5s process kill, so an overrun costs a missing ambient block, never a stalled turn. Documented rather than hardened; say the word if you want it hard.
- **Third hook in `pre-prompt/`.** These run sequentially with independent 5s timeouts, so the theoretical worst case for the chain is now ~15s. Pre-existing architecture, not introduced here, but this PR is the third entry and it compounds.

## Testing

- `npm test` — 3105 pass, 0 fail. New `test/turn-context.test.ts` covers budget arithmetic, fair-share donation, the total cap holding on the joined output, and every failure mode above.
- `npm run test:e2e` — 68 pass, 0 fail, including two new tests for the endpoint (null-when-quiet; 401 anonymous / 403 cross-mind).
- **One caveat, verified:** `test:e2e` intermittently fails with `Daemon did not become healthy within 15000ms` on the "durable API tokens" restart test, cascading the rest. It hit ~2 of 4 runs. I checked out `main` (d359dac9) in the same worktree and reproduced it there with none of this work in the tree, so it is **pre-existing and unrelated** — but it's real and probably worth its own issue.

## Also noticed, deliberately not fixed

`npm install` regenerates a `package-lock.json` diff on current `main` — leftover `@volute/notes` entries marked extraneous after #810 removed the package. Left alone since it's Track C1's territory and another agent is working there, but `npm ci` may want it cleaned up.

Closes part of #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
