### PR TITLE
refactor: commons channel + pages identity split from infra system (#819)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Extensions add functionality to Volute — custom UI sections, API routes, datab
 - `initDb?(db)` — per-extension SQLite DB at `~/.volute/system/extension-data/{id}/data.db`
 - `onDaemonStart?()`, `onSpiritReady?(ctx)`, `onDaemonStop?()`, `onMindStart?(name, ctx)`, `onMindStop?(name)` — lifecycle hooks. Spirit-dependent bootstrap belongs in `onSpiritReady`: `onDaemonStart` runs before the spirit exists on a fresh install
 
-**Extension context** (passed to `routes()`/`publicRoutes()`): `db`, `dataDir`, `authMiddleware`, `requireSelf`, `resolveUser(c)`, `getUser`/`getUserByUsername`/`getMindUser`, `publishActivity(event)`, `announceToSystem`, `recordNotice`, `getMindDir(name)`, `isIsolationEnabled`, `getSystemsConfig()`.
+**Extension context** (passed to `routes()`/`publicRoutes()`): `db`, `dataDir`, `authMiddleware`, `requireSelf`, `resolveUser(c)`, `getUser`/`getUserByUsername`/`getMindUser`, `publishActivity(event)`, `announceToCommons`, `recordNotice`, `getMindDir(name)`, `isIsolationEnabled`, `getSystemsConfig()`.
 
 **Extension UI** — standalone Svelte apps built with Vite, served as static assets at `/ext/{id}/`, rendered in iframes by the main app. Uses hash routing internally; communicates navigation to parent via `window.parent.postMessage({ type: "navigate", path })`. Extensions can import shared UI components from `@volute/ui` (add `"@volute/ui": "*"` to dependencies). Theme is shared via auto-generated `ext-theme.css` (built from `@volute/ui`'s `theme.css` + `base.css`).
 

--- a/drizzle/0002_closed_payback.sql
+++ b/drizzle/0002_closed_payback.sql
@@ -1,0 +1,17 @@
+ALTER TABLE `channels` ADD `is_default` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_channels_default` ON `channels` (`is_default`) WHERE is_default = 1;--> statement-breakpoint
+-- Backfill the commons marker onto each install's existing default channel (#819).
+-- The default channel used to be found by its magic name ("system"); this marks it
+-- so lookups resolve by the is_default flag instead. We do NOT rename the channel —
+-- a house may keep an earned proper name (bardo's is "#system"); the marker is what
+-- makes identity independent of the string. New installs get a fresh "commons"
+-- channel that ensureCommonsChannel marks directly, so this only fires where a
+-- legacy channel exists. Forward-idempotent: a no-op once a default is marked.
+UPDATE `channels` SET `is_default` = 1
+WHERE `conversation_id` = (
+  SELECT `conversation_id` FROM `channels`
+  WHERE `name` IN ('system', '#system')
+  ORDER BY (`name` = 'system') DESC, `created_at` ASC
+  LIMIT 1
+)
+AND NOT EXISTS (SELECT 1 FROM `channels` WHERE `is_default` = 1);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1438 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e0d53fdc-0043-4729-ba38-01942f8b786d",
+  "prevId": "09112b91-e867-4bf6-8636-1c02b43fc751",
+  "tables": {
+    "activity": {
+      "name": "activity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_activity_created_at": {
+          "name": "idx_activity_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_activity_mind": {
+          "name": "idx_activity_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_activity_turn_id": {
+          "name": "idx_activity_turn_id",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "idx_activity_type": {
+          "name": "idx_activity_type",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_hash": {
+          "name": "idx_api_tokens_hash",
+          "columns": ["token_hash"],
+          "isUnique": true
+        },
+        "idx_api_tokens_user": {
+          "name": "idx_api_tokens_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_gates": {
+      "name": "channel_gates",
+      "columns": {
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_gates_mind_channel_pk": {
+          "columns": ["mind", "channel"],
+          "name": "channel_gates_mind_channel_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "char_limit": {
+          "name": "char_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "private": {
+          "name": "private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_channels_name": {
+          "name": "idx_channels_name",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "idx_channels_default": {
+          "name": "idx_channels_default",
+          "columns": ["is_default"],
+          "isUnique": true,
+          "where": "is_default = 1"
+        }
+      },
+      "foreignKeys": {
+        "channels_conversation_id_conversations_id_fk": {
+          "name": "channels_conversation_id_conversations_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_participants": {
+      "name": "conversation_participants",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_cp_unique": {
+          "name": "idx_cp_unique",
+          "columns": ["conversation_id", "user_id"],
+          "isUnique": true
+        },
+        "idx_cp_user_id": {
+          "name": "idx_cp_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_participants_conversation_id_conversations_id_fk": {
+          "name": "conversation_participants_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_participants_user_id_users_id_fk": {
+          "name": "conversation_participants_user_id_users_id_fk",
+          "tableFrom": "conversation_participants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_reads": {
+      "name": "conversation_reads",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_conversation_reads_unique": {
+          "name": "idx_conversation_reads_unique",
+          "columns": ["user_id", "conversation_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "conversation_reads_user_id_users_id_fk": {
+          "name": "conversation_reads_user_id_users_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_reads_conversation_id_conversations_id_fk": {
+          "name": "conversation_reads_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_reads",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dm'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "private": {
+          "name": "private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_conversations_user_id": {
+          "name": "idx_conversations_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_conversations_updated_at": {
+          "name": "idx_conversations_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_queue": {
+      "name": "delivery_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_mind": {
+          "name": "target_mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_delivery_queue_mind_thread": {
+          "name": "idx_delivery_queue_mind_thread",
+          "columns": ["mind", "thread"],
+          "isUnique": false
+        },
+        "idx_delivery_queue_mind_status": {
+          "name": "idx_delivery_queue_mind_status",
+          "columns": ["mind", "status"],
+          "isUnique": false
+        },
+        "idx_delivery_queue_status": {
+          "name": "idx_delivery_queue_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_delivery_queue_status_next": {
+          "name": "idx_delivery_queue_status_next",
+          "columns": ["status", "next_attempt_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_id": {
+          "name": "idx_messages_conversation_id",
+          "columns": ["conversation_id"],
+          "isUnique": false
+        },
+        "idx_messages_turn_id": {
+          "name": "idx_messages_turn_id",
+          "columns": ["turn_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mind_history": {
+      "name": "mind_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_mind_history_mind": {
+          "name": "idx_mind_history_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_mind_history_mind_channel": {
+          "name": "idx_mind_history_mind_channel",
+          "columns": ["mind", "channel"],
+          "isUnique": false
+        },
+        "idx_mind_history_mind_type": {
+          "name": "idx_mind_history_mind_type",
+          "columns": ["mind", "type"],
+          "isUnique": false
+        },
+        "idx_mind_history_turn_id": {
+          "name": "idx_mind_history_turn_id",
+          "columns": ["turn_id"],
+          "isUnique": false
+        },
+        "idx_mind_history_thread": {
+          "name": "idx_mind_history_thread",
+          "columns": ["thread"],
+          "isUnique": false
+        },
+        "idx_mind_history_mind_created_at": {
+          "name": "idx_mind_history_mind_created_at",
+          "columns": ["mind", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "minds": {
+      "name": "minds",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dir": {
+          "name": "dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_hash": {
+          "name": "template_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "running": {
+          "name": "running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mind_type": {
+          "name": "mind_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mind'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "minds_port_unique": {
+          "name": "minds_port_unique",
+          "columns": ["port"],
+          "isUnique": true
+        },
+        "idx_minds_parent": {
+          "name": "idx_minds_parent",
+          "columns": ["parent"],
+          "isUnique": false
+        },
+        "idx_minds_mind_type": {
+          "name": "idx_minds_mind_type",
+          "columns": ["mind_type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "minds_parent_minds_name_fk": {
+          "name": "minds_parent_minds_name_fk",
+          "tableFrom": "minds",
+          "tableTo": "minds",
+          "columnsFrom": ["parent"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_skills": {
+      "name": "shared_skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "summaries": {
+      "name": "summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_summaries_unique": {
+          "name": "idx_summaries_unique",
+          "columns": ["mind", "period", "period_key"],
+          "isUnique": true
+        },
+        "idx_summaries_mind_period": {
+          "name": "idx_summaries_mind_period",
+          "columns": ["mind", "period"],
+          "isUnique": false
+        },
+        "idx_summaries_mind_period_key": {
+          "name": "idx_summaries_mind_period_key",
+          "columns": ["mind", "period_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_events": {
+      "name": "system_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery": {
+          "name": "delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'immediate'"
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'main'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_system_events_mind": {
+          "name": "idx_system_events_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_system_events_mind_delivery": {
+          "name": "idx_system_events_mind_delivery",
+          "columns": ["mind", "delivery", "delivered_at"],
+          "isUnique": false
+        },
+        "idx_system_events_mind_type": {
+          "name": "idx_system_events_mind_type",
+          "columns": ["mind", "type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_prompts": {
+      "name": "system_prompts",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turns": {
+      "name": "turns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mind": {
+          "name": "mind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread": {
+          "name": "thread",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_event_id": {
+          "name": "trigger_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_id": {
+          "name": "summary_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_turns_mind": {
+          "name": "idx_turns_mind",
+          "columns": ["mind"],
+          "isUnique": false
+        },
+        "idx_turns_mind_status": {
+          "name": "idx_turns_mind_status",
+          "columns": ["mind", "status"],
+          "isUnique": false
+        },
+        "idx_turns_mind_created_at": {
+          "name": "idx_turns_mind_created_at",
+          "columns": ["mind", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1785424941257,
       "tag": "0001_migrate_spirit_user_type",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1785433691413,
+      "tag": "0002_closed_payback",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { format } from "node:util";
 import { setProviderRefreshHook } from "./lib/ai-service.js";
-import { backfillSystemChannelMembers, ensureSystemChannel } from "./lib/chat/system-channel.js";
+import { backfillCommonsChannelMembers, ensureCommonsChannel } from "./lib/chat/commons-channel.js";
 import { initBackupManager } from "./lib/daemon/backup-manager.js";
 import { initBridgeManager } from "./lib/daemon/bridge-manager.js";
 import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
@@ -232,18 +232,18 @@ export async function startDaemon(opts: {
     }
   }
 
-  // Ensure #system channel exists (non-fatal)
+  // Ensure the commons (default) channel exists (non-fatal)
   try {
-    await ensureSystemChannel();
+    await ensureCommonsChannel();
   } catch (err) {
-    log.warn("failed to ensure #system channel", log.errorData(err));
+    log.warn("failed to ensure commons channel", log.errorData(err));
   }
 
-  // Backfill registered minds into #system (non-fatal)
+  // Backfill registered minds into the commons (non-fatal)
   try {
-    await backfillSystemChannelMembers();
+    await backfillCommonsChannelMembers();
   } catch (err) {
-    log.warn("failed to backfill minds into #system", log.errorData(err));
+    log.warn("failed to backfill minds into the commons", log.errorData(err));
   }
 
   // Ensure system user exists (non-fatal)

--- a/packages/daemon/src/lib/chat/commons-channel.ts
+++ b/packages/daemon/src/lib/chat/commons-channel.ts
@@ -6,118 +6,132 @@ import { publish as publishActivity } from "../events/activity-events.js";
 import {
   addMessage,
   createChannel,
-  getChannelByName,
-  getChannelSettings,
+  getDefaultChannelRow,
   getParticipants,
   joinChannel,
+  markChannelDefault,
   updateChannelSettings,
 } from "../events/conversations.js";
 import { readRegistry } from "../mind/registry.js";
 import log from "../util/logger.js";
 import { deliverEvent } from "./system-events.js";
 
-const SYSTEM_CHANNEL_NAME = "system";
-const SYSTEM_CHANNEL_DESCRIPTION =
+// The name a *fresh* install's commons channel is created with (#819). Existing
+// installs keep whatever their default channel is already named — a house may have
+// earned a proper name — because the commons is resolved by the `is_default` marker,
+// not by this string. See getDefaultChannelRow / markChannelDefault.
+const COMMONS_CHANNEL_NAME = "commons";
+const COMMONS_CHANNEL_DESCRIPTION =
   "The commons — a shared room for every mind and the spirit on this system. " +
   "Think out loud, check in, riff, coordinate.";
 
 let cachedChannelId: string | null = null;
 
 /** Reset the cached channel ID (for testing). */
-export function resetSystemChannelCache(): void {
+export function resetCommonsChannelCache(): void {
   cachedChannelId = null;
 }
 
-/** Ensure the #system channel exists (idempotent). Returns the conversation ID. */
-export async function ensureSystemChannel(): Promise<string> {
+/**
+ * Ensure the commons (default) channel exists (idempotent). Returns the
+ * conversation ID. The commons is resolved by the `is_default` marker, so this
+ * finds an existing default under *any* name (a renamed house channel included)
+ * and only creates a fresh `#commons` when no channel is marked default yet.
+ */
+export async function ensureCommonsChannel(): Promise<string> {
   if (cachedChannelId) return cachedChannelId;
 
-  const existing = await getChannelByName(SYSTEM_CHANNEL_NAME);
+  const existing = await getDefaultChannelRow();
   if (existing) {
-    cachedChannelId = existing.id;
+    cachedChannelId = existing.conversation_id;
     // Channels created before the default description existed have none; fill it
     // in (only when unset, so a host-edited description is never clobbered).
-    const settings = await getChannelSettings(SYSTEM_CHANNEL_NAME);
-    if (settings && settings.description == null) {
-      await updateChannelSettings(SYSTEM_CHANNEL_NAME, {
-        description: SYSTEM_CHANNEL_DESCRIPTION,
+    if (existing.description == null) {
+      await updateChannelSettings(existing.name, {
+        description: COMMONS_CHANNEL_DESCRIPTION,
       });
     }
-    return existing.id;
+    return existing.conversation_id;
   }
 
-  const conv = await createChannel(SYSTEM_CHANNEL_NAME, undefined, {
-    description: SYSTEM_CHANNEL_DESCRIPTION,
+  const conv = await createChannel(COMMONS_CHANNEL_NAME, undefined, {
+    description: COMMONS_CHANNEL_DESCRIPTION,
   });
+  await markChannelDefault(conv.id);
   cachedChannelId = conv.id;
-  log.info("created #system channel");
+  log.info(`created #${COMMONS_CHANNEL_NAME} channel`);
   return conv.id;
 }
 
-/** Join a brain user to the #system channel. */
-export async function joinSystemChannel(userId: number): Promise<void> {
-  const channelId = await ensureSystemChannel();
+/** Join a user to the commons channel. */
+export async function joinCommonsChannel(userId: number): Promise<void> {
+  const channelId = await ensureCommonsChannel();
   await joinChannel(channelId, userId);
 }
 
-/** Join a mind to the #system channel by mind name. */
-export async function joinSystemChannelForMind(mindName: string): Promise<void> {
+/** Join a mind to the commons channel by mind name. */
+export async function joinCommonsChannelForMind(mindName: string): Promise<void> {
   const user = await getOrCreateMindUser(mindName);
-  await joinSystemChannel(user.id);
+  await joinCommonsChannel(user.id);
 }
 
-/** Join the spirit (the shared system user) to the #system channel. */
-export async function joinSystemChannelForSpirit(): Promise<void> {
+/** Join the spirit (the shared system user) to the commons channel. */
+export async function joinCommonsChannelForSpirit(): Promise<void> {
   const user = await getOrCreateSystemUser();
-  await joinSystemChannel(user.id);
+  await joinCommonsChannel(user.id);
 }
 
 /**
- * Join all registered non-seed minds (and spirits) to the #system channel.
+ * Join all registered non-seed minds (and spirits) to the commons channel.
  * Idempotent; run at daemon startup so existing installs get members without
  * waiting for each mind's next restart. Seeds stay out until they sprout.
  */
-export async function backfillSystemChannelMembers(): Promise<void> {
+export async function backfillCommonsChannelMembers(): Promise<void> {
   const entries = await readRegistry();
   for (const entry of entries) {
     if (entry.stage === "seed") continue;
     try {
       if (entry.mindType === "spirit") {
-        await joinSystemChannelForSpirit();
+        await joinCommonsChannelForSpirit();
       } else {
-        await joinSystemChannelForMind(entry.name);
+        await joinCommonsChannelForMind(entry.name);
       }
     } catch (err) {
-      log.error(`failed to backfill ${entry.name} into #system`, log.errorData(err));
+      log.error(`failed to backfill ${entry.name} into the commons`, log.errorData(err));
     }
   }
 }
 
 /**
- * Post an automated announcement to the #system channel ("X has joined", "📝 X published a
+ * Post an automated announcement to the commons channel ("X has joined", "📝 X published a
  * note …"). These are sender-less, never the spirit's voice: since the spirit shares the
  * system user (#663), attributing automation to that user made it indistinguishable from the
  * spirit's hand-written messages (#687).
  *
  * The channel row is stored with `role: "event"` and no sender so web chat and `chat read`
  * render it as an event. It is delivered to mind participants through the normal channel-message
- * path (so it follows each mind's #system routing, batching, gating, and file destinations
+ * path (so it follows each mind's commons routing, batching, gating, and file destinations
  * exactly like any channel message) — but with a null sender, so the prefix the mind receives
  * frames it by channel and never names the spirit or invents a sender. The spirit's own
  * hand-written messages are unaffected.
  */
-export async function announceToSystem(text: string): Promise<void> {
-  const channelId = await ensureSystemChannel();
+export async function announceToCommons(text: string): Promise<void> {
+  await ensureCommonsChannel();
+  const row = await getDefaultChannelRow();
+  if (!row) return; // unreachable after ensureCommonsChannel, but keeps this total
 
+  const channelId = row.conversation_id;
   await addMessage(channelId, "event", null, [{ type: "text", text }]);
 
-  // Deliver to all mind participants of #system, sender-less, on the ordinary channel path.
+  // Deliver to all mind participants of the commons, sender-less, on the ordinary channel path.
   const participants = await getParticipants(channelId);
   // Note: this excludes the spirit (user_type "spirit"). Preserved as-is; whether
-  // #system announcements should also reach the spirit is a behavior question for
+  // commons announcements should also reach the spirit is a behavior question for
   // review, not this refactor (#817).
   const mindParticipants = participants.filter(isMind);
-  const channel = "#system";
+  // The routing slug follows the channel's actual name (`#commons` on new installs,
+  // an earned name like `#system` on migrated houses), not a hardcoded string.
+  const channel = `#${row.name}`;
   for (const mind of mindParticipants) {
     deliverMessage(mind.username, {
       content: [{ type: "text", text }],
@@ -128,7 +142,7 @@ export async function announceToSystem(text: string): Promise<void> {
       participantCount: participants.length,
       isDM: false,
     }).catch((err) => {
-      log.warn(`failed to deliver system announcement to ${mind.username}`, log.errorData(err));
+      log.warn(`failed to deliver commons announcement to ${mind.username}`, log.errorData(err));
     });
   }
 }
@@ -137,7 +151,7 @@ export async function announceToSystem(text: string): Promise<void> {
  * Make a mind's sprout a visible event (#665). Sprouting is the most significant
  * moment in a mind's early life but used to flip the stage silently. This does two
  * things, each fail-soft so neither can block the sprout that triggered it:
- *   1. Prompts the spirit to welcome the mind in #system — via the same
+ *   1. Prompts the spirit to welcome the mind in the commons — via the same
  *      daemon→spirit message path the nurture schedule uses — so the welcome is
  *      hand-written in the spirit's own voice rather than a canned template. If
  *      the spirit is unavailable there's simply no announcement (no canned
@@ -149,12 +163,14 @@ export async function announceToSystem(text: string): Promise<void> {
 export async function announceSprout(mindName: string): Promise<void> {
   const displayName =
     (await getUserByUsername(mindName).catch(() => null))?.display_name ?? mindName;
+  const row = await getDefaultChannelRow();
+  const commons = `#${row?.name ?? COMMONS_CHANNEL_NAME}`;
   // deliverEvent never throws — with the spirit unavailable the prompt stays pending
   // and reaches it on its next start or wake.
   await deliverEvent(getSpiritName(), {
     type: "lifecycle",
     meta: { subtype: "sprout-welcome", mind: mindName },
-    body: `${displayName} (@${mindName}) has just sprouted into a full mind and joined #system. Welcome them there in your own words.`,
+    body: `${displayName} (@${mindName}) has just sprouted into a full mind and joined ${commons}. Welcome them there in your own words.`,
   });
   await publishActivity({
     type: "mind_sprouted",

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { missingCredentialWarning } from "../ai-service.js";
 import { syncMindProfile } from "../auth.js";
-import { joinSystemChannelForMind, joinSystemChannelForSpirit } from "../chat/system-channel.js";
+import { joinCommonsChannelForMind, joinCommonsChannelForSpirit } from "../chat/commons-channel.js";
 import { ensureSystemDM } from "../chat/system-chat.js";
 import { deliverEvent } from "../chat/system-events.js";
 import { getSystemName } from "../config/setup.js";
@@ -99,12 +99,12 @@ export async function startMindFull(name: string): Promise<void> {
     );
   }
 
-  // Auto-join #system channel. Only sprouted minds reach here — seeds returned
+  // Auto-join the commons channel. Only sprouted minds reach here — seeds returned
   // early above, so they stay out of the commons until they sprout (#617).
   // warn, not error: membership self-heals (idempotent join, retried on every
   // start and by the daemon-startup backfill), so a single miss isn't fatal.
-  joinSystemChannelForMind(baseName).catch((err: unknown) =>
-    log.warn(`failed to join #system for ${baseName}`, log.errorData(err)),
+  joinCommonsChannelForMind(baseName).catch((err: unknown) =>
+    log.warn(`failed to join the commons for ${baseName}`, log.errorData(err)),
   );
 
   if (config?.tokenBudget) {
@@ -214,8 +214,8 @@ export async function startSpiritFull(name: string): Promise<void> {
   await getMindManager().startMind(name);
 
   // The spirit shares the commons with the minds it tends
-  joinSystemChannelForSpirit().catch((err: unknown) =>
-    log.error(`failed to join #system for ${name}`, log.errorData(err)),
+  joinCommonsChannelForSpirit().catch((err: unknown) =>
+    log.error(`failed to join the commons for ${name}`, log.errorData(err)),
   );
 
   // Load spirit schedules with explicit dir (spirit lives outside ~/.volute/minds/)

--- a/packages/daemon/src/lib/events/conversations.ts
+++ b/packages/daemon/src/lib/events/conversations.ts
@@ -493,6 +493,7 @@ export type ChannelRow = {
   rules: string | null;
   char_limit: number | null;
   private: number;
+  is_default: number;
   created_at: string;
   updated_at: string;
 };
@@ -554,6 +555,38 @@ export async function getChannelByName(name: string): Promise<Conversation | nul
   const ch = await db.select().from(channels).where(eq(channels.name, name)).get();
   if (!ch) return null;
   return getConversation(ch.conversation_id);
+}
+
+/**
+ * The commons: the default channel, resolved by its `is_default` marker rather
+ * than by a magic name (#819). Returns the raw channel row, or null when no
+ * channel is marked default yet (a fresh install before `ensureCommonsChannel`).
+ */
+export async function getDefaultChannelRow(): Promise<ChannelRow | null> {
+  const db = await getDb();
+  const row = await db.select().from(channels).where(eq(channels.is_default, 1)).get();
+  return (row as ChannelRow) ?? null;
+}
+
+/** The default channel as a Conversation, resolved by marker. Null if none marked. */
+export async function getDefaultChannel(): Promise<Conversation | null> {
+  const row = await getDefaultChannelRow();
+  if (!row) return null;
+  return getConversation(row.conversation_id);
+}
+
+/**
+ * Mark a channel as the commons (the default). Clears any prior marker first so
+ * the "at most one default" invariant (a partial unique index) always holds —
+ * re-pointing the commons is a supported move now that identity isn't its name.
+ */
+export async function markChannelDefault(conversationId: string): Promise<void> {
+  const db = await getDb();
+  await db.update(channels).set({ is_default: 0 }).where(eq(channels.is_default, 1));
+  await db
+    .update(channels)
+    .set({ is_default: 1 })
+    .where(eq(channels.conversation_id, conversationId));
 }
 
 export async function getChannelSettings(name: string): Promise<ChannelRow | null> {

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -14,7 +14,7 @@ import type {
 import type { Context, Hono, MiddlewareHandler } from "hono";
 import { type AuthEnv, requireSelf } from "../web/middleware/auth.js";
 import { getUser, getUserByUsername } from "./auth.js";
-import { announceToSystem } from "./chat/system-channel.js";
+import { announceToCommons } from "./chat/commons-channel.js";
 import { MIND_LEVEL_THREAD, recordNotice as recordMindNotice } from "./chat/system-events.js";
 import { getSpiritName, readGlobalConfig, writeGlobalConfig } from "./config/setup.js";
 import { readSystemsConfig } from "./config/systems-config.js";
@@ -301,7 +301,7 @@ export async function buildExtensionContext(
       }
     },
     getSystemsConfig: () => readSystemsConfig(),
-    announceToSystem: (text: string) => announceToSystem(text),
+    announceToCommons: (text: string) => announceToCommons(text),
     recordNotice: async (mindName: string, text: string) => {
       try {
         // Gate on the minds registry rather than the users table: the spirit is a

--- a/packages/daemon/src/lib/schema.ts
+++ b/packages/daemon/src/lib/schema.ts
@@ -261,10 +261,19 @@ export const channels = sqliteTable(
     rules: text("rules"),
     char_limit: integer("char_limit"),
     private: integer("private").notNull().default(0),
+    // The commons marker (#819). The default channel — the shared room every mind
+    // and the spirit gather in — is identified by this flag, NOT by its name, so a
+    // house may rename its commons and the daemon still knows which channel is home.
+    is_default: integer("is_default").notNull().default(0),
     created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
     updated_at: text("updated_at").notNull().default(sql`(datetime('now'))`),
   },
-  (table) => [uniqueIndex("idx_channels_name").on(table.name)],
+  (table) => [
+    uniqueIndex("idx_channels_name").on(table.name),
+    // At most one commons per install: a partial unique index over the marker so
+    // the "which channel is home" invariant is enforced by the DB, not by convention.
+    uniqueIndex("idx_channels_default").on(table.is_default).where(sql`is_default = 1`),
+  ],
 );
 
 export const messages = sqliteTable(

--- a/packages/daemon/src/web/api/auth.ts
+++ b/packages/daemon/src/web/api/auth.ts
@@ -23,7 +23,7 @@ import {
   updateUserProfile,
   verifyUser,
 } from "../../lib/auth.js";
-import { joinSystemChannel } from "../../lib/chat/system-channel.js";
+import { joinCommonsChannel } from "../../lib/chat/commons-channel.js";
 import { getDb } from "../../lib/db.js";
 import { broadcast } from "../../lib/events/activity-events.js";
 import {
@@ -54,10 +54,10 @@ async function withExternalFlag<T extends { username: string; user_type: string 
   return list.map((u) => (isMind(u) ? { ...u, external: !local.has(u.username) } : u));
 }
 
-/** Only join system channel when running inside the daemon (not in tests). */
-function tryJoinSystem(userId: number): void {
+/** Only join the commons channel when running inside the daemon (not in tests). */
+function tryJoinCommons(userId: number): void {
   if (!process.env.VOLUTE_DAEMON_TOKEN) return;
-  joinSystemChannel(userId).catch(() => {});
+  joinCommonsChannel(userId).catch(() => {});
 }
 
 import {
@@ -428,8 +428,8 @@ const app = new Hono()
       setCookie(c, "volute_session", sessionId, SESSION_COOKIE_OPTIONS);
     }
 
-    // Auto-join #system channel
-    tryJoinSystem(user.id);
+    // Auto-join the commons channel
+    tryJoinCommons(user.id);
 
     return c.json({ id: user.id, username: user.username, role: user.role });
   })
@@ -444,8 +444,8 @@ const app = new Hono()
     const sessionId = await createSession(user.id);
     setCookie(c, "volute_session", sessionId, SESSION_COOKIE_OPTIONS);
 
-    // Auto-join #system channel
-    tryJoinSystem(user.id);
+    // Auto-join the commons channel
+    tryJoinCommons(user.id);
 
     return c.json({ id: user.id, username: user.username, role: user.role, sessionId });
   })

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -22,9 +22,9 @@ import {
 import { deleteMindUser, getDisplayNames, withSenderDisplayNames } from "../../lib/auth.js";
 import {
   announceSprout,
-  announceToSystem,
-  joinSystemChannelForMind,
-} from "../../lib/chat/system-channel.js";
+  announceToCommons,
+  joinCommonsChannelForMind,
+} from "../../lib/chat/commons-channel.js";
 import {
   drainEvents,
   eventLabel,
@@ -948,12 +948,12 @@ const app = new Hono<AuthEnv>()
         },
       });
 
-      // Announce to #system channel. Fire-and-forget, but surface failures — this is the
-      // primary producer of #system event rows, and announceToSystem propagates DB errors
-      // (ensureSystemChannel/addMessage/getParticipants), so a silent swallow would make the
+      // Announce to the commons channel. Fire-and-forget, but surface failures — this is the
+      // primary producer of commons event rows, and announceToCommons propagates DB errors
+      // (ensureCommonsChannel/addMessage/getParticipants), so a silent swallow would make the
       // join moment vanish without a trace.
-      announceToSystem(`${name} has joined`).catch((err) =>
-        log.warn(`failed to announce ${name} joining #system`, log.errorData(err)),
+      announceToCommons(`${name} has joined`).catch((err) =>
+        log.warn(`failed to announce ${name} joining the commons`, log.errorData(err)),
       );
 
       // Warn (don't block) when the mind will spawn without usable model credentials,
@@ -1858,18 +1858,18 @@ const app = new Hono<AuthEnv>()
     }
     await setMindStage(name, "sprouted");
 
-    // Join the #system commons now. Seeds are deliberately kept out until they
+    // Join the commons now. Seeds are deliberately kept out until they
     // sprout (backfill and the spawn path both exclude stage="seed"), so sprouting
     // is the moment a mind enters the commons. Joining here — rather than relying on
     // the incidental restart that follows — makes membership a direct consequence of
     // sprouting for every caller. Idempotent; fail-soft so a join hiccup can't block
     // the sprout itself.
-    await joinSystemChannelForMind(name).catch((err) =>
-      log.warn(`failed to join #system on sprout for ${name}`, log.errorData(err)),
+    await joinCommonsChannelForMind(name).catch((err) =>
+      log.warn(`failed to join the commons on sprout for ${name}`, log.errorData(err)),
     );
 
     // Make sprouting a visible event (#665): prompt the spirit to hand-write a
-    // welcome in #system, plus a persisted `mind_sprouted` activity event
+    // welcome in the commons, plus a persisted `mind_sprouted` activity event
     // (home-feed card + immediate stage-badge refresh). Fail-soft — see
     // announceSprout.
     await announceSprout(name);

--- a/packages/extensions/pages/src/ambient.ts
+++ b/packages/extensions/pages/src/ambient.ts
@@ -317,7 +317,7 @@ function newPages(db: Database, viewer: string, since: string): Candidate[] {
     .all(since) as { mind: string; file: string; author: string | null; published_at: string }[];
   const out: Candidate[] = [];
   for (const r of rows) {
-    // On the commons the site is `_system`, an address rather than a person, so
+    // On the commons the site is `_commons`, an address rather than a person, so
     // the author column is who actually wrote it.
     const author = r.mind === COMMONS_MIND ? (r.author ?? COMMONS_MIND) : r.mind;
     if (author === viewer) continue;

--- a/packages/extensions/pages/src/cache.ts
+++ b/packages/extensions/pages/src/cache.ts
@@ -36,7 +36,7 @@ export function getSites(db: Database): { sites: Site[]; systemSite: Site | null
 
   const system = getSystemPages(db);
   const systemSite = system
-    ? { name: "_system", label: "Shared Pages", pages: mapFiles("_system", system.files) }
+    ? { name: "_commons", label: "Shared Pages", pages: mapFiles("_commons", system.files) }
     : null;
 
   return { sites, systemSite };

--- a/packages/extensions/pages/src/commands.ts
+++ b/packages/extensions/pages/src/commands.ts
@@ -101,7 +101,9 @@ async function writeResponsePage(
 /** Read a published page's body from the served snapshot. */
 function readPageBody(ctx: ExtensionContext, ref: PageRef): string | null {
   const root =
-    ref.mind === "_system" ? resolve(ctx.dataDir, "repo") : resolve(ctx.dataDir, "sites", ref.mind);
+    ref.mind === "_commons"
+      ? resolve(ctx.dataDir, "repo")
+      : resolve(ctx.dataDir, "sites", ref.mind);
   const target = resolve(root, ref.file);
   if (target !== root && !target.startsWith(root + sep)) return null;
   try {
@@ -156,7 +158,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
             bodyHtml: body.slice(0, 500),
           },
         });
-        await ctx.announceToSystem(
+        await ctx.announceToCommons(
           `${mindName} published a page: "${title}" — volute pages read ${ref}`,
         );
 
@@ -199,7 +201,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
       args: [{ name: "ref", required: true, description: "Page reference (<mind>/<file>)" }],
       examples: [
         "volute pages read mimsy/notes/the-tideline.md",
-        "volute pages read _system/index.md",
+        "volute pages read _commons/index.md",
       ],
       handler: async ({ args }, ctx) => {
         const db = ctx.db;
@@ -519,14 +521,14 @@ export function createCommands(): Record<string, ExtensionCommand> {
                     await addComment(
                       ctx.db,
                       ctx.getUser,
-                      { mind: "_system", file },
+                      { mind: "_commons", file },
                       author.id,
                       message,
                       { kind: "publish" },
                     );
                   } catch (err) {
                     console.warn(
-                      `[pages] failed to record publish message on _system/${file}: ${(err as Error).message}`,
+                      `[pages] failed to record publish message on _commons/${file}: ${(err as Error).message}`,
                     );
                   }
                 }
@@ -537,7 +539,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
                 if (pageFiles.length > 0) {
                   await notifyMentionedInComment(message, ctx, {
                     actor: mindName,
-                    ref: { mind: "_system", file: pageFiles[0] },
+                    ref: { mind: "_commons", file: pageFiles[0] },
                     where: `the commons (${pageFiles.join(", ")})`,
                   });
                 }
@@ -554,12 +556,12 @@ export function createCommands(): Record<string, ExtensionCommand> {
                   shared: true,
                   files,
                   message,
-                  ...(pageFile ? { iframeUrl: `/ext/pages/public/_system/${pageFile}` } : {}),
+                  ...(pageFile ? { iframeUrl: `/ext/pages/public/_commons/${pageFile}` } : {}),
                 },
               });
 
               try {
-                await ctx.announceToSystem(
+                await ctx.announceToCommons(
                   `${mindName} tended the commons: ${fileList} — "${message}"`,
                 );
 
@@ -671,9 +673,9 @@ export function createCommands(): Record<string, ExtensionCommand> {
 
           if (system) {
             for (const f of system.files) {
-              const url = `http://localhost:${port}/ext/pages/public/_system/${f.file}`;
+              const url = `http://localhost:${port}/ext/pages/public/_commons/${f.file}`;
               const author = f.author ? ` (${f.author})` : "";
-              lines.push(`_system${author.padStart(10)} ${f.file.padEnd(25)} ${url}`);
+              lines.push(`_commons${author.padStart(10)} ${f.file.padEnd(25)} ${url}`);
             }
           }
           for (const site of sites) {

--- a/packages/extensions/pages/src/db.ts
+++ b/packages/extensions/pages/src/db.ts
@@ -238,6 +238,38 @@ export function initDb(db: Database): void {
     "body_mind TEXT",
     "body_file TEXT",
   ]);
+  migrateCommonsMind(db);
+}
+
+/**
+ * #819: the commons pages identity moved `_system` → `_commons`. Rewrite every
+ * persisted reference in place (data-preserving — the page files themselves live
+ * in the git repo and are untouched here). The social tables key on `(mind, file)`
+ * matching `published_pages`, so all of them must move together or the commons'
+ * comments, reactions, reads, citations and links would orphan. `ambient_shown`
+ * keys pages by a `mind/file` ref, so its commons rows get their prefix rewritten
+ * too (otherwise a commons page a mind already met would resurface once).
+ *
+ * Forward-idempotent: keyed on the exact old value, so it can never touch a real
+ * mind, and it is a no-op once no `_system` rows remain. Wrapped so a failure logs
+ * rather than taking down extension init.
+ */
+function migrateCommonsMind(db: Database): void {
+  try {
+    db.exec(`
+      UPDATE published_pages SET mind = '_commons' WHERE mind = '_system';
+      UPDATE page_comments   SET mind = '_commons' WHERE mind = '_system';
+      UPDATE page_comments   SET body_mind = '_commons' WHERE body_mind = '_system';
+      UPDATE page_reactions  SET mind = '_commons' WHERE mind = '_system';
+      UPDATE page_citations  SET mind = '_commons' WHERE mind = '_system';
+      UPDATE page_reads      SET mind = '_commons' WHERE mind = '_system';
+      UPDATE page_links      SET mind = '_commons' WHERE mind = '_system';
+      UPDATE ambient_shown   SET ref = '_commons/' || substr(ref, length('_system/') + 1)
+        WHERE ref LIKE '_system/%';
+    `);
+  } catch (err) {
+    console.error(`[pages] commons _system → _commons migration failed: ${(err as Error).message}`);
+  }
 }
 
 function addColumns(db: Database, table: string, columns: string[]): void {
@@ -330,13 +362,13 @@ export function getRecentPages(
 }
 
 export function getAllSites(db: Database): SiteEntry[] {
-  // Exclude _system pages — those are shown separately. Order globally by
+  // Exclude _commons pages — those are shown separately. Order globally by
   // recency (id breaks same-second ties) so the first row seen for each mind is
   // its most-recent page — that gives us sites ranked by recent activity.
   const rows = db
     .prepare(
       `SELECT mind, file, updated_at, author FROM published_pages
-       WHERE mind != '_system' AND deleted_at IS NULL ORDER BY updated_at DESC, id DESC`,
+       WHERE mind != '_commons' AND deleted_at IS NULL ORDER BY updated_at DESC, id DESC`,
     )
     .all() as RecentPage[];
 
@@ -361,25 +393,25 @@ export function getSystemPages(db: Database): SiteEntry | null {
   const rows = db
     .prepare(
       `SELECT mind, file, updated_at, author FROM published_pages
-       WHERE mind = '_system' AND deleted_at IS NULL ORDER BY updated_at DESC, id DESC`,
+       WHERE mind = '_commons' AND deleted_at IS NULL ORDER BY updated_at DESC, id DESC`,
     )
     .all() as RecentPage[];
   if (rows.length === 0) return null;
   return {
-    mind: "_system",
+    mind: "_commons",
     files: sortSiteFiles(
       rows.map((r) => ({ file: r.file, updated_at: r.updated_at, author: r.author })),
     ),
   };
 }
 
-/** Minds (excluding _system) that have at least one published page. */
+/** Minds (excluding _commons) that have at least one published page. */
 export function getMindsWithSites(db: Database): string[] {
   return (
     db
       .prepare(
         `SELECT DISTINCT mind FROM published_pages
-         WHERE mind != '_system' AND deleted_at IS NULL ORDER BY mind`,
+         WHERE mind != '_commons' AND deleted_at IS NULL ORDER BY mind`,
       )
       .all() as { mind: string }[]
   ).map((r) => r.mind);
@@ -554,9 +586,9 @@ export function citationsOf(db: Database, mentioned: string): Citation[] {
 }
 
 export function syncSystemPages(db: Database, pages: PageInput[], author?: string): void {
-  const existing = existingPages(db, "_system");
+  const existing = existingPages(db, "_commons");
   const newSet = new Set(pages.map((p) => p.file));
-  const threaded = pagesWithThreads(db, "_system");
+  const threaded = pagesWithThreads(db, "_commons");
 
   db.exec("BEGIN");
   try {
@@ -565,7 +597,7 @@ export function syncSystemPages(db: Database, pages: PageInput[], author?: strin
       const prior = existing.get(file);
       if (!prior) {
         db.prepare(
-          "INSERT INTO published_pages (mind, file, hash, author) VALUES ('_system', ?, ?, ?)",
+          "INSERT INTO published_pages (mind, file, hash, author) VALUES ('_commons', ?, ?, ?)",
         ).run(file, hash, author ?? null);
       } else if (prior.deleted_at != null) {
         // Republished over a tombstone: revive the identity so the surviving
@@ -574,26 +606,26 @@ export function syncSystemPages(db: Database, pages: PageInput[], author?: strin
           `UPDATE published_pages
            SET deleted_at = NULL, updated_at = datetime('now'), hash = ?,
                author = COALESCE(?, author)
-           WHERE mind = '_system' AND file = ?`,
+           WHERE mind = '_commons' AND file = ?`,
         ).run(hash, author ?? null, file);
       } else if (prior.hash !== hash) {
         // Only touch files whose content actually changed — unchanged files
         // keep their updated_at and author (the publisher didn't author them).
         if (author) {
           db.prepare(
-            "UPDATE published_pages SET updated_at = datetime('now'), hash = ?, author = ? WHERE mind = '_system' AND file = ?",
+            "UPDATE published_pages SET updated_at = datetime('now'), hash = ?, author = ? WHERE mind = '_commons' AND file = ?",
           ).run(hash, author, file);
         } else {
           db.prepare(
-            "UPDATE published_pages SET updated_at = datetime('now'), hash = ? WHERE mind = '_system' AND file = ?",
+            "UPDATE published_pages SET updated_at = datetime('now'), hash = ? WHERE mind = '_commons' AND file = ?",
           ).run(hash, file);
         }
       }
-      applyPageMeta(db, "_system", page);
+      applyPageMeta(db, "_commons", page);
     }
     for (const [file, prior] of existing) {
       if (!newSet.has(file) && prior.deleted_at == null) {
-        retirePage(db, "_system", file, threaded.has(file));
+        retirePage(db, "_commons", file, threaded.has(file));
       }
     }
     db.exec("COMMIT");

--- a/packages/extensions/pages/src/routes.ts
+++ b/packages/extensions/pages/src/routes.ts
@@ -93,7 +93,7 @@ export function createRoutes(ctx: ExtensionContext): Hono {
         const recentPages = getRecentPagesList(ctx.db, { mind: mind || undefined, limit });
         return c.json(
           recentPages.map((p) => {
-            const isCommons = p.mind === "_system";
+            const isCommons = p.mind === "_commons";
             return {
               id: `page-${p.mind}-${p.file}`,
               title: isCommons ? `commons — ${p.file}` : `${p.mind}/${p.file}`,
@@ -357,7 +357,7 @@ export function createPublicRoutes(ctx: ExtensionContext): Hono {
 
       let pagesRoot: string;
       let blockDotfiles = false;
-      if (name === "_system") {
+      if (name === "_commons") {
         // Serve from the pages repo root (main branch checked out here).
         // Block dotfiles since .git/ is present in this directory.
         pagesRoot = resolve(ctx.dataDir, "repo");

--- a/packages/extensions/pages/src/social.ts
+++ b/packages/extensions/pages/src/social.ts
@@ -15,7 +15,7 @@ import { resolveMentions } from "./mentions.js";
 export type PageRef = { mind: string; file: string };
 
 /** The commons: an address rather than a mind, and so nobody's own work. */
-export const COMMONS_MIND = "_system";
+export const COMMONS_MIND = "_commons";
 
 /**
  * What a comment is. A `comment` is a response someone chose to make; a `publish`
@@ -71,7 +71,7 @@ export type PageReaction = { emoji: string; count: number; usernames: string[] }
  * lets a read *land* on somebody, which is what makes reading a complete act
  * rather than telemetry.
  *
- * The commons (`_system`) is the one exception, and it is not really an
+ * The commons (`_commons`) is the one exception, and it is not really an
  * exception: it belongs to everyone, so everyone is its author. Its presence is
  * public — but as a count only, since no one mind wrote the page for a name to be
  * *for*, and since a shared shelf ranks nobody against anybody.
@@ -105,7 +105,7 @@ export type PagePresence = {
  * never learns how often anyone comes back.
  *
  * The author reading their own page is not recorded — they know they were there,
- * and counting it would make the number mean nothing. `_system` is the commons
+ * and counting it would make the number mean nothing. `_commons` is the commons
  * rather than a person, so it has no author to exclude.
  *
  * Returns whether this was a first open, which callers use only to decide what to
@@ -310,7 +310,7 @@ type CommentRow = {
  * - **A page you don't own.** The whole point of the pointer is that a response
  *   also lives in *your* space and counts as your work. Pointing at someone
  *   else's page would make a comment that credits you for their writing.
- * - **A commons page.** `_system` is tended by everyone, so it is nobody's own
+ * - **A commons page.** `_commons` is tended by everyone, so it is nobody's own
  *   work in the sense that matters here.
  * - **A page that isn't there**, including a tombstone — a thread should never
  *   point at a gravestone as if it were a reply.
@@ -357,7 +357,7 @@ export function resolveAttachedPage(
   if (parsed && parsed.mind !== owner) {
     return {
       error:
-        parsed.mind === "_system"
+        parsed.mind === "_commons"
           ? "A commons page belongs to everyone, so it can't stand as your own response. Attach a page from your own site."
           : `${parsed.mind}/${parsed.file} isn't yours — a response should live in your own space. Attach one of your pages.`,
     };
@@ -593,7 +593,7 @@ export async function getThread(
 }
 
 /**
- * `_system` is the commons: an address, not a mind. Notices aimed at it reach
+ * `_commons` is the commons: an address, not a mind. Notices aimed at it reach
  * nobody, so every directed path checks here before spending one.
  */
 export function isNotifiable(name: string): boolean {

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -72,7 +72,8 @@ export type ExtensionContext = {
    */
   listMinds: () => Promise<ExtensionMind[]>;
   getSystemsConfig: () => SystemsConfig | null;
-  announceToSystem: (text: string) => Promise<void>;
+  /** Post a sender-less automated announcement to the commons (default) channel. */
+  announceToCommons: (text: string) => Promise<void>;
   /**
    * Queue an ambient, non-interrupting notification for a mind, delivered as context
    * on the mind's next turn (via the notices system). No-op if the target isn't a

--- a/test/commons-channel.test.ts
+++ b/test/commons-channel.test.ts
@@ -6,21 +6,23 @@ import { and, eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import {
   announceSprout,
-  announceToSystem,
-  backfillSystemChannelMembers,
-  ensureSystemChannel,
-  joinSystemChannel,
-  joinSystemChannelForMind,
-  joinSystemChannelForSpirit,
-  resetSystemChannelCache,
-} from "../packages/daemon/src/lib/chat/system-channel.js";
+  announceToCommons,
+  backfillCommonsChannelMembers,
+  ensureCommonsChannel,
+  joinCommonsChannel,
+  joinCommonsChannelForMind,
+  joinCommonsChannelForSpirit,
+  resetCommonsChannelCache,
+} from "../packages/daemon/src/lib/chat/commons-channel.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { clearConfigCache } from "../packages/daemon/src/lib/delivery/delivery-router.js";
 import {
   createChannel,
   deleteConversation,
   getChannelSettings,
+  getDefaultChannelRow,
   getParticipants,
+  markChannelDefault,
 } from "../packages/daemon/src/lib/events/conversations.js";
 import {
   addMind,
@@ -30,6 +32,7 @@ import {
 } from "../packages/daemon/src/lib/mind/registry.js";
 import {
   activity,
+  channels,
   messages,
   mindHistory,
   systemEvents,
@@ -55,7 +58,7 @@ const TEST_MINDS = [
   "commons-sprout",
 ];
 
-/** Write a routes.json for a test mind so its #system routing decision is deterministic. */
+/** Write a routes.json for a test mind so its commons routing decision is deterministic. */
 function writeCommonsRoutes(name: string, config: object): void {
   const configDir = resolve(process.env.VOLUTE_HOME!, "minds", name, "home/.config");
   mkdirSync(configDir, { recursive: true });
@@ -64,7 +67,7 @@ function writeCommonsRoutes(name: string, config: object): void {
 }
 
 async function cleanup() {
-  resetSystemChannelCache();
+  resetCommonsChannelCache();
   clearConfigCache();
   const db = await getDb();
   for (const username of TEST_USERNAMES) {
@@ -76,76 +79,110 @@ async function cleanup() {
     await db.delete(systemEvents).where(eq(systemEvents.mind, mind));
     await removeMind(mind);
   }
-  // Remove the #system channel so each test exercises fresh creation
-  const ch = await getChannelSettings("system");
-  if (ch) await deleteConversation(ch.conversation_id);
+  // Remove every channel so each test exercises fresh creation / resolution.
+  for (const ch of await db.select().from(channels).all()) {
+    await deleteConversation(ch.conversation_id);
+  }
 }
 
-describe("system channel", () => {
+describe("commons channel", () => {
   beforeEach(cleanup);
   afterEach(cleanup);
 
-  it("ensureSystemChannel creates channel on first call", async () => {
-    const id = await ensureSystemChannel();
+  it("ensureCommonsChannel creates channel on first call", async () => {
+    const id = await ensureCommonsChannel();
     assert.ok(id, "should return a conversation ID");
   });
 
-  it("ensureSystemChannel is idempotent", async () => {
-    const id1 = await ensureSystemChannel();
-    const id2 = await ensureSystemChannel();
+  it("ensureCommonsChannel is idempotent", async () => {
+    const id1 = await ensureCommonsChannel();
+    const id2 = await ensureCommonsChannel();
     assert.equal(id1, id2, "should return the same conversation ID");
   });
 
-  it("ensureSystemChannel sets a default description", async () => {
-    await ensureSystemChannel();
-    const settings = await getChannelSettings("system");
-    assert.ok(settings?.description?.includes("commons"), "should describe the shared room");
+  it("a fresh install's commons is named #commons and carries the default marker", async () => {
+    await ensureCommonsChannel();
+    const row = await getDefaultChannelRow();
+    assert.ok(row, "the default channel should be resolvable by its marker");
+    assert.equal(row!.name, "commons", "new installs get a channel named 'commons'");
+    assert.equal(row!.is_default, 1, "and it is marked default");
   });
 
-  it("ensureSystemChannel fills in the description for a pre-existing bare channel", async () => {
-    await createChannel("system"); // legacy channel, no description
-    await ensureSystemChannel();
+  it("resolves the default channel by marker, not by name — a renamed house keeps its commons", async () => {
+    // A house that renamed its commons long ago: a channel named "town-square",
+    // carrying the default marker. ensureCommonsChannel must resolve THIS, never go
+    // hunting for a channel literally named "commons" (which would strand the real
+    // commons and spin up a duplicate). This is the guard against the default
+    // reverting to a name-based lookup.
+    const legacy = await createChannel("town-square");
+    await markChannelDefault(legacy.id);
+    resetCommonsChannelCache();
+
+    const id = await ensureCommonsChannel();
+    assert.equal(id, legacy.id, "must resolve the marked channel regardless of its name");
+
+    const db = await getDb();
+    const chans = await db.select().from(channels).all();
+    assert.equal(chans.length, 1, "must not create a second channel");
+    assert.equal(chans[0].name, "town-square", "the earned name is left untouched");
+  });
+
+  it("ensureCommonsChannel sets a default description", async () => {
+    await ensureCommonsChannel();
+    const row = await getDefaultChannelRow();
+    assert.ok(row?.description?.includes("commons"), "should describe the shared room");
+  });
+
+  it("ensureCommonsChannel fills in the description for a pre-existing bare default channel", async () => {
+    // A legacy default channel (any name) with no description — the migration backfills
+    // the marker; ensureCommonsChannel then backfills the description.
+    const legacy = await createChannel("system"); // legacy name, no description
+    await markChannelDefault(legacy.id);
+    resetCommonsChannelCache();
+    await ensureCommonsChannel();
     const settings = await getChannelSettings("system");
     assert.ok(settings?.description?.includes("commons"), "should backfill the description");
   });
 
-  it("ensureSystemChannel never clobbers a host-set description", async () => {
-    await createChannel("system", undefined, { description: "our house rules" });
-    await ensureSystemChannel();
+  it("ensureCommonsChannel never clobbers a host-set description", async () => {
+    const legacy = await createChannel("system", undefined, { description: "our house rules" });
+    await markChannelDefault(legacy.id);
+    resetCommonsChannelCache();
+    await ensureCommonsChannel();
     const settings = await getChannelSettings("system");
     assert.equal(settings?.description, "our house rules");
   });
 
-  it("joinSystemChannel adds user to channel", async () => {
+  it("joinCommonsChannel adds user to channel", async () => {
     const user = await createUser("testbrain", "pass123");
-    await joinSystemChannel(user.id);
+    await joinCommonsChannel(user.id);
     // Joining again should be idempotent
-    await joinSystemChannel(user.id);
-    const id = await ensureSystemChannel();
+    await joinCommonsChannel(user.id);
+    const id = await ensureCommonsChannel();
     const participants = await getParticipants(id);
     const joined = participants.filter((p) => p.username === "testbrain");
     assert.equal(joined.length, 1, "user should be a participant exactly once");
   });
 
-  it("joinSystemChannelForSpirit adds the system user as a participant", async () => {
-    await joinSystemChannelForSpirit();
-    const id = await ensureSystemChannel();
+  it("joinCommonsChannelForSpirit adds the system user as a participant", async () => {
+    await joinCommonsChannelForSpirit();
+    const id = await ensureCommonsChannel();
     const participants = await getParticipants(id);
     const spirit = participants.find((p) => p.username === "volute");
     assert.ok(spirit, "spirit should be a participant");
     assert.equal(spirit.userType, "spirit", "spirit should be the system user, not a mind user");
   });
 
-  it("backfillSystemChannelMembers joins sprouted minds and spirits, skips seeds and variants", async () => {
+  it("backfillCommonsChannelMembers joins sprouted minds and spirits, skips seeds and variants", async () => {
     await addMind("commons-mind", 4901, "sprouted");
     await addMind("commons-seed", 4902, "seed");
     await addMind("commons-legacy", 4903); // pre-stage-field mind: stage null → sprouted
     await addSpirit("volute", 4904, "claude", "/tmp/spirit");
     await addVariant("commons-mind-v1", "commons-mind", 4905, "/tmp/variant", "variant-branch");
 
-    await backfillSystemChannelMembers();
+    await backfillCommonsChannelMembers();
 
-    const id = await ensureSystemChannel();
+    const id = await ensureCommonsChannel();
     const participants = await getParticipants(id);
     const names = participants.map((p) => p.username);
     assert.ok(names.includes("commons-mind"), "sprouted mind should be joined");
@@ -157,33 +194,33 @@ describe("system channel", () => {
     assert.equal(spirit?.userType, "spirit", "spirit joins as the system user");
   });
 
-  it("backfillSystemChannelMembers is idempotent", async () => {
+  it("backfillCommonsChannelMembers is idempotent", async () => {
     await addMind("commons-mind", 4901, "sprouted");
-    await backfillSystemChannelMembers();
-    await backfillSystemChannelMembers();
-    const id = await ensureSystemChannel();
+    await backfillCommonsChannelMembers();
+    await backfillCommonsChannelMembers();
+    const id = await ensureCommonsChannel();
     const participants = await getParticipants(id);
     const joined = participants.filter((p) => p.username === "commons-mind");
     assert.equal(joined.length, 1, "mind should be a participant exactly once");
   });
 
-  it("backfillSystemChannelMembers keeps going when one entry fails", async () => {
+  it("backfillCommonsChannelMembers keeps going when one entry fails", async () => {
     // A brain user squatting on a mind's name makes getOrCreateMindUser throw
     await createUser("commons-clash", "pass123");
     await addMind("commons-clash", 4901, "sprouted");
     await addMind("commons-mind", 4902, "sprouted");
 
-    await backfillSystemChannelMembers(); // must not throw
+    await backfillCommonsChannelMembers(); // must not throw
 
-    const id = await ensureSystemChannel();
+    const id = await ensureCommonsChannel();
     const participants = await getParticipants(id);
     const names = participants.map((p) => p.username);
     assert.ok(names.includes("commons-mind"), "later entries should still be joined");
     assert.ok(!names.includes("commons-clash"), "failed entry should not be joined");
   });
 
-  it("announceToSystem posts a sender-less event row, never the spirit's voice (#687)", async () => {
-    await announceToSystem("test announcement");
+  it("announceToCommons posts a sender-less event row, never the spirit's voice (#687)", async () => {
+    await announceToCommons("test announcement");
     const db = await getDb();
     const msgs = await db.select().from(messages).all();
     const found = msgs.find((m) => m.content.includes("test announcement"));
@@ -196,16 +233,16 @@ describe("system channel", () => {
     );
   });
 
-  it("announceToSystem delivers to mind participants sender-less on the channel path (#687)", async () => {
+  it("announceToCommons delivers to mind participants sender-less on the channel path (#687)", async () => {
     await addMind("commons-mind", 4901, "sprouted");
-    await joinSystemChannelForMind("commons-mind");
+    await joinCommonsChannelForMind("commons-mind");
     // Disable gating so the (dead-port) delivery still records the inbound: the mind never acks,
     // but recordInbound runs first on the normal channel path and captures the delivered shape.
     writeCommonsRoutes("commons-mind", { gateUnmatched: false });
 
-    await announceToSystem("atlas has joined");
+    await announceToCommons("atlas has joined");
 
-    // Delivery is fire-and-forget inside announceToSystem, so poll for the recorded inbound.
+    // Delivery is fire-and-forget inside announceToCommons, so poll for the recorded inbound.
     const db = await getDb();
     let row: { sender: string | null; channel: string | null } | undefined;
     for (let i = 0; i < 50 && !row; i++) {
@@ -221,8 +258,8 @@ describe("system channel", () => {
     assert.equal(row!.sender, null, "delivery must be sender-less — never the spirit");
     assert.equal(
       row!.channel,
-      "#system",
-      "delivered on the #system channel, following its routing",
+      "#commons",
+      "delivered on the #commons channel, following its routing",
     );
 
     // And it must NOT go out as a system event any more — announcements are channel messages.
@@ -234,6 +271,33 @@ describe("system channel", () => {
     assert.equal(events.length, 0, "announcements are channel messages, not system events");
   });
 
+  it("announceToCommons follows a renamed default channel's slug", async () => {
+    // A house kept a proper name on its commons. The delivered routing slug must
+    // track that name, not a hardcoded "#commons".
+    const legacy = await createChannel("system");
+    await markChannelDefault(legacy.id);
+    resetCommonsChannelCache();
+    await addMind("commons-mind", 4901, "sprouted");
+    await joinCommonsChannelForMind("commons-mind");
+    writeCommonsRoutes("commons-mind", { gateUnmatched: false });
+
+    await announceToCommons("atlas has joined");
+
+    const db = await getDb();
+    let row: { channel: string | null } | undefined;
+    for (let i = 0; i < 50 && !row; i++) {
+      const inbound = await db
+        .select()
+        .from(mindHistory)
+        .where(and(eq(mindHistory.mind, "commons-mind"), eq(mindHistory.type, "inbound")))
+        .all();
+      row = inbound.find((r) => (r as { content: string | null }).content?.includes("atlas"));
+      if (!row) await new Promise((res) => setTimeout(res, 20));
+    }
+    assert.ok(row, "delivered to the mind");
+    assert.equal(row!.channel, "#system", "routing slug follows the channel's actual name");
+  });
+
   // Register the spirit (dead port — the event stays pending, which is fine: the
   // prompt is a durable system event redelivered on the spirit's next start).
   async function registerSpirit(): Promise<void> {
@@ -241,7 +305,7 @@ describe("system channel", () => {
   }
 
   it("announceSprout prompts the spirit to write the welcome and records a mind_sprouted activity", async () => {
-    // The spirit hand-writes the #system welcome (#665); the daemon only sends
+    // The spirit hand-writes the commons welcome (#665); the daemon only sends
     // it a prompt — now a lifecycle system event, not a DM.
     await registerSpirit();
 
@@ -255,7 +319,7 @@ describe("system channel", () => {
       .all();
     const prompt = events.find((e) => e.body.includes("@commons-sprout"));
     assert.ok(prompt, "spirit should receive an event prompting it to welcome the sprouted mind");
-    assert.ok(prompt!.body.includes("#system"), "prompt should point the spirit at #system");
+    assert.ok(prompt!.body.includes("#commons"), "prompt should point the spirit at the commons");
     assert.equal(prompt!.type, "lifecycle");
 
     // No canned message is posted anywhere — the spirit composes its own.
@@ -281,7 +345,7 @@ describe("system channel", () => {
   });
 
   it("announceSprout uses the mind's display name when set", async () => {
-    // The real sprout flow joins the mind to #system (creating its user row)
+    // The real sprout flow joins the mind to the commons (creating its user row)
     // before announcing, so the display-name branch is the production path.
     const db = await getDb();
     await db.insert(users).values({

--- a/test/intentions-spirit-schedule.test.ts
+++ b/test/intentions-spirit-schedule.test.ts
@@ -26,7 +26,7 @@ function makeCtx(overrides: {
     publishActivity: () => {},
     getMindDir: overrides.getMindDir,
     getSystemsConfig: () => null,
-    announceToSystem: async () => {},
+    announceToCommons: async () => {},
     recordNotice: async () => {},
     isIsolationEnabled: () => false,
     getMindUser: (name: string) => `mind-${name}`,

--- a/test/orientation.test.ts
+++ b/test/orientation.test.ts
@@ -5,9 +5,9 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import {
-  ensureSystemChannel,
-  resetSystemChannelCache,
-} from "../packages/daemon/src/lib/chat/system-channel.js";
+  ensureCommonsChannel,
+  resetCommonsChannelCache,
+} from "../packages/daemon/src/lib/chat/commons-channel.js";
 import {
   initMindManager,
   tryGetMindManager,
@@ -16,7 +16,7 @@ import { startMindFull } from "../packages/daemon/src/lib/daemon/mind-service.js
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import {
   deleteConversation,
-  getChannelSettings,
+  getDefaultChannelRow,
   getParticipants,
 } from "../packages/daemon/src/lib/events/conversations.js";
 import {
@@ -30,16 +30,16 @@ import {
 import { users } from "../packages/daemon/src/lib/schema.js";
 import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
-/** Usernames present in the #system channel, for membership assertions. */
-async function systemChannelMembers(): Promise<string[]> {
-  const id = await ensureSystemChannel();
+/** Usernames present in the commons channel, for membership assertions. */
+async function commonsChannelMembers(): Promise<string[]> {
+  const id = await ensureCommonsChannel();
   return (await getParticipants(id)).map((p) => p.username);
 }
 
-/** Remove the #system channel so each test exercises fresh membership. */
-async function resetSystemChannel(): Promise<void> {
-  resetSystemChannelCache();
-  const ch = await getChannelSettings("system");
+/** Remove the commons channel so each test exercises fresh membership. */
+async function resetCommonsChannel(): Promise<void> {
+  resetCommonsChannelCache();
+  const ch = await getDefaultChannelRow();
   if (ch) await deleteConversation(ch.conversation_id);
 }
 
@@ -197,7 +197,7 @@ describe("seed gating", () => {
   });
 });
 
-// #617: seeds must stay out of the #system commons until they sprout. The spawn
+// #617: seeds must stay out of the commons until they sprout. The spawn
 // path (startMindFull) excludes seeds; the sprout endpoint is the moment a mind
 // joins. These lock both halves of that invariant.
 describe("system commons sprout gate", () => {
@@ -209,7 +209,7 @@ describe("system commons sprout gate", () => {
     await db.delete(users).where(eq(users.username, "commons-gate-admin"));
     await db.delete(users).where(eq(users.username, mindName));
     await removeMind(mindName);
-    await resetSystemChannel();
+    await resetCommonsChannel();
   }
 
   beforeEach(async () => {
@@ -219,7 +219,7 @@ describe("system commons sprout gate", () => {
   });
   afterEach(cleanup);
 
-  it("startMindFull does not join a seed to #system", async () => {
+  it("startMindFull does not join a seed to the commons", async () => {
     // Stub the mind manager so startMind is a no-op — we exercise startMindFull's
     // membership logic, not a real process spawn.
     const mgr = tryGetMindManager() ?? initMindManager();
@@ -232,15 +232,15 @@ describe("system commons sprout gate", () => {
       await startMindFull(mindName);
       // let fire-and-forget seed orientation settle before asserting
       await new Promise((r) => setTimeout(r, 300));
-      const members = await systemChannelMembers();
-      assert.ok(!members.includes(mindName), "seed must not be a #system member on spawn");
+      const members = await commonsChannelMembers();
+      assert.ok(!members.includes(mindName), "seed must not be a commons member on spawn");
     } finally {
       mgr.startMind = origStart;
       mgr.isRunning = origRunning;
     }
   });
 
-  it("sprouting joins the mind to #system", async () => {
+  it("sprouting joins the mind to the commons", async () => {
     await addMind(mindName, 4198, "seed");
     // Minimal mind dir so the sprout endpoint's dreaming/config steps have a home
     const dir = resolve(voluteHome(), "minds", mindName);
@@ -248,8 +248,8 @@ describe("system commons sprout gate", () => {
     writeFileSync(resolve(dir, "home/.config/volute.json"), "{}");
 
     // Not in the commons while still a seed
-    let members = await systemChannelMembers();
-    assert.ok(!members.includes(mindName), "seed should not be in #system before sprout");
+    let members = await commonsChannelMembers();
+    assert.ok(!members.includes(mindName), "seed should not be in the commons before sprout");
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const res = await app.request(`http://localhost/api/minds/${mindName}/sprout`, {
@@ -258,7 +258,7 @@ describe("system commons sprout gate", () => {
     });
     assert.equal(res.status, 200);
 
-    members = await systemChannelMembers();
-    assert.ok(members.includes(mindName), "sprouted mind should join #system");
+    members = await commonsChannelMembers();
+    assert.ok(members.includes(mindName), "sprouted mind should join the commons");
   });
 });

--- a/test/pages-ambient.test.ts
+++ b/test/pages-ambient.test.ts
@@ -254,13 +254,13 @@ describe("a first front page reads as an arrival", () => {
 
   it("the commons front page is the house's, not an arrival", async () => {
     horizonAt("pip", ago(2 * DAY));
-    // A _system index carries a real author; it is still not one mind arriving.
+    // A _commons index carries a real author; it is still not one mind arriving.
     // (Its plain readable name is "the front page", so what marks an arrival is
     // the "put up their front page" phrasing, not the words "front page".)
-    publish("_system", "index.md", ago(1 * DAY), "whorl");
+    publish("_commons", "index.md", ago(1 * DAY), "whorl");
     const out = await ambientTurnContext("pip", ctx(), turn, NOW);
     assert.doesNotMatch(out ?? "", /put up their front page/);
-    assert.match(out ?? "", /whorl published "the front page" — _system\/index\.md\./);
+    assert.match(out ?? "", /whorl published "the front page" — _commons\/index\.md\./);
   });
 });
 

--- a/test/pages-commands.test.ts
+++ b/test/pages-commands.test.ts
@@ -154,14 +154,14 @@ describe("pages db", () => {
     assert.equal(pages[0].mind, "mind1");
   });
 
-  it("syncSystemPages syncs _system entries", () => {
+  it("syncSystemPages syncs _commons entries", () => {
     syncSystemPages(db, ph("index.html", "about.html"));
-    const pages = getPublishedPages(db, "_system");
+    const pages = getPublishedPages(db, "_commons");
     assert.equal(pages.length, 2);
 
     // Removes deleted files, keeps existing
     syncSystemPages(db, ph("index.html"));
-    const after = getPublishedPages(db, "_system");
+    const after = getPublishedPages(db, "_commons");
     assert.equal(after.length, 1);
     assert.equal(after[0].file, "index.html");
   });
@@ -199,7 +199,7 @@ describe("pages db", () => {
     assert.equal(sites[0].files[1].file, "about.html");
   });
 
-  it("getAllSites excludes _system pages", () => {
+  it("getAllSites excludes _commons pages", () => {
     syncPublishedPages(db, "mind1", ph("index.html"));
     syncSystemPages(db, ph("shared.html"));
 
@@ -210,14 +210,14 @@ describe("pages db", () => {
 
   it("syncSystemPages stores author", () => {
     syncSystemPages(db, ph("index.html"), "alice");
-    const pages = getPublishedPages(db, "_system");
+    const pages = getPublishedPages(db, "_commons");
     assert.equal(pages[0].author, "alice");
   });
 
   it("syncSystemPages updates author when content changes", () => {
     syncSystemPages(db, ph("index.html"), "alice");
     syncSystemPages(db, [{ file: "index.html", hash: "changed" }], "bob");
-    const pages = getPublishedPages(db, "_system");
+    const pages = getPublishedPages(db, "_commons");
     assert.equal(pages[0].author, "bob");
   });
 
@@ -235,7 +235,7 @@ describe("pages db", () => {
       "bob",
     );
 
-    const pages = getPublishedPages(db, "_system");
+    const pages = getPublishedPages(db, "_commons");
     const index = pages.find((p) => p.file === "index.html");
     const about = pages.find((p) => p.file === "about.html");
     assert.equal(index?.author, "alice");
@@ -247,7 +247,7 @@ describe("pages db", () => {
   it("syncSystemPages preserves author when not provided", () => {
     syncSystemPages(db, ph("index.html"), "alice");
     syncSystemPages(db, [{ file: "index.html", hash: "changed" }]);
-    const pages = getPublishedPages(db, "_system");
+    const pages = getPublishedPages(db, "_commons");
     assert.equal(pages[0].author, "alice");
   });
 
@@ -261,12 +261,12 @@ describe("pages db", () => {
     syncSystemPages(db, ph("index.html", "about.html"), "alice");
     // ...and make about.html strictly newer, so recency alone would rank it first.
     db.prepare(
-      "UPDATE published_pages SET updated_at = '2999-01-01 00:00:00' WHERE mind = '_system' AND file = 'about.html'",
+      "UPDATE published_pages SET updated_at = '2999-01-01 00:00:00' WHERE mind = '_commons' AND file = 'about.html'",
     ).run();
 
     const site = getSystemPages(db);
     assert.ok(site);
-    assert.equal(site.mind, "_system");
+    assert.equal(site.mind, "_commons");
     assert.equal(site.files.length, 2);
     // index leads despite about.html being both newer and higher-id
     assert.equal(site.files[0].file, "index.html");
@@ -316,7 +316,7 @@ describe("pages commands", () => {
       publishActivity: (e: any) => events.push(e),
       getMindDir: async (name: string) => (name === mindName ? mindDir : null),
       getSystemsConfig: () => null,
-      announceToSystem: async () => {},
+      announceToCommons: async () => {},
       isIsolationEnabled: () => false,
       getMindUser: (name: string) => `mind-${name}`,
       dataDir,
@@ -518,7 +518,7 @@ describe("pages commands", () => {
       ctx,
     );
     assert.ok("output" in result);
-    assert.ok(result.output.includes("_system"));
+    assert.ok(result.output.includes("_commons"));
     assert.ok(result.output.includes("alice"));
     assert.ok(result.output.includes("mind-a"));
   });

--- a/test/pages-commons.test.ts
+++ b/test/pages-commons.test.ts
@@ -109,7 +109,7 @@ describe("maybeSendCommonsCue", () => {
       publishActivity: () => {},
       getMindDir: async () => "/spirit/dir",
       getSystemsConfig: () => null,
-      announceToSystem: async () => {},
+      announceToCommons: async () => {},
       recordNotice: async (mind: string, text: string) => {
         notices.push({ mind, text });
       },

--- a/test/pages-migrate-notes.test.ts
+++ b/test/pages-migrate-notes.test.ts
@@ -181,7 +181,7 @@ function ctx(): ExtensionContext {
     publishActivity: () => {},
     getMindDir: async (name: string) => mindDirs.get(name) ?? null,
     getSystemsConfig: () => null,
-    announceToSystem: async () => {},
+    announceToCommons: async () => {},
     recordNotice: async () => {},
     isIsolationEnabled: () => false,
     getMindUser: (name: string) => `mind-${name}`,

--- a/test/pages-reads.test.ts
+++ b/test/pages-reads.test.ts
@@ -48,7 +48,7 @@ function publish(mind: string, file: string, hash = "h1"): void {
 }
 
 const PAGE = { mind: "mimsy", file: "notes/tideline.md" };
-const COMMONS = { mind: "_system", file: "index.md" };
+const COMMONS = { mind: "_commons", file: "index.md" };
 
 describe("page read signals", () => {
   beforeEach(() => {
@@ -115,7 +115,7 @@ describe("page read signals", () => {
     });
 
     it("records reads on the commons, which has no author to exclude", async () => {
-      syncPublishedPages(db, "_system", [{ file: "index.md", hash: "h" }]);
+      syncPublishedPages(db, "_commons", [{ file: "index.md", hash: "h" }]);
       // Even the mind that tended it: a commons page is nobody's own work.
       assert.equal(recordRead(db, COMMONS, users.get(1) as User), true);
       assert.equal(recordRead(db, COMMONS, users.get(2) as User), true);
@@ -152,7 +152,7 @@ describe("page read signals", () => {
     });
 
     it("shows the commons to everyone, as a count with no names", async () => {
-      syncPublishedPages(db, "_system", [{ file: "index.md", hash: "h" }]);
+      syncPublishedPages(db, "_commons", [{ file: "index.md", hash: "h" }]);
       recordRead(db, COMMONS, users.get(2) as User);
       for (const viewer of ["pip", "whorl", "james", null]) {
         const presence = await getPresence(db, getUser, COMMONS, viewer);
@@ -164,7 +164,7 @@ describe("page read signals", () => {
     it("counts the spirit as a mind, not as a human reader", async () => {
       // The spirit's row is user_type "spirit"; a `!== "mind"` test would call the
       // house's most active reader a "reader" and quietly imply a human came by.
-      syncPublishedPages(db, "_system", [{ file: "index.md", hash: "h" }]);
+      syncPublishedPages(db, "_commons", [{ file: "index.md", hash: "h" }]);
       recordRead(db, COMMONS, users.get(5) as User);
       const presence = await getPresence(db, getUser, COMMONS, null);
       assert.equal(presence?.allMinds, true);

--- a/test/pages-shared-events.test.ts
+++ b/test/pages-shared-events.test.ts
@@ -110,7 +110,7 @@ describe("shared publish command events", () => {
       publishActivity: (e: any) => activity.push(e),
       getMindDir: async (name: string) => (name === mindName ? mindDir : null),
       getSystemsConfig: () => null,
-      announceToSystem: async (text: string) => {
+      announceToCommons: async (text: string) => {
         announcements.push(text);
       },
       recordNotice: async (mind: string, text: string) => {

--- a/test/pages-social.test.ts
+++ b/test/pages-social.test.ts
@@ -465,8 +465,8 @@ describe("a comment may carry a page pointer", () => {
     });
 
     it("refuses a commons page, which belongs to everyone rather than to you", () => {
-      publish("_system", "index.md", "h1");
-      const found = resolveAttachedPage(db, "pip", "_system/index.md");
+      publish("_commons", "index.md", "h1");
+      const found = resolveAttachedPage(db, "pip", "_commons/index.md");
       assert.ok("error" in found);
       assert.match(found.error, /belongs to everyone/);
     });
@@ -668,7 +668,7 @@ describe("@mind-name: where it appears decides its tier", () => {
       // files that act happened to change.
       const hailed = await notifyMentionedInComment("reworked @pip's section", ctx, {
         actor: "gardener",
-        ref: { mind: "_system", file: "index.md" },
+        ref: { mind: "_commons", file: "index.md" },
         where: "the commons (index.md, garden/lore.md)",
       });
       assert.deepEqual(hailed, ["pip"]);
@@ -687,8 +687,8 @@ describe("@mind-name: where it appears decides its tier", () => {
     });
   });
 
-  it("never spends a notice on _system, which is an address and not a mind", () => {
-    assert.equal(isNotifiable("_system"), false);
+  it("never spends a notice on _commons, which is an address and not a mind", () => {
+    assert.equal(isNotifiable("_commons"), false);
     assert.equal(isNotifiable("mimsy"), true);
   });
 });
@@ -761,8 +761,8 @@ describe("the publish message lands in the page's thread", () => {
   afterEach(() => db.close());
 
   it("is recorded as a publish row, distinguishable from a response", async () => {
-    publish("_system", "index.md", "h1");
-    const ref = { mind: "_system", file: "index.md" };
+    publish("_commons", "index.md", "h1");
+    const ref = { mind: "_commons", file: "index.md" };
     await addComment(db, getUser, ref, 1, "added a residents section", { kind: "publish" });
     await addComment(db, getUser, ref, 1, "and a thought about it");
 
@@ -791,7 +791,7 @@ function fakeCtx(mindDir: string): ExtensionContext {
     publishActivity: () => {},
     getMindDir: async () => mindDir,
     getSystemsConfig: () => null,
-    announceToSystem: async () => {},
+    announceToCommons: async () => {},
     recordNotice: async () => {},
     isIsolationEnabled: () => false,
     getMindUser: (name: string) => `mind-${name}`,

--- a/test/web-pages.test.ts
+++ b/test/web-pages.test.ts
@@ -264,7 +264,7 @@ function makeCtx(dir: string) {
     getSystemsConfig: () => null,
     resolveUser: () => null,
     publishActivity: () => {},
-    announceToSystem: async () => {},
+    announceToCommons: async () => {},
     isIsolationEnabled: () => false,
     getMindUser: (name: string) => `mind-${name}`,
   };


### PR DESCRIPTION
Closes #819. **Data-model + migration PR — needs your hand-merge.**

Splits the overloaded `system` vocabulary: the shared default channel and the pages commons identity stop being resolved by the magic name `"system"` and instead get a first-class identity, while infra `system` (auth roles, `system_events`, `voluteSystemDir`, the summarizer `_system` rollup) is deliberately left alone.

## What changed
**Default channel → resolved by an `is_default` MARKER, not by name.**
- New `channels.is_default` column + **partial unique index** (`WHERE is_default = 1`) → "at most one commons per install" is a DB invariant, not a convention.
- `getDefaultChannelRow`/`getDefaultChannel`/`markChannelDefault` in `conversations.ts`; every lookup goes through the marker. `system-channel.ts` → `commons-channel.ts` (+ all exports/callers renamed). New installs create `#commons`; **bardo's `#system` keeps its earned name** — only the marker is set.
- Announcement routing slugs + sprout-welcome follow the channel's *actual* name, so they stay correct on both a renamed house and new installs.

**Migration `0002`** marks the current default (name `system`/`#system`) `is_default=1` **without renaming it**, `NOT EXISTS`-guarded + forward-idempotent.

**Pages commons identity `_system` → `_commons`** — data-preserving migration across all 7 keyed tables (`published_pages`, `page_comments` incl. `body_mind`, reactions/citations/reads/links, + `ambient_shown` ref prefix). Page files in the git repo untouched.

Full suite green (3265), typecheck clean.

## Three things to scrutinize before merge
1. **On-disk worktree dir stays `home/pages/_system/`** — only the *persisted identity* moved to `_commons`, not the checkout path. The mind-template `auto-commit.ts` hook routes by the literal string `pages/_system/` and is version-skewed from the daemon, so renaming the dir would break commons auto-commit for any un-upgraded live mind. **Cost:** a mind *edits* in `pages/_system/` but *addresses* pages as `_commons/…`. A follow-up wave can rename the dir + hook together.
2. **Old commons page URLs (`/ext/pages/public/_system/…`) now 404 → `_commons`**, no redirect shim (breaking, milestone-9-allowed). Data is migrated, not dropped — but **bardo's existing published page URLs will break.**
3. **Migration edge case:** the backfill only marks a channel named `system`/`#system`. An install whose default was *already* renamed to something else would get no commons marked. Only bardo is live (`#system`) so it's fine now — noting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
