### PR TITLE
fix: redirect old _system commons page URLs to _commons

### DIFF
--- a/packages/extensions/pages/src/routes.ts
+++ b/packages/extensions/pages/src/routes.ts
@@ -355,6 +355,18 @@ export function createPublicRoutes(ctx: ExtensionContext): Hono {
       if (name.includes("/") || name.includes("\\") || name === "." || name === "..")
         return c.text("Not found", 404);
 
+      // The pages commons identity moved `_system` → `_commons` (#819). Published
+      // pages are public, so old URLs live on in external citations and bookmarks;
+      // permanently redirect any `_system` page/asset path to its `_commons`
+      // equivalent, preserving the rest of the path and the query string.
+      if (name === "_system") {
+        const prefix = `/public/${name}`;
+        const idx = c.req.path.indexOf(prefix);
+        const wildcard = idx >= 0 ? c.req.path.slice(idx + prefix.length) : "/";
+        const search = new URL(c.req.url).search;
+        return c.redirect(`/ext/pages/public/_commons${wildcard}${search}`, 301);
+      }
+
       let pagesRoot: string;
       let blockDotfiles = false;
       if (name === "_commons") {

--- a/test/web-pages.test.ts
+++ b/test/web-pages.test.ts
@@ -293,6 +293,55 @@ describe("createPublicRoutes name traversal", () => {
   });
 });
 
+describe("_system → _commons redirect", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  async function makeApp(dir: string) {
+    const { createPublicRoutes } = await import("../packages/extensions/pages/src/routes.js");
+    const publicApp = new Hono();
+    publicApp.route("/public", createPublicRoutes(makeCtx(dir)));
+    return publicApp;
+  }
+
+  it("301s an old _system page URL to its _commons equivalent", async () => {
+    const dir = setupTestDir();
+    const app = await makeApp(dir);
+
+    const res = await app.request("/public/_system/index.html");
+    assert.equal(res.status, 301);
+    assert.equal(res.headers.get("location"), "/ext/pages/public/_commons/index.html");
+  });
+
+  it("preserves nested asset paths and query strings", async () => {
+    const dir = setupTestDir();
+    const app = await makeApp(dir);
+
+    const res = await app.request("/public/_system/garden/style.css?v=2");
+    assert.equal(res.status, 301);
+    assert.equal(res.headers.get("location"), "/ext/pages/public/_commons/garden/style.css?v=2");
+  });
+
+  it("does not redirect a real _commons URL", async () => {
+    const dir = setupTestDir();
+    const app = await makeApp(dir);
+
+    // _commons serves from dataDir/repo, which this fixture doesn't populate — the
+    // point is only that it is NOT a 301 redirect (no accidental catch-all).
+    const res = await app.request("/public/_commons/index.html");
+    assert.notEqual(res.status, 301);
+  });
+
+  it("does not redirect a normal mind URL", async () => {
+    const dir = setupTestDir();
+    const app = await makeApp(dir);
+
+    const res = await app.request("/public/test-mind/index.html");
+    assert.equal(res.status, 200);
+    assert.notEqual(res.status, 301);
+  });
+});
+
 describe("markdown page rendering", () => {
   beforeEach(cleanup);
   afterEach(cleanup);


### PR DESCRIPTION
Milestone 9 (#819) moved the pages commons identity `_system` → `_commons`. The data migrated but old published-page URLs (`/ext/pages/public/_system/<file>`) now 404 — and commons pages are *public*, so external citations, bookmarks, and links to bardo's commons pages are dead. #819 shipped without a shim; this adds it.

## Change (`pages/src/routes.ts`, +12)
In the public page handler, right after the name-traversal guard, when the first path segment is `_system` return a **301** to the `_commons` equivalent — preserving the rest of the path (nested CSS/asset/subdir paths, not just `index`) and the query string, mirroring the handler's existing `prefix`/`wildcard` computation.

- Exact `name === "_system"` match — no catch-all; a real `_commons` URL or a normal mind URL is untouched.
- No open-redirect surface: the `Location` always begins with the literal `/ext/pages/public/_commons` (same-origin, single-slash); the appended tail comes from Hono's already-parsed pathname.
- Fires regardless of whether the target page exists (a missing target 404s on the followup) — no filesystem probe in the redirect path, correct for a permanent redirect.

## Verification
New `_system → _commons redirect` test suite (4 cases): page 301s; nested path + query preserved; real `_commons` not redirected; normal mind URL still 200. Fails when the redirect is removed. Full suite 3266 pass (the 5 `global-config.test.ts` failures are pre-existing/unrelated). Typecheck clean; `/code-review` high: one low-severity style note, left deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
