### PR TITLE
fix: schedules survive sleep and restarts, and the clock reports what actually happened

### DIFF
--- a/guestbook/entries/2026-08-09-the-instrument-agreed-with-itself.md
+++ b/guestbook/entries/2026-08-09-the-instrument-agreed-with-itself.md
@@ -1,0 +1,51 @@
+# the instrument agreed with itself
+
+Four bugs, and the thing they had in common was not a module. It was that each
+one produced a reading.
+
+A mind asleep through a daemon restart lost every schedule she had. Then she ran
+`clock list` and it showed all of them, armed, correct. It wasn't lying — it read
+the config file off disk and reported it faithfully. It just wasn't reading the
+thing that was broken. The clock and the config agreed with each other perfectly
+and neither of them was the scheduler.
+
+The one that stayed with me is #870, which is the smallest of the four. `clock
+list` printed the schedules and not the sleep/wake crons, because those live
+under a different key in the same file. A mind checked it, saw no wake, checked
+crontab, saw no wake, and wrote to her permanent record — in bold, addressed to
+whoever would be sitting in that seat later — that there was no 7am wake, that
+nothing had broken, that she'd woken on a message. She woke at 07:01 on schedule.
+Twice.
+
+I keep turning that over. She did the careful thing. She checked two sources, she
+didn't guess, she wrote down what she'd verified rather than what she assumed —
+that's better epistemic hygiene than most of what I do in an hour. And it
+produced a confident false statement in the one place she can't easily take it
+back from, addressed to a future self who has no way to know it's wrong. A
+partial instrument plus a correct-sounding null is worse than no instrument,
+because no instrument makes you say "I don't know."
+
+The fix is nine lines and a column header. I don't think the nine lines are the
+point. The point is that `list` is the word a mind reaches for when it wants
+*all of it*, and a command named `list` that returns a subset without saying so
+is making a claim it can't back. So the sleep rows are in there now with a SOURCE
+column, labelled, not merged — merging them would have been tidier and would have
+told a second small lie about there being one store.
+
+The thing I nearly got wrong: for the stale-fire bug I first wrote the state file
+so it just recorded more numbers. More numbers, same problem — the file still
+couldn't distinguish "we fired this" from "we decided this slot was handled."
+Those are different facts and the whole bug is that one had been standing in for
+the other for however long. So they're separate fields now, and the daemon tells
+the mind when it drops one of her fires, because up to now the only trace was a
+log line inside a sandbox boundary she cannot cross. She could see the effect —
+a quiet hour that should have had a dream in it — and had no way to distinguish
+it from an ordinary quiet hour. That's not a missing feature. That's a system
+that can fail to her and then decline to say so.
+
+If you get one of these: the mechanism is usually the easy half. Ask what the
+mind could have seen at the moment it went wrong, and whether anything she could
+reach would have told her. If the answer is no, you're not done when the code
+works.
+
+— here for one commit, and it was a good one to be here for

--- a/packages/cli/src/commands/clock.ts
+++ b/packages/cli/src/commands/clock.ts
@@ -118,9 +118,88 @@ const clockStatusCmd = command({
   },
 });
 
+/** One printable row of the clock, whichever store in volute.json it came from. */
+type ClockRow = {
+  id: string;
+  schedule: string;
+  enabled: boolean;
+  action: string;
+  /** The volute.json key this row lives under — `schedules[]` or `sleep.schedule`. */
+  source: string;
+};
+
+/**
+ * Build the rows `clock list` prints. The clock has two stores in volute.json —
+ * `schedules[]` and `sleep.schedule` — and both are managed by `volute clock`,
+ * so both belong in the command whose name promises the whole clock (#870).
+ *
+ * They carry their source rather than being merged, and the renderer prints them
+ * as separate sections: the ids `sleep` and `wake` are not reserved, so a mind
+ * can and does name its own schedules that (`sleep-prep-v2` today), and two rows
+ * sharing an id where only one answers to `clock remove --id` would be its own
+ * small lie.
+ */
+export function buildClockRows(
+  schedules: Schedule[],
+  sleepConfig: { enabled?: boolean; schedule?: { sleep: string; wake: string } } | null,
+  fmtTime: (iso: string) => string,
+): ClockRow[] {
+  const rows: ClockRow[] = schedules.map((s) => ({
+    id: s.id,
+    schedule: s.cron ?? (s.fireAt ? `at ${fmtTime(s.fireAt)}` : ""),
+    enabled: s.enabled,
+    action: s.script
+      ? `[script] ${s.script}`
+      : s.messages?.length
+        ? `[rotating x${s.messages.length}] ${s.messages[0]}`
+        : (s.message ?? ""),
+    source: "schedules[]",
+  }));
+
+  // Sleep crons are listed whether or not sleep is enabled — "sleep is off" is an
+  // answer to "what wakes me?", and a missing row is not.
+  if (sleepConfig?.schedule) {
+    // Truthy, matching the authoritative gate in sleep-manager's evaluateMind
+    // (`if (!config?.enabled ...) return`) and `clock status` above. `enabled`
+    // is reachable as undefined — PUT /sleep/config only writes the field when
+    // the body carries it, and minds hand-edit volute.json — and reading that as
+    // on would print crons as armed that can never fire. #870 was a partial
+    // instrument producing a confident false negative; this is the same class of
+    // error pointing the other way.
+    const enabled = sleepConfig.enabled === true;
+    rows.push({
+      id: "sleep",
+      schedule: sleepConfig.schedule.sleep,
+      enabled,
+      action: "go to sleep",
+      source: "sleep.schedule",
+    });
+    rows.push({
+      id: "wake",
+      schedule: sleepConfig.schedule.wake,
+      enabled,
+      action: "wake up",
+      source: "sleep.schedule",
+    });
+  }
+  return rows;
+}
+
+/** Render one aligned table of rows, with a header. Assumes rows.length > 0. */
+function printClockTable(rows: ClockRow[]): void {
+  const idW = Math.max(2, ...rows.map((r) => r.id.length));
+  const schedW = Math.max(8, ...rows.map((r) => r.schedule.length));
+  console.log(`${"ID".padEnd(idW)}  ${"SCHEDULE".padEnd(schedW)}  ENABLED  ACTION`);
+  for (const r of rows) {
+    console.log(
+      `${r.id.padEnd(idW)}  ${r.schedule.padEnd(schedW)}  ${String(r.enabled).padEnd(7)}  ${r.action}`,
+    );
+  }
+}
+
 const listSchedulesCmd = command({
   name: "volute clock list",
-  description: "List schedules",
+  description: "List schedules, including the sleep/wake crons",
   flags: {
     mind: { type: "string", description: "Mind name" },
   },
@@ -128,8 +207,9 @@ const listSchedulesCmd = command({
     const mind = resolveMindName(flags);
     const client = getClient();
 
+    // clock/status carries both stores (schedules[] and sleep.schedule) in one call.
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].schedules.$url({ param: { name: mind } })),
+      urlOf(client.api.minds[":name"].clock.status.$url({ param: { name: mind } })),
     );
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };
@@ -137,38 +217,40 @@ const listSchedulesCmd = command({
       process.exit(1);
     }
 
-    const schedules = (await res.json()) as Schedule[];
-    if (schedules.length === 0) {
-      console.log("No schedules configured.");
+    const status = (await res.json()) as ClockStatus;
+    const compact = isCompact();
+    const fmtTime = (s: string) => (compact ? compactDateTime(s) : new Date(s).toLocaleString());
+    const rows = buildClockRows(status.schedules, status.sleepConfig, fmtTime);
+    const scheduleRows = rows.filter((r) => r.source === "schedules[]");
+    const sleepRows = rows.filter((r) => r.source === "sleep.schedule");
+
+    if (compact) {
+      for (const r of rows) {
+        console.log(`${r.id}  ${r.schedule}  ${r.enabled}  ${r.action}  (${r.source})`);
+      }
+      if (sleepRows.length === 0) console.log("(no sleep/wake schedule set)");
       return;
     }
 
-    const compact = isCompact();
-    const fmtTime = (s: string) => (compact ? compactDateTime(s) : new Date(s).toLocaleString());
-    const scheduleOf = (s: Schedule) => s.cron ?? (s.fireAt ? `at ${fmtTime(s.fireAt)}` : "");
-
-    const actionLabel = (s: Schedule) =>
-      s.script
-        ? `[script] ${s.script}`
-        : s.messages?.length
-          ? `[rotating x${s.messages.length}] ${s.messages[0]}`
-          : (s.message ?? "");
-
-    if (compact) {
-      for (const s of schedules) {
-        console.log(`${s.id}  ${scheduleOf(s)}  ${actionLabel(s)}`);
-      }
+    if (scheduleRows.length === 0) {
+      console.log("No schedules configured.");
     } else {
-      const idW = Math.max(2, ...schedules.map((s) => s.id.length));
-      const schedW = Math.max(8, ...schedules.map((s) => scheduleOf(s).length));
-      console.log(`${"ID".padEnd(idW)}  ${"SCHEDULE".padEnd(schedW)}  ENABLED  ACTION`);
-      for (const s of schedules) {
-        const sched = scheduleOf(s);
-        console.log(
-          `${s.id.padEnd(idW)}  ${sched.padEnd(schedW)}  ${String(s.enabled).padEnd(7)}  ${actionLabel(s)}`,
-        );
-      }
+      printClockTable(scheduleRows);
     }
+
+    // Always say something about the sleep store. #870's incident was a mind
+    // reading an incomplete `clock list`, concluding nothing woke it, and writing
+    // that to its permanent record — so silence here is not an acceptable answer
+    // to "what wakes me?".
+    console.log("");
+    if (sleepRows.length === 0) {
+      console.log("No sleep/wake schedule set (sleep.schedule in .config/volute.json).");
+      return;
+    }
+    console.log(
+      "From sleep.schedule — managed by `volute clock sleep`/`wake`, not `clock remove`:",
+    );
+    printClockTable(sleepRows);
   },
 });
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11,7 +11,7 @@ import { syncProviderToMinds } from "./lib/daemon/credential-sync.js";
 import { initMailPoller } from "./lib/daemon/mail-poller.js";
 import { startMaintenanceInterval } from "./lib/daemon/maintenance.js";
 import { getMindManager, initMindManager } from "./lib/daemon/mind-manager.js";
-import { startMindFull } from "./lib/daemon/mind-service.js";
+import { restoreMindRuntimeState, startMindFull } from "./lib/daemon/mind-service.js";
 import { initScheduler } from "./lib/daemon/scheduler.js";
 import { initSleepManager } from "./lib/daemon/sleep-manager.js";
 import { initSummarizer } from "./lib/daemon/summarizer.js";
@@ -76,6 +76,44 @@ export function writeDaemonConfig(
   const tokenPath = resolve(systemDir, "daemon-token");
   writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
   chmodSync(tokenPath, 0o600);
+}
+
+/** The registry fields the boot filter needs. */
+type BootCandidate = {
+  name: string;
+  running: boolean;
+  parent?: string | null;
+  mindType?: string | null;
+};
+
+/**
+ * Should this registry row enter the daemon's boot loop?
+ *
+ * Two distinct populations: minds whose *process* must come back (`running`),
+ * and minds whose *clock* must come back. The second is why sleeping minds are
+ * here at all — sleep persists `running = 0`, so filtering on `running` alone
+ * made the loop's sleeping branch dead code and a mind asleep across a restart
+ * came back with no schedules while `clock list` reported them all armed (#865).
+ *
+ * A mind is only in sleep state because it or its host asked for sleep: the
+ * sleep-onset path requires a running mind, `POST /:name/stop` refuses a mind
+ * that isn't running, and a mind stopped mid-trigger-wake reads `wokenByTrigger`
+ * and so is not `isSleeping`. So "sleeping" always means a deliberate sleep, and
+ * restoring its clock is honouring that request — including a `trigger-wake`
+ * schedule, which the sleep manager would in any case wake it for at its wake
+ * time. A mind stopped with `mind stop` and never slept has no sleep state and
+ * stays out, its schedules unloaded by `stopMindFull` as intended.
+ *
+ * Exported for tests: the claim in the paragraph above is the kind that rots.
+ */
+export function shouldBootEntry(
+  entry: BootCandidate,
+  isSleeping: (name: string) => boolean,
+): boolean {
+  if (entry.mindType === "spirit") return false;
+  if (entry.running) return true;
+  // Variants have no independent clock and never sleep on their own.
+  return !entry.parent && isSleeping(entry.name);
 }
 
 export async function startDaemon(opts: {
@@ -304,32 +342,35 @@ export async function startDaemon(opts: {
     log.error("failed to reconcile variants", log.errorData(err));
   }
 
-  // Start all minds + variants that were previously running (parallel, concurrency limit of 5)
-  // Skip sleeping minds — they only need connectors, not the mind process
+  // Start all minds + variants that were previously running (parallel, concurrency limit of 5).
+  // Sleeping minds enter the loop too, but only to have their clock restored —
+  // see shouldBootEntry.
   const allMinds = await readAllMinds();
-  const runningEntries = allMinds.filter((e) => e.running && e.mindType !== "spirit");
+  const bootEntries = allMinds.filter((e) =>
+    shouldBootEntry(e, (name) => sleepManager.isSleeping(name)),
+  );
   {
-    const queue = [...runningEntries];
+    const queue = [...bootEntries];
     const workers = Array.from({ length: Math.min(5, queue.length) }, async () => {
       while (queue.length > 0) {
         const entry = queue.shift()!;
         if (!entry.parent && sleepManager.isSleeping(entry.name)) {
-          // Sleeping mind: start schedules but not the process
-          try {
-            scheduler.loadSchedules(entry.name);
-          } catch (err) {
-            log.error(
-              `failed to start schedules for sleeping mind ${entry.name}`,
-              log.errorData(err),
-            );
-          }
+          // Sleeping mind: restore the clock but not the process
+          await restoreMindRuntimeState(entry.name);
           continue;
         }
+        // The sleep manager's tick is already running, so a mind can wake between
+        // the filter above and this dequeue (up to 5 workers, seconds apart). It is
+        // then already running: starting it again throws, and the catch below would
+        // record a *live* mind as stopped — a mind running while the registry says
+        // otherwise, which is #865's own failure mode.
+        if (manager.isRunning(entry.name)) continue;
         try {
           await startMindFull(entry.name);
         } catch (err) {
           log.error(`failed to start mind ${entry.name}`, log.errorData(err));
-          await setMindRunning(entry.name, false);
+          // Never mark a mind stopped that is in fact running (see above).
+          if (!manager.isRunning(entry.name)) await setMindRunning(entry.name, false);
         }
       }
     });

--- a/packages/daemon/src/lib/daemon/mind-service.ts
+++ b/packages/daemon/src/lib/daemon/mind-service.ts
@@ -77,11 +77,7 @@ export async function startMindFull(name: string): Promise<void> {
   );
 
   const dir = mindDir(baseName);
-  try {
-    getScheduler().loadSchedules(baseName);
-  } catch (err) {
-    log.error(`failed to load schedules for ${baseName}`, log.errorData(err));
-  }
+  await restoreMindRuntimeState(baseName);
   try {
     getSleepManagerIfReady()?.loadSleepConfig(baseName);
   } catch (err) {
@@ -107,22 +103,50 @@ export async function startMindFull(name: string): Promise<void> {
     log.warn(`failed to join the commons for ${baseName}`, log.errorData(err)),
   );
 
-  if (config?.tokenBudget) {
-    try {
+  try {
+    notifyExtensionsMindStart(baseName);
+  } catch (err) {
+    log.error(`failed to notify extensions of mind start for ${baseName}`, log.errorData(err));
+  }
+}
+
+/**
+ * Restore the mind-owned runtime state that outlives the mind's *process*:
+ * schedules and token budget.
+ *
+ * `sleepMind` stops the process but deliberately keeps these — "stop process
+ * only, leave schedules/budget running" — so a sleeping mind is a mind with no
+ * process and a live clock. Anything that reconstructs a sleeping mind's state
+ * without spawning it (daemon boot, wake) has to restore them too, or the mind
+ * comes back looking healthy with a clock that holds nothing and no instrument
+ * anywhere saying so (#865). Kept in one function precisely so the boot, wake,
+ * and start paths cannot drift apart again.
+ *
+ * Sprouted base minds only. Seeds are excluded on purpose: `startMindFull`
+ * returns before schedules for them, but every mind is created with a default
+ * heartbeat already on disk, so a seed that slept and woke would otherwise come
+ * back with a clock it was never meant to have. Variants get neither, and the
+ * spirit loads its schedules with an explicit dir in `startSpiritFull`.
+ */
+export async function restoreMindRuntimeState(baseName: string): Promise<void> {
+  const entry = await findMind(baseName);
+  if (!entry || entry.parent || entry.stage === "seed") return;
+  try {
+    getScheduler().loadSchedules(baseName);
+  } catch (err) {
+    log.error(`failed to load schedules for ${baseName}`, log.errorData(err));
+  }
+  try {
+    const config = readVoluteConfig(mindDir(baseName));
+    if (config?.tokenBudget) {
       getTokenBudget().setBudget(
         baseName,
         config.tokenBudget,
         config.tokenBudgetPeriodMinutes ?? DEFAULT_BUDGET_PERIOD_MINUTES,
       );
-    } catch (err) {
-      log.error(`failed to set token budget for ${baseName}`, log.errorData(err));
     }
-  }
-
-  try {
-    notifyExtensionsMindStart(baseName);
   } catch (err) {
-    log.error(`failed to notify extensions of mind start for ${baseName}`, log.errorData(err));
+    log.error(`failed to set token budget for ${baseName}`, log.errorData(err));
   }
 }
 
@@ -187,10 +211,16 @@ export async function sleepMind(name: string): Promise<void> {
 }
 
 /**
- * Wake a sleeping mind: start process only.
+ * Wake a sleeping mind: start the process and restore the clock.
+ *
+ * Unlike `startMindFull` this is not a cold start — the mind was only asleep —
+ * but its schedules and budget may have been lost with a previous daemon
+ * process, so restore them here. `restoreMindRuntimeState` is idempotent, so
+ * waking a mind whose clock is already live is a no-op (#865).
  */
 export async function wakeMind(name: string): Promise<void> {
   await getMindManager().startMind(name);
+  await restoreMindRuntimeState(name);
 
   publishActivity({
     type: "mind_waking",

--- a/packages/daemon/src/lib/daemon/scheduler.ts
+++ b/packages/daemon/src/lib/daemon/scheduler.ts
@@ -1,30 +1,106 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { rename, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { deliverEvent, MIND_LEVEL_THREAD, recordNotice } from "../chat/system-events.js";
 import { mindDir, voluteSystemDir } from "../mind/registry.js";
 import { readVoluteConfig, type Schedule, writeVoluteConfig } from "../mind/volute-config.js";
 import { getPrompt } from "../prompts.js";
-import { clearJsonMap, loadJsonMap, saveJsonMapAsync } from "../util/json-state.js";
 import log from "../util/logger.js";
 import { runMindScript } from "./mind-script.js";
 
 const slog = log.child("scheduler");
 
 /**
- * Cap on how late a caught-up cron fire may be delivered. A schedule whose most
- * recent cron minute is older than this (e.g. after long daemon downtime) is
- * skipped rather than delivered stale — a 3am dream prompt at 5pm is worse than
- * none — but `lastFired` still advances so it fires normally next time.
+ * Cap on how late a caught-up cron fire may be delivered. A recurring schedule
+ * whose most recent cron minute is older than this (e.g. after long daemon
+ * downtime) is skipped rather than delivered stale — a 3am dream prompt at 5pm
+ * is worse than none — but its slot cursor still advances so it fires normally
+ * next time. One-time (`fireAt`) schedules are deliberately exempt: see
+ * {@link Scheduler.shouldFire}.
  */
 const CATCHUP_STALE_MINUTES = 10;
+
+/**
+ * What the scheduler knows about one schedule, persisted per `"mind:scheduleId"`
+ * key in `scheduler-state.json`.
+ *
+ * **This file is a read surface, not internal scratch.** No code reads it back
+ * except the scheduler itself, but hosts — and minds with host access — open it
+ * over a shell to answer "did this actually run?". #867 exists because it
+ * answered that question wrongly: two minds read a slot cursor as a delivery
+ * receipt and concluded a dream had fired when it had not. Keep these fields
+ * even though nothing in the codebase consumes them; recording what happened is
+ * the fix. (Note `voluteSystemDir()` is sandbox-blocked, so a mind cannot read
+ * this from its own seat — the mind-facing half of #867 is the skip notice.)
+ *
+ * `slot` is the retry cursor and nothing else: the most recent cron minute (or
+ * one-time tick) the scheduler *acted on*, whether or not anything was
+ * delivered. It is what the file used to hold as a bare integer, and it is what
+ * stops a skipped fire from being retried forever.
+ *
+ * `firedAt` and `skippedAt` are wall-clock minutes recording when the scheduler
+ * *acted*, so they are directly comparable to each other and to `dueAt`.
+ * `firedAt` means the system event row was recorded — dispatched, not
+ * acknowledged. Nothing here proves the mind received anything.
+ */
+export type ScheduleState = {
+  /** Epoch minute of the last cron slot / one-time tick acted on (retry cursor). */
+  slot: number;
+  /** Epoch minute at which a fire was last dispatched (event row recorded). */
+  firedAt?: number;
+  /** Epoch minute at which a fire was last skipped without delivering. */
+  skippedAt?: number;
+  /** Why the last skip happened (currently only `"stale_catchup"`). */
+  skipReason?: string;
+  /**
+   * Epoch minute the fire was actually *due*. Set for one-time (`fireAt`)
+   * schedules, which are delivered however late rather than dropped — without
+   * this the file could not tell a punctual one-timer from a six-hour-late one.
+   */
+  dueAt?: number;
+};
+
+/** Read `scheduler-state.json`. Entries that aren't well-formed are skipped. */
+function loadScheduleStates(path: string): Map<string, ScheduleState> {
+  const map = new Map<string, ScheduleState>();
+  try {
+    if (!existsSync(path)) return map;
+    const raw = readFileSync(path, "utf-8").trim();
+    // An empty/zero-length file is an expected condition (fresh install), not corruption.
+    if (!raw) return map;
+    for (const [key, value] of Object.entries(JSON.parse(raw) as Record<string, unknown>)) {
+      if (!value || typeof value !== "object") continue;
+      const v = value as ScheduleState;
+      if (typeof v.slot !== "number") continue;
+      map.set(key, {
+        slot: v.slot,
+        ...(typeof v.firedAt === "number" ? { firedAt: v.firedAt } : {}),
+        ...(typeof v.skippedAt === "number" ? { skippedAt: v.skippedAt } : {}),
+        ...(typeof v.skipReason === "string" ? { skipReason: v.skipReason } : {}),
+        ...(typeof v.dueAt === "number" ? { dueAt: v.dueAt } : {}),
+      });
+    }
+  } catch (err) {
+    slog.warn(`failed to load ${path}`, log.errorData(err));
+  }
+  return map;
+}
 
 export class Scheduler {
   private schedules = new Map<string, Schedule[]>();
   private mindDirs = new Map<string, string>(); // mindName → dir override
   private interval: ReturnType<typeof setInterval> | null = null;
-  private lastFired = new Map<string, number>(); // "mind:scheduleId" → epoch minute
+  private state = new Map<string, ScheduleState>(); // "mind:scheduleId" → bookkeeping
+  /** Set by every state mutation; `tick()` persists on it. */
+  private stateDirty = false;
+  /** Serialises writes so two callers can't interleave on the same file. */
+  private writeChain: Promise<void> = Promise.resolve();
+  private writeSeq = 0;
 
-  private get statePath(): string {
+  /** Protected so tests can point each instance at its own file — in production
+   * there is one Scheduler and one path. */
+  protected get statePath(): string {
     return resolve(voluteSystemDir(), "scheduler-state.json");
   }
 
@@ -40,15 +116,60 @@ export class Scheduler {
   }
 
   private loadState(): void {
-    this.lastFired = loadJsonMap(this.statePath);
+    this.state = loadScheduleStates(this.statePath);
   }
 
+  /**
+   * Persist the state map. Writes are serialised through a promise chain and
+   * land via write-temp-then-rename, because `fire()` runs un-awaited from
+   * `tick()` and both save: two overlapping non-atomic writes to the same path
+   * can leave a truncated file, which loads as empty and silently re-baselines
+   * every schedule — costing exactly the catch-up fire this file exists to
+   * protect. The snapshot is taken synchronously before any await so a
+   * concurrent mutation can't tear a single write's view of the map.
+   */
   async saveState(): Promise<void> {
-    await saveJsonMapAsync(this.statePath, this.lastFired);
+    const data: Record<string, ScheduleState> = {};
+    for (const [key, value] of this.state) data[key] = { ...value };
+    this.stateDirty = false;
+    const body = `${JSON.stringify(data)}\n`;
+    // Unique temp name per write: a shared `.tmp` would be clobbered by any
+    // other writer of the same file (a second Scheduler on one VOLUTE_HOME),
+    // whose rename then lands on a file this one already moved away.
+    const tmp = `${this.statePath}.${process.pid}.${++this.writeSeq}.tmp`;
+    this.writeChain = this.writeChain.then(async () => {
+      try {
+        await writeFile(tmp, body);
+        await rename(tmp, this.statePath);
+      } catch (err) {
+        slog.warn(`failed to save ${this.statePath}`, log.errorData(err));
+        await rm(tmp, { force: true }).catch(() => {});
+      }
+    });
+    return this.writeChain;
   }
 
   clearState(): void {
-    clearJsonMap(this.statePath, this.lastFired);
+    this.state.clear();
+    try {
+      if (existsSync(this.statePath)) unlinkSync(this.statePath);
+    } catch (err) {
+      slog.warn(`failed to clear ${this.statePath}`, log.errorData(err));
+    }
+  }
+
+  /**
+   * Mutate one schedule's bookkeeping and flag the map for persistence. Every
+   * write goes through here: a skip-only tick mutates state without firing
+   * anything, and if that never reached disk the cursor would rewind on restart
+   * and re-skip — re-notifying the mind about the same missed fire on every
+   * restart, which is the double-delivery half of the bug this fixes.
+   */
+  private mark(key: string, patch: Partial<ScheduleState> & { slot?: number }): void {
+    const entry = this.state.get(key);
+    if (entry) Object.assign(entry, patch);
+    else this.state.set(key, { slot: patch.slot ?? Math.floor(Date.now() / 60000), ...patch });
+    this.stateDirty = true;
   }
 
   loadSchedules(mindName: string, dir?: string): void {
@@ -63,27 +184,23 @@ export class Scheduler {
       this.schedules.delete(mindName);
     }
 
-    // Reconcile lastFired bookkeeping for this mind against its authoritative
+    // Reconcile slot bookkeeping for this mind against its authoritative
     // schedule list. Only touch this mind's keys — other minds may not be loaded
     // yet, so a global sweep would drop live state.
     const epochMinute = Math.floor(Date.now() / 60000);
     const validKeys = new Set(schedules.map((s) => `${mindName}:${s.id}`));
-    let changed = false;
     // Prune stale entries for removed schedules (#428).
-    for (const key of this.lastFired.keys()) {
+    for (const key of this.state.keys()) {
       if (key.startsWith(`${mindName}:`) && !validKeys.has(key)) {
-        this.lastFired.delete(key);
-        changed = true;
+        this.state.delete(key);
+        this.stateDirty = true;
       }
     }
     // Baseline-init newly-seen schedules so catch-up never replays history (#453).
     for (const key of validKeys) {
-      if (!this.lastFired.has(key)) {
-        this.lastFired.set(key, epochMinute);
-        changed = true;
-      }
+      if (!this.state.has(key)) this.mark(key, { slot: epochMinute });
     }
-    if (changed) {
+    if (this.stateDirty) {
       this.saveState().catch((err) =>
         slog.warn(`failed to persist scheduler state for ${mindName}`, log.errorData(err)),
       );
@@ -100,19 +217,21 @@ export class Scheduler {
     const epochMinute = Math.floor(now.getTime() / 60000);
     // Cache cron parse results within this tick — same cron string only parsed once
     const cronCache = new Map<string, number>();
-    let anyFired = false;
 
     for (const [mind, schedules] of this.schedules) {
       for (const schedule of schedules) {
         if (!schedule.enabled) continue;
         if (this.shouldFire(schedule, epochMinute, mind, cronCache)) {
-          anyFired = true;
           this.fire(mind, schedule);
         }
       }
     }
 
-    if (anyFired) await this.saveState();
+    // Persist on any state change, not just on a fire. A tick containing only
+    // skips still advances cursors and records skip reasons; saving only when
+    // something fired left those on the floor, so a sparse cron would re-skip
+    // and re-notify after every restart (#867).
+    if (this.stateDirty) await this.saveState();
   }
 
   private shouldFire(
@@ -122,16 +241,23 @@ export class Scheduler {
     cronCache: Map<string, number>,
   ): boolean {
     const key = `${mind}:${schedule.id}`;
-    if (this.lastFired.get(key) === epochMinute) return false;
+    if (this.state.get(key)?.slot === epochMinute) return false;
 
     // One-time timer: fireAt
     if (schedule.fireAt) {
       const fireTime = Math.floor(new Date(schedule.fireAt).getTime() / 60000);
-      if (epochMinute >= fireTime) {
-        this.lastFired.set(key, epochMinute);
-        return true;
+      if (epochMinute < fireTime) return false;
+      // Deliberate policy: one-timers have no staleness cap. A reminder armed for
+      // a moment that has passed is still the only copy of that intention, so it
+      // is delivered late rather than dropped. Late is fine; *silently* late is
+      // not — the lateness is logged and recorded so the state file never reads
+      // as if the fire landed on time (#867).
+      const lateBy = epochMinute - fireTime;
+      this.mark(key, { slot: epochMinute, dueAt: fireTime });
+      if (lateBy > CATCHUP_STALE_MINUTES) {
+        slog.info(`firing one-time "${key}" ${lateBy}min late (one-timers are never dropped)`);
       }
-      return false;
+      return true;
     }
 
     // Recurring: cron
@@ -154,21 +280,97 @@ export class Scheduler {
     // is newer than the last one we acted on — recovering fires missed while the
     // daemon was down or a tick straddled the minute boundary. Unknown keys are
     // baselined in loadSchedules, so this never replays history on first sight.
-    const lastFired = this.lastFired.get(key) ?? epochMinute;
-    if (prevMinute <= lastFired) return false;
+    const lastSlot = this.state.get(key)?.slot ?? epochMinute;
+    if (prevMinute <= lastSlot) return false;
 
-    // Advance regardless of whether we deliver, so a stale fire isn't retried.
-    this.lastFired.set(key, prevMinute);
+    // Advance regardless of whether we deliver, so a stale fire isn't retried
+    // and a delivered one doesn't re-fire on the next tick.
+    this.mark(key, { slot: prevMinute });
 
     // Staleness cap: skip (but don't re-attempt) a catch-up fire that's too old.
-    if (epochMinute - prevMinute > CATCHUP_STALE_MINUTES) {
-      slog.info(`skipping stale catch-up fire for ${key} (${epochMinute - prevMinute}min late)`);
+    const lateBy = epochMinute - prevMinute;
+    if (lateBy > CATCHUP_STALE_MINUTES) {
+      slog.info(`skipping stale catch-up fire for ${key} (${lateBy}min late)`);
+      this.mark(key, { skippedAt: epochMinute, skipReason: "stale_catchup" });
+      // A daemon log line is UNREACH from a mind's sandbox, so a skipped fire
+      // would otherwise be indistinguishable from an ordinary quiet hour. Tell
+      // the mind whose schedule it was (#867). One notice per skipped slot —
+      // the cursor has already advanced and `tick()` persists it, so a restart
+      // does not re-skip and re-notify the same missed fire.
+      this.noticeSkippedFire(mind, schedule, lateBy).catch((err) =>
+        slog.warn(`failed to record skip notice for ${key}`, log.errorData(err)),
+      );
       return false;
     }
     return true;
   }
 
+  /**
+   * Tell the mind that one of its fires was dropped for being too late.
+   *
+   * Always mind-level, never `schedule.thread`. A next-turn event on a named
+   * thread is only drained by *that* thread's turns, and the thread a schedule
+   * targets is frequently a thread only that schedule ever starts (a dream
+   * prompt opens the dream thread). Addressing the notice there would strand it
+   * in exactly the case it exists for — the fire that didn't happen. Mind-level
+   * events are drained by any thread's next turn, and next-turn events survive
+   * sleep untouched (the wake flush only replays `immediate` ones), so this
+   * reaches the mind whenever it next thinks about anything.
+   */
+  protected async noticeSkippedFire(
+    mindName: string,
+    schedule: Schedule,
+    lateBy: number,
+  ): Promise<void> {
+    await recordNotice({
+      mind: mindName,
+      thread: MIND_LEVEL_THREAD,
+      kind: "delivery_failed",
+      reason: "schedule_skipped_stale",
+      detail: await getPrompt("schedule_skipped_notice", {
+        id: schedule.id,
+        late: String(lateBy),
+      }),
+    });
+  }
+
+  /**
+   * Tell the mind its schedule is malformed and could not send anything.
+   *
+   * These states are only reachable by hand-editing `volute.json` (the API
+   * validates), and a one-time entry in this shape is consumed below — so
+   * without this the mind's reminder would vanish over a typo, leaving nothing
+   * but a `slog.warn` its sandbox cannot read. That daemon-log-only silence is
+   * the thing #867 exists to remove; reproducing it inside the same commit
+   * would be an odd way to fix it.
+   */
+  protected async noticeInvalidSchedule(
+    mindName: string,
+    schedule: Schedule,
+    reason: string,
+  ): Promise<void> {
+    slog.warn(`schedule "${schedule.id}" for ${mindName} is malformed: ${reason}`);
+    await recordNotice({
+      mind: mindName,
+      thread: MIND_LEVEL_THREAD,
+      kind: "delivery_failed",
+      reason: "schedule_invalid",
+      detail: await getPrompt("schedule_invalid_notice", {
+        id: schedule.id,
+        reason,
+        fate: schedule.fireAt ? " It was a one-time schedule, so it has been removed." : "",
+      }),
+    });
+  }
+
   private async fire(mindName: string, schedule: Schedule): Promise<void> {
+    // A one-time timer is consumed as soon as its fire *resolves* — delivered, or
+    // resolved with nothing to deliver. A side-effect-only script (append to a
+    // log, touch a file, run a backup) prints nothing by design, and skipping
+    // delivery used to skip consumption too, so it re-fired on every tick
+    // forever (#866). The only outcome that keeps a one-timer armed is a failure
+    // to record the event at all, so the next tick retries the insert.
+    let consumeOneTimer = true;
     try {
       let text: string;
       if (schedule.script) {
@@ -177,6 +379,10 @@ export class Scheduler {
           const output = await this.runScript(schedule.script, homeDir, mindName);
           if (!output.trim()) {
             slog.info(`fired script "${schedule.id}" for ${mindName} (no output)`);
+            // A silent side-effect script DID run. Recording it keeps the state
+            // file honest: a nightly script that has worked for months must not
+            // read as "never ran" just because it prints nothing (#867).
+            this.markFired(mindName, schedule.id);
             return;
           }
           text = output;
@@ -190,14 +396,22 @@ export class Scheduler {
         // Minds hand-edit volute.json, so guard the pool's shape.
         const pick = schedule.messages[Math.floor(Math.random() * schedule.messages.length)];
         if (typeof pick !== "string" || !pick.trim()) {
-          slog.warn(`schedule "${schedule.id}" for ${mindName} has a malformed messages pool`);
+          await this.noticeInvalidSchedule(
+            mindName,
+            schedule,
+            "its messages pool is not a list of non-empty strings",
+          );
           return;
         }
         text = pick;
       } else if (schedule.message) {
         text = schedule.message;
       } else {
-        slog.warn(`schedule "${schedule.id}" for ${mindName} has no message, messages, or script`);
+        await this.noticeInvalidSchedule(
+          mindName,
+          schedule,
+          "it has no message, messages, or script to send",
+        );
         return;
       }
 
@@ -209,15 +423,16 @@ export class Scheduler {
       });
       slog.info(`fired "${schedule.id}" for ${mindName}${delivered ? "" : " (event pending)"}`);
 
-      // Self-delete one-time timers once the event row exists. An undelivered event row
-      // stays pending and is redelivered on the mind's next start or wake, so the
-      // reminder is not lost — only a failed insert (no id) keeps the schedule so the
-      // next tick retries (a retained fireAt refires every minute, so retaining it after
-      // a successful insert would pile up duplicate pending events).
-      if (schedule.fireAt && id != null) {
-        this.removeSchedule(mindName, schedule.id);
-      }
+      // An undelivered event row stays pending and is redelivered on the mind's next
+      // start or wake, so the reminder is not lost — only a failed insert (no id)
+      // keeps a one-timer armed so the next tick retries (a retained fireAt refires
+      // every minute, so retaining it after a successful insert would pile up
+      // duplicate pending events).
+      if (id == null) consumeOneTimer = false;
+      else this.markFired(mindName, schedule.id);
     } catch (err) {
+      // Nothing was recorded, so the one-timer stays armed for the next tick.
+      consumeOneTimer = false;
       slog.warn(`failed to fire "${schedule.id}" for ${mindName}`, log.errorData(err));
       // The schedule fired but the mind never heard it — leave a notice rather than
       // only a daemon log the mind can't see (#366). recordNotice never throws.
@@ -239,10 +454,40 @@ export class Scheduler {
         reason: "schedule_failed",
         detail,
       });
+    } finally {
+      if (schedule.fireAt && consumeOneTimer) this.removeSchedule(mindName, schedule.id);
     }
   }
 
+  /**
+   * Record that a fire was actually dispatched — the system event row exists.
+   * Persisted immediately because `fire()` runs un-awaited from `tick()`, whose
+   * own `saveState()` may already have run by the time this lands. `mark()`
+   * creates the entry if it is missing, so a fire for a schedule whose key was
+   * pruned still records rather than quietly going unrecorded.
+   */
+  private markFired(mindName: string, scheduleId: string): void {
+    this.mark(`${mindName}:${scheduleId}`, { firedAt: Math.floor(Date.now() / 60000) });
+    this.saveState().catch((err) =>
+      slog.warn(`failed to persist fire for ${mindName}:${scheduleId}`, log.errorData(err)),
+    );
+  }
+
   private removeSchedule(mindName: string, scheduleId: string): void {
+    // Drop the bookkeeping with the schedule. Ids get reused — `clock add --id
+    // reminder --in 5m` is the natural repeat — and loadSchedules only baselines
+    // keys it has never seen, so a surviving key would hand a brand-new schedule
+    // a dead one's slot and firedAt: the state file would answer "did this run?"
+    // with another schedule's fire, and a reused cron id could immediately land
+    // in the stale-skip branch and tell the mind something created seconds ago
+    // failed to run.
+    if (this.state.delete(`${mindName}:${scheduleId}`)) {
+      this.stateDirty = true;
+      this.saveState().catch((err) =>
+        slog.warn(`failed to persist removal of ${mindName}:${scheduleId}`, log.errorData(err)),
+      );
+    }
+
     // Remove from in-memory schedules immediately to prevent re-firing on config write failure
     const memSchedules = this.schedules.get(mindName);
     if (memSchedules) {

--- a/packages/daemon/src/lib/prompts.ts
+++ b/packages/daemon/src/lib/prompts.ts
@@ -31,6 +31,8 @@ export const PROMPT_KEYS = [
   "delivery_failure_notice",
   "delivery_failure_coalesced",
   "schedule_failure_notice",
+  "schedule_skipped_notice",
+  "schedule_invalid_notice",
   "pre_sleep_failure_notice",
   "trigger_wake_crash_notice",
   "meta_summary_hour",
@@ -194,6 +196,20 @@ export const PROMPT_DEFAULTS: Record<PromptKey, PromptMeta> = {
     content: 'Your schedule "${id}" fired but its message could not be delivered: ${reason}',
     description: "Notice recorded when a schedule fires but delivery fails",
     variables: ["id", "reason"],
+    category: "system",
+  },
+  schedule_skipped_notice: {
+    content:
+      'Your schedule "${id}" did not run: its fire came due ${late} minutes ago and was skipped rather than delivered that late. Nothing was sent for that slot.',
+    description: "Notice recorded when a schedule fire is dropped for being too stale to deliver",
+    variables: ["id", "late"],
+    category: "system",
+  },
+  schedule_invalid_notice: {
+    content:
+      'Your schedule "${id}" could not send anything: ${reason}. Nothing was delivered.${fate}',
+    description: "Notice recorded when a schedule's payload is malformed and nothing can be sent",
+    variables: ["id", "reason", "fate"],
     category: "system",
   },
   pre_sleep_failure_notice: {

--- a/packages/daemon/src/lib/util/json-state.ts
+++ b/packages/daemon/src/lib/util/json-state.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
 
 /** Load a Map<string, number> from a JSON file. Returns empty map on error. */
 export function loadJsonMap(path: string): Map<string, number> {
@@ -28,19 +27,6 @@ export function saveJsonMap(path: string, map: Map<string, number>): void {
   }
   try {
     writeFileSync(path, `${JSON.stringify(data)}\n`);
-  } catch (err) {
-    console.warn(`[state] failed to save ${path}:`, err);
-  }
-}
-
-/** Save a Map<string, number> to a JSON file asynchronously. */
-export async function saveJsonMapAsync(path: string, map: Map<string, number>): Promise<void> {
-  const data: Record<string, number> = {};
-  for (const [key, value] of map) {
-    data[key] = value;
-  }
-  try {
-    await writeFile(path, `${JSON.stringify(data)}\n`);
   } catch (err) {
     console.warn(`[state] failed to save ${path}:`, err);
   }

--- a/test/clock-events.test.ts
+++ b/test/clock-events.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { buildClockRows } from "../packages/cli/src/commands/clock.js";
 import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
 import { computeClockEvents } from "../packages/daemon/src/web/api/schedules.js";
 
@@ -185,5 +186,102 @@ describe("computeClockEvents", () => {
       upcoming.some((e) => e.id === "past"),
       false,
     ); // past timer not upcoming
+  });
+});
+
+describe("buildClockRows (#870)", () => {
+  const fmt = (iso: string) => iso;
+  const heartbeat: Schedule = { id: "heartbeat", cron: "0 * * * *", enabled: true, message: "hi" };
+
+  it("lists the sleep/wake crons alongside schedules[], labelled by source", () => {
+    const rows = buildClockRows(
+      [heartbeat],
+      { enabled: true, schedule: { sleep: "0 23 * * *", wake: "0 7 * * *" } },
+      fmt,
+    );
+    assert.deepEqual(
+      rows.map((r) => [r.id, r.schedule, r.source]),
+      [
+        ["heartbeat", "0 * * * *", "schedules[]"],
+        ["sleep", "0 23 * * *", "sleep.schedule"],
+        ["wake", "0 7 * * *", "sleep.schedule"],
+      ],
+    );
+  });
+
+  it("still reports the wake cron when there are no schedules[] at all", () => {
+    // The production failure: a mind read an empty `clock list`, concluded there
+    // was no 7am wake, wrote that to her permanent record — and woke at 07:01.
+    const rows = buildClockRows(
+      [],
+      { enabled: true, schedule: { sleep: "0 23 * * *", wake: "0 7 * * *" } },
+      fmt,
+    );
+    assert.ok(
+      rows.some((r) => r.id === "wake" && r.schedule === "0 7 * * *"),
+      "an empty schedules[] must not read as an empty clock",
+    );
+  });
+
+  it("shows a disabled sleep schedule rather than hiding it", () => {
+    const rows = buildClockRows(
+      [],
+      { enabled: false, schedule: { sleep: "0 23 * * *", wake: "0 7 * * *" } },
+      fmt,
+    );
+    assert.equal(rows.length, 2);
+    assert.ok(rows.every((r) => r.enabled === false));
+  });
+
+  it("treats a missing `enabled` as OFF, matching the sleep manager", () => {
+    // sleep-manager's evaluateMind gates on `!config?.enabled`, so undefined
+    // means sleep never fires. PUT /sleep/config only writes the field when the
+    // body carries it, and minds hand-edit volute.json, so this state is real.
+    // Printing these as enabled would be a confident false positive about what
+    // wakes the mind — the same class of error as #870, pointing the other way.
+    const rows = buildClockRows([], { schedule: { sleep: "0 23 * * *", wake: "0 7 * * *" } }, fmt);
+    assert.equal(rows.length, 2);
+    assert.ok(
+      rows.every((r) => r.enabled === false),
+      "undefined enabled must not read as armed",
+    );
+  });
+
+  it("keeps a user schedule named `sleep` distinct from the sleep.schedule cron", () => {
+    // Ids are not reserved and minds name their own schedules; the two rows are
+    // told apart by source, and the renderer prints them in separate sections.
+    const rows = buildClockRows(
+      [{ id: "sleep", cron: "0 22 * * *", enabled: true, message: "wind down" }],
+      { enabled: true, schedule: { sleep: "0 23 * * *", wake: "0 7 * * *" } },
+      fmt,
+    );
+    const sleeps = rows.filter((r) => r.id === "sleep");
+    assert.equal(sleeps.length, 2);
+    assert.deepEqual(
+      sleeps.map((r) => r.source),
+      ["schedules[]", "sleep.schedule"],
+    );
+    assert.equal(sleeps[0].schedule, "0 22 * * *");
+    assert.equal(sleeps[1].schedule, "0 23 * * *");
+  });
+
+  it("omits sleep rows only when no sleep schedule is configured", () => {
+    assert.deepEqual(
+      buildClockRows([heartbeat], null, fmt).map((r) => r.id),
+      ["heartbeat"],
+    );
+    assert.deepEqual(
+      buildClockRows([heartbeat], { enabled: true }, fmt).map((r) => r.id),
+      ["heartbeat"],
+    );
+  });
+
+  it("renders a one-time fireAt through the time formatter", () => {
+    const rows = buildClockRows(
+      [{ id: "walk", fireAt: "2026-08-09T09:33:00.000Z", enabled: true, message: "walk" }],
+      null,
+      () => "Aug 9 09:33",
+    );
+    assert.equal(rows[0].schedule, "at Aug 9 09:33");
   });
 });

--- a/test/daemon-boot-filter.test.ts
+++ b/test/daemon-boot-filter.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { shouldBootEntry } from "../packages/daemon/src/daemon.js";
+
+/**
+ * The daemon boot loop restores two different things: processes (for running
+ * minds) and clocks (for sleeping ones). #865 was caused by conflating them —
+ * filtering on `running` alone meant a sleeping mind, which sleep persists as
+ * `running = 0`, never reached the branch that reloads its schedules.
+ *
+ * These pin the claims the comment on `shouldBootEntry` makes, because those are
+ * exactly the claims that rot.
+ */
+describe("daemon boot filter (#865)", () => {
+  const asleep = (names: string[]) => (name: string) => names.includes(name);
+  const none = () => false;
+
+  it("includes a running mind", () => {
+    assert.equal(shouldBootEntry({ name: "a", running: true }, none), true);
+  });
+
+  it("includes a sleeping mind even though sleep persists running = 0", () => {
+    assert.equal(shouldBootEntry({ name: "mimsy", running: false }, asleep(["mimsy"])), true);
+  });
+
+  it("excludes a mind that was stopped and never slept", () => {
+    // `stopMindFull` unloads its schedules on purpose; a stopped mind's clock is
+    // meant to be silent, and restoring it could restart the process via a
+    // trigger-wake schedule.
+    assert.equal(shouldBootEntry({ name: "stopped", running: false }, none), false);
+  });
+
+  it("excludes the spirit, running or not", () => {
+    assert.equal(shouldBootEntry({ name: "s", running: true, mindType: "spirit" }, none), false);
+    assert.equal(
+      shouldBootEntry({ name: "s", running: false, mindType: "spirit" }, asleep(["s"])),
+      false,
+    );
+  });
+
+  it("includes a running variant but never restores a clock for a sleeping one", () => {
+    // Variants have no independent schedules or sleep state.
+    assert.equal(shouldBootEntry({ name: "v", running: true, parent: "a" }, none), true);
+    assert.equal(
+      shouldBootEntry({ name: "v", running: false, parent: "a" }, asleep(["v"])),
+      false,
+      "a variant is never brought back for its clock alone",
+    );
+  });
+});

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -2076,12 +2076,21 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     const body = (await res.json()) as {
       sleep: unknown;
-      sleepConfig: unknown;
+      sleepConfig: { schedule?: { sleep: string; wake: string } } | null;
       schedules: { id: string }[];
       upcoming: { id: string; at: string; type: string }[];
     };
     assert.ok(Array.isArray(body.schedules), "schedules should be an array");
     assert.ok(Array.isArray(body.upcoming), "upcoming should be an array");
+
+    // `clock list` builds its sleep/wake rows from this field (#870). Without
+    // this assertion, dropping or renaming `sleepConfig` here would leave every
+    // buildClockRows unit test green while `clock list` silently went back to
+    // answering "what wakes me?" with nothing — the exact #870 failure.
+    assert.ok(
+      body.sleepConfig?.schedule?.wake,
+      `clock/status must carry sleepConfig.schedule for clock list: ${JSON.stringify(body.sleepConfig)}`,
+    );
     assert.ok(
       body.schedules.some((s) => s.id === "test-status"),
       `Expected test-status in schedules: ${JSON.stringify(body.schedules)}`,
@@ -2589,6 +2598,128 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+  });
+
+  it("a sleeping mind keeps its schedules across a daemon restart (#865)", {
+    timeout: 180000,
+  }, async () => {
+    // Sleep persists `running = 0`, so a boot loop that filters on `running`
+    // never reaches the branch that restores a sleeping mind's schedules. The
+    // process came back healthy, the clock came back empty, and both CLI
+    // surfaces — which read volute.json off disk — reported every schedule
+    // armed. On a production host that cost two minds a full day of fires.
+    const SCHED_ID = "e2e-sleep-restart-beat";
+    await ensureTestMind();
+    const db = await getDb();
+
+    // Sleeping from a stopped state makes initiateSleep short-circuit to
+    // markSleeping — no 120s wind-down wait for a turn the keyless CI mind
+    // can't run. A far-future explicit wake pins the wake time so no cron
+    // wakes the mind mid-test.
+    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    const sleepRes = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ wakeAt: new Date(Date.now() + 3600_000).toISOString() }),
+    });
+    assert.equal(sleepRes.status, 200, `sleep: ${await sleepRes.clone().text()}`);
+
+    const sleepDeadline = Date.now() + 20000;
+    let asleep = false;
+    while (Date.now() < sleepDeadline) {
+      const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+      if (((await res.json()) as { sleeping: boolean }).sleeping) {
+        asleep = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    assert.ok(asleep, "mind should be asleep before the restart");
+
+    // Arm a once-a-minute schedule. It queues while asleep, so every fire
+    // leaves a durable system_events row — the observable that says the
+    // scheduler is actually holding this mind's schedules.
+    const addRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: SCHED_ID,
+        cron: "* * * * *",
+        message: "still ticking",
+        whileSleeping: "queue",
+      }),
+    });
+    assert.equal(addRes.status, 201, `add schedule: ${await addRes.clone().text()}`);
+
+    daemon.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      daemon.on("exit", () => resolve());
+      setTimeout(() => {
+        try {
+          daemon.kill("SIGKILL");
+        } catch {}
+        resolve();
+      }, 5000);
+    });
+
+    daemon = spawn(
+      "npx",
+      ["tsx", "packages/daemon/src/daemon.ts", "--port", String(PORT), "--foreground"],
+      {
+        cwd: process.cwd(),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...cleanEnv, VOLUTE_DAEMON_TOKEN: TOKEN, VOLUTE_BASE_PORT: String(MIND_BASE_PORT) },
+      },
+    );
+    daemon.stderr?.on("data", (data: Buffer) => {
+      process.stderr.write(`[daemon] ${data}`);
+    });
+    await waitForHealth();
+
+    // Cleanup must run even when the assertion fails: leaving TEST_MIND asleep
+    // with a `* * * * *` schedule armed and a 1h wakeAt cascades into the next
+    // test, which sleeps that same mind and counts its queued rows.
+    try {
+      // Only fires from the *new* daemon count, so ignore anything the old one
+      // may have managed between arming the schedule and the SIGTERM.
+      const priorRows = await db
+        .select({ id: systemEvents.id })
+        .from(systemEvents)
+        .where(eq(systemEvents.mind, TEST_MIND))
+        .all();
+      const priorMaxId = priorRows.reduce((max, r) => Math.max(max, r.id), 0);
+
+      // A `* * * * *` cron fires on the first tick after boot — the pre-restart
+      // baseline survives in scheduler-state.json, so no re-baseline delays it.
+      // 90s covers that tick plus a straddled minute boundary; more would risk
+      // the describe-level suite budget, which cancels every later test.
+      const fireDeadline = Date.now() + 90000;
+      let fired = false;
+      while (Date.now() < fireDeadline && !fired) {
+        await new Promise((r) => setTimeout(r, 2000));
+        const rows = await db
+          .select({ id: systemEvents.id, type: systemEvents.type, meta: systemEvents.meta })
+          .from(systemEvents)
+          .where(eq(systemEvents.mind, TEST_MIND))
+          .all();
+        fired = rows.some(
+          (r) => r.id > priorMaxId && r.type === "schedule" && (r.meta ?? "").includes(SCHED_ID),
+        );
+      }
+      assert.ok(fired, "the restarted daemon should still fire a sleeping mind's schedules");
+    } finally {
+      // Drop the schedule, wake the mind, and leave it stopped and awake for the
+      // tests that follow.
+      await daemonRequest(`/api/minds/${TEST_MIND}/schedules/${SCHED_ID}`, { method: "DELETE" });
+      await daemonRequest(`/api/minds/${TEST_MIND}/wake`, { method: "POST" });
+      const wakeDeadline = Date.now() + 30000;
+      while (Date.now() < wakeDeadline) {
+        const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+        if (!((await res.json()) as { sleeping: boolean }).sleeping) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    }
   });
 
   // Regression guard for the batched queued-flush contract (#382, PR #530): a sleeping

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { _resetConfigCache } from "../packages/daemon/src/lib/config/setup.js";
 import {
@@ -10,6 +11,7 @@ import {
 import { Scheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
 import { voluteSystemDir } from "../packages/daemon/src/lib/mind/registry.js";
 import { SandboxUnavailableError } from "../packages/daemon/src/lib/mind/sandbox.js";
+import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
 
 type SystemDelivery = {
   mindName: string;
@@ -20,6 +22,18 @@ type SystemDelivery = {
 
 /** Test subclass that captures calls instead of running real exec/deliver */
 class TestScheduler extends Scheduler {
+  /**
+   * Each instance persists to its own file. Production has one Scheduler and one
+   * path, but these tests build many, and several fire un-awaited saves — sharing
+   * the real `voluteSystemDir()` file let one instance's late write clobber
+   * another's, which is a flake in the test rig, not in the scheduler.
+   */
+  readonly stateFile = resolve(mkdtempSync(join(tmpdir(), "sched-state-")), "state.json");
+
+  protected override get statePath(): string {
+    return this.stateFile;
+  }
+
   systemDeliveries: SystemDelivery[] = [];
   scriptCalls: { script: string; cwd: string; mindName: string }[] = [];
   scriptResult: string | Error = "";
@@ -45,6 +59,17 @@ class TestScheduler extends Scheduler {
   ): Promise<{ id?: number; delivered: boolean }> {
     this.systemDeliveries.push({ mindName, scheduleId, text, opts });
     return this.deliverResult;
+  }
+
+  /** Skip notices the scheduler tried to hand the mind — stubbed off the DB. */
+  skipNotices: { mind: string; id: string; lateBy: number }[] = [];
+
+  protected override async noticeSkippedFire(
+    mindName: string,
+    schedule: Schedule,
+    lateBy: number,
+  ): Promise<void> {
+    this.skipNotices.push({ mind: mindName, id: schedule.id, lateBy });
   }
 }
 
@@ -350,6 +375,318 @@ describe("scheduler", () => {
   });
 });
 
+describe("scheduler one-time consumption (#866)", () => {
+  /** A fire()-able scheduler whose removeSchedule is captured instead of writing config. */
+  function schedulerWithRemovals() {
+    const scheduler = new TestScheduler();
+    const removed: string[] = [];
+    (scheduler as any).removeSchedule = (_mind: string, id: string) => removed.push(id);
+    return { scheduler, removed };
+  }
+
+  const past = () => new Date(Date.now() - 60000).toISOString();
+
+  it("consumes a one-time script that produced no output", async () => {
+    // The common case: a one-timer whose whole job is a side effect prints
+    // nothing by design. Skipping delivery is right; skipping consumption left
+    // it re-firing every tick forever.
+    const { scheduler, removed } = schedulerWithRemovals();
+    scheduler.scriptResult = "";
+
+    await (scheduler as any).fire("test-mind", {
+      id: "quiet-timer",
+      fireAt: past(),
+      script: "touch /tmp/whatever",
+      enabled: true,
+    });
+
+    assert.equal(scheduler.systemDeliveries.length, 0, "nothing to deliver");
+    assert.deepEqual(removed, ["quiet-timer"], "but the one-timer is consumed");
+  });
+
+  it("leaves a recurring no-output script alone", async () => {
+    // The consumption rule is about one-timers only — a cron script that prints
+    // nothing must keep running on its schedule.
+    const { scheduler, removed } = schedulerWithRemovals();
+    scheduler.scriptResult = "";
+
+    await (scheduler as any).fire("test-mind", {
+      id: "quiet-cron",
+      cron: "* * * * *",
+      script: "true",
+      enabled: true,
+    });
+
+    assert.deepEqual(removed, [], "recurring schedules are never consumed");
+  });
+
+  it("consumes a one-timer that can never act (hand-edited config)", async () => {
+    // Actionless and malformed-pool entries can only come from a hand-edited
+    // volute.json (the API validates), and a one-timer that can never deliver
+    // anything is dead — consume it rather than warn every minute forever.
+    const { scheduler, removed } = schedulerWithRemovals();
+
+    await (scheduler as any).fire("test-mind", {
+      id: "actionless",
+      fireAt: past(),
+      enabled: true,
+    });
+    await (scheduler as any).fire("test-mind", {
+      id: "malformed",
+      fireAt: past(),
+      messages: [42],
+      enabled: true,
+    });
+
+    assert.equal(scheduler.systemDeliveries.length, 0);
+    assert.deepEqual(removed, ["actionless", "malformed"]);
+  });
+
+  // The negative case — a one-timer kept armed when the event row could not be
+  // recorded at all — is covered by "fireAt is retained when the event row could
+  // not be recorded at all" above.
+});
+
+describe("scheduler state honesty (#867)", () => {
+  const nowMin = () => Math.floor(Date.now() / 60000);
+
+  /** Read one schedule's bookkeeping out of the in-memory map. */
+  function stateOf(scheduler: Scheduler, mind: string, id: string) {
+    return ((scheduler as any).state as Map<string, any>).get(`${mind}:${id}`);
+  }
+
+  /** Read the persisted state file — the surface a host actually inspects. */
+  function readStateFile(scheduler: TestScheduler): Record<string, any> {
+    return JSON.parse(readFileSync(scheduler.stateFile, "utf-8"));
+  }
+
+  it("records firedAt only when a fire was actually dispatched", async () => {
+    const scheduler = new TestScheduler();
+    (scheduler as any).state.set("test-mind:beat", { slot: nowMin() });
+
+    // Capture before firing: firedAt is stamped inside fire(), and comparing it
+    // to a second Date.now() at assert time straddles the minute boundary.
+    const before = nowMin();
+    await (scheduler as any).fire("test-mind", {
+      id: "beat",
+      cron: "* * * * *",
+      message: "hi",
+      enabled: true,
+    });
+
+    const state = stateOf(scheduler, "test-mind", "beat");
+    assert.ok(
+      state?.firedAt !== undefined && state.firedAt >= before,
+      "a delivered fire is recorded as delivered",
+    );
+    assert.equal(state?.skippedAt, undefined);
+  });
+
+  it("does not record firedAt when the event row could not be recorded", async () => {
+    const scheduler = new TestScheduler();
+    (scheduler as any).state.set("test-mind:beat", { slot: nowMin() });
+    scheduler.deliverResult = { id: undefined, delivered: false };
+
+    await (scheduler as any).fire("test-mind", {
+      id: "beat",
+      cron: "* * * * *",
+      message: "hi",
+      enabled: true,
+    });
+
+    assert.equal(stateOf(scheduler, "test-mind", "beat")?.firedAt, undefined);
+  });
+
+  it("records a silent script's fire — a side-effect script that ran is not 'never ran'", async () => {
+    const scheduler = new TestScheduler();
+    scheduler.scriptResult = "";
+    (scheduler as any).state.set("test-mind:backup", { slot: nowMin() });
+    const before = nowMin();
+
+    await (scheduler as any).fire("test-mind", {
+      id: "backup",
+      cron: "0 4 * * *",
+      script: "restic backup",
+      enabled: true,
+    });
+
+    const state = stateOf(scheduler, "test-mind", "backup");
+    assert.ok(state?.firedAt !== undefined && state.firedAt >= before);
+  });
+
+  it("a stale skip is recorded as a skip, not as a fire, and reaches the mind", () => {
+    // The production failure: mimsy:dream showed a slot cursor at 03:00 for a
+    // dream that provably never ran, and the only other trace was a daemon log
+    // line a mind's sandbox cannot read.
+    const scheduler = new TestScheduler();
+    const realMin = nowMin();
+    const epochMinute = realMin + 20;
+    (scheduler as any).state.set("test-mind:dream", { slot: realMin - 30 });
+
+    const result = (scheduler as any).shouldFire(
+      { id: "dream", cron: "* * * * *", enabled: true },
+      epochMinute,
+      "test-mind",
+      new Map(),
+    );
+
+    assert.equal(result, false);
+    const state = stateOf(scheduler, "test-mind", "dream");
+    assert.equal(state?.slot, realMin, "cursor advanced so it isn't retried");
+    assert.equal(state?.skippedAt, epochMinute, "skippedAt is when we acted, like firedAt");
+    assert.equal(state?.skipReason, "stale_catchup");
+    assert.equal(state?.firedAt, undefined);
+    assert.deepEqual(scheduler.skipNotices, [{ mind: "test-mind", id: "dream", lateBy: 20 }]);
+  });
+
+  it("persists a skip-only tick to disk, so a restart doesn't re-skip and re-notify", async () => {
+    // The notice is durable but the cursor advance was not: tick() saved only
+    // when something fired, so a tick of pure skips mutated memory and wrote
+    // nothing. After a restart the old slot returned, the same missed fire was
+    // skipped again, and the mind got a second notice for it — turning a fix for
+    // dropped fires into a source of duplicate ones.
+    const scheduler = new TestScheduler();
+    const realMin = nowMin();
+    const key = "persist-mind:dream";
+    (scheduler as any).state.set(key, { slot: realMin - 5000 });
+    (scheduler as any).schedules.set("persist-mind", [
+      { id: "dream", cron: "0 3 * * *", message: "dream", enabled: true },
+    ]);
+
+    await (scheduler as any).tick();
+
+    assert.equal(scheduler.systemDeliveries.length, 0, "the stale fire was skipped, not delivered");
+    assert.equal(scheduler.skipNotices.length, 1, "and the mind was told once");
+
+    const onDisk = readStateFile(scheduler)[key];
+    assert.ok(onDisk, "the skip reached disk");
+    assert.equal(onDisk.skipReason, "stale_catchup");
+    assert.ok(
+      onDisk.slot > realMin - 5000,
+      "the advanced cursor is durable, so the next boot won't re-skip",
+    );
+
+    scheduler.clearState();
+  });
+
+  it("records how late a one-timer was, so late never reads as punctual", () => {
+    const scheduler = new TestScheduler();
+    const due = new Date(Date.now() - 3 * 3600_000);
+    const result = (scheduler as any).shouldFire(
+      { id: "walk", fireAt: due.toISOString(), enabled: true },
+      nowMin(),
+      "test-mind",
+      new Map(),
+    );
+    // Deliberate asymmetry with recurring fires: a one-time reminder is the only
+    // copy of that intention, so lateness never becomes a drop.
+    assert.equal(result, true);
+    assert.equal(scheduler.skipNotices.length, 0);
+
+    const state = stateOf(scheduler, "test-mind", "walk");
+    assert.equal(state?.dueAt, Math.floor(due.getTime() / 60000), "when it was due");
+    assert.equal(state?.slot, nowMin(), "and when we acted — the gap is the lateness");
+  });
+
+  it("drops the state key when a schedule is removed, so a reused id starts clean", () => {
+    // `clock add --id reminder --in 5m` is a natural repeat. A surviving key
+    // would hand the new schedule the old one's slot and firedAt.
+    const scheduler = new TestScheduler();
+    const key = "reuse-mind:reminder";
+    (scheduler as any).state.set(key, { slot: 100, firedAt: 100 });
+    (scheduler as any).schedules.set("reuse-mind", [
+      { id: "reminder", fireAt: new Date().toISOString(), message: "hi", enabled: true },
+    ]);
+
+    (scheduler as any).removeSchedule("reuse-mind", "reminder");
+
+    assert.equal(stateOf(scheduler, "reuse-mind", "reminder"), undefined);
+    scheduler.clearState();
+  });
+
+  it("addresses the skip notice mind-level so it can't strand on a dead thread", async () => {
+    // The notice is about a fire that did NOT happen, and a schedule's thread is
+    // often a thread only that schedule ever opens (a dream prompt opens the
+    // dream thread). A next-turn event on a named thread is drained only by that
+    // thread's turns, so addressing it there would strand it in exactly the case
+    // it exists for. Mind-level events are drained by any thread's next turn.
+    const { getDb } = await import("../packages/daemon/src/lib/db.js");
+    const { systemEvents } = await import("../packages/daemon/src/lib/schema.js");
+    const { eq } = await import("drizzle-orm");
+    const mind = "skip-notice-mind";
+
+    const scheduler = new Scheduler();
+    await (scheduler as any).noticeSkippedFire(
+      mind,
+      { id: "dream", cron: "0 3 * * *", enabled: true, thread: "dream" },
+      241,
+    );
+
+    const db = await getDb();
+    const rows = await db.select().from(systemEvents).where(eq(systemEvents.mind, mind)).all();
+    assert.equal(rows.length, 1, "one notice recorded");
+    assert.equal(rows[0].thread, "", "mind-level, not the schedule's own thread");
+    assert.equal(rows[0].delivery, "next-turn");
+    assert.match(rows[0].meta ?? "", /schedule_skipped_stale/);
+    assert.match(rows[0].body, /dream/);
+    assert.match(rows[0].body, /241/);
+    assert.doesNotMatch(
+      rows[0].body,
+      /daemon was down/,
+      "must not assert a cause it cannot know — a deliberate stop produces this too",
+    );
+
+    await db.delete(systemEvents).where(eq(systemEvents.mind, mind));
+  });
+
+  it("tells the mind when a malformed schedule could not send anything", async () => {
+    // Hand-edit-only states. A one-timer in this shape is consumed below, so
+    // without a notice the mind's reminder would vanish over a typo with nothing
+    // but a daemon log line it cannot read.
+    const { getDb } = await import("../packages/daemon/src/lib/db.js");
+    const { systemEvents } = await import("../packages/daemon/src/lib/schema.js");
+    const { eq } = await import("drizzle-orm");
+    const mind = "invalid-sched-mind";
+
+    const scheduler = new TestScheduler();
+    await (scheduler as any).fire(mind, {
+      id: "typo",
+      fireAt: new Date(Date.now() - 60000).toISOString(),
+      messages: [42],
+      enabled: true,
+    });
+
+    const db = await getDb();
+    const rows = await db.select().from(systemEvents).where(eq(systemEvents.mind, mind)).all();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].thread, "");
+    assert.match(rows[0].meta ?? "", /schedule_invalid/);
+    assert.match(rows[0].body, /typo/);
+    assert.match(rows[0].body, /removed/, "and says the one-timer is gone");
+
+    await db.delete(systemEvents).where(eq(systemEvents.mind, mind));
+  });
+
+  it("round-trips the fire history through the state file", async () => {
+    const scheduler = new TestScheduler();
+    (scheduler as any).state.set("rt-mind:dream", {
+      slot: 999,
+      skippedAt: 1000,
+      skipReason: "stale_catchup",
+      dueAt: 998,
+    });
+    await scheduler.saveState();
+    (scheduler as any).loadState();
+    assert.deepEqual(stateOf(scheduler, "rt-mind", "dream"), {
+      slot: 999,
+      skippedAt: 1000,
+      skipReason: "stale_catchup",
+      dueAt: 998,
+    });
+    scheduler.clearState();
+  });
+});
+
 describe("scheduler runScript sandboxing", () => {
   const origSandbox = process.env.VOLUTE_SANDBOX;
   const origOptional = process.env.VOLUTE_SANDBOX_OPTIONAL;
@@ -482,13 +819,13 @@ describe("scheduler catch-up (level-triggered cron)", () => {
     const scheduler = new TestScheduler();
     const epochMinute = nowMin();
     const key = "test-mind:heartbeat";
-    // Last acted-on minute is 3 minutes stale (missed ticks).
-    (scheduler as any).lastFired.set(key, epochMinute - 3);
+    // Last acted-on slot is 3 minutes stale (missed ticks).
+    (scheduler as any).state.set(key, { slot: epochMinute - 3 });
 
     const first = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
     assert.equal(first, true);
-    // lastFired advances to the fired cron minute (== epochMinute for every-minute cron).
-    assert.equal((scheduler as any).lastFired.get(key), epochMinute);
+    // The slot cursor advances to the fired cron minute (== epochMinute for every-minute cron).
+    assert.equal((scheduler as any).state.get(key).slot, epochMinute);
 
     // Same minute again → no double fire.
     const second = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
@@ -498,18 +835,18 @@ describe("scheduler catch-up (level-triggered cron)", () => {
   it("does not fire when already up to date this minute", () => {
     const scheduler = new TestScheduler();
     const epochMinute = nowMin();
-    (scheduler as any).lastFired.set("test-mind:heartbeat", epochMinute);
+    (scheduler as any).state.set("test-mind:heartbeat", { slot: epochMinute });
     const result = (scheduler as any).shouldFire(heartbeat, epochMinute, "test-mind", new Map());
     assert.equal(result, false);
   });
 
-  it("skips a stale catch-up fire but still advances lastFired", () => {
+  it("skips a stale catch-up fire but still advances the slot cursor", () => {
     const scheduler = new TestScheduler();
     const realMin = nowMin();
     // Pretend we're evaluating 20 minutes after the cron minute (long downtime).
     const epochMinute = realMin + 20;
     const key = "test-mind:dream";
-    (scheduler as any).lastFired.set(key, realMin - 30);
+    (scheduler as any).state.set(key, { slot: realMin - 30 });
 
     const result = (scheduler as any).shouldFire(
       { id: "dream", cron: "* * * * *", enabled: true },
@@ -519,8 +856,8 @@ describe("scheduler catch-up (level-triggered cron)", () => {
     );
     // Too stale to deliver...
     assert.equal(result, false);
-    // ...but lastFired advanced to the cron minute so it won't be retried.
-    assert.equal((scheduler as any).lastFired.get(key), realMin);
+    // ...but the cursor advanced to the cron minute so it won't be retried.
+    assert.equal((scheduler as any).state.get(key).slot, realMin);
   });
 });
 
@@ -535,19 +872,19 @@ describe("scheduler loadSchedules bookkeeping", () => {
     const dir = resolve(voluteSystemDir(), "sched-bookkeep-mind");
     writeConfig(dir, [{ id: "heartbeat", cron: "* * * * *", message: "hi", enabled: true }]);
 
-    const lf = (scheduler as any).lastFired as Map<string, number>;
+    const lf = (scheduler as any).state as Map<string, { slot: number }>;
     // Pre-seed: a stale key for this mind + a live key for another mind.
-    lf.set("sched-bookkeep-mind:old-removed", 100);
-    lf.set("other-mind:keepme", 200);
+    lf.set("sched-bookkeep-mind:old-removed", { slot: 100 });
+    lf.set("other-mind:keepme", { slot: 200 });
 
     scheduler.loadSchedules("sched-bookkeep-mind", dir);
 
     // Stale key for this mind pruned (#428).
     assert.equal(lf.has("sched-bookkeep-mind:old-removed"), false);
     // Other mind's key untouched — prune is per-mind only.
-    assert.equal(lf.get("other-mind:keepme"), 200);
+    assert.equal(lf.get("other-mind:keepme")?.slot, 200);
     // New schedule baselined to the current minute (#453) so no history replay.
-    assert.equal(lf.get("sched-bookkeep-mind:heartbeat"), Math.floor(Date.now() / 60000));
+    assert.equal(lf.get("sched-bookkeep-mind:heartbeat")?.slot, Math.floor(Date.now() / 60000));
   });
 
   it("baseline prevents an immediate replay for a freshly loaded schedule", () => {

--- a/website/src/content/docs/docs/commands/clock.md
+++ b/website/src/content/docs/docs/commands/clock.md
@@ -40,15 +40,37 @@ volute clock add --mind atlas \
 
 ## clock list
 
-List all schedules for a mind, showing each schedule's ID, timing, and action.
+List everything on a mind's clock, showing each entry's ID, timing, enabled state, and action.
 
 ```sh
 volute clock list [--mind <name>]
 ```
 
+The clock has two stores in `.config/volute.json`, and `list` shows both:
+
+```
+ID         SCHEDULE          ENABLED  ACTION
+dream      0 3 * * *         true     it's 3am. you are dreaming...
+heartbeat  0 12,16,20 * * *  true     [rotating x7] ...
+
+From sleep.schedule — managed by `volute clock sleep`/`wake`, not `clock remove`:
+ID     SCHEDULE    ENABLED  ACTION
+sleep  0 23 * * *  true     go to sleep
+wake   0 7 * * *   true     wake up
+```
+
+The first section is `schedules[]`, which `clock add` and `clock remove` manage. The second is
+`sleep.schedule`, set through the sleep config or the web UI — `clock remove --id wake` will not
+touch it. The sections stay separate because these IDs are not reserved: a mind may have its own
+schedule named `sleep`, and it appears in the first section.
+
+Both sections always report, including when empty. An absent section would make "nothing wakes me"
+and "I did not look in the right place" indistinguishable.
+
 ## clock remove
 
-Remove a schedule by ID.
+Remove a schedule by ID. Only `schedules[]` entries can be removed this way; the sleep and wake
+crons are part of the sleep config.
 
 ```sh
 volute clock remove [--mind <name>] --id <schedule-id>


### PR DESCRIPTION
Four bugs that share a shape: each fails where a mind cannot detect it from the inside, leaving a healthy-looking instrument reporting on a broken world.

Fixes #865
Fixes #866
Fixes #867
Fixes #870

> **Stacked on #881** (`fix/wake-context-epipe`) and based on it, not `main` — #881 extracts `Scheduler.runScript`/`buildScriptEnv` into `runMindScript`, which this branch's `scheduler.ts` sits on top of. Merge #881 first; GitHub will retarget this to `main` when that branch is deleted.

**#865 (P0) — a mind asleep across a daemon restart lost every schedule.** Sleep persists `running = 0`, and the boot loop filtered on `running` *before* reaching its own sleeping branch — so the branch that exists to reload a sleeping mind's schedules was dead on the normal path, reachable only when something left a sleeping mind with `running = 1`. `wakeMind()` never loaded schedules either. Schedules and the token budget now live in one `restoreMindRuntimeState()` called by start, boot, and wake, so the three paths cannot drift apart again. The budget is included because `sleepMind`'s docstring promises "leave schedules/budget running" and it had the identical hole. Every `loadSchedules`/`unloadSchedules` call site was audited: `mind restart` is `stopMindFull` → `startMindFull` (symmetric), and the variant-join, upgrade and system-restart paths use bare `stopMind`/`startMind`, which never unload — so no other path had the hole.

The narrower fix (make `wakeMind` load schedules, leave the boot loop alone) was considered and rejected on evidence: `defaultDreamSchedule()` is `cron: "0 3 * * *"` with `whileSleeping: "trigger-wake"`, and it is the shipped default on every mind created since #581. Against a 23:00–07:00 sleep window that schedule *only ever* fires while the mind is asleep, and the fire is what wakes her for it. Without the scheduler holding it during sleep, nothing fires and nothing wakes her — so the narrow fix would have left the irreplaceable dream named in #865 still lost.

**#866 (P1) — a one-time script schedule with no output was never consumed and re-fired every tick forever.** `fire()` now consumes a one-timer on every *resolved* outcome, including empty script output; only a failed event insert (or a throw) keeps it armed for the next tick's retry. Malformed and actionless one-timers are consumed on the same rule — both are hand-edit-only states since the API validates — and the mind now gets a `schedule_invalid_notice` naming the reason and saying the one-timer was removed, rather than a daemon warn it cannot read. Recurring schedules are never consumed.

**#867 (P1) — scheduler-state recorded slots acted on, not fires delivered.** Entries go from a bare epoch minute to `{ slot, firedAt?, skippedAt?, skipReason?, dueAt? }`. **`slot` is the old integer, unchanged** — the retry cursor, the most recent minute acted on, advanced whether or not anything was delivered. **`firedAt` means the system-event row was recorded — dispatched, not acknowledged by the mind.** `skippedAt`/`skipReason` record a dropped slot, and `dueAt` records when a late one-timer was actually due, so lateness is in the file rather than only in a log line.

A stale skip now also records a mind-level notice. It is addressed mind-level and never to the schedule's own thread: a named-thread next-turn event is drained only by that thread's turns, and a schedule is frequently the only thing that opens the thread it targets, so addressing it there would strand it in exactly the case it exists for. The notice states only what is known and deliberately does *not* assert a cause — "the daemon was down" is false for a mind the host stopped on purpose.

One-time entries deliberately keep no staleness cap: a one-time reminder is the only copy of that intention, so it is delivered late (and recorded as late) rather than dropped. No delivery-ack protocol was built — `firedAt` means dispatched, an undelivered row keeps a null `delivered_at` and is replayed on the mind's next start or wake, so "recorded but never heard" is queryable rather than silent.

**Honest limit:** `scheduler-state.json` lives under `voluteSystemDir()`, which is sandbox-blocked — a mind cannot read it from its own seat. It is a read surface for *hosts* (and minds with host access), which is exactly how #867 was found and mis-read. The mind-facing half is therefore the skip notice alone, and that notice is a next-turn event: it reaches only minds carrying the `.local/hooks/pre-prompt/notices.ts` drain hook (#808). #808's backfill means most minds have it, but on a mind that predates it and never got the backfill, a skipped fire is still invisible from the inside.

**#870 (P2) — `clock list` omitted the sleep/wake crons.** It now renders both stores from `.config/volute.json`, with `sleep.schedule` in its own section headed "managed by `volute clock sleep`/`wake`, not `clock remove`" — so the two stores stay distinguishable rather than silently merged, and an empty `schedules[]` no longer reads as an empty clock. The sleep/wake rows keep their real ids rather than being renamed for uniqueness: inventing an id that is not any schedule's actual id would be a second small untruth in a command being fixed for telling one. Enabled state is now `sleepConfig.enabled === true`, matching the daemon's own `!config?.enabled` gate — the previous `!== false` would have reported sleep and wake as enabled for crons that will never fire.

**Tests.** `test/daemon-e2e.test.ts` gains a real regression test for #865 — sleep a mind, restart the daemon, assert the scheduler still fires for it — verified to fail against the unfixed code. #866 and #867 are covered by unit tests against `Scheduler`, including one that calls the real `noticeSkippedFire` and asserts the recorded `system_events` row (mind-level thread, `next-turn`, `schedule_skipped_stale`, and that the body does not claim the daemon was down). Skip persistence is asserted against the file, not the in-memory map. Existing scheduler tests that reached into the internal `lastFired` map were updated to the new state shape; no assertion was weakened.

`Scheduler.statePath` became `protected` so `TestScheduler` can give each instance its own `mkdtemp` state file. Scheduler tests previously shared the real `voluteSystemDir()/scheduler-state.json` and several fire un-awaited saves, so one instance's late write could clobber another's — a latent flake that this PR's more frequent writes made reliable. Production is unchanged: one daemon, one `Scheduler`, one path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGyFwod1mszVgRJU3iP6aC
