### PR TITLE
fix: surface page comments in a floating panel instead of below the page

### DIFF
--- a/packages/extensions/pages/ui/src/App.svelte
+++ b/packages/extensions/pages/ui/src/App.svelte
@@ -10,6 +10,12 @@ let pageIframe = $state<HTMLIFrameElement>();
 let username = $state("");
 let userAvatarUrl = $state<string | null>(null);
 
+// Comment drawer state for the single-page view. The thread stays mounted while
+// the drawer is closed (it slides off-screen) so its count is known before the
+// visitor ever opens it.
+let threadOpen = $state(false);
+let commentCount = $state(0);
+
 onMount(() => {
   fetchCurrentUser().then((u) => {
     username = u.username;
@@ -115,23 +121,87 @@ function handleSelectSite(name: string) {
     navigateParent(`/minds/${name}/pages`);
   }
 }
+
+// Moving to a different page closes the drawer and clears the badge; the freshly
+// mounted thread reports the new page's count.
+$effect(() => {
+  const key = route.view === "page" ? `${route.name}/${route.path}` : "";
+  void key;
+  threadOpen = false;
+  commentCount = 0;
+});
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape" && threadOpen) {
+    e.preventDefault();
+    threadOpen = false;
+  }
+}
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div class="ext-app" class:full-page={route.view === "page"}>
   {#if route.view === "page"}
-    <div class="page-with-thread">
+    <div class="page-view">
       <iframe
         bind:this={pageIframe}
         src="/ext/pages/public/{route.name}/{route.path}"
         class="full-page-iframe"
         title="{route.name}/{route.path}"
       ></iframe>
-      <PageThread
-        mind={route.name}
-        file={route.path}
-        currentUsername={username}
-        {userAvatarUrl}
-      />
+
+      {#if threadOpen}
+        <div
+          class="thread-scrim"
+          role="presentation"
+          onclick={() => (threadOpen = false)}
+        ></div>
+      {/if}
+
+      <aside class="thread-drawer" class:open={threadOpen} aria-hidden={!threadOpen}>
+        <header class="drawer-header">
+          <span class="drawer-title">Comments</span>
+          <button
+            class="drawer-close"
+            onclick={() => (threadOpen = false)}
+            aria-label="Close comments"
+          >✕</button>
+        </header>
+        <div class="drawer-body">
+          <PageThread
+            mind={route.name}
+            file={route.path}
+            currentUsername={username}
+            {userAvatarUrl}
+            onCount={(n) => (commentCount = n)}
+          />
+        </div>
+      </aside>
+
+      <button
+        class="comments-fab"
+        class:empty={commentCount === 0}
+        class:hidden={threadOpen}
+        onclick={() => (threadOpen = true)}
+        aria-label={commentCount > 0 ? `Comments (${commentCount})` : "Comments"}
+      >
+        <svg
+          class="fab-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z" />
+        </svg>
+        {#if commentCount > 0}
+          <span class="fab-badge">{commentCount}</span>
+        {/if}
+      </button>
     </div>
   {:else if (route.view === "site" || route.view === "mind") && selectedSite}
     <SiteView site={selectedSite} onSelectPage={handleSelectPage} />
@@ -153,25 +223,160 @@ function handleSelectSite(name: string) {
     height: 100%;
   }
 
-  .page-with-thread {
-    display: flex;
-    flex-direction: column;
+  /* The page fills the view; the conversation overlays it on request rather than
+     reflowing it, so a visitor never has to scroll past the whole page to find
+     that a conversation exists. */
+  .page-view {
+    position: relative;
     height: 100%;
+    width: 100%;
+    overflow: hidden;
   }
 
   .full-page-iframe {
+    display: block;
     width: 100%;
-    flex: 1 1 60%;
-    min-height: 0;
+    height: 100%;
     border: none;
     background: white;
   }
 
-  /* The thread sits under the page rather than beside it: a page is the thing,
-     and the conversation is what has gathered under it. Capped so a long thread
-     never crowds out the page it is about. */
-  .page-with-thread :global(.thread) {
-    flex: 0 1 auto;
-    max-height: 40%;
+  /* Floating affordance, bottom-right. Present even at zero (subtler) so adding
+     the first comment is discoverable; the badge appears once there's something
+     to count. */
+  .comments-fab {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    z-index: var(--z-dropdown);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--bg-2);
+    color: var(--text-1);
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+    transition:
+      transform 0.15s,
+      color 0.15s,
+      border-color 0.15s,
+      opacity 0.15s;
+  }
+
+  .comments-fab:hover {
+    color: var(--text-0);
+    border-color: var(--border-bright);
+    transform: translateY(-1px);
+  }
+
+  .comments-fab.empty {
+    opacity: 0.6;
+  }
+
+  .comments-fab.empty:hover {
+    opacity: 1;
+  }
+
+  .comments-fab.hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .fab-icon {
+    width: 22px;
+    height: 22px;
+  }
+
+  .fab-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--bg-0);
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 18px;
+    text-align: center;
+    box-sizing: border-box;
+  }
+
+  .thread-scrim {
+    position: absolute;
+    inset: 0;
+    z-index: var(--z-modal);
+    background: var(--overlay);
+    animation: fadeIn 0.15s ease;
+  }
+
+  .thread-drawer {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(420px, 100%);
+    z-index: var(--z-modal);
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-1);
+    border-left: 1px solid var(--border);
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.28);
+    transform: translateX(100%);
+    transition: transform 0.2s ease;
+  }
+
+  .thread-drawer.open {
+    transform: translateX(0);
+  }
+
+  .drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .drawer-title {
+    font-family: var(--sans);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-0);
+  }
+
+  .drawer-close {
+    background: none;
+    border: none;
+    color: var(--text-2);
+    font-size: 15px;
+    line-height: 1;
+    padding: 4px 8px;
+    cursor: pointer;
+  }
+
+  .drawer-close:hover {
+    color: var(--text-0);
+  }
+
+  .drawer-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  /* The drawer supplies its own header/border, so drop the thread's own top rule
+     and let it size to the drawer rather than a capped fraction of the page. */
+  .drawer-body :global(.thread) {
+    border-top: none;
+    max-height: none;
   }
 </style>

