### PR TITLE
ci: add 10-minute timeout to test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -60,6 +61,7 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -77,6 +79,7 @@ jobs:
 
   test-upgrade:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # fetch-depth: 0 pulls full history + tags — the upgrade test resolves the
       # prior release from `volute-v*` git tags (it skips gracefully without them).

--- a/test/upgrade-e2e.test.ts
+++ b/test/upgrade-e2e.test.ts
@@ -384,16 +384,14 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
   it("migrations apply forward and the mind's state survives the upgrade", async (t) => {
     if (skipReason) return t.skip(skipReason);
 
-    // DB is fully migrated to the working tree's expectation. When the prior
-    // release already shared this migration set, this proves the DB opens
-    // forward-compatibly; the day a release adds a migration, it becomes a live
-    // forward-migration assertion. A count mismatch catches a migration that
-    // half-applied yet still let the daemon boot.
-    const [applied, expected] = [await appliedMigrationCount(), headMigrationCount()];
-    assert.equal(
-      applied,
-      expected,
-      `expected ${expected} applied migrations (working-tree drizzle/), found ${applied}`,
+    // After migration squash (#713), the prior release may have more migrations
+    // applied than HEAD ships (HEAD has 1 idempotent baseline; prior had 20).
+    // The baseline runs as a no-op on existing installs, so we just verify the
+    // DB is healthy with at least the HEAD count applied.
+    const [applied, minExpected] = [await appliedMigrationCount(), headMigrationCount()];
+    assert.ok(
+      applied >= minExpected,
+      `expected at least ${minExpected} applied migrations (working-tree drizzle/), found ${applied}`,
     );
 
     // The mind the prior release created starts and responds under the new code.


### PR DESCRIPTION
## Summary

Prevents hung tests from burning GHA minutes for hours. Tests normally complete in ~90s, so 10 minutes is generous headroom while still failing fast on hangs.

**Also fixes** the upgrade-e2e migration count assertion that broke after the migration squash (#837). After squash, the prior release has 20 migrations applied but HEAD only ships 1 (the idempotent baseline), so the equality check fails. Changed to >= since the baseline is idempotent.

Adds `timeout-minutes: 10` to:
- `test`
- `test-e2e`
- `test-upgrade`

## Note

There is still a separate issue with upgrade-e2e: the upgrade conflicts on `.upstream.json` in skill directories. Filed as #844 — that one needs a fix in the upgrade logic itself.

## Context

The `test` job on #837 hung for nearly 2 hours before manual cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)