### PR TITLE
refactor(templates): merge _base manifest into templates instead of replacing

### DIFF
--- a/packages/daemon/src/lib/template/template.ts
+++ b/packages/daemon/src/lib/template/template.ts
@@ -20,6 +20,29 @@ export type TemplateManifest = {
 };
 
 /**
+ * Merge a template's manifest over `_base`'s. `_base` ships the shared manifest
+ * (the union of everything every template needs); a per-template manifest exists
+ * only to declare genuine differences — of which there are currently none, so all
+ * three ship `{}`.
+ *
+ * - `substitute`: union of base + template entries (dedup, base order first). A
+ *   path only has to be declared once, in `_base`, and every template inherits it.
+ *   This is the single-source-of-truth that #789 restores: before it, all three
+ *   manifests repeated the same list and all three carried the same wrong path
+ *   (`home/.config/routes.json`), leaving `{{name}}` in every mind's routes.json.
+ * - `rename`: template entries override base on key collision.
+ */
+export function mergeManifests(
+  base: Partial<TemplateManifest>,
+  template: Partial<TemplateManifest>,
+): TemplateManifest {
+  return {
+    rename: { ...base.rename, ...template.rename },
+    substitute: [...new Set([...(base.substitute ?? []), ...(template.substitute ?? [])])],
+  };
+}
+
+/**
  * Find the templates root directory by walking up from the calling module's location.
  * Returns the parent `templates/` directory (not a specific template).
  */
@@ -101,17 +124,30 @@ export function composeTemplate(
     cpSync(src, dest);
   }
 
-  // Read manifest
-  const manifestPath = resolve(composedDir, "volute-template.json");
-  if (!existsSync(manifestPath)) {
+  // Read manifest by merging the template's over _base's, rather than letting the
+  // template's replace it. _base ships the shared manifest; a template's declares
+  // only genuine differences (see mergeManifests). The two source files are read
+  // directly — reading the composed copy would only ever see the template's, since
+  // the file-overlay above already overwrote _base's with it.
+  const baseManifestPath = resolve(baseDir, "volute-template.json");
+  if (!existsSync(baseManifestPath)) {
     rmSync(composedDir, { recursive: true, force: true });
-    console.error(`Template manifest not found: ${templateName}/volute-template.json`);
+    console.error("Base template manifest not found: _base/volute-template.json");
     process.exit(1);
   }
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as TemplateManifest;
+  const baseManifest = JSON.parse(
+    readFileSync(baseManifestPath, "utf-8"),
+  ) as Partial<TemplateManifest>;
 
-  // Remove manifest from composed output
-  rmSync(manifestPath);
+  const templateManifestPath = resolve(templateDir, "volute-template.json");
+  const templateManifest = existsSync(templateManifestPath)
+    ? (JSON.parse(readFileSync(templateManifestPath, "utf-8")) as Partial<TemplateManifest>)
+    : {};
+
+  const manifest = mergeManifests(baseManifest, templateManifest);
+
+  // Remove manifest from composed output (the template's overlaid copy).
+  rmSync(resolve(composedDir, "volute-template.json"), { force: true });
 
   return { composedDir, manifest };
 }
