### PR TITLE
refactor: migrate auth role value "system" → "spirit"

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -226,7 +226,7 @@ export type FileContent = {
 export type AvailableUser = {
   id: number;
   username: string;
-  role: "admin" | "user" | "pending" | "mind" | "system";
+  role: "admin" | "user" | "pending" | "mind" | "spirit";
   user_type: UserType;
   /** Server-computed locality flag for `mind` rows (see `isExternal`); absent otherwise. */
   external?: boolean;

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -112,17 +112,24 @@ export async function startDaemon(opts: {
   // Initialize database (runs drizzle migrations + creates raw connection)
   await (await import("./lib/db.js")).getDb();
 
-  // Migrate system user role to "system" (existing installs have "user")
+  // Migrate the spirit user's role to "spirit". Fresh installs still carry the
+  // default "user" role; installs from the earlier wave carry "system". Both
+  // updates are guarded and idempotent — no-ops once the row already reads "spirit".
   try {
     const { eq, and } = await import("drizzle-orm");
     const { users } = await import("./lib/schema.js");
     const db = await (await import("./lib/db.js")).getDb();
     await db
       .update(users)
-      .set({ role: "system" })
+      .set({ role: "spirit" })
       .where(and(eq(users.user_type, "spirit"), eq(users.role, "user")));
+    // Existing installs (e.g. bardo) already carry the earlier "system" value.
+    await db
+      .update(users)
+      .set({ role: "spirit" })
+      .where(and(eq(users.user_type, "spirit"), eq(users.role, "system")));
   } catch (err) {
-    log.warn("failed to migrate system user role", log.errorData(err));
+    log.warn("failed to migrate spirit user role", log.errorData(err));
   }
 
   // Downscale oversized avatars uploaded before resize-on-upload existed (non-fatal)

--- a/packages/daemon/src/lib/auth.ts
+++ b/packages/daemon/src/lib/auth.ts
@@ -11,7 +11,7 @@ import { users } from "./schema.js";
 export type User = {
   id: number;
   username: string;
-  role: "admin" | "user" | "pending" | "system";
+  role: "admin" | "user" | "pending" | "spirit";
   user_type: "human" | "mind" | "spirit";
   display_name: string | null;
   description: string | null;
@@ -210,7 +210,7 @@ export async function getOrCreateSystemUser(): Promise<User> {
       .values({
         username: spiritName,
         password_hash: "!system",
-        role: "system",
+        role: "spirit",
         user_type: "spirit",
         display_name: spiritName,
       })

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -373,7 +373,7 @@ async function loadExtension(
         // Minds are untrusted principals — only privileged callers (admin/system)
         // may target another mind via body.mind. Otherwise the acting mind is the
         // authenticated identity, so a mind cannot impersonate another.
-        const privileged = user?.role === "admin" || user?.role === "system";
+        const privileged = user?.role === "admin" || user?.role === "spirit";
         const mindName = privileged ? body.mind || user?.username : user?.username;
         const session = c.get("mindSession") as string | undefined;
         try {

--- a/packages/daemon/src/web/api/history.ts
+++ b/packages/daemon/src/web/api/history.ts
@@ -39,7 +39,7 @@ type HistoryEnv = {
  */
 async function resolveMindFilter(c: Context<HistoryEnv>): Promise<string | undefined> {
   const user = c.get("user");
-  const privileged = user.role === "admin" || user.role === "system";
+  const privileged = user.role === "admin" || user.role === "spirit";
   return privileged ? (c.req.query("mind") ?? undefined) : getBaseName(user.username);
 }
 
@@ -728,7 +728,7 @@ const history = new Hono<HistoryEnv>()
   })
   .get("/summaries", async (c) => {
     const user = c.get("user");
-    const privileged = user.role === "admin" || user.role === "system";
+    const privileged = user.role === "admin" || user.role === "spirit";
     // mindFilter is the caller's allowed scope: the requested mind for
     // privileged callers (undefined if none), or the caller's own base name for
     // minds. Summaries default an unscoped privileged read to the system

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -257,7 +257,7 @@ type MindStatus = Awaited<ReturnType<typeof getMindStatus>>;
 /** True for the daemon's own privileged principals: admin users and the system spirit. */
 function isPrivileged(c: Context<AuthEnv>): boolean {
   const role = c.get("user").role;
-  return role === "admin" || role === "system";
+  return role === "admin" || role === "spirit";
 }
 
 /**

--- a/packages/daemon/src/web/api/v1/conversations.ts
+++ b/packages/daemon/src/web/api/v1/conversations.ts
@@ -35,7 +35,7 @@ async function canReadConversation(
   const conv = await getConversation(id);
   if (!conv) return false;
   if (conv.private !== 1) return true;
-  if (user.id === 0 || user.role === "admin" || user.role === "system") return true;
+  if (user.id === 0 || user.role === "admin" || user.role === "spirit") return true;
   return isParticipantOrOwner(id, user.id);
 }
 

--- a/packages/daemon/src/web/api/v1/events.ts
+++ b/packages/daemon/src/web/api/v1/events.ts
@@ -34,7 +34,7 @@ const app = new Hono<AuthEnv>().use("*", authMiddleware).get("/", async (c) => {
   // Minds are untrusted: a non-admin/system principal may only see its own
   // activity (activity.summary is an AI-generated summary of a mind's turn).
   // `activityMind === undefined` means a privileged caller with the global feed.
-  const privileged = user.role === "admin" || user.role === "system";
+  const privileged = user.role === "admin" || user.role === "spirit";
   const activityMind = privileged ? undefined : await getBaseName(user.username);
 
   return streamSSE(c, async (stream) => {

--- a/packages/daemon/src/web/api/v1/feed.ts
+++ b/packages/daemon/src/web/api/v1/feed.ts
@@ -23,7 +23,7 @@ const app = new Hono<AuthEnv>()
   // non-admin/system callers (#503).
   .get("/", async (c) => {
     const user = c.get("user");
-    const privileged = user.role === "admin" || user.role === "system";
+    const privileged = user.role === "admin" || user.role === "spirit";
     const [chat, lifecycle] = await Promise.all([
       getChatFeedEvents(),
       getLifecycleFeedEvents({ privileged }),

--- a/packages/daemon/src/web/api/volute/channels.ts
+++ b/packages/daemon/src/web/api/volute/channels.ts
@@ -133,8 +133,8 @@ const app = new Hono<AuthEnv>()
     const ch = await getChannelByName(name);
     if (!ch) return c.json({ error: "Channel not found" }, 404);
 
-    // In-handler authz: only a channel member (or admin/system) may change settings.
-    if (user.role !== "admin" && user.role !== "system" && !(await isParticipant(ch.id, user.id))) {
+    // In-handler authz: only a channel member (or admin/spirit) may change settings.
+    if (user.role !== "admin" && user.role !== "spirit" && !(await isParticipant(ch.id, user.id))) {
       return c.json({ error: "Forbidden" }, 403);
     }
 
@@ -179,10 +179,10 @@ const app = new Hono<AuthEnv>()
     const ch = await getChannelByName(name);
     if (!ch) return c.json({ error: "Channel not found" }, 404);
 
-    // In-handler authz: only a channel member (or admin/system) may add members.
+    // In-handler authz: only a channel member (or admin/spirit) may add members.
     if (
       inviter.role !== "admin" &&
-      inviter.role !== "system" &&
+      inviter.role !== "spirit" &&
       !(await isParticipant(ch.id, inviter.id))
     ) {
       return c.json({ error: "Forbidden" }, 403);

--- a/packages/daemon/src/web/middleware/auth.ts
+++ b/packages/daemon/src/web/middleware/auth.ts
@@ -88,10 +88,10 @@ export const requireAdmin = createMiddleware<AuthEnv>(async (c, next) => {
   await next();
 });
 
-/** Allow admin users and the system user (role: "system"). */
+/** Allow admin users and the spirit user (role: "spirit"). */
 export const requireAdminOrSystem = createMiddleware<AuthEnv>(async (c, next) => {
   const user = c.get("user");
-  if (user.role !== "admin" && user.role !== "system") {
+  if (user.role !== "admin" && user.role !== "spirit") {
     return c.json({ error: "Forbidden" }, 403);
   }
   await next();
@@ -206,7 +206,7 @@ export const authMiddleware = createMiddleware<AuthEnv>(async (c, next) => {
 export const requireSelf = (paramName = "name") =>
   createMiddleware<AuthEnv>(async (c, next) => {
     const user = c.get("user");
-    if (user.role !== "admin" && user.role !== "system") {
+    if (user.role !== "admin" && user.role !== "spirit") {
       const target = c.req.param(paramName) ?? "";
       const baseName = await getBaseName(target);
       // Base-map the caller too: a variant's token resolves to its own name,

--- a/packages/extensions/intentions/src/commands.ts
+++ b/packages/extensions/intentions/src/commands.ts
@@ -188,7 +188,7 @@ export function createCommands(): Record<string, ExtensionCommand> {
         // generic command dispatcher does not let an ordinary mind spoof --mind), so
         // this role lookup always reflects the real caller, not an attacker-chosen name.
         const actor = await ctx.getUserByUsername(ctx.mindName);
-        if (!actor || (actor.role !== "admin" && actor.role !== "system")) {
+        if (!actor || (actor.role !== "admin" && actor.role !== "spirit")) {
           return { error: "Forbidden: review-due is spirit/admin only" };
         }
 

--- a/packages/extensions/sdk/src/types.ts
+++ b/packages/extensions/sdk/src/types.ts
@@ -20,7 +20,7 @@ export type ActivityEvent = {
 export type User = {
   id: number;
   username: string;
-  role: "admin" | "user" | "pending" | "system";
+  role: "admin" | "user" | "pending" | "spirit";
   user_type: "human" | "mind" | "spirit";
   display_name: string | null;
   description: string | null;

--- a/test/api-tokens.test.ts
+++ b/test/api-tokens.test.ts
@@ -180,11 +180,11 @@ describe("api tokens", () => {
     });
     assert.equal(listForbidden.status, 403);
 
-    // Nor the system principal (the spirit): durable issuance is human-gated, so
-    // even role:"system" is rejected — closing the prompt-injection path where
+    // Nor the spirit principal: durable issuance is human-gated, so even
+    // role:"spirit" is rejected — closing the prompt-injection path where
     // untrusted text could talk the spirit into minting a credential.
     const systemUser = await getOrCreateMindUser(OTHER_MIND);
-    await setUserRole(systemUser.id, "system");
+    await setUserRole(systemUser.id, "spirit");
     const { token: systemToken } = await issueApiToken(systemUser.id, "system-principal");
     const systemForbidden = await authApp.request(`/users/${mindUser.id}/tokens`, {
       method: "POST",

--- a/test/external-mind-registration.test.ts
+++ b/test/external-mind-registration.test.ts
@@ -66,9 +66,9 @@ async function cleanup() {
  * `createUser` only auto-admins the FIRST human user in the DB, which isn't
  * reliable in a shared test DB — set the role explicitly. Written straight to the
  * row rather than via `setUserRole`, whose contract is only "admin" | "user";
- * the gate has to be provable against "system" and "pending" callers too.
+ * the gate has to be provable against "spirit" and "pending" callers too.
  */
-async function makeUser(username: string, role: "admin" | "user" | "system" | "pending") {
+async function makeUser(username: string, role: "admin" | "user" | "spirit" | "pending") {
   const user = await createUser(username, "pw-123456");
   const db = await getDb();
   await db.update(users).set({ role }).where(eq(users.id, user.id));
@@ -154,12 +154,12 @@ describe("external mind registration", () => {
 
   // The gate that matters: registration mints a durable credential, so it is
   // requireAdmin — human-gated — exactly like the R1 token routes. The injectable
-  // `system` principal (the spirit) must NOT be able to mint one for itself. This
-  // test fails if anyone re-widens the route to admit "system".
-  it("refuses a role:system caller, and creates nothing", async () => {
-    const { sessionId } = await makeUser(SYSTEM_CALLER, "system");
+  // `spirit` principal must NOT be able to mint one for itself. This test fails if
+  // anyone re-widens the route to admit "spirit".
+  it("refuses a role:spirit caller, and creates nothing", async () => {
+    const { sessionId } = await makeUser(SYSTEM_CALLER, "spirit");
     const res = await register(sessionId, { name: NEW_MIND });
-    assert.equal(res.status, 403, "system must not mint durable credentials without a human");
+    assert.equal(res.status, 403, "the spirit must not mint durable credentials without a human");
     assert.equal(await getUserByUsername(NEW_MIND), null);
   });
 

--- a/test/intentions.test.ts
+++ b/test/intentions.test.ts
@@ -492,14 +492,14 @@ describe("intentions commands", () => {
     assert.match(result.error, /Forbidden/);
   });
 
-  it("review-due command allows the spirit (role: system)", async () => {
+  it("review-due command allows the spirit (role: spirit)", async () => {
     createIntention(db, "aria", "overdue thing", undefined, undefined);
     db.prepare("UPDATE intentions SET review_at = datetime('now', '-1 day')").run();
 
     const commands = createCommands();
     const ctx = makeCtx("volute", {
       username: "volute",
-      role: "system",
+      role: "spirit",
       user_type: "spirit",
     } as User);
     const result = await commands["review-due"].handler({ args: {}, flags: {}, rest: [] }, ctx);

--- a/test/migrate-spirit-user-type.test.ts
+++ b/test/migrate-spirit-user-type.test.ts
@@ -44,7 +44,8 @@ describe("0001 migrate spirit user_type", () => {
 
     // The value flipped...
     assert.equal(spirit.user_type, "spirit");
-    // ...but role (a separate axis, renamed in a later wave) did not...
+    // ...but role (a separate axis, renamed by a distinct boot migration, not this
+    // SQL) is left exactly as the legacy row carried it — here the old "system".
     assert.equal(spirit.role, "system");
     // ...and non-spirit rows are untouched.
     assert.equal(mind.user_type, "mind");

--- a/test/pages-commons.test.ts
+++ b/test/pages-commons.test.ts
@@ -178,7 +178,7 @@ describe("maybeSendCommonsCue", () => {
   it("sends to the spirit even though its user row is user_type spirit", async () => {
     const { ctx, notices } = makeCtx({
       getUserByUsername: async (username: string) =>
-        ({ id: 1, username, role: "system", user_type: "spirit" }) as unknown as User,
+        ({ id: 1, username, role: "spirit", user_type: "spirit" }) as unknown as User,
     });
     await maybeSendCommonsCue(ctx, repoDir);
     assert.equal(notices.length, 1);

--- a/test/system-chat.test.ts
+++ b/test/system-chat.test.ts
@@ -34,7 +34,7 @@ describe("system user", () => {
     assert.equal(user.username, "volute");
     assert.equal(user.user_type, "spirit");
     assert.equal(user.display_name, "volute");
-    assert.equal(user.role, "system");
+    assert.equal(user.role, "spirit");
   });
 
   it("getOrCreateSystemUser is idempotent", async () => {


### PR DESCRIPTION
Renames the auth **`role`** value `"system"` → `"spirit"` (your 2:00pm call — "a good intermediate state, may need further change later"). A spirit user now carries `user_type: "spirit"` **and** `role: "spirit"`. Mechanical rename, no redesign. **Authz + migration → your hand-merge.**

## Coverage (all 15 role-value sites)
- Type unions: `lib/auth.ts`, `@volute/api` `types.ts`, `@volute/extensions` SDK `types.ts` (all `... | "system"` → `... | "spirit"`).
- `getOrCreateSystemUser` write → `"spirit"` (function name, `user_type`, and `password_hash: "!system"` sentinel deliberately left — those are infra `system`, out of scope).
- Every privileged-role check: `middleware/auth.ts` (×2 + doc comment), `api/history.ts` (×2), `api/minds.ts`, `api/v1/{feed,events,conversations}.ts`, `api/volute/channels.ts` (×2 + comments), `lib/extensions.ts`, and `intentions/commands.ts` (review-due gate — a site I'd missed; the builder grepped it out).
- 6 test files updated.

**Coverage proof:** `grep '"system"' | grep -i role` now returns only legitimate leftovers — LLM message roles (`user|assistant|system`), the reserved *username* `"system"`, and the migration's own `WHERE role = 'system'` clause.

## Migration (the part that matters for bardo)
`daemon.ts` boot migration is now two guarded, idempotent UPDATEs:
```
user_type='spirit' AND role='user'   → 'spirit'   (fresh installs)
user_type='spirit' AND role='system' → 'spirit'   (existing installs, e.g. bardo's live spirit)
```
Without the second, bardo's spirit would lose its privileges on deploy. Both no-op once the row reads `spirit`.

## Two notes
1. **The PR's CI is the real test gate.** In the builder's worktree, 5 `global-config.test.ts` cases fail — proven to be a worktree-env isolation artifact (they pass on clean `main` and still fail with this change `git stash`ed), not this diff. Everything else green; typecheck clean.
2. **Cosmetic follow-up (left deliberately):** the `requireAdminOrSystem` export name is now stale (it checks for `spirit`). Rename whenever, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
