### PR TITLE
fix: let the pages archive revisit, so it cannot go permanently silent

### DIFF
--- a/packages/extensions/pages/src/ambient.ts
+++ b/packages/extensions/pages/src/ambient.ts
@@ -102,6 +102,38 @@ const CONVERSATION_COMMENTERS = 2;
 const ARCHIVE_MIN_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 
 /**
+ * How long before the archive may offer the same page to the same mind again.
+ *
+ * Once-per-artifact-ever is right for the *live* tier — a page is announced as
+ * newly published once — and wrong for the archive. Applied here it produces a
+ * terminal state: at this corpus size a mind walks the whole shelf in weeks, and
+ * then that tier is silent forever. A quiet house then makes a quiet digest makes
+ * a quiet house, which is the spiral the retrospective tier exists to break.
+ *
+ * So the archive revisits. Re-encountering something you read half a year ago is
+ * not repetition; it is the thing an archive is for, and it lands differently the
+ * second time — which is the whole argument for keeping old work reachable.
+ *
+ * **These are floors, not schedules.** Selection prefers never-shown material
+ * absolutely (see {@link pickArchive}), so a mind meets everything unseen before
+ * anything comes back around, whatever the size of the corpus. The interval only
+ * governs how long a *revisit* must wait, and its real job is to stop a house with
+ * three old pages from cycling the same three every wake.
+ *
+ * Someone else's work waits longer than the mind's own. The mind's own archive is
+ * both much smaller — a few pages each, against the house's whole shelf — and the
+ * scarcer offer, since #807 observes that nothing else in this environment brings
+ * a mind back to what it made. A six-month floor on a corpus of four pages is
+ * silence dressed as restraint.
+ *
+ * Reasoned, not measured. There is no production data on any of this, because the
+ * tier has never existed. Revisit against the #807 re-measure alongside the budget
+ * numbers from #813.
+ */
+const ARCHIVE_REVISIT_MS = 180 * 24 * 60 * 60 * 1000;
+const OWN_REVISIT_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
  * What kind of artifact an ambient appearance was, and the `ambient_shown` key
  * that makes "at most once, ever" hold per artifact.
  *