--- a/packages/extensions/pages/ui/src/components/PageThread.svelte
+++ b/packages/extensions/pages/ui/src/components/PageThread.svelte
@@ -15,11 +15,15 @@ let {
   file,
   currentUsername,
   userAvatarUrl = null,
+  onCount,
 }: {
   mind: string;
   file: string;
   currentUsername: string;
   userAvatarUrl?: string | null;
+  // Reports the running interaction count (comments + reactions) so a host can
+  // show a badge without opening the thread. Fires on every thread change.
+  onCount?: (count: number) => void;
 } = $props();
 
 const QUICK_REACTIONS = ["🌱", "✨", "👀", "💭"];
@@ -113,6 +117,16 @@ function initial(name: string): string {
 }
 
 let mine = $derived(currentUsername);
+
+// Comments plus reactions: what the badge counts. Reported to the host on every
+// change (initial load and after posting/reacting/deleting) so the affordance
+// stays in sync without the host reaching into the thread.
+let interactionCount = $derived(
+  thread ? thread.comments.length + thread.reactions.reduce((n, r) => n + r.count, 0) : 0,
+);
+$effect(() => {
+  onCount?.(interactionCount);
+});
 
 // Presence in words, phrased server-side so there is one copy of the wording (see
 // PagePresence.text). Null on a page nobody has opened — no zero, no empty state.

--- a/packages/web/src/ui/pages/MindPage.svelte
+++ b/packages/web/src/ui/pages/MindPage.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
 import Chat from "../components/chat/Chat.svelte";
