### PR TITLE
refactor: operator→host copy + [human] label regression guard (#493)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY packages/extensions/pages/skills/ packages/extensions/pages/skills/
 COPY packages/extensions/intentions/dist/ui/ packages/extensions/intentions/dist/ui/
 COPY packages/extensions/intentions/skills/ packages/extensions/intentions/skills/
 
-# Make volute CLI available in PATH for minds and operators
+# Make volute CLI available in PATH for minds and hosts
 RUN ln -s /opt/volute/dist/cli.js /usr/local/bin/volute
 
 ENV VOLUTE_HOME=/data

--- a/test/template-event-format.test.ts
+++ b/test/template-event-format.test.ts
@@ -106,6 +106,37 @@ describe("sender-less channel announcements (#687)", () => {
   });
 });
 
+// #493: the participant label a mind reads is the display term for a user's type. Humans render
+// as `[human]` — the retired "brain" jargon must never surface here. The label is the raw
+// user_type today (there is no "brain" value to migrate), so this test guards against a
+// regression that reintroduces a human→"brain" mapping in the prefix formatter.
+describe("participant profile labels (#493)", () => {
+  it("labels a human participant [human] and never [brain]", () => {
+    const prefix = formatPrefix(
+      {
+        channel: "#garden",
+        sender: "alice",
+        participantProfiles: [{ username: "alice", userType: "human", displayName: "Alice" }],
+      },
+      "2026-07-12 07:30",
+    );
+    assert.ok(prefix.includes("alice (Alice) [human]"), "human renders as [human]");
+    assert.ok(!prefix.toLowerCase().includes("brain"), "the retired [brain] label must not return");
+  });
+
+  it("labels a mind participant [mind]", () => {
+    const prefix = formatPrefix(
+      {
+        channel: "#garden",
+        sender: "atlas",
+        participantProfiles: [{ username: "atlas", userType: "mind" }],
+      },
+      "2026-07-12 07:30",
+    );
+    assert.ok(prefix.includes("atlas [mind]"), "mind renders as [mind]");
+  });
+});
+
 describe("router event dispatch", () => {
   it("applies the system-event heading and no sender/DM framing to an event dispatch", () => {
     const handled: { content: VoluteContentPart[]; meta: HandlerMeta }[] = [];


### PR DESCRIPTION
Part of milestone 9 (#493 display cleanup).

**Finding:** most of #493 already landed in #684/#686 (getSystemName + `${system}` substitution, VOLUTE.md name anchor, human/host terminology). The label already renders `[human]` (there was never a live `brain` user_type value) and install-name substitution is already wired via `substitute()`/`getSystemName()`.

**This PR closes the two genuine gaps:**
- `Dockerfile`: the one surfaced owner-role "operator" → "hosts". Philosophy page keeps "operator" deliberately (rhetorical host-vs-operator contrast); changelog/test-label uses left alone.
- A regression-guard test: a human renders `[human]`, never `[brain]` (builder verified it fails when a human→brain mapping is reintroduced).

No data-model, authz, or migration. Reviewed line-by-line; targeted test green. Local pre-push test-suite hook is flaky on dreamscape (env: github-copilot OAuth) — relying on CI.