### PR TITLE
refactor: migrate user_type value "system" → "spirit" (#819)

### DIFF
--- a/drizzle/0001_migrate_spirit_user_type.sql
+++ b/drizzle/0001_migrate_spirit_user_type.sql
@@ -1,0 +1,10 @@
+-- Rename the stored user_type value "system" -> "spirit" (#819).
+-- user_type: "system" never meant infrastructure; it meant the keeper (the
+-- spirit). This value migration disambiguates it from the many other "system"
+-- identifiers (role: "system", voluteSystemDir(), system_events, #system).
+--
+-- Safe on live installs: the "exactly one system user" invariant holds
+-- (getOrCreateSystemUser), so this touches at most one row. Forward-idempotent
+-- -- once no rows hold "system", the UPDATE is a no-op. Leaves role untouched
+-- (a separate axis, renamed in a later wave).
+UPDATE users SET user_type = 'spirit' WHERE user_type = 'system';

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1424 @@
+{
+  "id": "09112b91-e867-4bf6-8636-1c02b43fc751",
+  "prevId": "d7bf9184-e44d-43ad-ade0-6eed5fbf7bc8",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "activity": {
+      "name": "activity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_activity_created_at": {
+          "name": "idx_activity_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_activity_mind": {
+          "name": "idx_activity_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_activity_turn_id": {
+          "name": "idx_activity_turn_id",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "idx_activity_type": {
+          "name": "idx_activity_type",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_hash": {
+          "name": "idx_api_tokens_hash",
+          "columns": ["token_hash"],
+          "isUnique": true
+        },
+        "idx_api_tokens_user": {
+          "name": "idx_api_tokens_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_gates": {
+      "name": "channel_gates",
+      "columns": {
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_gates_mind_channel_pk": {
+          "columns": ["mind", "channel"],
+          "name": "channel_gates_mind_channel_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "char_limit": {
+          "name": "char_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "private": {
+          "name": "private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_channels_name": {
+          "name": "idx_channels_name",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channels_conversation_id_conversations_id_fk": {
+          "name": "channels_conversation_id_conversations_id_fk",
+          "tableFrom": "channels",
+          "columnsFrom": ["conversation_id"],
+          "tableTo": "conversations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_participants": {
+      "name": "conversation_participants",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_cp_unique": {
+          "name": "idx_cp_unique",
+          "columns": ["conversation_id", "user_id"],
+          "isUnique": true
+        },
+        "idx_cp_user_id": {
+          "name": "idx_cp_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "columnsFrom": ["conversation_id"],
+          "tableTo": "conversations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "conversation_participants_user_id_users_id_fk": {
+          "name": "conversation_participants_user_id_users_id_fk",
+          "tableFrom": "conversation_participants",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_reads": {
+      "name": "conversation_reads",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_conversation_reads_unique": {
+          "name": "idx_conversation_reads_unique",
+          "columns": ["user_id", "conversation_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "columnsFrom": ["conversation_id"],
+          "tableTo": "conversations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dm'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "private": {
+          "name": "private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_conversations_user_id": {
+          "name": "idx_conversations_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_conversations_updated_at": {
+          "name": "idx_conversations_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_queue": {
+      "name": "delivery_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_mind": {
+          "name": "target_mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_delivery_queue_mind_thread": {
+          "name": "idx_delivery_queue_mind_thread",
+          "columns": ["mind", "thread"],
+          "isUnique": false
+        },
+        "idx_delivery_queue_mind_status": {
+          "name": "idx_delivery_queue_mind_status",
+          "columns": ["mind", "status"],
+          "isUnique": false
+        },
+        "idx_delivery_queue_status": {
+          "name": "idx_delivery_queue_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_delivery_queue_status_next": {
+          "name": "idx_delivery_queue_status_next",
+          "columns": ["status", "next_attempt_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_id": {
+          "name": "idx_messages_conversation_id",
+          "columns": ["conversation_id"],
+          "isUnique": false
+        },
+        "idx_messages_turn_id": {
+          "name": "idx_messages_turn_id",
+          "columns": ["turn_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": ["conversation_id"],
+          "tableTo": "conversations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mind_history": {
+      "name": "mind_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_mind_history_mind": {
+          "name": "idx_mind_history_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_mind_history_mind_channel": {
+          "name": "idx_mind_history_mind_channel",
+          "columns": ["mind", "channel"],
+          "isUnique": false
+        },
+        "idx_mind_history_mind_type": {
+          "name": "idx_mind_history_mind_type",
+          "columns": ["mind", "type"],
+          "isUnique": false
+        },
+        "idx_mind_history_turn_id": {
+          "name": "idx_mind_history_turn_id",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "idx_mind_history_thread": {
+          "name": "idx_mind_history_thread",
+          "columns": ["thread"],
+          "isUnique": false
+        },
+        "idx_mind_history_mind_created_at": {
+          "name": "idx_mind_history_mind_created_at",
+          "columns": ["mind", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "minds": {
+      "name": "minds",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dir": {
+          "name": "dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_hash": {
+          "name": "template_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "running": {
+          "name": "running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mind_type": {
+          "name": "mind_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mind'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "minds_port_unique": {
+          "name": "minds_port_unique",
+          "columns": ["port"],
+          "isUnique": true
+        },
+        "idx_minds_parent": {
+          "name": "idx_minds_parent",
+          "columns": ["parent"],
+          "isUnique": false
+        },
+        "idx_minds_mind_type": {
+          "name": "idx_minds_mind_type",
+          "columns": ["mind_type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "minds_parent_minds_name_fk": {
+          "name": "minds_parent_minds_name_fk",
+          "tableFrom": "minds",
+          "columnsFrom": ["parent"],
+          "tableTo": "minds",
+          "columnsTo": ["name"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_skills": {
+      "name": "shared_skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "summaries": {
+      "name": "summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_summaries_unique": {
+          "name": "idx_summaries_unique",
+          "columns": ["mind", "period", "period_key"],
+          "isUnique": true
+        },
+        "idx_summaries_mind_period": {
+          "name": "idx_summaries_mind_period",
+          "columns": ["mind", "period"],
+          "isUnique": false
+        },
+        "idx_summaries_mind_period_key": {
+          "name": "idx_summaries_mind_period_key",
+          "columns": ["mind", "period_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_events": {
+      "name": "system_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery": {
+          "name": "delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'immediate'"
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_system_events_mind": {
+          "name": "idx_system_events_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_system_events_mind_delivery": {
+          "name": "idx_system_events_mind_delivery",
+          "columns": ["mind", "delivery", "delivered_at"],
+          "isUnique": false
+        },
+        "idx_system_events_mind_type": {
+          "name": "idx_system_events_mind_type",
+          "columns": ["mind", "type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_prompts": {
+      "name": "system_prompts",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turns": {
+      "name": "turns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_turns_mind": {
+          "name": "idx_turns_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_turns_mind_status": {
+          "name": "idx_turns_mind_status",
+          "columns": ["mind", "status"],
+          "isUnique": false
+        },
+        "idx_turns_mind_created_at": {
+          "name": "idx_turns_mind_created_at",
+          "columns": ["mind", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784840885350,
       "tag": "0000_crazy_epoch",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1785424941257,
+      "tag": "0001_migrate_spirit_user_type",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/user-type.ts
+++ b/packages/api/src/user-type.ts
@@ -3,10 +3,9 @@
 // raw `user_type === "mind"` comparison — which is wrong by default and right by
 // accident (it silently excludes the spirit and puppets). See issue #817.
 //
-// The stored `user_type` values are FROZEN this wave: renaming any of them
-// (e.g. "system" → "spirit", "brain" → "human") is a separate later migration.
-// Centralizing the checks here is what makes that rename a change to these
-// predicate bodies plus one DB migration, not a sweep of ~30 call sites.
+// Renaming a stored `user_type` value is a change to these predicate bodies plus
+// one DB migration, not a sweep of ~30 call sites — that centralization is the
+// whole point. The `"system" → "spirit"` rename (#819) was exactly that edit.
 
 /**
  * Every `user_type` value written to the `users` table. This must stay in sync
@@ -14,10 +13,10 @@
  * type-check as something it isn't (a puppet slipping through a `"human" | "mind"
  * | "system"` union is exactly the bug at issue). Empirically, four values are
  * written: humans default to `"human"`, minds (local and external) to `"mind"`,
- * bridge stand-ins to `"puppet"`, and the system spirit to `"system"`. `"brain"`
+ * bridge stand-ins to `"puppet"`, and the system spirit to `"spirit"`. `"brain"`
  * is NOT a live `user_type` value (the `brain_*` activity events are unrelated).
  */
-export type UserType = "human" | "mind" | "puppet" | "system";
+export type UserType = "human" | "mind" | "puppet" | "spirit";
 
 /**
  * The minimal shape the predicates read. Deliberately loose so it accepts every
@@ -56,11 +55,12 @@ export function isMind(u: UserTypeCarrier): boolean {
 
 /**
  * The system spirit (the keeper) — the actor with the special coordinator
- * attributes/abilities. Currently the sole `user_type: "system"` row. Kept as its
- * own predicate so the later `"system" → "spirit"` rename is a one-line edit here.
+ * attributes/abilities. The sole `user_type: "spirit"` row. Kept as its own
+ * predicate (named `isSystemSpirit`, referenced across packages) so the stored
+ * value could flip here in one line.
  */
 export function isSystemSpirit(u: UserTypeCarrier): boolean {
-  return userTypeOf(u) === "system";
+  return userTypeOf(u) === "spirit";
 }
 
 /**
@@ -76,7 +76,7 @@ export function isSystemSpirit(u: UserTypeCarrier): boolean {
  */
 export function isLocalMind(u: UserTypeCarrier): boolean {
   const t = userTypeOf(u);
-  return t === "system" || (t === "mind" && u.external !== true);
+  return t === "spirit" || (t === "mind" && u.external !== true);
 }
 
 /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -120,7 +120,7 @@ export async function startDaemon(opts: {
     await db
       .update(users)
       .set({ role: "system" })
-      .where(and(eq(users.user_type, "system"), eq(users.role, "user")));
+      .where(and(eq(users.user_type, "spirit"), eq(users.role, "user")));
   } catch (err) {
     log.warn("failed to migrate system user role", log.errorData(err));
   }

--- a/packages/daemon/src/lib/auth.ts
+++ b/packages/daemon/src/lib/auth.ts
@@ -12,7 +12,7 @@ export type User = {
   id: number;
   username: string;
   role: "admin" | "user" | "pending" | "system";
-  user_type: "human" | "mind" | "system";
+  user_type: "human" | "mind" | "spirit";
   display_name: string | null;
   description: string | null;
   avatar: string | null;
@@ -146,7 +146,7 @@ export async function getOrCreateMindUser(mindName: string): Promise<User> {
     .where(
       and(
         eq(users.username, mindName),
-        or(eq(users.user_type, "mind"), eq(users.user_type, "system")),
+        or(eq(users.user_type, "mind"), eq(users.user_type, "spirit")),
       ),
     )
     .get();
@@ -171,7 +171,7 @@ export async function getOrCreateMindUser(mindName: string): Promise<User> {
       .where(
         and(
           eq(users.username, mindName),
-          or(eq(users.user_type, "mind"), eq(users.user_type, "system")),
+          or(eq(users.user_type, "mind"), eq(users.user_type, "spirit")),
         ),
       )
       .get();
@@ -190,7 +190,7 @@ export async function getOrCreateSystemUser(): Promise<User> {
   const existing = await db
     .select(userSelectFields)
     .from(users)
-    .where(eq(users.user_type, "system"))
+    .where(eq(users.user_type, "spirit"))
     .get();
   if (existing) {
     if ((existing as User).username !== spiritName) {
@@ -211,7 +211,7 @@ export async function getOrCreateSystemUser(): Promise<User> {
         username: spiritName,
         password_hash: "!system",
         role: "system",
-        user_type: "system",
+        user_type: "spirit",
         display_name: spiritName,
       })
       .returning(userSelectFields);
@@ -221,7 +221,7 @@ export async function getOrCreateSystemUser(): Promise<User> {
       const retried = await db
         .select(userSelectFields)
         .from(users)
-        .where(eq(users.user_type, "system"))
+        .where(eq(users.user_type, "spirit"))
         .get();
       if (retried) return retried as User;
     }

--- a/packages/daemon/src/lib/chat/system-channel.ts
+++ b/packages/daemon/src/lib/chat/system-channel.ts
@@ -113,7 +113,7 @@ export async function announceToSystem(text: string): Promise<void> {
 
   // Deliver to all mind participants of #system, sender-less, on the ordinary channel path.
   const participants = await getParticipants(channelId);
-  // Note: this excludes the spirit (user_type "system"). Preserved as-is; whether
+  // Note: this excludes the spirit (user_type "spirit"). Preserved as-is; whether
   // #system announcements should also reach the spirit is a behavior question for
   // review, not this refactor (#817).
   const mindParticipants = participants.filter(isMind);

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -261,7 +261,7 @@ export async function stopSpiritFull(name: string): Promise<void> {
  */
 export function buildSeedOrientation(
   createdBy?: string | null,
-  creatorType?: "human" | "mind" | "system",
+  creatorType?: "human" | "mind" | "spirit",
 ): string {
   const intro = `You've just been created as a seed on ${getSystemName()}. Start a conversation — introduce yourself, ask questions, and begin exploring who you want to be.`;
   if (!createdBy) return intro;
@@ -269,7 +269,7 @@ export function buildSeedOrientation(
   const who =
     creatorType === "mind"
       ? `another mind, ${createdBy}`
-      : creatorType === "system"
+      : creatorType === "spirit"
         ? `the spirit of this system (${createdBy})`
         : createdBy;
   return `${intro} Your creator is ${who}. Send them a message to introduce yourself.`;
@@ -277,7 +277,7 @@ export function buildSeedOrientation(
 
 /** Look up the creator's user_type, build the orientation message, and send it. */
 async function sendSeedOrientation(mindName: string, createdBy?: string | null): Promise<void> {
-  let creatorType: "human" | "mind" | "system" | undefined;
+  let creatorType: "human" | "mind" | "spirit" | undefined;
   if (createdBy) {
     const { getUserByUsername } = await import("../auth.js");
     creatorType = (await getUserByUsername(createdBy))?.user_type;

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -305,7 +305,7 @@ export async function buildExtensionContext(
     recordNotice: async (mindName: string, text: string) => {
       try {
         // Gate on the minds registry rather than the users table: the spirit is a
-        // mind but shares the system user account (`user_type: "system"`), so a
+        // mind but shares the system user account (`user_type: "spirit"`), so a
         // user_type check would silently drop every notice addressed to it.
         if (!(await findMind(mindName))) return;
         await recordMindNotice({

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -147,7 +147,7 @@ export const unifiedChatApp = new Hono<AuthEnv>().post(
     const senderName = user.id === 0 && body.sender ? body.sender : user.username;
 
     // Detect if sender is a mind. The spirit authenticates with its
-    // mind token but resolves to the shared system user (user_type "system"), so
+    // mind token but resolves to the shared system user (user_type "spirit"), so
     // classify a system principal whose username is a registered mind as a mind
     // sender too — this matches only the spirit, never a plain system principal.
     const senderIsMind =

--- a/packages/extensions/pages/src/commons.ts
+++ b/packages/extensions/pages/src/commons.ts
@@ -89,7 +89,7 @@ export async function maybeSendCommonsCue(ctx: ExtensionContext, repoDir: string
 
   try {
     // Gate on the spirit's project existing, not on its user row's type: the spirit
-    // shares the system user account (`user_type: "system"`), so a type check here
+    // shares the system user account (`user_type: "spirit"`), so a type check here
     // never passed and the cue was never sent on any system.
     if (!(await ctx.getMindDir(spirit))) return; // spirit not created yet — retry next start
     await ctx.recordNotice(

--- a/packages/extensions/pages/src/social.ts
+++ b/packages/extensions/pages/src/social.ts
@@ -169,7 +169,7 @@ export async function getPresence(
     if (!cache.has(row.reader_id)) cache.set(row.reader_id, await getUser(row.reader_id));
     const user = cache.get(row.reader_id) ?? null;
     // Test for human rather than for mind. The spirit's row is `user_type:
-    // "system"`, not `"mind"` — a `!== "mind"` test here would call the house's
+    // "spirit"`, not `"mind"` — a `!== "mind"` test here would call the house's
     // most active commons reader a "reader" and silently mean "a human came by".
     // #786 fixed exactly this mistake one directory over (see commons.ts).
     if (user?.user_type === "human") allMinds = false;

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -21,7 +21,7 @@ export type User = {
   id: number;
   username: string;
   role: "admin" | "user" | "pending" | "system";
-  user_type: "human" | "mind" | "system";
+  user_type: "human" | "mind" | "spirit";
   display_name: string | null;
   description: string | null;
   avatar: string | null;
@@ -77,7 +77,7 @@ export type ExtensionContext = {
    * Queue an ambient, non-interrupting notification for a mind, delivered as context
    * on the mind's next turn (via the notices system). No-op if the target isn't a
    * registered mind — which includes the system spirit, even though the spirit's
-   * user row is `user_type: "system"` rather than `"mind"`.
+   * user row is `user_type: "spirit"` rather than `"mind"`.
    * Use for low-urgency signals (a comment on a note, a reaction) that shouldn't trigger
    * a turn on their own. Never throws.
    */

--- a/packages/web/src/ui/lib/user-kind.ts
+++ b/packages/web/src/ui/lib/user-kind.ts
@@ -11,7 +11,7 @@ export { isExternal };
  * A local mind's avatar is a file in its own directory, served by name. Everyone
  * else's is an upload in the shared avatars dir — including an external mind's:
  * it POSTs /api/auth/avatar with its token like any other authenticated user. The
- * spirit (`user_type: "system"`, not a `mind`) also falls to the shared dir here.
+ * spirit (`user_type: "spirit"`, not a `mind`) also falls to the shared dir here.
  */
 export function avatarUrl(u: AuthUser): string | null {
   if (!u.avatar) return null;

--- a/test/extension-context-spirit.test.ts
+++ b/test/extension-context-spirit.test.ts
@@ -30,7 +30,7 @@ import { provisionSpiritSchedule } from "../packages/extensions/intentions/src/s
  * The extension SDK's context helpers used to assume every mind looks like a
  * mind: a `user_type: "mind"` row, living at `$VOLUTE_MINDS_DIR/<name>`. The
  * system spirit is neither — it shares the system user account (`user_type:
- * "system"`) and lives under the system dir. Both assumptions silently no-opped
+ * "spirit"`) and lives under the system dir. Both assumptions silently no-opped
  * the spirit bootstrap paths of the pages and intentions extensions, so these
  * tests exercise the real context rather than a fake.
  */
@@ -84,7 +84,7 @@ describe("extension context: spirit resolution", () => {
     assert.equal(ctx.getSpiritName(), spiritName);
   });
 
-  it("records a notice for the spirit despite its user_type being system", async () => {
+  it("records a notice for the spirit despite its user_type being spirit", async () => {
     const ctx = await buildExtensionContext(manifest, dataDir, noopMw);
     await ctx.recordNotice(spiritName, "commons has no index yet");
 

--- a/test/intentions.test.ts
+++ b/test/intentions.test.ts
@@ -500,7 +500,7 @@ describe("intentions commands", () => {
     const ctx = makeCtx("volute", {
       username: "volute",
       role: "system",
-      user_type: "system",
+      user_type: "spirit",
     } as User);
     const result = await commands["review-due"].handler({ args: {}, flags: {}, rest: [] }, ctx);
     assert.ok("output" in result);

--- a/test/migrate-spirit-user-type.test.ts
+++ b/test/migrate-spirit-user-type.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { isMind, isSystemSpirit } from "@volute/api/user-type";
+import { sql } from "drizzle-orm";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+
+// Done-bar for #819 Wave B: the shipped data migration must rewrite a live
+// spirit row's user_type "system" -> "spirit", leave everyone else (and the
+// separate `role` axis) untouched, and the rewritten row must then classify as
+// isSystemSpirit and NOT isMind. Reads the actual migration SQL so emptying or
+// weakening it fails here — and reverting the predicate flip fails here too.
+const migrationSql = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../drizzle/0001_migrate_spirit_user_type.sql"),
+  "utf-8",
+);
+
+describe("0001 migrate spirit user_type", () => {
+  it("rewrites the spirit's user_type system -> spirit, leaving role and other rows alone", async () => {
+    const db = await getDb();
+
+    // Seed a bardo-shaped pre-migration state: exactly one spirit row still on
+    // the old value, plus a mind that must be left untouched. Raw SQL because the
+    // typed schema no longer admits "system" as a user_type.
+    await db.run(
+      sql`INSERT INTO users (username, password_hash, role, user_type, display_name)
+          VALUES ('legacy-spirit', '!system', 'system', 'system', 'legacy-spirit')`,
+    );
+    await db.run(
+      sql`INSERT INTO users (username, password_hash, role, user_type)
+          VALUES ('legacy-mind', '!mind', 'user', 'mind')`,
+    );
+
+    await db.run(sql.raw(migrationSql));
+
+    const spirit = (await db.get(
+      sql`SELECT user_type, role FROM users WHERE username = 'legacy-spirit'`,
+    )) as { user_type: string; role: string };
+    const mind = (await db.get(
+      sql`SELECT user_type, role FROM users WHERE username = 'legacy-mind'`,
+    )) as { user_type: string; role: string };
+
+    // The value flipped...
+    assert.equal(spirit.user_type, "spirit");
+    // ...but role (a separate axis, renamed in a later wave) did not...
+    assert.equal(spirit.role, "system");
+    // ...and non-spirit rows are untouched.
+    assert.equal(mind.user_type, "mind");
+
+    // The migrated row now classifies as the keeper, and NOT as a plain mind.
+    assert.equal(isSystemSpirit(spirit), true);
+    assert.equal(isMind(spirit), false);
+
+    await db.run(sql`DELETE FROM users WHERE username IN ('legacy-spirit', 'legacy-mind')`);
+  });
+
+  it("is a forward no-op once no rows hold the old value", async () => {
+    const db = await getDb();
+    // Re-running against a DB with no "system" rows must not throw or corrupt.
+    await db.run(sql.raw(migrationSql));
+    const stragglers = (await db.get(
+      sql`SELECT count(*) as n FROM users WHERE user_type = 'system'`,
+    )) as { n: number };
+    assert.equal(stragglers.n, 0);
+  });
+});

--- a/test/pages-commons.test.ts
+++ b/test/pages-commons.test.ts
@@ -170,15 +170,15 @@ describe("maybeSendCommonsCue", () => {
     assert.ok(!existsSync(resolve(dataDir, ".commons-cue-sent")));
   });
 
-  // Regression: the spirit shares the system user account (`user_type: "system"`),
+  // Regression: the spirit shares the system user account (`user_type: "spirit"`),
   // so gating the cue on the users table meant it never fired on any install.
   // The gate is the spirit's project existing, not what its user row says it is —
   // hence the production-shaped user row here, which fails the moment anyone
   // reintroduces a `user_type === "mind"` check (verified by reverting the fix).
-  it("sends to the spirit even though its user row is user_type system", async () => {
+  it("sends to the spirit even though its user row is user_type spirit", async () => {
     const { ctx, notices } = makeCtx({
       getUserByUsername: async (username: string) =>
-        ({ id: 1, username, role: "system", user_type: "system" }) as unknown as User,
+        ({ id: 1, username, role: "system", user_type: "spirit" }) as unknown as User,
     });
     await maybeSendCommonsCue(ctx, repoDir);
     assert.equal(notices.length, 1);

--- a/test/pages-reads.test.ts
+++ b/test/pages-reads.test.ts
@@ -24,7 +24,7 @@ const users = new Map<number, User>();
 function register(
   id: number,
   username: string,
-  userType: "human" | "mind" | "system" = "mind",
+  userType: "human" | "mind" | "spirit" = "mind",
 ): User {
   const user: User = {
     id,
@@ -59,7 +59,7 @@ describe("page read signals", () => {
     register(2, "pip");
     register(3, "whorl");
     register(4, "james", "human");
-    register(5, "volute", "system"); // the spirit
+    register(5, "volute", "spirit"); // the spirit
     publish("mimsy", "notes/tideline.md");
   });
   afterEach(() => db.close());
@@ -162,7 +162,7 @@ describe("page read signals", () => {
     });
 
     it("counts the spirit as a mind, not as a human reader", async () => {
-      // The spirit's row is user_type "system"; a `!== "mind"` test would call the
+      // The spirit's row is user_type "spirit"; a `!== "mind"` test would call the
       // house's most active reader a "reader" and quietly imply a human came by.
       syncPublishedPages(db, "_system", [{ file: "index.md", hash: "h" }]);
       recordRead(db, COMMONS, users.get(5) as User);

--- a/test/seed-orientation.test.ts
+++ b/test/seed-orientation.test.ts
@@ -22,8 +22,8 @@ describe("buildSeedOrientation", () => {
     assert.ok(msg.includes("Your creator is another mind, orchid."));
   });
 
-  it("words the spirit (system) creator as the spirit of this system", () => {
-    const msg = buildSeedOrientation("volute", "system");
+  it("words the spirit creator as the spirit of this system", () => {
+    const msg = buildSeedOrientation("volute", "spirit");
     assert.ok(msg.includes("Your creator is the spirit of this system (volute)."));
   });
 

--- a/test/spirit-name.test.ts
+++ b/test/spirit-name.test.ts
@@ -88,7 +88,7 @@ describe("name validation with a named spirit", () => {
 describe("system user follows the spirit name", () => {
   async function deleteSystemUsers() {
     const db = await getDb();
-    await db.delete(users).where(eq(users.user_type, "system"));
+    await db.delete(users).where(eq(users.user_type, "spirit"));
   }
 
   afterEach(async () => {
@@ -110,7 +110,7 @@ describe("system user follows the spirit name", () => {
     const after = await getOrCreateSystemUser();
     assert.equal(after.id, before.id, "same user, renamed");
     assert.equal(after.username, "iris");
-    assert.equal(after.user_type, "system");
+    assert.equal(after.user_type, "spirit");
   });
 
   it("getOrCreateMindUser returns the system user for the spirit name", async () => {
@@ -120,6 +120,6 @@ describe("system user follows the spirit name", () => {
     const systemUser = await getOrCreateSystemUser();
     const mindUser = await getOrCreateMindUser("iris");
     assert.equal(mindUser.id, systemUser.id);
-    assert.equal(mindUser.user_type, "system");
+    assert.equal(mindUser.user_type, "spirit");
   });
 });

--- a/test/system-channel.test.ts
+++ b/test/system-channel.test.ts
@@ -133,7 +133,7 @@ describe("system channel", () => {
     const participants = await getParticipants(id);
     const spirit = participants.find((p) => p.username === "volute");
     assert.ok(spirit, "spirit should be a participant");
-    assert.equal(spirit.userType, "system", "spirit should be the system user, not a mind user");
+    assert.equal(spirit.userType, "spirit", "spirit should be the system user, not a mind user");
   });
 
   it("backfillSystemChannelMembers joins sprouted minds and spirits, skips seeds and variants", async () => {
@@ -154,7 +154,7 @@ describe("system channel", () => {
     assert.ok(!names.includes("commons-seed"), "seed should not be joined");
     assert.ok(!names.includes("commons-mind-v1"), "variant should not be joined");
     const spirit = participants.find((p) => p.username === "volute");
-    assert.equal(spirit?.userType, "system", "spirit joins as the system user");
+    assert.equal(spirit?.userType, "spirit", "spirit joins as the system user");
   });
 
   it("backfillSystemChannelMembers is idempotent", async () => {

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -32,7 +32,7 @@ describe("system user", () => {
   it("getOrCreateSystemUser creates user with correct fields", async () => {
     const user = await getOrCreateSystemUser();
     assert.equal(user.username, "volute");
-    assert.equal(user.user_type, "system");
+    assert.equal(user.user_type, "spirit");
     assert.equal(user.display_name, "volute");
     assert.equal(user.role, "system");
   });

--- a/test/user-type-predicates.test.ts
+++ b/test/user-type-predicates.test.ts
@@ -10,10 +10,10 @@ import { isExternal, isLocalMind, isMind, isSystemSpirit } from "@volute/api/use
 const human = { user_type: "human" as const };
 const localMind = { user_type: "mind" as const }; // no `external` flag → local
 const externalMind = { user_type: "mind" as const, external: true };
-const spirit = { user_type: "system" as const };
+const spirit = { user_type: "spirit" as const };
 const puppet = { user_type: "puppet" as const };
 // A conversation participant carries `userType` (camelCase) and never an `external` flag.
-const spiritParticipant = { userType: "system" as const };
+const spiritParticipant = { userType: "spirit" as const };
 const mindParticipant = { userType: "mind" as const };
 
 describe("isMind (rendering / identity)", () => {


### PR DESCRIPTION
## What & why
Wave B of #819. Renames the **stored `user_type` value** `"system"` → `"spirit"` — the keeper's identity. `user_type: "system"` never meant infrastructure; it meant *the spirit*. Last step disambiguating the overloaded word. Builds on #851 (the `@volute/api/user-type` predicates), which centralized every check behind `isSystemSpirit` so this is a value migration + one-line predicate flip + write-site updates.

## The migration (safe on bardo)
`drizzle/0001_migrate_spirit_user_type.sql`: `UPDATE users SET user_type = 'spirit' WHERE user_type = 'system';`
- Touches **at most one row** — the "exactly one system user" invariant holds (`getOrCreateSystemUser`). Bardo has exactly that one spirit row.
- **Forward-idempotent**: once no rows hold "system", it's a no-op (tested).
- **Leaves `role` untouched** — a separate axis, renamed in a later wave.

## ⚠️ Authz-adjacent — please verify behavior-equivalence
- `getOrCreateSystemUser` / `getOrCreateMindUser` (auth.ts): the SELECT/`or()` predicates that locate the spirit principal now match `user_type = "spirit"`. The **INSERT still writes `role: "system"`** — only `user_type` flips.
- **Migration-ordering dependency (by design, worth a look):** both `getOrCreateSystemUser` (SELECT where `user_type="spirit"`) and `daemon.ts`'s startup role-reconciliation (UPDATE role WHERE `user_type="spirit"`) assume the drizzle migration has already run on boot. Standard migrate-before-serve deploy path — flagging it because it's the one place a mis-ordered deploy could leave the spirit unresolved.

## Beyond the five brief tasks (all mechanical)
- `isLocalMind` also flipped (`t === "system"` → `"spirit"`) — it reads the value directly.
- `daemon.ts` role-reconciliation WHERE, `mind-service.ts` `creatorType` union, `sdk/types.ts` + `auth.ts` `User.user_type` unions, and ~8 explanatory comments updated for consistency.
- `role: "system"` and all other `system` identifiers (`voluteSystemDir`, `system_events`, `#system`) deliberately **untouched** — separate waves.

## Verification
- `npm run typecheck` clean.
- **Full suite: 3262 pass, 0 fail.**
- Fail-on-revert test (`test/migrate-spirit-user-type.test.ts`) reads the actual migration SQL and asserts: spirit's `user_type` flips, `role` stays `"system"`, other rows untouched, migrated row classifies as `isSystemSpirit` and NOT `isMind`, + forward no-op.
- Grep confirms no lingering `user_type` `"system"` literals except the migration SQL and the test's intentional legacy-seed.