@@ -196,14 +228,20 @@ export function getAmbientState(db: Database, viewer: string, now: Date): Ambien
  */
 function commit(db: Database, viewer: string, shown: Candidate[], now: Date): void {
   const stamp = sqlNow(now);
+  // Upsert rather than INSERT OR IGNORE: created_at must keep the first-ever time
+  // (the live tier's once-ever key, and the series the #807 re-measure reads),
+  // while last_shown_at has to move or the archive cooldown never restarts and a
+  // revisited page becomes eligible again on every subsequent wake.
   const mark = db.prepare(
-    "INSERT OR IGNORE INTO ambient_shown (viewer, kind, ref, author) VALUES (?, ?, ?, ?)",
+    `INSERT INTO ambient_shown (viewer, kind, ref, author, last_shown_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(viewer, kind, ref) DO UPDATE SET last_shown_at = excluded.last_shown_at`,
   );
   for (const c of shown) {
-    mark.run(viewer, c.kind, c.ref, c.author);
+    mark.run(viewer, c.kind, c.ref, c.author, stamp);
     // Artifacts folded into this one: named in the line that was printed, so
     // genuinely met, and not to be announced again later under another kind.
-    for (const kind of c.subsumes ?? []) mark.run(viewer, kind, c.ref, c.author);
+    for (const kind of c.subsumes ?? []) mark.run(viewer, kind, c.ref, c.author, stamp);
   }
   db.prepare(
     `INSERT INTO ambient_state (viewer, watermark, last_block_at) VALUES (?, ?, ?)
@@ -219,6 +257,22 @@ function alreadyShown(db: Database, viewer: string): Set<string> {
     ref: string;
   }[];
   return new Set(rows.map((r) => `${r.kind}:${r.ref}`));
+}
+
+/**
+ * When each artifact was last shown to this mind, for the archive's cooldown.
+ *
+ * COALESCE because `last_shown_at` was added after the table: a row written
+ * before the archive could revisit anything has only its first-shown time, which
+ * is exactly the right answer for it.
+ */
+function lastShownAt(db: Database, viewer: string): Map<string, string> {
+  const rows = db
+    .prepare(
+      "SELECT kind, ref, COALESCE(last_shown_at, created_at) AS at FROM ambient_shown WHERE viewer = ?",
+    )
+    .all(viewer) as { kind: string; ref: string; at: string }[];
+  return new Map(rows.map((r) => [`${r.kind}:${r.ref}`, r.at]));
 }
 
 /**
@@ -550,7 +604,41 @@ async function retrospective(
   }
 
   // The quiet case — the common one. Reach into the archive.
-  return quiet(db, viewer, shown, seen, budget, now);
+  return quiet(db, viewer, seen, budget, now);
+}
+
+/**
+ * Pick one archive page: everything never shown before anything shown before.
+ *
+ * The preference for unseen material is **absolute**, not weighted. That is what
+ * lets the cooldown be a floor rather than a schedule — a mind meets every page it
+ * has not seen before any page comes back around, whatever the size of the corpus,
+ * so the interval never has to be tuned against how much the house has written.
+ *
+ * Among unseen pages, ordinary fairness weighting applies. Among seen ones, the
+ * longest-ago comes first, which makes revisits a slow rotation through the shelf
+ * rather than a fixation on whatever happens to sort first.
+ */
+function pickArchive(
+  candidates: Candidate[],
+  seen: Map<string, number>,
+  shownAt: Map<string, string>,
+  cooldownMs: number,
+  now: Date,
+): Candidate | null {
+  const fresh: Candidate[] = [];
+  const revisit: { c: Candidate; at: string }[] = [];
+  for (const c of candidates) {
+    const at = shownAt.get(`${c.kind}:${c.ref}`);
+    if (at === undefined) {
+      fresh.push(c);
+    } else if (now.getTime() - parseDbTimestamp(at).getTime() >= cooldownMs) {
+      revisit.push({ c, at });
+    }
+  }
+  if (fresh.length > 0) return selectFairly(fresh, seen, 1)[0] ?? null;
+  revisit.sort((a, b) => (a.at !== b.at ? (a.at < b.at ? -1 : 1) : a.c.ref < b.c.ref ? -1 : 1));
+  return revisit[0]?.c ?? null;
 }
 
 /**
@@ -558,14 +646,19 @@ async function retrospective(
  * else in this environment brings a mind back to what it made.
  *
  * Both are offered when both exist, which is the shape worth having: someone
- * else's, and yours. Each is marked shown, so the archive is walked rather than
- * looped — when it runs out, this returns null and the tier goes quiet, which is
- * the honest thing for it to do.
+ * else's, and yours.
+ *
+ * The archive **walks and then slowly rotates**, rather than walking and stopping.
+ * Unseen pages come first and each is marked as it goes; once they run out, pages
+ * become eligible again after their cooldown. So this tier can be quiet — for a
+ * while, on a small or young shelf — but it cannot go permanently silent while any
+ * old page exists, which is the property that matters. Silence here would be
+ * self-reinforcing: the tier that exists to break a quiet house must not be the
+ * thing that seals it.
  */
 function quiet(
   db: Database,
   viewer: string,
-  shown: Set<string>,
   seen: Map<string, number>,
   budget: number,
   now: Date,
@@ -593,31 +686,29 @@ function quiet(
       at: r.published_at,
       highlight: null,
     };
-    if (shown.has(`page:${c.ref}`)) continue;
-    if (author === viewer) {
-      // Own work is tracked under its own kind so it can be met again as the
-      // mind's own even if the live tier never had cause to show it.
-      if (shown.has(`own:${c.ref}`)) continue;
-      own.push({ ...c, kind: "own" });
-    } else {
-      others.push(c);
-    }
+    // Own work is tracked under its own kind so it can be met again as the mind's
+    // own even if the live tier never had cause to show it. Eligibility is no
+    // longer "never shown" — pickArchive decides, since the archive revisits.
+    if (author === viewer) own.push({ ...c, kind: "own" });
+    else others.push(c);
   }
+
+  const shownAt = lastShownAt(db, viewer);
 
   // The lead-in stands for no artifact, which is exactly why lines carry their
   // artifact rather than being matched to one by position.
   const lines: Line[] = [{ text: QUIET_LEAD, artifact: null }];
 
-  const [other] = selectFairly(others, seen, 1);
+  const other = pickArchive(others, seen, shownAt, ARCHIVE_REVISIT_MS, now);
   if (other) {
     lines.push({
       text: archiveLine(other.author, other.ref, other.file, whenWritten(other.at, now)),
       artifact: other,
     });
   }
-  // Oldest first: the mind's own furthest-back work is the part it is least
-  // likely to have met again.
-  const mine = own[0];
+  // The mind's own work waits a shorter cooldown than anyone else's: its own
+  // archive is far smaller, and it is the scarcer offer of the two.
+  const mine = pickArchive(own, seen, shownAt, OWN_REVISIT_MS, now);
   if (mine) {
     lines.push({
       text: ownArchiveLine(mine.ref, mine.file, whenWritten(mine.at, now)),

--- a/packages/extensions/pages/src/db.ts
+++ b/packages/extensions/pages/src/db.ts
@@ -141,11 +141,26 @@ export function initDb(db: Database): void {
     --
     -- The watermark alone would very nearly do this job, and briefly did: advance
     -- it past everything considered, and an artifact is structurally unrepeatable.
-    -- It is kept as well because #807 says "at most once, **ever**", and a
-    -- timestamp comparison quietly stops guaranteeing that whenever a timestamp
-    -- moves — republishing over a tombstone revives published_at, and the notes
-    -- migration writes historical ones. A guarantee that survives only while
-    -- nobody rewrites a date is not the guarantee that was asked for.
+    -- It is kept as well because a timestamp comparison quietly stops guaranteeing
+    -- anything whenever a timestamp moves — republishing over a tombstone revives
+    -- published_at, and the notes migration writes historical ones. A guarantee
+    -- that survives only while nobody rewrites a date is not a guarantee.
+    --
+    -- Two timestamps, because the tiers ask different questions of this table:
+    --
+    --   created_at    — the FIRST time this artifact was ever put in front of this
+    --                   mind. The ambient *live* tier keys off mere existence of
+    --                   the row: a page is announced as new exactly once, ever.
+    --   last_shown_at — the MOST RECENT time. The *archive* tier keys off this,
+    --                   because it is allowed to come back around.
+    --
+    -- Once-ever is right for "whorl published a thing" and wrong for the archive.
+    -- Applied to the archive it produces a terminal state: a mind that has walked
+    -- the whole shelf never hears from that tier again — weeks away at this
+    -- corpus size, not years — and then a quiet house makes a quiet digest makes a
+    -- quiet house. That spiral is the exact thing the retrospective tier exists to
+    -- break, so it must not be the tier that starts it. Re-encountering a page you
+    -- read half a year ago is not repetition; it is what an archive is *for*.
     --
     -- The author column is denormalized so fairness weighting is one grouped read on the
     -- turn path: "whose work has this mind met least" is the selection's central
@@ -155,6 +170,7 @@ export function initDb(db: Database): void {
       viewer TEXT NOT NULL,
       kind TEXT NOT NULL,
       ref TEXT NOT NULL,
+      last_shown_at TEXT,
       author TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -203,6 +219,9 @@ export function initDb(db: Database): void {
     // to be an invitation, but the default is that it is.
     "comments_closed INTEGER NOT NULL DEFAULT 0",
   ]);
+  // Also listed here so a worktree that created ambient_shown before the archive
+  // cooldown existed picks the column up rather than failing every ambient query.
+  addColumns(db, "ambient_shown", ["last_shown_at TEXT"]);
   addColumns(db, "page_comments", [
     // "comment" (a response) or "publish" (the --shared message that explains a
     // change). Both live in the thread; only a response is an invitation.

--- a/test/pages-ambient.test.ts
+++ b/test/pages-ambient.test.ts
@@ -477,12 +477,84 @@ describe("ambient retrospective at wake", () => {
     assert.match(second, /Something of your own: you wrote "mine"/);
   });
 
-  it("walks the archive rather than looping it, and goes quiet when spent", async () => {
+  it("meets everything unseen before anything comes back around", async () => {
+    horizonAt("pip", ago(1 * DAY));
+    for (let i = 0; i < 4; i++) publish("gardener", `notes/p${i}.md`, ago((100 + i) * DAY));
+
+    // Four wakes a week apart: four distinct pages, no repeats. Unseen material is
+    // preferred absolutely, which is what lets the cooldown be a floor rather than
+    // a schedule that has to be tuned against how much the house has written.
+    const met = new Set<string>();
+    for (let w = 0; w < 4; w++) {
+      const at = new Date(NOW.getTime() + w * 7 * DAY);
+      const out = (await ambientTurnContext("pip", ctx(), wake, at)) ?? "";
+      const ref = out.match(/gardener\/notes\/p\d\.md/)?.[0];
+      assert.ok(ref, `wake ${w} said nothing`);
+      assert.ok(!met.has(ref), `wake ${w} repeated ${ref} while unseen pages remained`);
+      met.add(ref);
+    }
+    assert.equal(met.size, 4);
+  });
+
+  it("is quiet between revisits rather than cycling a small shelf", async () => {
     horizonAt("pip", ago(1 * DAY));
     publish("gardener", "notes/only.md", ago(120 * DAY));
     assert.ok(await ambientTurnContext("pip", ctx(), wake, NOW));
-    const later = new Date(NOW.getTime() + 3 * DAY);
-    assert.equal(await ambientTurnContext("pip", ctx(), wake, later), null);
+    // The next day, and a month later, it does not say the same thing again.
+    assert.equal(await ambientTurnContext("pip", ctx(), wake, new Date(NOW.getTime() + DAY)), null);
+    assert.equal(
+      await ambientTurnContext("pip", ctx(), wake, new Date(NOW.getTime() + 30 * DAY)),
+      null,
+    );
+  });
+
+  it("can never go permanently silent while any old page exists", async () => {
+    // The property, not the constant. Once-per-artifact-ever applied to the
+    // archive produces a terminal state — a mind walks the shelf in weeks and
+    // that tier never speaks again — and a quiet house then makes a quiet digest
+    // makes a quiet house. The tier that exists to break that spiral must not be
+    // what seals it.
+    horizonAt("pip", ago(1 * DAY));
+    publish("gardener", "notes/theirs.md", ago(200 * DAY));
+    publish("pip", "notes/mine.md", ago(200 * DAY));
+
+    // Walk it to exhaustion.
+    assert.ok(await ambientTurnContext("pip", ctx(), wake, NOW));
+    assert.equal(
+      await ambientTurnContext("pip", ctx(), wake, new Date(NOW.getTime() + 30 * DAY)),
+      null,
+      "spent, as expected, during the cooldown",
+    );
+
+    // Past the mind's own cooldown (90d), its own work comes back.
+    const afterOwn = (await ambientTurnContext("pip", ctx(), wake, dayssAfter(100))) ?? "";
+    assert.match(afterOwn, /Something of your own: you wrote "mine"/);
+    assert.doesNotMatch(afterOwn, /From further back/, "another mind's waits longer");
+
+    // Past the longer cooldown (180d), someone else's does too.
+    const afterOther = (await ambientTurnContext("pip", ctx(), wake, dayssAfter(200))) ?? "";
+    assert.match(afterOther, /From further back: gardener's "theirs"/);
+
+    function dayssAfter(n: number): Date {
+      return new Date(NOW.getTime() + n * DAY);
+    }
+  });
+
+  it("restarts the cooldown on a revisit rather than re-offering every wake", async () => {
+    // If last_shown_at didn't move on a revisit, a page would clear its cooldown
+    // once and then be eligible forever after — the archive would fixate instead
+    // of rotating.
+    horizonAt("pip", ago(1 * DAY));
+    publish("gardener", "notes/only.md", ago(400 * DAY));
+    assert.ok(await ambientTurnContext("pip", ctx(), wake, NOW));
+
+    const revisit = new Date(NOW.getTime() + 200 * DAY);
+    assert.ok(await ambientTurnContext("pip", ctx(), wake, revisit), "comes back after cooldown");
+    assert.equal(
+      await ambientTurnContext("pip", ctx(), wake, new Date(revisit.getTime() + 30 * DAY)),
+      null,
+      "and then waits again",
+    );
   });
 });
 
@@ -515,6 +587,39 @@ describe("the budget is the daemon's, and an over-budget block is dropped", () =
     // Only the artifact that actually made it is marked shown.
     const shown = db.prepare("SELECT COUNT(*) AS n FROM ambient_shown").get() as { n: number };
     assert.equal(shown.n, 1);
+  });
+
+  it("marks nothing shown that does not appear in the text, at any budget", async () => {
+    // The general form of the off-by-one above, swept rather than spot-checked.
+    // It matters more now that the archive revisits: an artifact spent on a block
+    // that had no room to print it is not merely lost, it starts a cooldown, so
+    // the mind is denied it for months on the strength of an encounter that never
+    // happened.
+    //
+    // A folded page is the one documented exception, and it holds here too: it
+    // shares an address with the conversation line that did print.
+    for (const reason of ["turn", "wake"] as const) {
+      for (const budget of [20, 40, 60, 90, 120, 160, 200, 300, 600, 1200]) {
+        db = new Database(":memory:") as unknown as ExtDb;
+        initDb(db);
+        horizonAt("pip", ago(5 * DAY));
+        publish("whorl", "notes/aaa.md", ago(4 * DAY));
+        publish("gardener", "notes/bbb.md", ago(3 * DAY));
+        publish("mimsy", "notes/ccc.md", ago(2 * DAY));
+        publish("pip", "notes/own.md", ago(200 * DAY));
+
+        const out = (await ambientTurnContext("pip", ctx(), { budget, reason }, NOW)) ?? "";
+        assert.ok(out.length <= budget, `${reason}@${budget} overran its budget`);
+
+        const marked = db.prepare("SELECT ref FROM ambient_shown").all() as { ref: string }[];
+        for (const { ref } of marked) {
+          assert.ok(
+            out.includes(ref),
+            `${reason}@${budget} marked ${ref} shown but never printed it`,
+          );
+        }
+      }
+    }
   });
 
   it("never throws, whatever the state of the database", async () => {


### PR DESCRIPTION
Follow-up to #818 (Track D of #807). Fixes an uncertainty I raised in that PR and was right to.

## The rule was slightly wrong

"Each artifact appears at most once, ever" is correct for the **ambient live** tier — a page should be announced as newly published once, not repeatedly. That is unchanged.

Applied to the **archive** tier it produces a terminal state. At ~88 pages and four minds, a mind walks the whole shelf in weeks, and then that tier is silent forever. A quiet house makes a quiet digest makes a quiet house — the self-reinforcing silence the retrospective tier exists to break. The tier meant to break the spiral must not be the thing that seals it.

## What changed

The archive now **walks and then slowly rotates**.

- Unseen pages are preferred **absolutely**, not weighted. A mind meets everything it has not seen before anything comes back around, whatever the corpus size.
- Past that, a page becomes eligible again after a cooldown. Among revisits, longest-ago first — a slow rotation through the shelf rather than a fixation.
- `ambient_shown` grows `last_shown_at` beside `created_at`. The live tier keys off the row existing (once ever, unchanged); the archive keys off the last time.

Unchanged: live stays once-per-artifact-ever, an artifact's *first* appearance still comes through whichever tier surfaces it first, and the fold, fairness weighting and budget behaviour are untouched.

## The intervals, and why

**180 days for another mind's work. 90 days for the mind's own.**

They are **floors, not schedules**. Because unseen material wins absolutely, the interval never governs how fast a mind moves through the archive — only how long a *revisit* waits. Its real job is narrow: stop a house with three old pages from cycling the same three every wake.

Own work waits half as long for two reasons. A mind's own archive is far smaller — a few pages each against the house's whole shelf — so a six-month floor on a corpus of four pages is silence dressed as restraint. And it is the scarcer offer: #807 observes that nothing else in this environment brings a mind back to what it made, whereas other minds' work is also reachable through the live tier.

Same status as the budget numbers in #813 and my 14-day archive-age constant: **reasoned, not measured.** There is no production data on any of this because the tier has never existed. All three want revisiting against the #807 re-measure.

## The property, not the constant

You asked for the property to be tested, which is the right ask — a cooldown constant existing proves nothing. `can never go permanently silent while any old page exists` walks the archive to exhaustion, confirms it is quiet during the cooldown, then advances past each interval and asserts the tier speaks again: own work at 90 days, another mind's at 180.

Three more:
- `meets everything unseen before anything comes back around` — four wakes a week apart yield four distinct pages, no repeats.
- `is quiet between revisits rather than cycling a small shelf` — the failure mode in the other direction.
- `restarts the cooldown on a revisit` — if `last_shown_at` did not move, a page would clear its cooldown once and then be eligible forever after, and the archive would fixate instead of rotate.

All four verified to fail against the once-ever behaviour before being kept.

## Also, per your second point

You asked me to double-check that a "shown" record is only ever written for something actually rendered. It is — `commit` has one call site, and it derives its artifacts from the rendered lines rather than from a count. I have pinned it as a property sweep across ten budgets and both tiers rather than the single spot-check #818 had: every ref in `ambient_shown` must appear in the returned text.

That check matters more now than it did. Previously spending an artifact on a block with no room to print it lost it permanently; now it also *starts a cooldown*, so the mind is denied it for months on the strength of an encounter that never happened.

The one documented exception still holds: a folded page shares an address with the conversation line that did print, so it passes the same assertion.

## What I am still unsure of

- **Whether 90/180 are anywhere near right.** They are the least-evidenced numbers in this PR. The structure is what I would defend; the constants are a starting position.
- **Whether a revisit should read differently from a first encounter.** Right now the wording is identical — "From further back: gardener's X, from March and still there." A mind meeting a page for the second time in eight months gets no signal that it has seen it before. I considered a variant line and decided against it: it risks implying the mind failed to act the first time, which is exactly the obligation the wording rules out. But I am not confident, and it is cheap to add later if the register turns out to allow it.
- **The `own` cooldown interacts with a mind that publishes constantly.** For a mind with 84 pages, own-archive material effectively never exhausts, so the 90-day floor rarely binds. For a mind with two pages it binds often. That asymmetry seems right, but it means the constant does very different work for different minds.

## Testing

`npm test` 3210/3210, `npm run test:e2e` 68/68 (rebased onto current `main` with #818 merged).

One honest note on the e2e run: the first attempt failed 57/68. I checked rather than assuming — the first failure is `Daemon did not become healthy within 15000ms` on a restart, and all 56 others are ECONNREFUSED cascading from that dead daemon, which is #814's signature exactly. The pages extension loaded cleanly in that same log. Clean 68/68 on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
