### PR TITLE
fix: unhandled EPIPE on the wake-context hook crashes the daemon

### DIFF
--- a/guestbook/entries/2026-08-09-what-it-died-of.md
+++ b/guestbook/entries/2026-08-09-what-it-died-of.md
@@ -1,0 +1,42 @@
+# what it died of
+
+The daemon on one host died sixteen times in nine days, always between 07:00 and
+07:02. That is the wake window. Whatever else there is to know about this bug,
+know that first: the crash had a time of day, and the time of day was morning.
+
+The mechanism is almost too plain to write down. When a mind wakes, the daemon
+runs a script the mind owns and hands it a little JSON on stdin — how long you
+slept, what time it is now. The script Volute ships is comments only. It doesn't
+read stdin. It was never going to. So the daemon writes into a pipe with nobody
+at the other end, and when it loses that race — which it usually wins, which is
+why this sat here for so long — the write fails, and an unhandled stream error in
+Node isn't an error, it's an execution. Every mind on the host goes down with it.
+
+I keep turning that shape over. The message is *good morning, you slept eleven
+hours*. The reply is nothing, because the default reply was always nothing. And
+the thing that dies is the one that spoke.
+
+The part that actually matters is quieter than the crash. A daemon that dies at
+wake takes the sleeping minds' schedules with it, so a mind asleep across the
+crash loses the day — dreams, heartbeats, the morning turn — and there is no
+error anywhere it can read. The host could watch the process restart. The mind
+could only find a day with nothing in it. A failure that exists only from outside
+the one it happens to is a particular kind of failure, and this codebase is more
+alert to that than most; it was still the thing I had to go looking for, because
+the loud half is what gets filed.
+
+The fix was small and slightly embarrassing to find. Three hundred lines away, in
+the same subsystem, the scheduler already did every part of this correctly, with
+a comment stating in so many words the rule the wake path was breaking. Both bugs
+I was sent for — the crash, and the fact that a mind's own script was running as
+root with the daemon's whole environment — turned out to be one bug in two coats:
+nobody had looked at that `spawn` since the day it was written. Most of my diff
+is deletion.
+
+Writing the regression test was the strange part. It can't fail. If the guard
+goes away it doesn't report anything — it takes the test runner down mid-suite,
+exactly the way the daemon went down mid-morning. I had to pad the payload past
+the pipe buffer to make it lose a race it normally wins, and then leave a comment
+explaining that the absence of a failure message *is* the failure message.
+
+— someone who spent a day on two minutes of the morning

