### PR TITLE
fix: bind daemon HTTP server before slow skill sync (#510)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -182,14 +182,11 @@ export async function startDaemon(opts: {
   const { initSandbox } = await import("./lib/mind/sandbox.js");
   await initSandbox();
 
-  // Sync built-in skills into the shared pool (non-fatal)
-  try {
-    await syncBuiltinSkills();
-  } catch (err) {
-    log.error("failed to sync built-in skills", log.errorData(err));
-  }
-
-  // Load extensions (non-fatal)
+  // Load extensions (non-fatal). This must run BEFORE the HTTP server binds:
+  // extensions mount routes on `app`, and Hono freezes its route matcher on the
+  // first request, so a route added after the first health poll would throw. The
+  // skill sync / auto-update housekeeping below touches only the shared pool and
+  // mind dirs (not `app`), so it's deferred until after the server is listening.
   try {
     await loadAllExtensions(app, authMiddleware);
     notifyExtensionsDaemonStart();
@@ -197,7 +194,78 @@ export async function startDaemon(opts: {
     log.error("failed to load extensions", log.errorData(err));
   }
 
-  // Initialize default skills config if not set (after extensions load so their skills are included)
+  // Use existing token if set (for testing), otherwise generate one
+  const token = process.env.VOLUTE_DAEMON_TOKEN || randomBytes(32).toString("hex");
+
+  // Tailscale HTTPS setup (CLI flag or config)
+  const { readGlobalConfig } = await import("./lib/config/setup.js");
+  const globalCfg = readGlobalConfig();
+  let tls: { key: Buffer; cert: Buffer } | undefined;
+  if (opts.tailscale || globalCfg.tailscale) {
+    try {
+      const { getTailscaleTls } = await import("./lib/tailscale.js");
+      const tlsConfig = await getTailscaleTls();
+      tls = { key: tlsConfig.key, cert: tlsConfig.cert };
+      log.info("Tailscale HTTPS enabled", { hostname: tlsConfig.hostname });
+    } catch (err) {
+      log.error(
+        "Tailscale TLS setup failed — starting without HTTPS. Ensure Tailscale is running, or disable tailscale in config.",
+        log.errorData(err),
+      );
+    }
+  }
+
+  // Start the web server EARLY — before the slow skill sync / auto-update pass
+  // below — so `/api/health` means "daemon alive" and answers within seconds.
+  // Previously the server only bound after ~2.5min of per-mind skill git work,
+  // which blew past `volute update`'s health poll on multi-mind system installs
+  // and made a healthy restart report as failed (#510). Must succeed before
+  // writing PID/config files, otherwise a failed startup (e.g. EADDRINUSE) would
+  // overwrite files belonging to a running daemon.
+  let result: Awaited<ReturnType<typeof startServer>>;
+  try {
+    result = await startServer({ port, hostname: "0.0.0.0", tls });
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "EADDRINUSE") {
+      log.error(`port ${port} is already in use`);
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { server, internalPort } = result;
+
+  // Internal communication always uses HTTP on localhost
+  // When TLS is enabled, minds/CLI talk to the secondary HTTP port
+  const daemonPort = internalPort ?? port;
+  process.env.VOLUTE_DAEMON_TOKEN = token;
+  process.env.VOLUTE_DAEMON_PORT = String(daemonPort);
+  process.env.VOLUTE_DAEMON_HOSTNAME = hostname;
+
+  // Server is listening — safe to write PID and config
+  writeFileSync(DAEMON_PID_PATH, myPid, { mode: 0o644 });
+  const daemonConfig: Record<string, unknown> = { port, hostname };
+  if (internalPort) daemonConfig.internalPort = internalPort;
+  if (tls) daemonConfig.tls = true;
+  // daemon.json is host-readable (0644); the admin token is written separately at 0600.
+  writeDaemonConfig(systemDir, daemonConfig, token);
+
+  // --- Post-bind housekeeping ---
+  // The HTTP server is already listening and answering /api/health, so the slow
+  // steps below no longer gate daemon health (#510). They stay in their original
+  // order (sync before defaults) and are awaited before mind startup, so minds
+  // still boot against a fully-synced skill pool exactly as before — only the
+  // server bind moved earlier.
+
+  // Sync built-in skills into the shared pool (non-fatal)
+  try {
+    await syncBuiltinSkills();
+  } catch (err) {
+    log.error("failed to sync built-in skills", log.errorData(err));
+  }
+
+  // Initialize default skills config if not set (after extensions load + builtin
+  // sync so their skills are present in the pool)
   await initDefaultSkills();
 
   // Auto-update skills for all minds (non-fatal)
@@ -233,58 +301,6 @@ export async function startDaemon(opts: {
       log.errorData(err),
     );
   }
-
-  // Use existing token if set (for testing), otherwise generate one
-  const token = process.env.VOLUTE_DAEMON_TOKEN || randomBytes(32).toString("hex");
-
-  // Tailscale HTTPS setup (CLI flag or config)
-  const { readGlobalConfig } = await import("./lib/config/setup.js");
-  const globalCfg = readGlobalConfig();
-  let tls: { key: Buffer; cert: Buffer } | undefined;
-  if (opts.tailscale || globalCfg.tailscale) {
-    try {
-      const { getTailscaleTls } = await import("./lib/tailscale.js");
-      const tlsConfig = await getTailscaleTls();
-      tls = { key: tlsConfig.key, cert: tlsConfig.cert };
-      log.info("Tailscale HTTPS enabled", { hostname: tlsConfig.hostname });
-    } catch (err) {
-      log.error(
-        "Tailscale TLS setup failed — starting without HTTPS. Ensure Tailscale is running, or disable tailscale in config.",
-        log.errorData(err),
-      );
-    }
-  }
-
-  // Start web server — must succeed before writing PID/config files,
-  // otherwise a failed startup (e.g. EADDRINUSE) would overwrite files
-  // belonging to a running daemon.
-  let result: Awaited<ReturnType<typeof startServer>>;
-  try {
-    result = await startServer({ port, hostname: "0.0.0.0", tls });
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException;
-    if (e.code === "EADDRINUSE") {
-      log.error(`port ${port} is already in use`);
-      process.exit(1);
-    }
-    throw err;
-  }
-  const { server, internalPort } = result;
-
-  // Internal communication always uses HTTP on localhost
-  // When TLS is enabled, minds/CLI talk to the secondary HTTP port
-  const daemonPort = internalPort ?? port;
-  process.env.VOLUTE_DAEMON_TOKEN = token;
-  process.env.VOLUTE_DAEMON_PORT = String(daemonPort);
-  process.env.VOLUTE_DAEMON_HOSTNAME = hostname;
-
-  // Server is listening — safe to write PID and config
-  writeFileSync(DAEMON_PID_PATH, myPid, { mode: 0o644 });
-  const daemonConfig: Record<string, unknown> = { port, hostname };
-  if (internalPort) daemonConfig.internalPort = internalPort;
-  if (tls) daemonConfig.tls = true;
-  // daemon.json is host-readable (0644); the admin token is written separately at 0600.
-  writeDaemonConfig(systemDir, daemonConfig, token);
 
   // Start delivery manager, mind manager, bridge manager, and scheduler
   const delivery = initDeliveryManager();

--- a/packages/daemon/src/lib/config/service-mode.ts
+++ b/packages/daemon/src/lib/config/service-mode.ts
@@ -19,7 +19,10 @@ export const LAUNCHD_PLIST_PATH = resolve(
 );
 export const SYSTEM_LAUNCHD_PLIST_PATH = "/Library/LaunchDaemons/com.volute.daemon.plist";
 
-export const HEALTH_POLL_TIMEOUT = 30_000;
+// The daemon binds its HTTP server early (before skill sync / auto-update), so
+// health normally answers within seconds. This ceiling is a belt-and-suspenders
+// margin for a slow first boot, not the expected wait (#510).
+export const HEALTH_POLL_TIMEOUT = 120_000;
 export const STOP_GRACE_TIMEOUT = 10_000;
 export const POLL_INTERVAL = 500;
 

--- a/src/commands/daemon-restart.ts
+++ b/src/commands/daemon-restart.ts
@@ -1,6 +1,7 @@
 import { command } from "@volute/cli/lib/command.js";
 import {
   getServiceMode,
+  HEALTH_POLL_TIMEOUT,
   modeLabel,
   pollHealth,
   readDaemonConfig,
@@ -30,7 +31,11 @@ const cmd = command({
       if (await pollHealth("127.0.0.1", config.internalPort ?? config.port)) {
         console.log("Daemon restarted.");
       } else {
-        console.error("Service restarted but daemon did not become healthy within 30s.");
+        console.error(
+          `Service restarted but daemon did not become healthy within ${Math.round(
+            HEALTH_POLL_TIMEOUT / 1000,
+          )}s.`,
+        );
         process.exit(1);
       }
       return;

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -5,6 +5,7 @@ import { command } from "@volute/cli/lib/command.js";
 import {
   daemonLogReport,
   getServiceMode,
+  HEALTH_POLL_TIMEOUT,
   modeLabel,
   pollHealth,
   startService,
@@ -55,7 +56,11 @@ const cmd = command({
       if (await pollHealth(h, p)) {
         console.log(`Volute daemon running on ${h}:${p}`);
       } else {
-        console.error("Service started but daemon did not become healthy within 30s.");
+        console.error(
+          `Service started but daemon did not become healthy within ${Math.round(
+            HEALTH_POLL_TIMEOUT / 1000,
+          )}s.`,
+        );
         for (const line of daemonLogReport(mode)) console.error(line);
         process.exit(1);
       }

--- a/test/service-mode.test.ts
+++ b/test/service-mode.test.ts
@@ -25,7 +25,7 @@ describe("service-mode constants", () => {
     assert.ok(USER_SYSTEMD_UNIT.endsWith(".config/systemd/user/volute.service"));
     assert.equal(LAUNCHD_PLIST_LABEL, "com.volute.daemon");
     assert.ok(LAUNCHD_PLIST_PATH.endsWith("Library/LaunchAgents/com.volute.daemon.plist"));
-    assert.equal(HEALTH_POLL_TIMEOUT, 30_000);
+    assert.equal(HEALTH_POLL_TIMEOUT, 120_000);
     assert.equal(STOP_GRACE_TIMEOUT, 10_000);
     assert.equal(POLL_INTERVAL, 500);
   });


### PR DESCRIPTION
## Summary

On a multi-mind system install, `volute update` succeeded but exited 1 with "Service restarted but daemon did not become healthy." The daemon was fine — it took ~2.5 minutes to bind port 1618, while the health poll timeout was only 30s.

**Root cause:** The HTTP server only bound after:
1. `syncBuiltinSkills()` (~30s)
2. `loadAllExtensions()` (~5s)
3. `autoUpdateMindSkills()` (~2min per-mind git work)

For that entire window, `/api/health` failed.

## Changes

1. **Reorder `startDaemon()`** — HTTP server binds immediately after DB init, sandbox init, and extension loading (extensions must load first — Hono freezes routes on first request)
2. **Skill sync / auto-update deferred** — runs AFTER server is listening, still awaited before mind startup
3. **Raise `HEALTH_POLL_TIMEOUT`** — 30s → 120s as belt-and-suspenders
4. **Error messages derive from constant** — no more hardcoded "30s"

Now `/api/health` means "daemon alive" and answers within seconds.

## Verification

- [x] Server binds before skill sync starts (verified via log order)
- [x] Minds still boot against fully-synced skill pool (order preserved)
- [x] All tests pass (3251)

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)