### PR TITLE
feat: deliver commons announcements to the spirit too (#817)

### DIFF
--- a/packages/daemon/src/lib/chat/commons-channel.ts
+++ b/packages/daemon/src/lib/chat/commons-channel.ts
@@ -1,4 +1,4 @@
-import { isMind } from "@volute/api/user-type";
+import { isMind, isSystemSpirit } from "@volute/api/user-type";
 import { getOrCreateMindUser, getOrCreateSystemUser, getUserByUsername } from "../auth.js";
 import { getSpiritName } from "../config/setup.js";
 import { deliverMessage } from "../delivery/message-delivery.js";
@@ -109,11 +109,12 @@ export async function backfillCommonsChannelMembers(): Promise<void> {
  * spirit's hand-written messages (#687).
  *
  * The channel row is stored with `role: "event"` and no sender so web chat and `chat read`
- * render it as an event. It is delivered to mind participants through the normal channel-message
- * path (so it follows each mind's commons routing, batching, gating, and file destinations
- * exactly like any channel message) — but with a null sender, so the prefix the mind receives
- * frames it by channel and never names the spirit or invents a sender. The spirit's own
- * hand-written messages are unaffected.
+ * render it as an event. It is delivered to mind participants — and to the spirit (#817),
+ * whose room the commons is — through the normal channel-message path (so it follows each
+ * recipient's commons routing, batching, gating, and file destinations exactly like any
+ * channel message) — but with a null sender, so the prefix the recipient receives frames it
+ * by channel and never names the spirit or invents a sender. The spirit's own hand-written
+ * messages are unaffected.
  */
 export async function announceToCommons(text: string): Promise<void> {
   await ensureCommonsChannel();
@@ -123,17 +124,25 @@ export async function announceToCommons(text: string): Promise<void> {
   const channelId = row.conversation_id;
   await addMessage(channelId, "event", null, [{ type: "text", text }]);
 
-  // Deliver to all mind participants of the commons, sender-less, on the ordinary channel path.
+  // Deliver sender-less on the ordinary channel path to every mind participant AND the
+  // spirit (#817). The commons is the spirit's own room, so it should perceive
+  // joins/publishes there — the same way it already perceives real channel messages, which
+  // fan-out delivers to it via `isLocalMind`. `isMind` excludes the spirit by design, so it
+  // is added explicitly via `isSystemSpirit`: the set of *minds* that receive is exactly as
+  // before, and this only adds the spirit as a recipient. The null sender is preserved, so
+  // the spirit sees an event in its commons, never a message attributed to its own voice.
+  //
+  // Self-echo: a few announcements are the spirit's own action ("<spirit> published a
+  // page …"). The actor is only embedded in the free-form announcement text, not a
+  // structured field, so suppressing self-echo would need a fragile name match. The rare
+  // self-echo (still a sender-less event, not the spirit's voice) is accepted instead.
   const participants = await getParticipants(channelId);
-  // Note: this excludes the spirit (user_type "spirit"). Preserved as-is; whether
-  // commons announcements should also reach the spirit is a behavior question for
-  // review, not this refactor (#817).
-  const mindParticipants = participants.filter(isMind);
+  const recipients = participants.filter((p) => isMind(p) || isSystemSpirit(p));
   // The routing slug follows the channel's actual name (`#commons` on new installs,
   // an earned name like `#system` on migrated houses), not a hardcoded string.
   const channel = `#${row.name}`;
-  for (const mind of mindParticipants) {
-    deliverMessage(mind.username, {
+  for (const recipient of recipients) {
+    deliverMessage(recipient.username, {
       content: [{ type: "text", text }],
       channel,
       conversationId: channelId,
@@ -142,7 +151,10 @@ export async function announceToCommons(text: string): Promise<void> {
       participantCount: participants.length,
       isDM: false,
     }).catch((err) => {
-      log.warn(`failed to deliver commons announcement to ${mind.username}`, log.errorData(err));
+      log.warn(
+        `failed to deliver commons announcement to ${recipient.username}`,
+        log.errorData(err),
+      );
     });
   }
 }

--- a/test/commons-channel.test.ts
+++ b/test/commons-channel.test.ts
@@ -271,6 +271,53 @@ describe("commons channel", () => {
     assert.equal(events.length, 0, "announcements are channel messages, not system events");
   });
 
+  it("announceToCommons delivers to the spirit participant, sender-less (#817)", async () => {
+    // The commons is the spirit's room, so it must perceive announcements there too.
+    // The spirit is a `user_type: "spirit"` participant that `isMind` excludes; delivery
+    // must still reach it — on the same sender-less channel path minds get — because
+    // removing that inclusion is exactly the regression this guards.
+    await addSpirit("volute", 4906, "claude", "/tmp/spirit");
+    await joinCommonsChannelForSpirit();
+    await addMind("commons-mind", 4901, "sprouted");
+    await joinCommonsChannelForMind("commons-mind");
+    // Disable gating so the (dead-port) delivery still records the inbound for both.
+    writeCommonsRoutes("volute", { gateUnmatched: false });
+    writeCommonsRoutes("commons-mind", { gateUnmatched: false });
+
+    await announceToCommons("atlas has joined");
+
+    // Delivery is fire-and-forget; poll for the spirit's recorded inbound.
+    const db = await getDb();
+    let spiritRow: { sender: string | null; channel: string | null } | undefined;
+    for (let i = 0; i < 50 && !spiritRow; i++) {
+      const inbound = await db
+        .select()
+        .from(mindHistory)
+        .where(and(eq(mindHistory.mind, "volute"), eq(mindHistory.type, "inbound")))
+        .all();
+      spiritRow = inbound.find((r) => r.content?.includes("atlas has joined"));
+      if (!spiritRow) await new Promise((res) => setTimeout(res, 20));
+    }
+    assert.ok(spiritRow, "the announcement should be delivered to the spirit participant");
+    assert.equal(
+      spiritRow!.sender,
+      null,
+      "spirit delivery must be sender-less — not its own voice",
+    );
+    assert.equal(spiritRow!.channel, "#commons", "delivered on the #commons channel");
+
+    // Mind delivery is unchanged: the mind participant still receives it too.
+    const mindInbound = await db
+      .select()
+      .from(mindHistory)
+      .where(and(eq(mindHistory.mind, "commons-mind"), eq(mindHistory.type, "inbound")))
+      .all();
+    assert.ok(
+      mindInbound.some((r) => r.content?.includes("atlas has joined")),
+      "mind participants still receive the announcement",
+    );
+  });
+
   it("announceToCommons follows a renamed default channel's slug", async () => {
     // A house kept a proper name on its commons. The delivered routing slug must
     // track that name, not a hardcoded "#commons".


### PR DESCRIPTION
Closes #817. The commons is the spirit's own room, but `announceToCommons` delivered its sender-less events ("X has joined", "📝 X published…") only to participants matching `isMind` — which excludes the `user_type: "spirit"` row. So the spirit never perceived activity in its own commons. This adds it as a recipient.

## Change (`commons-channel.ts`, +40)
Delivery filter `participants.filter(isMind)` → `participants.filter(p => isMind(p) || isSystemSpirit(p))`. The set of *minds* that receive is unchanged (external minds still included — deliberately not `isLocalMind`, which would have dropped them); this purely adds the spirit, on the same sender-less channel path, with the null sender preserved (an event in its commons, never attributed to its own voice).

## Judgment calls
- **`deliverMessage`, not `deliverEvent`** — traced how the spirit already perceives real commons messages (`fanOutToMinds` → `isLocalMind`, which includes the spirit); that's `deliverMessage`. `announceSprout`'s `deliverEvent` is a different thing (a lifecycle prompt). Announcements are channel messages → `deliverMessage` is consistent.
- **Self-echo left un-suppressed (your call to sanity-check):** a few announcements are the spirit's own action ("<spirit> published…"). The actor is only in the free-form `text`, not a structured field — suppressing would need a fragile prose match, or an actor param rippling through the `@volute/extensions` SDK and every caller. Accepted the rare self-echo instead (still sender-less, and joins — the common case — are never the spirit). Flagging so you can veto if you'd rather it be suppressed.

## Verification
New test: spirit gets the announcement sender-less on `#commons` AND the mind still receives it; fails when the spirit delivery is reverted (verified empirically). Full suite 3263 pass (the 5 `global-config.test.ts` failures are pre-existing/unrelated — identical with this diff stashed). Typecheck clean, `/code-review` high: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