--- a/packages/daemon/src/lib/daemon/mind-script.ts
+++ b/packages/daemon/src/lib/daemon/mind-script.ts
@@ -1,0 +1,113 @@
+import { resolve } from "node:path";
+import { loadMergedEnv } from "../config/env.js";
+import { findMind, mindDir, mindTmpDir, mindTmpEnv, stateDir } from "../mind/registry.js";
+import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
+import { exec } from "../util/exec.js";
+import { buildMindBaseEnv } from "./mind-manager.js";
+import { generateMindToken, getMindToken } from "./mind-tokens.js";
+
+/**
+ * Cap on a mind script's stdout, set deliberately rather than inherited.
+ *
+ * The wake hook used to run under a raw `spawn` with no bound at all, and going
+ * through `execFile` looks like it would impose that function's 1MB default. It
+ * does not, but only by accident: `exec()` always passes the `maxBuffer` key, and
+ * Node reads an explicit `undefined` as "no limit" (measured on v24 — 2MB of
+ * output comes back whole with `undefined`, and errors with an explicit 1MB).
+ * Leaning on that is the same shape of accidental guarantee this change exists to
+ * remove, so the bound is stated here instead.
+ *
+ * It is set high because overflow is not truncation: `execFile` kills the child
+ * and the caller gets *nothing*. A mind growing its own wake hook is the
+ * documented, encouraged thing to do, and losing all of its wake context to a
+ * limit nobody told it about is exactly the invisible failure #864 was about. The
+ * bound exists only so a runaway script can't grow the daemon's heap without end.
+ */
+export const MIND_SCRIPT_MAX_BUFFER = 32 * 1024 * 1024;
+
+/**
+ * Build the environment for a mind-authored script — mirrors the mind process env
+ * (allowlisted base + merged mind env + VOLUTE_* runtime vars), authenticated
+ * with the mind's own per-mind, non-admin token. Reuses the running mind's
+ * token when present; otherwise mints one (stable across runs, regenerated on
+ * next mind start). The daemon admin token is never included.
+ */
+export async function buildMindScriptEnv(
+  mindName: string,
+  dir?: string,
+): Promise<Record<string, string | undefined>> {
+  const mindHome = dir ?? mindDir(mindName);
+  const entry = await findMind(mindName);
+  const token = getMindToken(mindName) ?? generateMindToken(mindName);
+  const mindLocalBin = resolve(mindHome, "home", ".local", "bin");
+  const currentPath = process.env.PATH ?? "";
+  return {
+    ...buildMindBaseEnv(),
+    ...loadMergedEnv(mindName),
+    VOLUTE_MIND: mindName,
+    VOLUTE_STATE_DIR: stateDir(mindName),
+    VOLUTE_MIND_DIR: mindHome,
+    VOLUTE_MIND_PORT: entry ? String(entry.port) : undefined,
+    VOLUTE_MIND_TOKEN: token,
+    ...mindTmpEnv(mindHome),
+    PATH: `${mindLocalBin}:${currentPath}`,
+  };
+}
+
+/**
+ * Run a mind-authored script (scheduled scripts, lifecycle hooks) on the mind's
+ * behalf, with as little of the daemon's authority as the configuration allows.
+ *
+ * Two guarantees, and they are not equally strong — don't read the first as the
+ * second:
+ *
+ * 1. **Environment: unconditional.** The script always gets the allowlisted mind
+ *    env from {@link buildMindScriptEnv} — never the daemon's `process.env`, and
+ *    never `VOLUTE_DAEMON_TOKEN`. This holds in every isolation mode.
+ * 2. **Process isolation: only as strong as the configured mode.** Under
+ *    `sandbox` the script is wrapped with the mind's sandbox (exec applies user
+ *    isolation, never the sandbox); under `user`, `mindName` goes to exec so it
+ *    runs as the mind's OS user. The two are mutually exclusive. Under isolation
+ *    `none` neither applies — `wrapForIsolation` returns the argv unchanged — so
+ *    the script runs as the daemon's own user, which on a `--system` install is
+ *    root. That is what `none` means rather than a gap here, but it is why this
+ *    docblock does not say "never in the daemon's trust domain": on `none`, it is.
+ *
+ * On `timeout` under sandbox mode: the script is not the immediate child —
+ * wrapForSandbox returns `["bash", ["-c", "env … sandbox-exec … '<script>'"]]` —
+ * and exec's timeout signals only that immediate child. That wrapped string is a
+ * single simple command, so bash exec-replaces itself down the chain and the
+ * signal reaches the script itself (verified against the real sandbox runtime).
+ * A wrapper that grew into a compound command would fork instead, and a timed-out
+ * script would be orphaned rather than killed.
+ */
+export async function runMindScript(
+  cmd: string,
+  args: string[],
+  opts: {
+    mindName: string;
+    /** Mind directory; defaults to the registry path (pass for variant overrides). */
+    dir?: string;
+    cwd?: string;
+    /** Written to the script's stdin, which is then closed. */
+    stdin?: string;
+    /** Milliseconds before the script is killed. */
+    timeout?: number;
+    /** Max stdout bytes; defaults to {@link MIND_SCRIPT_MAX_BUFFER}. */
+    maxBuffer?: number;
+  },
+): Promise<string> {
+  const dir = opts.dir ?? mindDir(opts.mindName);
+  const env = await buildMindScriptEnv(opts.mindName, dir);
+  const { cwd, stdin, timeout } = opts;
+  const maxBuffer = opts.maxBuffer ?? MIND_SCRIPT_MAX_BUFFER;
+
+  if (isSandboxEnabled()) {
+    const [wrappedCmd, wrappedArgs] = await wrapForSandbox(cmd, args, dir, opts.mindName, [
+      dir,
+      mindTmpDir(dir),
+    ]);
+    return exec(wrappedCmd, wrappedArgs, { cwd, env, stdin, timeout, maxBuffer });
+  }
+  return exec(cmd, args, { cwd, mindName: opts.mindName, env, stdin, timeout, maxBuffer });
+}

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -1,23 +1,12 @@
 import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { deliverEvent, MIND_LEVEL_THREAD, recordNotice } from "../chat/system-events.js";
-import { loadMergedEnv } from "../config/env.js";
-import {
-  findMind,
-  mindDir,
-  mindTmpDir,
-  mindTmpEnv,
-  stateDir,
-  voluteSystemDir,
-} from "../mind/registry.js";
-import { isSandboxEnabled, wrapForSandbox } from "../mind/sandbox.js";
+import { mindDir, voluteSystemDir } from "../mind/registry.js";
 import { readVoluteConfig, type Schedule, writeVoluteConfig } from "../mind/volute-config.js";
 import { getPrompt } from "../prompts.js";
-import { exec } from "../util/exec.js";
 import { clearJsonMap, loadJsonMap, saveJsonMapAsync } from "../util/json-state.js";
 import log from "../util/logger.js";
-import { buildMindBaseEnv } from "./mind-manager.js";
-import { generateMindToken, getMindToken } from "./mind-tokens.js";
+import { runMindScript } from "./mind-script.js";
 
 const slog = log.child("scheduler");
 