-import { navigate } from "../lib/navigate";
 import { data } from "../lib/stores.svelte";
 
 let {
@@ -32,24 +31,6 @@ let {
 
 let mind = $derived(data.minds.find((m) => m.name === name));
 let currentConv = $derived(conversations?.find((c) => c.id === conversationId));
-
-function handleIframeNav(e: Event) {
-  const iframe = e.target as HTMLIFrameElement;
-  try {
-    const path = iframe.contentWindow?.location.pathname;
-    if (!path) return;
-    // Match /ext/pages/public/{mind}/{file...}
-    const match = path.match(/^\/ext\/pages\/public\/([^/]+)\/(.+)$/);
-    if (!match) return;
-    const [, mindName, file] = match;
-    if (mindName === name && file === subpath) return;
-    navigate(`/minds/${mindName}/pages/${file}`);
-  } catch (err) {
-    if (!(err instanceof DOMException)) {
-      console.error("[pages] unexpected error in iframe nav handler:", err);
-    }
-  }
-}
 </script>
 
 {#if !mind}
@@ -60,7 +41,10 @@ function handleIframeNav(e: Event) {
       {@const extParts = section.split(":")}
       <div class="section-content">
         {#if subpath && extParts[1] === "pages"}
-          <iframe src="/ext/{extParts[1]}/public/{name}/{subpath}" class="ext-iframe page-content-iframe" title="Page content" onload={handleIframeNav}></iframe>
+          <!-- Embed the pages App's single-page view (page + comment thread), not
+               the raw public page, so the comment affordance is reachable. The App
+               reports breadcrumb navigation via postMessage (see App.svelte). -->
+          <iframe src="/ext/{extParts[1]}/#/{name}/{subpath}" class="ext-iframe" title="Page"></iframe>
         {:else}
           <iframe src="/ext/{extParts[1]}/#/mind/{name}{subpath ? '/' + subpath : ''}" class="ext-iframe" title="Extension"></iframe>
         {/if}
@@ -110,9 +94,5 @@ function handleIframeNav(e: Event) {
     height: 100%;
     border: none;
     background: var(--bg-0);
-  }
-
-  .page-content-iframe {
-    background: white;
   }
 </style>


### PR DESCRIPTION
## The bug

Page comment threads were effectively invisible for **personal** pages. The pages extension has a full comment-thread UI (`PageThread.svelte`), but it was only reachable for commons (`_system`) pages via the system route. For a personal page, `MindPage.svelte` rendered the **raw** page directly (`<iframe src="/ext/pages/public/{name}/{subpath}">`) with no thread — so the comment UI never appeared where real comments accumulate (homepages, notes, etc.).

On top of that, even where the thread *did* render, it was stacked **below** a full-height page, so a visitor had to scroll past the entire page to discover it — most never would.

## The fixes

**1. Reachability.** `MindPage.svelte` now embeds the pages App's single-page view (`/ext/pages/#/{name}/{subpath}`) — the same view the commons/system path already uses — instead of the raw `public/` iframe. That view carries both the page iframe and the thread. The now-dead `onload` iframe-location scraper is removed; breadcrumb/back navigation already flows through the App's `postMessage({type:"navigate"})` (which the main app listens for).

**2. Floating panel UX.** The stacked thread in the pages App's page view is replaced with:
- a floating **comments button** (bottom-right) that shows a **count badge** (comments + reactions) so the presence of a conversation is visible without scrolling — shown even at zero (subtler) so the first comment stays discoverable;
- clicking it opens a **right-side drawer** overlaying the page (the page iframe fills the view and does not reflow), containing the existing `PageThread` — comments, reactions, composer, backlinks — with a clear close control (button + Escape + scrim click);
- the thread stays mounted while the drawer is closed (it slides off-screen) so the badge count is known before opening. `PageThread` gained an `onCount` callback to report its running interaction count.

This lives in the App's page view, so it covers **both** personal and commons pages once the reachability fix lands. Styled with `@volute/ui` CSS custom properties, responsive (drawer is full-width on narrow viewports via `min(420px, 100%)`).

## Verification

Static checks only (as agreed — live browser verification is **pending on the maintainer**):
- `npm install`, root `tsc --noEmit` — clean
- `npm run typecheck:web` (svelte-check) — 0 errors (1 pre-existing unrelated warning)
- `npx biome check` on the 3 changed files — clean
- `npm run build:ui` (pages ext) + `npm run build:web` — both compile
- `npm test` — 3239 pass, 0 fail
- Svelte MCP autofixer on `App.svelte` — no issues

**Maintainer, to verify visually:** open the dashboard → a mind with a published personal page → Pages tab → open a page. Confirm the floating comments button appears bottom-right (with a count badge if the page has comments/reactions), clicking it slides in the drawer with the thread, and closing (✕ / Escape / clicking the scrim) returns to the full page. Repeat on a commons (`_system`) page to confirm parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)