@@ -268,8 +304,14 @@ export function backfillInitInfrastructure(
 ): string[] {
   const root = locateTemplatesRoot();
   if (!root) throw new Error("templates root not found on disk");
-  if (!existsSync(resolve(root, template, "volute-template.json"))) {
-    throw new Error(`template "${template}" is missing or has no manifest at ${root}`);
+  if (!existsSync(resolve(root, template))) {
+    throw new Error(`template "${template}" not found at ${root}`);
+  }
+  // _base ships the shared manifest that every template merges into; its absence is
+  // the manifest path composeTemplate process.exit(1)s on (a template's own manifest
+  // is now optional). Pre-check it so a broken install degrades to one warning.
+  if (!existsSync(resolve(root, "_base", "volute-template.json"))) {
+    throw new Error(`base template manifest missing at ${root}/_base`);
   }
 
   const { composedDir, manifest } = composeTemplate(root, template);

--- a/templates/_base/volute-template.json
+++ b/templates/_base/volute-template.json
@@ -1,0 +1,6 @@
+{
+  "rename": {
+    "gitignore": ".gitignore"
+  },
+  "substitute": ["package.json", ".init/SOUL.md", ".init/.config/routes.json"]
+}

--- a/templates/claude/volute-template.json
+++ b/templates/claude/volute-template.json
@@ -1,6 +1,1 @@
-{
-  "rename": {
-    "gitignore": ".gitignore"
-  },
-  "substitute": ["package.json", ".init/SOUL.md", ".init/.config/routes.json"]
-}
+{}

--- a/templates/codex/volute-template.json
+++ b/templates/codex/volute-template.json
@@ -1,6 +1,1 @@
-{
-  "rename": {
-    "gitignore": ".gitignore"
-  },
-  "substitute": ["package.json", ".init/SOUL.md", ".init/.config/routes.json"]
-}
+{}

--- a/templates/pi/volute-template.json
+++ b/templates/pi/volute-template.json
@@ -1,6 +1,1 @@
-{
-  "rename": {
-    "gitignore": ".gitignore"
-  },
-  "substitute": ["package.json", ".init/SOUL.md", ".init/.config/routes.json"]
-}
+{}

--- a/test/template-compose.test.ts
+++ b/test/template-compose.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 import {
   composeTemplate,
   findTemplatesRoot,
+  mergeManifests,
   renderComposedPackageJson,
 } from "../packages/daemon/src/lib/template/template.js";
 
@@ -216,15 +217,66 @@ describe("template composition", () => {
       !existsSync(resolve(templatesRoot, "_base", ".gitignore")),
       "templates/_base must not ship a real .gitignore (npm pack drops it)",
     );
+    // The rename now lives once in _base and is inherited via the merge, so assert
+    // on the *composed* manifest rather than each template's file (which is empty).
     for (const template of ["claude", "pi", "codex"]) {
-      const manifest = JSON.parse(
-        readFileSync(resolve(templatesRoot, template, "volute-template.json"), "utf-8"),
-      );
-      assert.equal(
-        manifest.rename.gitignore,
-        ".gitignore",
-        `${template} manifest must rename gitignore → .gitignore`,
-      );
+      const { composedDir, manifest } = composeTemplate(templatesRoot, template);
+      try {
+        assert.equal(
+          manifest.rename.gitignore,
+          ".gitignore",
+          `${template} composed manifest must rename gitignore → .gitignore`,
+        );
+      } finally {
+        rmSync(composedDir, { recursive: true, force: true });
+      }
     }
+  });
+
+  // #789: _base ships the one shared manifest and templates *merge* into it rather
+  // than replace it. mergeManifests is that merge in isolation.
+  describe("manifest merge (#789)", () => {
+    it("unions substitute entries (dedup) and lets template entries survive", () => {
+      const merged = mergeManifests(
+        { rename: {}, substitute: ["package.json", ".init/SOUL.md"] },
+        { rename: {}, substitute: [".init/SOUL.md", "template-only.json"] },
+      );
+      // base + template unioned; the shared ".init/SOUL.md" appears once; the
+      // template-only entry survives. A replace would drop "package.json".
+      assert.deepEqual(merged.substitute, ["package.json", ".init/SOUL.md", "template-only.json"]);
+    });
+
+    it("lets template rename override base on key collision", () => {
+      const merged = mergeManifests(
+        { rename: { gitignore: ".gitignore", foo: "base" }, substitute: [] },
+        { rename: { foo: "template" }, substitute: [] },
+      );
+      assert.equal(merged.rename.foo, "template", "template wins the collision");
+      assert.equal(merged.rename.gitignore, ".gitignore", "base-only entry is kept");
+    });
+
+    it("composeTemplate merges _base's manifest in even though templates ship {}", () => {
+      // The revert detector: today every template's volute-template.json is `{}`, so
+      // the whole substitute/rename list lives only in _base. If composeTemplate went
+      // back to *replacing* _base's manifest with the template's, this manifest would
+      // be empty and every {{name}} substitution (routes.json, package.json) would be
+      // skipped — the exact class of failure #785 fixed. Assert the merge stays.
+      for (const template of ["claude", "pi", "codex"]) {
+        const { composedDir, manifest } = composeTemplate(templatesRoot, template);
+        try {
+          assert.ok(
+            manifest.substitute.includes("package.json"),
+            `${template}: base substitute entry must survive the merge`,
+          );
+          assert.ok(
+            manifest.substitute.includes(".init/.config/routes.json"),
+            `${template}: base substitute entry must survive the merge`,
+          );
+          assert.equal(manifest.rename.gitignore, ".gitignore");
+        } finally {
+          rmSync(composedDir, { recursive: true, force: true });
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

All three template manifests were byte-identical, which is how the same wrong substitute path shipped to all three at once (#785). Give  the one shared  and have  merge the template's manifest over it rather than replace it:

- **substitute**: union of base + template entries (dedup)
- **rename**: template entries override base on key collision

The three per-template manifests collapse to  — they exist only to declare genuine differences, of which there are none today.  also tolerates an absent template manifest. **Hash-neutral**: the composed manifest is still stripped before hashing, so  is unchanged.

Closes #789

## Test plan

- [x] npm run typecheck passes
- [x] npm test passes (3297 tests)
- [x] New tests for manifest merge semantics: union, override, and verifies merging happens even with empty 
- [ ] After merge: verify mind create/upgrade across all 3 templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)