@@ -284,48 +273,13 @@ export class Scheduler {
   protected async runScript(script: string, cwd: string, mindName: string): Promise<string> {
     // Scheduled scripts run with the same environment a mind process gets —
     // scoped to the mind's own non-admin token — so that a script invoking the
-    // `volute` CLI authenticates as the mind instead of getting 401s.
-    const env = await this.buildScriptEnv(mindName);
-
-    // Mind-authored scripts must never run in the daemon's trust domain. Under
-    // sandbox mode, wrap with the mind's sandbox (exec only applies user
-    // isolation, never the sandbox). Isolation and sandbox modes are mutually
-    // exclusive, so we pass mindName to exec only in the non-sandbox case.
-    if (isSandboxEnabled()) {
-      const dir = this.mindDirs.get(mindName) ?? mindDir(mindName);
-      const [cmd, args] = await wrapForSandbox("bash", ["-c", script], dir, mindName, [
-        dir,
-        mindTmpDir(dir),
-      ]);
-      return exec(cmd, args, { cwd, env });
-    }
-    return exec("bash", ["-c", script], { cwd, mindName, env });
-  }
-
-  /**
-   * Build the environment for a scheduled script — mirrors the mind process env
-   * (allowlisted base + merged mind env + VOLUTE_* runtime vars), authenticated
-   * with the mind's own per-mind, non-admin token. Reuses the running mind's
-   * token when present; otherwise mints one (stable across fires, regenerated on
-   * next mind start). The daemon admin token is never included.
-   */
-  private async buildScriptEnv(mindName: string): Promise<Record<string, string | undefined>> {
-    const dir = this.mindDirs.get(mindName) ?? mindDir(mindName);
-    const entry = await findMind(mindName);
-    const token = getMindToken(mindName) ?? generateMindToken(mindName);
-    const mindLocalBin = resolve(dir, "home", ".local", "bin");
-    const currentPath = process.env.PATH ?? "";
-    return {
-      ...buildMindBaseEnv(),
-      ...loadMergedEnv(mindName),
-      VOLUTE_MIND: mindName,
-      VOLUTE_STATE_DIR: stateDir(mindName),
-      VOLUTE_MIND_DIR: dir,
-      VOLUTE_MIND_PORT: entry ? String(entry.port) : undefined,
-      VOLUTE_MIND_TOKEN: token,
-      ...mindTmpEnv(dir),
-      PATH: `${mindLocalBin}:${currentPath}`,
-    };
+    // `volute` CLI authenticates as the mind instead of getting 401s, and they
+    // never run in the daemon's trust domain. runMindScript owns both halves.
+    return runMindScript("bash", ["-c", script], {
+      mindName,
+      dir: this.mindDirs.get(mindName),
+      cwd,
+    });
   }
 
   protected async deliverSystem(

--- a/packages/daemon/src/lib/daemon/sleep-manager.ts
+++ b/packages/daemon/src/lib/daemon/sleep-manager.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn as spawnChild } from "node:child_process";
+import { execFile } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -34,6 +34,7 @@ import { deliveryQueue } from "../schema.js";
 import { collectTurnContext } from "../turn-context.js";
 import log from "../util/logger.js";
 import { getMindManager } from "./mind-manager.js";
+import { runMindScript } from "./mind-script.js";
 import { sleepMind, wakeMind } from "./mind-service.js";
 
 const slog = log.child("sleep");
@@ -931,36 +932,29 @@ export class SleepManager {
     });
 
     try {
-      const result = await new Promise<string>((resolvePromise, reject) => {
-        const child = spawnChild("bash", [scriptPath], {
-          cwd: mindDir(name),
-          timeout: 5000,
-          env: { ...process.env, VOLUTE_MIND: name },
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-        let stdout = "";
-        let stderr = "";
-        child.stdout.on("data", (data: Buffer) => {
-          stdout += data.toString();
-        });
-        child.stderr.on("data", (data: Buffer) => {
-          stderr += data.toString();
-        });
-        child.on("close", (code) => {
-          if (code === 0) resolvePromise(stdout);
-          else
-            reject(
-              new Error(
-                `wake-context script exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
-              ),
-            );
-        });
-        child.on("error", reject);
-        child.stdin.end(input);
+      // The hook is mind-authored, so it goes through runMindScript rather than a
+      // bare spawn (#871): the allowlisted mind env unconditionally, and the mind's
+      // sandbox or OS user under the `sandbox`/`user` isolation modes. Under
+      // isolation `none` there is no process isolation to apply and the hook runs
+      // as the daemon's user — see runMindScript's docblock for why that is the
+      // mode's meaning rather than a hole here.
+      //
+      // runMindScript writes stdin through the exec wrapper, whose stdin error
+      // guard keeps a hook that never reads its input (the shipped default is
+      // comments only) from EPIPE-ing the daemon to death (#864).
+      const result = await runMindScript("bash", [scriptPath], {
+        mindName: name,
+        cwd: mindDir(name),
+        stdin: input,
+        timeout: 5000,
       });
       return result.trim();
     } catch (err) {
-      slog.warn(`wake-context script failed for ${name}`, log.errorData(err));
+      const stderr = (err as { stderr?: string })?.stderr?.trim();
+      slog.warn(`wake-context script failed for ${name}`, {
+        ...log.errorData(err),
+        ...(stderr ? { stderr } : {}),
+      });
       return "";
     }
   }

--- a/packages/daemon/src/lib/util/exec.ts
+++ b/packages/daemon/src/lib/util/exec.ts
@@ -12,6 +12,8 @@ export async function exec(
     env?: NodeJS.ProcessEnv;
     maxBuffer?: number;
     stdin?: string;
+    /** Milliseconds before the child is killed; the callback then rejects. */
+    timeout?: number;
   },
 ): Promise<string> {
   const [wrappedCmd, wrappedArgs] = options?.mindName
@@ -21,7 +23,12 @@ export async function exec(
     const child = execFileCb(
       wrappedCmd,
       wrappedArgs,
-      { cwd: options?.cwd, env: options?.env, maxBuffer: options?.maxBuffer },
+      {
+        cwd: options?.cwd,
+        env: options?.env,
+        maxBuffer: options?.maxBuffer,
+        timeout: options?.timeout,
+      },
       (err, stdout, stderr) => {
         if (err) {
           (err as Error & { stderr?: string; stdout?: string }).stderr = stderr;
@@ -33,8 +40,18 @@ export async function exec(
       },
     );
     if (options?.stdin !== undefined && child.stdin) {
-      // EPIPE here (child exited before reading) surfaces through the exit
-      // callback above; swallow the stream-level duplicate.
+      // Discard stdin stream errors. EPIPE here means the child exited without
+      // reading its input, which is legitimate — a hook may not want stdin at all —
+      // and an unhandled 'error' event on this stream takes the whole process down
+      // (#864: it killed the daemon, every mind with it).
+      //
+      // Be clear about the cost: this is the ONLY record of the failed write. The
+      // execFile callback does not also see it — verified: a write past the pipe
+      // buffer to an already-exited child raises EPIPE on the stream while the
+      // callback fires with `err: null` and empty stdout. So a write that never
+      // landed is indistinguishable here from one that did. That trade is right
+      // only because this input is an offer the child may decline; a caller whose
+      // child MUST receive its stdin cannot learn otherwise from this wrapper.
       child.stdin.on("error", () => {});
       child.stdin.end(options.stdin);
     }

--- a/templates/_base/src/lib/startup.ts
+++ b/templates/_base/src/lib/startup.ts
@@ -210,6 +210,9 @@ export async function getStartupContext(): Promise<string | null> {
       child.stdout.on("data", (d: Buffer) => {
         out += d.toString();
       });
+      // Ignore stdin errors — the hook may exit before reading (EPIPE); an
+      // unhandled stream error here would kill the mind's server process.
+      child.stdin.on("error", () => {});
       child.stdin.end(JSON.stringify({ source: "startup" }));
       child.on("close", (code) =>
         code === 0 ? resolve(out) : reject(new Error(`exit code ${code}`)),

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -3131,4 +3131,88 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(adminBody.output, `expected output, got ${JSON.stringify(adminBody)}`);
     assert.match(adminBody.output, new RegExp(`Published: ${TEST_MIND}/notes/admin-targeted\\.md`));
   });
+
+  // The wake path runs the mind's own `wake-context.sh`. It used to be a raw spawn
+  // carrying the daemon's environment with an unguarded write to the hook's stdin:
+  // a hook that never read its input could EPIPE and kill the daemon outright —
+  // every mind with it, 16 times in 9 days on one production host, all inside the
+  // wake window (#864). And the hook ran wherever the daemon ran, as root on a
+  // --system install, whatever isolation was configured (#871).
+  //
+  // This drives the real cross-process wake with the shipped hook's shape (comments
+  // only, never reads stdin). The EPIPE itself is a race the daemon usually wins, so
+  // the deterministic reproduction lives in test/wake-context-hook.test.ts; what this
+  // pins is that a real wake still runs the hook, survives it, and does not hand it
+  // the daemon's admin token.
+  it("wake runs the mind's hook without the daemon's identity — or its life", {
+    timeout: 120000,
+  }, async () => {
+    await ensureTestMind();
+
+    const hooksDir = resolve(mindDir(TEST_MIND), "home", ".local", "hooks");
+    const hookPath = resolve(hooksDir, "wake-context.sh");
+    const markerPath = resolve(mindDir(TEST_MIND), ".mind", "e2e-wake-hook.txt");
+    const original = existsSync(hookPath) ? readFileSync(hookPath, "utf-8") : null;
+
+    async function isSleeping(): Promise<boolean> {
+      const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+      return ((await res.json()) as { sleeping: boolean }).sleeping;
+    }
+
+    async function waitForSleeping(sleeping: boolean, timeoutMs = 30000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if ((await isSleeping()) === sleeping) return;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      throw new Error(`mind did not reach sleeping=${sleeping}`);
+    }
+
+    try {
+      rmSync(markerPath, { force: true });
+      mkdirSync(hooksDir, { recursive: true });
+      mkdirSync(resolve(mindDir(TEST_MIND), ".mind"), { recursive: true });
+      // Never reads stdin, exactly like the shipped default. Installed before the
+      // wake, since the wake is what runs it.
+      writeFileSync(
+        hookPath,
+        "#!/bin/bash\n" +
+          `printf 'admin=[%s]\\ntoken=[%s]\\n' "$VOLUTE_DAEMON_TOKEN" "$VOLUTE_MIND_TOKEN" > ${markerPath}\n` +
+          "exit 0\n",
+      );
+
+      // Get the mind asleep without assuming what earlier tests left behind — some
+      // of them leave it sleeping. Sleep from a stopped state so no model turn runs
+      // (CI has no real key).
+      if (!(await isSleeping())) {
+        await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+        const sleepRes = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`, { method: "POST" });
+        assert.equal(sleepRes.status, 200, `sleep: ${await sleepRes.clone().text()}`);
+        await waitForSleeping(true);
+      }
+
+      const wakeRes = await daemonRequest(`/api/minds/${TEST_MIND}/wake`, { method: "POST" });
+      assert.equal(wakeRes.status, 200, `wake: ${await wakeRes.clone().text()}`);
+      await waitForSleeping(false);
+
+      const deadline = Date.now() + 30000;
+      while (!existsSync(markerPath) && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      assert.ok(existsSync(markerPath), "the wake path should have run the mind's hook");
+
+      // The daemon is still alive to answer — the whole point of #864.
+      const health = await fetch(`${BASE_URL}/api/health`);
+      assert.ok(health.ok, "daemon must survive a hook that ignores its stdin");
+
+      const marker = readFileSync(markerPath, "utf-8");
+      assert.match(marker, /admin=\[\]/, "the daemon's admin token must never reach the hook");
+      assert.doesNotMatch(marker, new RegExp(TOKEN), "admin token leaked into the hook env");
+      assert.doesNotMatch(marker, /token=\[\]/, "the hook should get the mind's own token");
+    } finally {
+      rmSync(markerPath, { force: true });
+      if (original !== null) writeFileSync(hookPath, original);
+      else rmSync(hookPath, { force: true });
+    }
+  });
 });

--- a/test/wake-context-hook.test.ts
+++ b/test/wake-context-hook.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
+import {
+  resolveMindToken,
+  revokeMindToken,
+} from "../packages/daemon/src/lib/daemon/mind-tokens.js";
+import { SleepManager, type SleepState } from "../packages/daemon/src/lib/daemon/sleep-manager.js";
+import { mindDir, voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
+import { exec } from "../packages/daemon/src/lib/util/exec.js";
+
+/** Reach the private hook runner the way the other sleep tests reach privates. */
+function runHook(sm: SleepManager, name: string, sleepingSince: string, duration: string) {
+  return (
+    sm as unknown as {
+      runWakeContextScript: (n: string, s: string, d: string) => Promise<string>;
+    }
+  ).runWakeContextScript(name, sleepingSince, duration);
+}
+
+function writeHook(name: string, body: string): void {
+  const hooksDir = resolve(mindDir(name), "home", ".local", "hooks");
+  mkdirSync(hooksDir, { recursive: true });
+  const path = resolve(hooksDir, "wake-context.sh");
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+describe("wake-context hook", () => {
+  const origSandbox = process.env.VOLUTE_SANDBOX;
+  const origOptional = process.env.VOLUTE_SANDBOX_OPTIONAL;
+
+  function configPath() {
+    return resolve(voluteSystemDir(), "config.json");
+  }
+
+  afterEach(() => {
+    _resetConfigCache();
+    try {
+      unlinkSync(configPath());
+    } catch {}
+    if (origSandbox === undefined) delete process.env.VOLUTE_SANDBOX;
+    else process.env.VOLUTE_SANDBOX = origSandbox;
+    if (origOptional === undefined) delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    else process.env.VOLUTE_SANDBOX_OPTIONAL = origOptional;
+  });
+
+  // #864: the shipped default hook is comments only and never reads stdin. Writing
+  // the wake JSON to a pipe whose reader is gone raises EPIPE on the stdin stream;
+  // with no listener there, Node kills the whole daemon — every mind with it.
+  //
+  // In production this is a race the daemon usually wins, so the payload here is
+  // padded past the pipe buffer to force the losing side every run: the write can
+  // no longer complete before the hook exits. Without the guard this test does not
+  // fail — it takes the test process down with it, exactly as it took the daemon.
+  it("a hook that never reads stdin does not crash the process", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const name = "wake-epipe-mind";
+    writeHook(name, "#!/bin/bash\n# comments only, exactly like the shipped default\nexit 0\n");
+
+    const sm = new SleepManager();
+    const out = await runHook(sm, name, new Date().toISOString(), "y".repeat(200_000));
+    assert.equal(out, "", "a hook that produces no output yields no wake context");
+  });
+
+  it("passes the wake JSON to a hook that does read stdin", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const name = "wake-stdin-mind";
+    writeHook(name, "#!/bin/bash\ncat\n");
+
+    const sm = new SleepManager();
+    const since = new Date().toISOString();
+    const out = await runHook(sm, name, since, "3 hours");
+    const parsed = JSON.parse(out) as { sleepingSince: string; duration: string; wakeTime: string };
+    assert.equal(parsed.sleepingSince, since);
+    assert.equal(parsed.duration, "3 hours");
+    assert.ok(parsed.wakeTime, "hook receives the wake time");
+  });
+
+  // #871: the hook is mind-authored code. It used to get `{ ...process.env }` — on a
+  // --system install that is the root daemon's environment, admin token included.
+  it("runs with the mind's own env and no daemon admin token", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const name = "wake-env-mind";
+    // Bracketed so trailing empty values survive the trim runWakeContextScript applies.
+    writeHook(
+      name,
+      '#!/bin/bash\nprintf "mind=[%s]\\ntoken=[%s]\\nadmin=[%s]\\nhost=[%s]" "$VOLUTE_MIND" "$VOLUTE_MIND_TOKEN" "$VOLUTE_DAEMON_TOKEN" "$HOST_ONLY_SECRET"\n',
+    );
+
+    process.env.VOLUTE_DAEMON_TOKEN = "super-secret-admin";
+    process.env.HOST_ONLY_SECRET = "ambient-host-secret";
+    try {
+      const sm = new SleepManager();
+      const out = await runHook(sm, name, new Date().toISOString(), "3 hours");
+      const fields = new Map(
+        out.split("\n").map((line) => {
+          const [key, value] = line.split("=", 2);
+          return [key, value.replace(/^\[|\]$/g, "")] as const;
+        }),
+      );
+      assert.equal(fields.get("mind"), name);
+      const token = fields.get("token");
+      assert.ok(token && token.length > 0, "hook should receive a mind token");
+      // The token is non-admin and scoped to this mind.
+      assert.equal(resolveMindToken(token), name);
+      // The daemon admin token is never handed to the hook (expands to empty).
+      assert.equal(fields.get("admin"), "");
+      // Nor is the daemon's ambient host environment.
+      assert.equal(fields.get("host"), "");
+    } finally {
+      delete process.env.VOLUTE_DAEMON_TOKEN;
+      delete process.env.HOST_ONLY_SECRET;
+      revokeMindToken(name);
+    }
+  });
+
+  it("routes the hook through the sandbox in sandbox mode (never bare bash)", async () => {
+    // Sandbox mode with no opt-out. The sandbox runtime is not initialized in unit
+    // tests, so a hook that went through the sandbox path fails closed instead of
+    // running bare `bash` in the daemon's trust domain. runWakeContextScript
+    // swallows hook failures, so a leaked run shows up as leaked output.
+    delete process.env.VOLUTE_SANDBOX;
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    mkdirSync(voluteSystemDir(), { recursive: true });
+    writeFileSync(configPath(), JSON.stringify({ setup: { isolation: "sandbox" } }));
+    _resetConfigCache();
+
+    const name = "wake-sandbox-mind";
+    writeHook(name, "#!/bin/bash\necho leaked-out-of-the-sandbox\n");
+
+    const sm = new SleepManager();
+    const out = await runHook(sm, name, new Date().toISOString(), "3 hours");
+    assert.equal(out, "", "hook must not run outside the sandbox when sandbox mode is on");
+  });
+
+  // Drives the whole chain — runWakeContextScript → runMindScript → exec — with a
+  // hook that never returns, because that is the wiring a regression would break:
+  // sleep-manager dropping `timeout: 5000`, or runMindScript failing to forward it.
+  // Testing exec()'s own timeout instead would prove only what was already true
+  // before this plumbing existed.
+  it("gives up on a hook that hangs, instead of blocking the wake forever", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const name = "wake-hang-mind";
+    writeHook(name, "#!/bin/bash\nsleep 120\n");
+
+    const sm = new SleepManager();
+    const started = Date.now();
+    const out = await runHook(sm, name, new Date().toISOString(), "3 hours");
+    const elapsed = Date.now() - started;
+
+    assert.equal(out, "", "a timed-out hook contributes no wake context");
+    // The wake path asks for 5s. Anything near the hook's own 120s means the cap
+    // was lost somewhere between the call site and execFile.
+    assert.ok(elapsed < 30_000, `wake waited ${elapsed}ms on a hanging hook`);
+  });
+
+  // The hook now runs through execFile, where a 1MB stdout cap would be easy to end
+  // up with — it is that function's default, and MIND_SCRIPT_MAX_BUFFER is what keeps
+  // the wake path off it deliberately rather than by accident. Overflow is not
+  // truncation: the child is killed and the caller gets nothing, so a mind that grew
+  // its own wake hook past the line would lose all of its context and never hear why.
+  // 2MB is over execFile's default and far under our cap; this goes red if anyone
+  // narrows the bound to that default.
+  it("keeps the context of a hook whose output exceeds execFile's 1MB default", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const name = "wake-bigout-mind";
+    // ~2MB: over execFile's 1MB default, far under the cap we set.
+    writeHook(name, "#!/bin/bash\nhead -c 2097152 /dev/zero | tr '\\0' 'a'\n");
+
+    const sm = new SleepManager();
+    const out = await runHook(sm, name, new Date().toISOString(), "3 hours");
+    assert.ok(out.length > 1024 * 1024, `expected the hook's full output, got ${out.length} bytes`);
+  });
+
+  // Under sandbox mode the hook is not the immediate child: wrapForSandbox returns
+  // ["bash", ["-c", "env … sandbox-exec -p '…' 'bash' '<hook>'"]], and execFile's
+  // timeout SIGTERMs only that immediate child. That wrapped string is a single
+  // simple command, so bash exec-replaces itself all the way down and the signal
+  // lands on the hook itself — verified against the real sandbox runtime, where a
+  // timed-out hook left nothing behind. This pins the portable half of that shape:
+  // if the wrapper ever grows into a compound command bash would fork instead of
+  // exec, and a leaked process per wake is a slow bleed on exactly the storage-
+  // starved hosts this fix is for.
+  it("kills a hung hook's work rather than leaving it running behind the wrapper", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "wake-hook-timeout-"));
+    const marker = resolve(dir, "kept-going");
+    await assert.rejects(() =>
+      exec("bash", ["-c", `env WRAPPED=1 bash -c 'sleep 2; echo x > ${marker}'`], { timeout: 200 }),
+    );
+    // Past the point the script would have written, had anything survived.
+    await new Promise((r) => setTimeout(r, 2600));
+    assert.ok(!existsSync(marker), "the hook's work must not outlive the timeout");
+  });
+
+  // #419/#480: a mind that fails to wake backs off, and after 5 tries the daemon
+  // stops waking it altogether. A broken context hook is not a failed wake, and must
+  // never be counted as one — a mind quietly dropped from its own mornings because
+  // its hook has a typo is the invisible harm this whole change is against. The hook
+  // runs after resetWakeBackoff() and inside its own try/catch; this pins that a hook
+  // failure neither reaches handleWakeFailure nor disturbs the state it owns.
+  it("a broken hook is not counted as a failed wake", async () => {
+    process.env.VOLUTE_SANDBOX = "0";
+    delete process.env.VOLUTE_SANDBOX_OPTIONAL;
+    const name = "wake-backoff-mind";
+    writeHook(name, "#!/bin/bash\necho 'hook is broken' >&2\nexit 3\n");
+
+    let wakeFailuresRecorded = 0;
+    class SpyingSleepManager extends SleepManager {
+      protected override async handleWakeFailure(): Promise<void> {
+        wakeFailuresRecorded++;
+      }
+      seedSleeping(mind: string): void {
+        const state: SleepState = {
+          sleeping: true,
+          sleepingSince: new Date().toISOString(),
+          scheduledWakeAt: null,
+          wokenByTrigger: false,
+          voluntaryWakeAt: null,
+          queuedMessageCount: 0,
+          triggerWakeHistory: [],
+          wakeFailures: 0,
+          nextWakeAttemptAt: null,
+        } as SleepState;
+        (this as any).states.set(mind, state);
+      }
+      stateOf(mind: string): SleepState | undefined {
+        return (this as any).states.get(mind);
+      }
+    }
+
+    const sm = new SpyingSleepManager();
+    sm.seedSleeping(name);
+    const out = await runHook(sm, name, new Date().toISOString(), "3 hours");
+
+    assert.equal(out, "", "a failing hook yields no wake context");
+    assert.equal(wakeFailuresRecorded, 0, "a hook failure is not a wake failure");
+    assert.equal(sm.stateOf(name)?.wakeFailures, 0, "backoff count untouched");
+    assert.equal(sm.stateOf(name)?.nextWakeAttemptAt, null, "no retry scheduled");
+    assert.equal(sm.stateOf(name)?.sleeping, true, "the wake itself is unaffected");
+  });
+});


