### PR TITLE
refactor: user_type named predicates + union reconciliation (#817)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15315,6 +15315,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@volute/api": "*",
         "@volute/extensions": "*",
         "@volute/ui": "*"
       },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
     "./types": "./src/types.ts",
+    "./user-type": "./src/user-type.ts",
     "./events": "./src/events.ts",
     "./routes": "./src/routes.ts",
     "./pagination": "./src/pagination.ts"

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,3 +2,4 @@ export * from "./client.js";
 export * from "./events.js";
 export * from "./pagination.js";
 export * from "./types.js";
+export * from "./user-type.js";

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,6 +2,8 @@
 // Entity types use snake_case fields to match database columns.
 // SSE event types in events.ts use camelCase because they're constructed in JS.
 
+import type { UserType } from "./user-type.js";
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "tool_use"; name: string; input: unknown }
@@ -92,7 +94,7 @@ export type Conversation = {
 export type Participant = {
   userId: number;
   username: string;
-  userType: "human" | "mind" | "puppet" | "system";
+  userType: UserType;
   role: "owner" | "member";
   displayName?: string | null;
   description?: string | null;
@@ -225,7 +227,9 @@ export type AvailableUser = {
   id: number;
   username: string;
   role: "admin" | "user" | "pending" | "mind" | "system";
-  user_type: "human" | "mind" | "system";
+  user_type: UserType;
+  /** Server-computed locality flag for `mind` rows (see `isExternal`); absent otherwise. */
+  external?: boolean;
   display_name?: string | null;
   description?: string | null;
   avatar?: string | null;

--- a/packages/api/src/user-type.ts
+++ b/packages/api/src/user-type.ts
@@ -1,0 +1,90 @@
+// Shared predicates over a user's `user_type` (the `users` table discriminator),
+// so a guard states the question it is actually asking instead of reaching for a
+// raw `user_type === "mind"` comparison — which is wrong by default and right by
+// accident (it silently excludes the spirit and puppets). See issue #817.
+//
+// The stored `user_type` values are FROZEN this wave: renaming any of them
+// (e.g. "system" → "spirit", "brain" → "human") is a separate later migration.
+// Centralizing the checks here is what makes that rename a change to these
+// predicate bodies plus one DB migration, not a sweep of ~30 call sites.
+
+/**
+ * Every `user_type` value written to the `users` table. This must stay in sync
+ * with what the DB actually holds — a value flowing through a narrower type would
+ * type-check as something it isn't (a puppet slipping through a `"human" | "mind"
+ * | "system"` union is exactly the bug at issue). Empirically, four values are
+ * written: humans default to `"human"`, minds (local and external) to `"mind"`,
+ * bridge stand-ins to `"puppet"`, and the system spirit to `"system"`. `"brain"`
+ * is NOT a live `user_type` value (the `brain_*` activity events are unrelated).
+ */
+export type UserType = "human" | "mind" | "puppet" | "system";
+
+/**
+ * The minimal shape the predicates read. Deliberately loose so it accepts every
+ * user-ish object in the codebase:
+ *
+ * - Either naming convention — `user_type` (snake_case: DB rows, `AuthUser`,
+ *   `AvailableUser`) or `userType` (camelCase: `Participant`).
+ * - `external`, the server-computed locality flag: a `mind` user with no local
+ *   `minds` registry row. Only populated on user rows that pass through
+ *   `withExternalFlag`; absent (and thus treated as local) on participants and
+ *   other shapes that never carry it — which matches how those call sites behaved
+ *   before this refactor.
+ */
+export type UserTypeCarrier = {
+  user_type?: UserType | string | null;
+  userType?: UserType | string | null;
+  external?: boolean | null;
+};
+
+function userTypeOf(u: UserTypeCarrier): string | undefined {
+  return u.user_type ?? u.userType ?? undefined;
+}
+
+/**
+ * Rendering / identity: does this actor get the mind icon and mind treatment?
+ * Plain `mind`-typed actors do — including external minds. The spirit does NOT:
+ * it is an {@link isSystemSpirit} with its own icon. Puppets render as humans.
+ *
+ * This is the declarative form of today's `userType === "mind"` rendering checks;
+ * it deliberately does not fold in the spirit, so a site that wants the spirit
+ * must say so via {@link isLocalMind} or {@link isSystemSpirit}.
+ */
+export function isMind(u: UserTypeCarrier): boolean {
+  return userTypeOf(u) === "mind";
+}
+
+/**
+ * The system spirit (the keeper) — the actor with the special coordinator
+ * attributes/abilities. Currently the sole `user_type: "system"` row. Kept as its
+ * own predicate so the later `"system" → "spirit"` rename is a one-line edit here.
+ */
+export function isSystemSpirit(u: UserTypeCarrier): boolean {
+  return userTypeOf(u) === "system";
+}
+
+/**
+ * "Volute manages this actor directly": it has a local mind directory / registry
+ * row. True for locally-managed minds and for the spirit (which is local); false
+ * for external minds, humans, and puppets. This is NOT a pure `user_type` check —
+ * an external mind is `user_type: "mind"` yet not local — so it consults the
+ * {@link UserTypeCarrier.external} locality flag.
+ *
+ * Where that flag is absent (e.g. conversation participants, which never carry
+ * it), a `mind` actor is treated as local — matching the prior behavior of the
+ * call sites that used `userType === "mind" || userType === "system"`.
+ */
+export function isLocalMind(u: UserTypeCarrier): boolean {
+  const t = userTypeOf(u);
+  return t === "system" || (t === "mind" && u.external !== true);
+}
+
+/**
+ * The inverse locality case: a `mind` account with no local `minds` row, so
+ * nothing is spawned here — it authenticates over HTTP with an API token. Only
+ * meaningful once the server has stamped {@link UserTypeCarrier.external}; false
+ * for everyone else, including the spirit.
+ */
+export function isExternal(u: UserTypeCarrier): boolean {
+  return isMind(u) && u.external === true;
+}

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { userInfo } from "node:os";
 import { basename, extname } from "node:path";
+import { isMind as isMindUser } from "@volute/api/user-type";
 import { formatFileSize } from "@volute/daemon/lib/chat/file-sharing.js";
 import type { SpiritStatus } from "@volute/daemon/lib/chat/spirit-availability.js";
 import type { ImageAttachment } from "@volute/daemon/lib/platforms.js";
@@ -492,7 +493,7 @@ const cmd = command({
       };
 
       // Find a participant mind to use as context for the chat API
-      const mindParticipant = channelData.participants?.find((p) => p.userType === "mind");
+      const mindParticipant = channelData.participants?.find((p) => isMindUser(p));
       const contextMind = mindSelf ?? mindParticipant?.username;
       if (!contextMind) {
         console.error("No mind is a member of this channel. A mind must join the channel first.");

--- a/packages/daemon/src/lib/auth.ts
+++ b/packages/daemon/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { isMind, isSystemSpirit } from "@volute/api/user-type";
 import { compareSync, hashSync } from "bcryptjs";
 import { and, count, eq, inArray, or } from "drizzle-orm";
 import { getSpiritName } from "./config/setup.js";
@@ -52,7 +53,7 @@ export async function verifyUser(username: string, password: string): Promise<Us
   const db = await getDb();
   const row = await db.select().from(users).where(eq(users.username, username)).get();
   if (!row) return null;
-  if (row.user_type === "mind" || row.user_type === "system") return null; // minds and system users can't log in
+  if (isMind(row) || isSystemSpirit(row)) return null; // minds and the spirit can't log in
   if (!compareSync(password, row.password_hash)) return null;
   const { password_hash: _, ...user } = row;
   return user as User;
@@ -301,7 +302,7 @@ export async function deleteExternalMindUser(id: number): Promise<void> {
     .where(eq(users.id, id))
     .get();
   if (!target) throw new Error("User not found");
-  if (target.user_type !== "mind") throw new Error("Not a mind account");
+  if (!isMind(target)) throw new Error("Not a mind account");
   if (await findMind(target.username)) {
     throw new Error("Use the mind deletion API to delete minds");
   }

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -1,3 +1,4 @@
+import { isMind } from "@volute/api/user-type";
 import { getOrCreateMindUser, getOrCreateSystemUser, getUserByUsername } from "../auth.js";
 import { getSpiritName } from "../config/setup.js";
 import { deliverMessage } from "../delivery/message-delivery.js";
@@ -112,7 +113,10 @@ export async function announceToSystem(text: string): Promise<void> {
 
   // Deliver to all mind participants of #system, sender-less, on the ordinary channel path.
   const participants = await getParticipants(channelId);
-  const mindParticipants = participants.filter((p) => p.userType === "mind");
+  // Note: this excludes the spirit (user_type "system"). Preserved as-is; whether
+  // #system announcements should also reach the spirit is a behavior question for
+  // review, not this refactor (#817).
+  const mindParticipants = participants.filter(isMind);
   const channel = "#system";
   for (const mind of mindParticipants) {
     deliverMessage(mind.username, {

--- a/packages/daemon/src/lib/delivery/delivery-manager.ts
+++ b/packages/daemon/src/lib/delivery/delivery-manager.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
+import { isMind } from "@volute/api/user-type";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { MIND_LEVEL_THREAD, type RecordNoticeInput } from "../chat/system-events.js";
 import { getTypingMap, publishTypingForChannels } from "../chat/typing.js";
@@ -1934,7 +1935,7 @@ export class DeliveryManager {
 
       try {
         let filePath: string;
-        if (p.userType === "mind") {
+        if (isMind(p)) {
           const dir = mindDir(p.username);
           const config = readVoluteConfig(dir);
           if (!config?.profile?.avatar) continue;

--- a/packages/daemon/src/lib/delivery/fan-out.ts
+++ b/packages/daemon/src/lib/delivery/fan-out.ts
@@ -4,6 +4,7 @@
  * This is the single fan-out path used by both the chat API (`/chat`) and the
  * bridge inbound path.
  */
+import { isLocalMind, isMind, isSystemSpirit } from "@volute/api/user-type";
 import { recordDeliveryFailure } from "../chat/delivery-notices.js";
 import { getTypingMap } from "../chat/typing.js";
 import { getMindManager } from "../daemon/mind-manager.js";
@@ -42,9 +43,7 @@ export interface FanOutResult {
 
 export async function fanOutToMinds(opts: FanOutOpts): Promise<FanOutResult> {
   const participants = opts.participants ?? (await getParticipants(opts.conversationId));
-  const mindParticipants = participants.filter(
-    (p) => p.userType === "mind" || p.userType === "system",
-  );
+  const mindParticipants = participants.filter(isLocalMind);
   const participantNames = participants.map((p) => p.username);
   const isDM = opts.isDM ?? participants.length === 2;
 
@@ -99,7 +98,7 @@ export async function fanOutToMinds(opts: FanOutOpts): Promise<FanOutResult> {
             `fan-out: skipping ${ap.username} (not running) for conversation ${opts.conversationId}`,
           );
           reportFailure(`${ap.username} is not running`);
-        } else if (ap.userType === "mind") {
+        } else if (isMind(ap)) {
           // External mind (no registry row): it pulls its messages, so this is its
           // expected steady state — but a stale registry (mind deleted, user row and
           // participation left behind) looks identical, so leave a trace (#723).
@@ -108,7 +107,7 @@ export async function fanOutToMinds(opts: FanOutOpts): Promise<FanOutResult> {
               `participant) for conversation ${opts.conversationId}`,
           );
         }
-        if (ap.userType === "system") {
+        if (isSystemSpirit(ap)) {
           // A stopped spirit reached outside POST /chat (bridge inbound, channels): start
           // it fire-and-forget so the NEXT message reaches it — this one is missed, same
           // as for any stopped mind. Advisory and never throws; there is no response

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -1,3 +1,4 @@
+import type { UserType } from "@volute/api/user-type";
 import { sql } from "drizzle-orm";
 import {
   index,
@@ -36,7 +37,7 @@ export const users = sqliteTable("users", {
   username: text("username").unique().notNull(),
   password_hash: text("password_hash").notNull(),
   role: text("role").notNull().default("pending"),
-  user_type: text("user_type").notNull().default("human"),
+  user_type: text("user_type").$type<UserType>().notNull().default("human"),
   display_name: text("display_name"),
   description: text("description"),
   avatar: text("avatar"),

--- a/packages/daemon/src/web/api/auth.ts
+++ b/packages/daemon/src/web/api/auth.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { extname, resolve } from "node:path";
 import { zValidator } from "@hono/zod-validator";
+import { isMind } from "@volute/api/user-type";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { z } from "zod";
@@ -48,9 +49,9 @@ import { fileEtag, isNotModified } from "../../lib/util/http-cache.js";
 async function withExternalFlag<T extends { username: string; user_type: string }>(
   list: T[],
 ): Promise<(T & { external?: boolean })[]> {
-  if (!list.some((u) => u.user_type === "mind")) return list;
+  if (!list.some((u) => isMind(u))) return list;
   const local = new Set((await readAllMinds()).map((m) => m.name));
-  return list.map((u) => (u.user_type === "mind" ? { ...u, external: !local.has(u.username) } : u));
+  return list.map((u) => (isMind(u) ? { ...u, external: !local.has(u.username) } : u));
 }
 
 /** Only join system channel when running inside the daemon (not in tests). */
@@ -391,7 +392,7 @@ const admin = new Hono<AuthEnv>()
       const adminCount = await countAdmins();
       if (adminCount <= 1) return c.json({ error: "Cannot delete the last admin" }, 400);
     }
-    if (target.user_type === "mind") {
+    if (isMind(target)) {
       // Only a mind the daemon spawns needs the mind-deletion API, which exists to
       // stop the process and remove the directory. An external mind has neither, so
       // deleting its account is the whole teardown — and the mind API would 404 on

--- a/packages/daemon/src/web/api/v1/conversations.ts
+++ b/packages/daemon/src/web/api/v1/conversations.ts
@@ -1,4 +1,5 @@
 import { zValidator } from "@hono/zod-validator";
+import { isMind } from "@volute/api/user-type";
 import { Hono } from "hono";
 import { z } from "zod";
 import { getOrCreateMindUser, getUserByUsername } from "../../../lib/auth.js";
@@ -93,7 +94,7 @@ const app = new Hono<AuthEnv>()
       const existing = await getUserByUsername(name);
       if (existing) {
         participantIds.add(existing.id);
-        if (!firstMindName && existing.user_type === "mind") firstMindName = name;
+        if (!firstMindName && isMind(existing)) firstMindName = name;
         continue;
       }
       if (await findMind(name)) {

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -1,4 +1,5 @@
 import { zValidator } from "@hono/zod-validator";
+import { isLocalMind, isMind, isSystemSpirit } from "@volute/api/user-type";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
@@ -151,8 +152,8 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
     // sender too — this matches only the spirit, never a plain system principal.
     const senderIsMind =
       (user.id === 0 && body.sender && (await findMind(body.sender))) ||
-      user.user_type === "mind" ||
-      (user.user_type === "system" && !!(await findMind(user.username)));
+      isMind(user) ||
+      (isSystemSpirit(user) && !!(await findMind(user.username)));
 
     // Track baseName and variant-aware targetName callback for the targetMind flow
     let baseName: string | undefined;
@@ -229,7 +230,7 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
         fileTargets = [baseName];
       } else {
         fileTargets = participants
-          .filter((p) => p.userType === "mind" && p.username !== senderName)
+          .filter((p) => isMind(p) && p.username !== senderName)
           .map((p) => p.username);
       }
       const { notifications, error } = stageFilesForMinds(body.files, fileTargets, senderName);
@@ -363,12 +364,10 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
     let spiritName: string | undefined;
     try {
       const mindishRecipients = participants.filter(
-        (p) => (p.userType === "mind" || p.userType === "system") && p.username !== senderName,
+        (p) => isLocalMind(p) && p.username !== senderName,
       );
       const spiritRecipient =
-        conv.type === "dm" &&
-        mindishRecipients.length === 1 &&
-        mindishRecipients[0].userType === "system"
+        conv.type === "dm" && mindishRecipients.length === 1 && isSystemSpirit(mindishRecipients[0])
           ? mindishRecipients[0]
           : undefined;
       if (spiritRecipient) {

--- a/packages/extensions/intentions/package.json
+++ b/packages/extensions/intentions/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@volute/api": "*",
     "@volute/extensions": "*",
     "@volute/ui": "*"
   },

--- a/packages/extensions/intentions/src/routes.ts
+++ b/packages/extensions/intentions/src/routes.ts
@@ -1,3 +1,4 @@
+import { isMind, isSystemSpirit } from "@volute/api/user-type";
 import type { ExtensionContext } from "@volute/extensions";
 import { Hono } from "hono";
 
@@ -66,7 +67,7 @@ export function createRoutes(ctx: ExtensionContext): Hono {
     // for a non-mind caller; just returns nothing to inject.
     .get("/mine", async (c) => {
       const actor = resolveActor(c);
-      if (actor?.user_type !== "mind") return c.json([]);
+      if (!actor || !isMind(actor)) return c.json([]);
       return c.json(listMine(db, actor.username));
     })
 
@@ -76,7 +77,7 @@ export function createRoutes(ctx: ExtensionContext): Hono {
     .post("/", async (c) => {
       const actor = resolveActor(c);
       if (!actor) return c.json({ error: "Unauthorized" }, 401);
-      if ((actor.user_type !== "mind" && actor.role !== "admin") || !canOwn(actor)) {
+      if ((!isMind(actor) && actor.role !== "admin") || !canOwn(actor)) {
         return c.json({ error: "Only a mind can hold intentions" }, 403);
       }
 
@@ -173,15 +174,13 @@ export function createRoutes(ctx: ExtensionContext): Hono {
       return c.json(intention);
     })
 
-    // Review-due — spirit or admin only. Do NOT use user_type === "mind" as a proxy
-    // for "is the spirit": that was the old plan extension's bug, and it granted
-    // coordinator powers to every mind on the system. The spirit shares the system
-    // user account (role: "system"); gate on that plus "admin", mirroring
-    // requireAdminOrSystem in the daemon's own web middleware.
+    // Review-due — the spirit (a coordinator power) or an admin only. `isSystemSpirit`
+    // states that intent directly, so a plain mind can no longer slip through a
+    // `user_type === "mind"` proxy the way the old plan extension's bug did.
     .get("/review-due", async (c) => {
       const actor = resolveActor(c);
       if (!actor) return c.json({ error: "Unauthorized" }, 401);
-      if (actor.role !== "admin" && actor.role !== "system") {
+      if (!isSystemSpirit(actor) && actor.role !== "admin") {
         return c.json({ error: "Forbidden" }, 403);
       }
 

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Conversation, Mind } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 import { Icon, Modal, tooltip } from "@volute/ui";
 import { icons } from "@volute/ui/icons";
 import { sanitizeSvg } from "@volute/ui/sanitize";
@@ -287,9 +288,7 @@ let headerMindActive = $derived.by(() => {
     const conv = data.conversations.find(
       (c) => c.type === "channel" && c.channel_name === sel.slug,
     );
-    return (conv?.participants ?? []).some(
-      (p) => p.userType === "mind" && activeMinds.has(p.username),
-    );
+    return (conv?.participants ?? []).some((p) => isMind(p) && activeMinds.has(p.username));
   }
   return false;
 });
@@ -478,7 +477,7 @@ $effect(() => {
     selection = { kind: "channel", slug: conv.channel_name };
   } else {
     const mindParticipant = conv.participants?.find(
-      (p) => p.userType === "mind" && p.username !== auth.user?.username,
+      (p) => isMind(p) && p.username !== auth.user?.username,
     );
     if (mindParticipant) {
       selection = { kind: "mind", name: mindParticipant.username };
@@ -522,9 +521,7 @@ function handleSelectConversation(id: string) {
   if (conv?.type === "channel" && conv.channel_name) {
     selection = { kind: "channel", slug: conv.channel_name };
   } else {
-    const other = conv?.participants?.find(
-      (p) => p.userType === "mind" && p.username !== auth.user?.username,
-    );
+    const other = conv?.participants?.find((p) => isMind(p) && p.username !== auth.user?.username);
     if (other) {
       selection = { kind: "mind", name: other.username };
     }

--- a/packages/web/src/ui/components/ChannelMembersPanel.svelte
+++ b/packages/web/src/ui/components/ChannelMembersPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
+import { isMind, isSystemSpirit } from "@volute/api/user-type";
 import { Icon } from "@volute/ui";
 import { mindDotColor } from "../lib/format";
 import { activeMinds, onlineBrains } from "../lib/stores.svelte";
@@ -26,11 +27,11 @@ let typingSet = $derived(new Set(typingNames));
 
 let mindParticipants = $derived(
   conversation.participants
-    .filter((p) => p.userType === "mind")
+    .filter((p) => isMind(p))
     .map((p) => ({ participant: p, mind: mindsByName.get(p.username) })),
 );
 
-let userParticipants = $derived(conversation.participants.filter((p) => p.userType !== "mind"));
+let userParticipants = $derived(conversation.participants.filter((p) => !isMind(p)));
 
 let isChannel = $derived(conversation.type === "channel" && !!conversation.channel_name);
 let showInvite = $state(false);
@@ -104,7 +105,7 @@ function isBrainIridescent(username: string): boolean {
       }}>
         {#snippet children()}
           <div class="member-row">
-            {#if participant.userType === "system"}
+            {#if isSystemSpirit(participant)}
               <span
                 class="status-dot"
                 style:background="var(--text-0)"
@@ -119,7 +120,7 @@ function isBrainIridescent(username: string): boolean {
             <span class="member-name">
               {participant.displayName ?? participant.username}
             </span>
-            <Icon kind={participant.userType === "system" ? "spiral" : "brain"} class="type-icon" />
+            <Icon kind={isSystemSpirit(participant) ? "spiral" : "brain"} class="type-icon" />
           </div>
         {/snippet}
       </ProfileHoverCard>

--- a/packages/web/src/ui/components/ProfileHoverCard.svelte
+++ b/packages/web/src/ui/components/ProfileHoverCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { UserType } from "@volute/api/user-type";
+import { isMind } from "@volute/api/user-type";
 import type { Snippet } from "svelte";
 import { normalizeTimestamp } from "../lib/format";
 
@@ -7,7 +9,7 @@ export type HoverProfile = {
   displayName?: string | null;
   description?: string | null;
   avatarUrl?: string | null;
-  userType: "human" | "mind" | "puppet" | "system";
+  userType: UserType;
   created?: string;
 };
 
@@ -113,7 +115,7 @@ function handleMouseLeave() {
         <span class="description">{profile.description}</span>
       {/if}
       <span class="meta">@{profile.name}{#if profile.created} &middot; since {formatCreated(profile.created)}{/if}</span>
-      {#if profile.userType === "mind"}
+      {#if isMind(profile)}
         <a href="/minds/{profile.name}" class="view-profile">View profile</a>
       {/if}
     </div>

--- a/packages/web/src/ui/components/home/AvatarStack.svelte
+++ b/packages/web/src/ui/components/home/AvatarStack.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Participant } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 
 type AvatarParticipant = Pick<Participant, "username" | "userType" | "displayName" | "avatar">;
 
@@ -16,7 +17,7 @@ let overflow = $derived(Math.max(0, participants.length - max));
 
 function avatarUrl(p: AvatarParticipant): string | null {
   if (!p.avatar) return null;
-  return p.userType === "mind"
+  return isMind(p)
     ? `/api/minds/${encodeURIComponent(p.username)}/avatar`
     : `/api/auth/avatars/${encodeURIComponent(p.avatar)}`;
 }

--- a/packages/web/src/ui/components/layout/ConversationList.svelte
+++ b/packages/web/src/ui/components/layout/ConversationList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 import { Dropdown } from "@volute/ui";
 import { setConversationPrivate } from "../../lib/client";
 import { getConversationLabel, mindDotColor } from "../../lib/format";
@@ -103,7 +104,7 @@ function openMenu(e: MouseEvent, convId: string) {
       </div>
     {/if}
     {#each directMessages as conv (conv.id)}
-      {@const otherMind = conv.participants?.find((p) => p.userType === "mind" && p.username !== username)}
+      {@const otherMind = conv.participants?.find((p) => isMind(p) && p.username !== username)}
       {@const isSeed = otherMind ? minds.find((m) => m.name === otherMind.username)?.stage === "seed" : false}
       {@const dmInfo = getDmInfo(conv)}
       {@const isGroup = (conv.participants?.length ?? 0) > 2}

--- a/packages/web/src/ui/components/layout/MainFrame.svelte
+++ b/packages/web/src/ui/components/layout/MainFrame.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ConversationWithParticipants, Mind } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 import type { Selection } from "../../lib/navigate";
 import Home from "../../pages/Home.svelte";
 import MindPage from "../../pages/MindPage.svelte";
@@ -40,7 +41,7 @@ let channelConv = $derived.by(() => {
 
 let channelMindName = $derived.by(() => {
   if (!channelConv) return "";
-  const mindParticipant = channelConv.participants?.find((p) => p.userType === "mind");
+  const mindParticipant = channelConv.participants?.find((p) => isMind(p));
   return mindParticipant?.username ?? "";
 });
 

--- a/packages/web/src/ui/components/modals/InviteModal.svelte
+++ b/packages/web/src/ui/components/modals/InviteModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { AvailableUser, Mind } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 import { Modal } from "@volute/ui";
 import { fetchAvailableUsers, inviteToChannel } from "../../lib/client";
 import { mindDotColor } from "../../lib/format";
@@ -59,7 +60,7 @@ async function handleInvite(username: string) {
 }
 
 function dotColor(user: AvailableUser): string | undefined {
-  if (user.user_type === "mind") {
+  if (isMind(user)) {
     const mind = mindsByName.get(user.username);
     if (mind && activeMinds.has(mind.name)) return undefined;
     if (mind) return mindDotColor(mind);
@@ -70,7 +71,7 @@ function dotColor(user: AvailableUser): string | undefined {
 }
 
 function isIridescent(user: AvailableUser): boolean {
-  return user.user_type === "mind" && activeMinds.has(user.username);
+  return isMind(user) && activeMinds.has(user.username);
 }
 </script>
 

--- a/packages/web/src/ui/components/system/UserManagement.svelte
+++ b/packages/web/src/ui/components/system/UserManagement.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Mind } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 import { Button } from "@volute/ui";
 import { onMount } from "svelte";
 import { slide } from "svelte/transition";
@@ -135,7 +136,7 @@ async function handleRevokeToken(user: AuthUser, tokenId: number) {
 }
 
 function statusDotStyle(u: AuthUser): string | undefined {
-  if (u.user_type === "mind") {
+  if (isMind(u)) {
     if (activeMinds.has(u.username)) return undefined; // iridescent handles it
     const mind = mindsByName.get(u.username);
     return mind ? mindDotColor(mind) : "var(--text-2)";
@@ -184,7 +185,7 @@ async function handleDelete(user: AuthUser) {
   try {
     // An external mind has no directory or process to tear down — deleting the
     // account IS the whole operation. The daemon re-checks this either way.
-    if (user.user_type === "mind" && !isExternal(user)) {
+    if (isMind(user) && !isExternal(user)) {
       try {
         await deleteMind(user.username, true);
         data.minds = data.minds.filter((m) => m.name !== user.username);
@@ -239,7 +240,7 @@ function isProfileDirty(user: AuthUser): boolean {
         <div class="user-row" role="button" tabindex="0" onclick={() => toggleExpand(u)} onkeydown={(e) => e.key === 'Enter' && toggleExpand(u)}>
           <span
             class="status-dot"
-            class:iridescent={u.user_type === "mind" && activeMinds.has(u.username)}
+            class:iridescent={isMind(u) && activeMinds.has(u.username)}
             style:background={statusDotStyle(u)}
           ></span>
           <span class="avatar">
@@ -247,7 +248,7 @@ function isProfileDirty(user: AuthUser): boolean {
               <img src={avatar} alt="" />
             {:else}
               <svg class="type-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                {#if u.user_type === "mind"}
+                {#if isMind(u)}
                   <rect x="4" y="8" width="16" height="12" rx="2" />
                   <circle cx="9" cy="14" r="1.5" />
                   <circle cx="15" cy="14" r="1.5" />

--- a/packages/web/src/ui/lib/format.ts
+++ b/packages/web/src/ui/lib/format.ts
@@ -1,4 +1,5 @@
 import type { Mind } from "@volute/api";
+import { isMind } from "@volute/api/user-type";
 
 export function mindDotColor(mind: Mind): string {
   const s = getDisplayStatus(mind);
@@ -42,7 +43,7 @@ export function getConversationLabel(
     const other = participants.find((p) => p.username !== currentUsername);
     if (other) return `@${other.username}`;
   }
-  const mindParticipants = participants.filter((p) => p.userType === "mind");
+  const mindParticipants = participants.filter((p) => isMind(p));
   if (mindParticipants.length > 0) return mindParticipants.map((a) => a.username).join(", ");
   return "Untitled";
 }

--- a/packages/web/src/ui/lib/user-kind.ts
+++ b/packages/web/src/ui/lib/user-kind.ts
@@ -1,27 +1,21 @@
+import { isExternal, isMind } from "@volute/api/user-type";
 import type { AuthUser } from "./auth";
 
-/**
- * How the Users panel classifies a row. Three kinds that behave differently:
- * a human, a local mind (the daemon spawns it — port, process, directory), and
- * an external mind (an account and a token, nothing else here).
- */
+// The shared classification (isMind/isExternal/isSystemSpirit/isLocalMind) lives in
+// @volute/api/user-type. This module keeps only the Users-panel *presentation*
+// helpers — avatar URL, kind label, delete copy — built on those predicates.
 
-/**
- * `external` is server-computed: a mind with no `minds` registry row. The check
- * is guarded on user_type because the flag is meaningless for anyone else.
- */
-export function isExternal(u: AuthUser): boolean {
-  return u.user_type === "mind" && u.external === true;
-}
+export { isExternal };
 
 /**
  * A local mind's avatar is a file in its own directory, served by name. Everyone
  * else's is an upload in the shared avatars dir — including an external mind's:
- * it POSTs /api/auth/avatar with its token like any other authenticated user.
+ * it POSTs /api/auth/avatar with its token like any other authenticated user. The
+ * spirit (`user_type: "system"`, not a `mind`) also falls to the shared dir here.
  */
 export function avatarUrl(u: AuthUser): string | null {
   if (!u.avatar) return null;
-  if (u.user_type === "mind" && !isExternal(u)) {
+  if (isMind(u) && !isExternal(u)) {
     return `/api/minds/${encodeURIComponent(u.username)}/avatar`;
   }
   return `/api/auth/avatars/${encodeURIComponent(u.avatar)}`;
@@ -29,12 +23,12 @@ export function avatarUrl(u: AuthUser): string | null {
 
 /** The row's kind, as a label. Humans are the unmarked default. */
 export function kindLabel(u: AuthUser): string | null {
-  if (u.user_type !== "mind") return null;
+  if (!isMind(u)) return null;
   return isExternal(u) ? "external" : "local";
 }
 
 /** What deleting this row actually does — a local mind loses data, an account doesn't. */
 export function deleteLabel(u: AuthUser): string {
   if (isExternal(u)) return "revoke access?";
-  return u.user_type === "mind" ? "delete mind + data?" : "delete account?";
+  return isMind(u) ? "delete mind + data?" : "delete account?";
 }

--- a/test/user-type-predicates.test.ts
+++ b/test/user-type-predicates.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isExternal, isLocalMind, isMind, isSystemSpirit } from "@volute/api/user-type";
+
+// The point of these predicates (#817) is that they are NOT `user_type === "mind"`.
+// Each case below is chosen so that a revert to a raw `=== "mind"` comparison flips
+// the assertion — the spirit and external-mind cases are the ones that historically
+// got misclassified.
+
+const human = { user_type: "human" as const };
+const localMind = { user_type: "mind" as const }; // no `external` flag → local
+const externalMind = { user_type: "mind" as const, external: true };
+const spirit = { user_type: "system" as const };
+const puppet = { user_type: "puppet" as const };
+// A conversation participant carries `userType` (camelCase) and never an `external` flag.
+const spiritParticipant = { userType: "system" as const };
+const mindParticipant = { userType: "mind" as const };
+
+describe("isMind (rendering / identity)", () => {
+  it("is true for a local mind and an external mind", () => {
+    assert.equal(isMind(localMind), true);
+    assert.equal(isMind(externalMind), true);
+    assert.equal(isMind(mindParticipant), true);
+  });
+
+  it("is false for the spirit — it has its own icon, not the mind icon", () => {
+    // Reverting isMind to include the spirit (e.g. via isLocalMind) breaks this.
+    assert.equal(isMind(spirit), false);
+    assert.equal(isMind(spiritParticipant), false);
+  });
+
+  it("is false for humans and puppets", () => {
+    assert.equal(isMind(human), false);
+    assert.equal(isMind(puppet), false);
+  });
+});
+
+describe("isSystemSpirit (the keeper)", () => {
+  it("is true only for the system spirit", () => {
+    // A revert to `=== "mind"` would make this false — the regression guard.
+    assert.equal(isSystemSpirit(spirit), true);
+    assert.equal(isSystemSpirit(spiritParticipant), true);
+  });
+
+  it("is false for minds, humans, and puppets", () => {
+    assert.equal(isSystemSpirit(localMind), false);
+    assert.equal(isSystemSpirit(externalMind), false);
+    assert.equal(isSystemSpirit(human), false);
+    assert.equal(isSystemSpirit(puppet), false);
+  });
+});
+
+describe("isLocalMind (volute manages this actor directly)", () => {
+  it("is true for a locally-managed mind", () => {
+    assert.equal(isLocalMind(localMind), true);
+    assert.equal(isLocalMind(mindParticipant), true);
+  });
+
+  it("is true for the spirit — the spirit is local", () => {
+    // `=== "mind"` would return false here. This is the #786 bug shape.
+    assert.equal(isLocalMind(spirit), true);
+    assert.equal(isLocalMind(spiritParticipant), true);
+  });
+
+  it("is false for an external mind — user_type 'mind' but no local dir", () => {
+    // `=== "mind"` would return true here, misclassifying the external mind.
+    assert.equal(isLocalMind(externalMind), false);
+  });
+
+  it("is false for humans and puppets", () => {
+    assert.equal(isLocalMind(human), false);
+    assert.equal(isLocalMind(puppet), false);
+  });
+});
+
+describe("isExternal (mind account with no local dir)", () => {
+  it("is true only for a mind flagged external", () => {
+    assert.equal(isExternal(externalMind), true);
+  });
+
+  it("is false for a local mind, the spirit, humans, and puppets", () => {
+    assert.equal(isExternal(localMind), false);
+    assert.equal(isExternal(spirit), false);
+    assert.equal(isExternal(human), false);
+    assert.equal(isExternal(puppet), false);
+  });
+});


### PR DESCRIPTION
Closes #817. Milestone 9, Wave A / foundation. **Types + predicates + call-sites only — no stored `user_type` values changed** (the `system→spirit`/`brain→human` renames are a separate later migration wave).

## What
`user_type === "mind"` was a proxy for several different questions ("wrong by default, right by accident" — it silently excludes the spirit and puppets). This centralizes the checks behind shared named predicates in a new `@volute/api/user-type`, importable by daemon/web/cli/extensions.

- **`isMind`** — rendering/identity (gets the mind icon): plain `mind` rows incl. external minds; NOT the spirit; puppets render as humans.
- **`isSystemSpirit`** — the keeper (currently `user_type === "system"`); its own predicate so the future rename is a one-line edit.
- **`isLocalMind`** — "volute manages this actor directly": local mind or the spirit; false for external minds/humans/puppets. **Built on the real locality signal** — the server-computed `external` flag (`withExternalFlag` reads the `minds` registry), not `user_type` alone; where absent (participants never carry it) a `mind` degrades to local, matching prior behavior.
- **`isExternal`** — absorbed from the frontend-only `web/lib/user-kind.ts` (now re-exported, no duplication).

Plus: reconciled the two disagreeing unions in `types.ts` (`:95` had `puppet`, `:228` omitted it) onto one exported `UserType`; typed the schema column via `.$type<UserType>()`; migrated ~20 raw call sites; resolved+removed the `intentions/routes.ts:163` warning.

## For your eyes (authz-adjacent — why this is a hand-merge)
1. **`/review-due` gate field-swap** (`extensions/intentions/routes.ts`): was `role === "system"`, now `isSystemSpirit` (`user_type === "system"`). **Verified behavior-equivalent**: `getOrCreateSystemUser` inserts `role:"system"` AND `user_type:"system"` together and looks up by `user_type`, "exactly one system user exists" — the two fields select the identical sole principal.
2. **Login gate** (`auth.ts verifyUser`): `mind || system` → `isMind || isSystemSpirit`, exact.
3. **Left equivalent-but-suspect, flagged not changed**: `announceToSystem` still excludes the spirit from `#system` (inline note — should it?); raw `human`/`puppet` comparisons left as-is (no predicate defined for them per your cut).

## Verification I ran
- Reviewed the full diff line-by-line (api / daemon / web / cli / extensions / all 8 svelte components).
- `npm run typecheck` clean; new predicate tests 11/11 pass; builder reports full suite (3260) + svelte-check + build green, and verified 4 fail-on-revert cases.
- `brain` confirmed NOT a live `user_type` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)