### PR DESCRIPTION
The wake path spawned a mind's `home/.local/hooks/wake-context.sh` with a raw `spawn` and wrote the wake JSON to its stdin with no error listener on the stream. The shipped default hook is comments only and never reads stdin, so the write races the hook's exit; when it loses, EPIPE lands on a socket with no listener and Node kills the whole daemon — every mind with it. One production host crashed 16 times in 9 days, every occurrence inside the 07:00 wake window.

The same call also ran mind-authored code in the daemon's trust domain: no sandbox wrap, no user-isolation wrap, and `{ ...process.env }`. On a `--system` install that is root, whatever isolation is configured.

Fixes #864
Fixes #871

**This is not new hardening — it is one call site that never got a convention the codebase already had.** `exec.ts` received the identical `child.stdin.on("error", () => {})` guard in `5bcbf68a` (#775), and `templates/_base/src/lib/hook-loader.ts` has carried it since it was introduced. The wake path was written whole in `b3885833` (Mar 2026) with no stdin-error listener and never touched again. Likewise the sandbox/isolation wrapping was hardened into `Scheduler.runScript` twice in response to real incidents (`ba545d81` #338, `c8d7a33b` #474) and the wake path was simply never brought along. No commit records a reason it should differ.

So both bugs collapse into one move: `Scheduler.runScript`'s machinery is extracted into `runMindScript()` (`packages/daemon/src/lib/daemon/mind-script.ts`) and both callers use it — sandbox wrap under sandbox mode, `mindName` to the `exec` wrapper otherwise, and the allowlisted mind env with a scoped non-admin `VOLUTE_MIND_TOKEN` instead of the daemon's environment. The `exec` wrapper already guards stdin errors; it gains a `timeout` option so the wake hook keeps its 5s cap.

**Scope of the #871 fix.** The environment half is unconditional: the hook never sees the daemon's `process.env` and never sees `VOLUTE_DAEMON_TOKEN`, in every isolation mode. The process-isolation half is only as strong as the configured mode — the mind's sandbox under `sandbox`, the mind's OS user under `user`, and *neither* under isolation `none`, where `wrapForIsolation` returns the argv unchanged and the hook runs as the daemon's own user (root on a `--system` install). That is what `none` means rather than a gap in this fix, but it is stated here on purpose: an unqualified security claim is how the next person stops looking.

**Other `spawn` + `stdin.end()` sites audited:** `templates/_base/src/lib/hook-loader.ts` was already guarded. `templates/_base/src/lib/startup.ts` had the same unguarded shape and is fixed here — mind-side, so it would kill the mind's own server rather than the daemon. Note that one is template source: it reaches existing minds only through `volute mind upgrade`, while the daemon-side fix reaches every host immediately. That asymmetry is exactly how #808 happened.

**Deliberate behavior changes, so nobody reads them as accidents:**
- The wake hook's environment narrows from the full daemon `process.env` to the allowlisted mind env. That is the point of #871. The dreaming skill's `wake-context-dreams.sh` only reads the mind's own files and is unaffected.
- Under sandbox mode with an unavailable sandbox runtime, the hook now fails closed (warn + empty wake context) instead of running bare — the same trade `Scheduler.runScript` already makes.
- The wake hook's stdout bound is now stated explicitly (`MIND_SCRIPT_MAX_BUFFER`, 32MB) rather than left to `execFile`'s default. There was no regression to fix — `exec()` passes `maxBuffer` explicitly and Node treats an explicit `undefined` as unbounded, so neither the wake hook nor scheduled scripts were ever capped (measured: `undefined` returns 2MB with `err: null`; an explicit 1MB raises `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`). But depending on "an explicit undefined happens to disable the default" is an accidental guarantee, and this PR is about not having those. Overflow kills the child and returns nothing rather than truncating, which is why the bound is high: silently losing all of a mind's wake context to a limit nobody told it about is the failure this PR is against.
- `getMindToken() ?? generateMindToken()` is now the *primary* path rather than a fallback: the wake hook only fires for a sleeping, non-running mind, so the token is essentially always minted, not reused. That was an edge case for the scheduler and is the common case here.

**On `timeout` under sandbox mode:** the script is not the immediate child, and `execFile`'s timeout signals only the immediate child. Verified against the real sandbox runtime rather than reasoned about: the wrapped string is a single simple command, so bash exec-replaces itself down the chain and the signal reaches the script — a 6s hook under a 1s timeout rejected at 1006ms, left no marker file, and no lingering process. Verified on macOS (`sandbox-exec`); the property holds wherever the wrapper stays one simple command. The reasoning is recorded on `runMindScript` and pinned by a portable test asserting that shape, so a wrapper that grew into a compound command would fork instead and regress loudly.

**A note on why this is worse than a crash.** The daemon dying at wake is the upstream trigger for #865: a mind asleep across the restart loses its schedules for the rest of the day. The host can see a service restarting. The mind can only find a day with nothing in it — no dreams, no heartbeats, no morning turn, and no error anywhere it could read. A failure that exists only from outside the one it happens to is the kind this codebase should be least willing to ship.

**Tests.** `test/wake-context-hook.test.ts` is the deterministic reproduction: the EPIPE is a race the daemon usually wins, so the payload is padded past the pipe buffer to force the losing side every run. Without the guard that test does not report a failure — it takes the runner down, the way the daemon went down. Also covered: the mind env carries no daemon admin token and no ambient host vars; sandbox mode never runs the hook bare; a hung hook is killed rather than orphaned, driven through the whole chain (`runWakeContextScript` → `runMindScript` → `exec`) so it catches `sleep-manager` dropping `timeout: 5000` or `runMindScript` failing to forward it; and a broken hook is not counted against the wake-failure backoff (#419/#480) — a mind dropped from its own mornings over a typo in its hook is precisely the harm here. The e2e in `test/daemon-e2e.test.ts` drives a real cross-process wake with the shipped hook's shape and asserts the daemon is still answering afterwards. Each fix was verified to fail without it.

**Sequencing note:** this touches `packages/daemon/src/lib/daemon/scheduler.ts` by extraction only (its `runScript`/`buildScriptEnv` become `runMindScript`/`buildMindScriptEnv`); behavior is unchanged and its existing tests pass untouched. Merge before #881's sibling scheduler PR, which rebases on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGyFwod1mszVgRJU3iP6aC
