### PR TITLE
refactor: extract mind lifecycle from minds.ts; unify variant merge (#330)

### DIFF
--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -9,6 +9,7 @@ import { detectSystemInstallHint } from "./system-install.js";
 // `headersTimeout` and abort the CLI's fetch with UND_ERR_HEADERS_TIMEOUT. The
 // daemon is a trusted process on localhost, so disable the headers/body timeouts
 // for CLI→daemon calls (a hung request can still be interrupted with Ctrl-C).
+// TODO(#330 follow-up): restore sane timeouts once lifecycle ops are async jobs.
 export const daemonDispatcher = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
 
 function voluteUserHome(): string {

--- a/packages/daemon/src/lib/daemon/mind-manager.ts
+++ b/packages/daemon/src/lib/daemon/mind-manager.ts
@@ -24,6 +24,11 @@ import log from "../util/logger.js";
 import { RotatingLog } from "../util/rotating-log.js";
 import { injectPiProviderCredentials, writeClaudeCredentials } from "./credential-sync.js";
 import { generateMindToken, revokeMindToken } from "./mind-tokens.js";
+import {
+  clearPendingContext,
+  setPendingContext as persistPendingContext,
+  readPendingContext,
+} from "./pending-context.js";
 import { RestartTracker } from "./restart-tracker.js";
 import { clearMind as clearTurnState, summarizeOrphanedTurns } from "./turn-tracker.js";
 
@@ -176,7 +181,6 @@ export class MindManager {
   private stopping = new Set<string>();
   private shuttingDown = false;
   private restartTracker = new RestartTracker();
-  private pendingContext = new Map<string, Record<string, unknown>>();
   // Per-name lifecycle mutex: start/stop/restart for a given mind serialize so
   // concurrent callers can't double-spawn or have a loser's cleanup delete the
   // winner's tracked child.
@@ -614,20 +618,22 @@ export class MindManager {
   }
 
   setPendingContext(name: string, context: Record<string, unknown>): void {
-    this.pendingContext.set(name, context);
+    persistPendingContext(name, context);
   }
 
   /** Deliver pending context (merge info, sprout, restart) directly to the mind via HTTP.
    *  Intentionally bypasses DeliveryManager — these are system messages that should not be
-   *  routed, gated, or batched. */
+   *  routed, gated, or batched. Backed by a durable per-mind file (#330), so context set
+   *  before a daemon crash is still delivered on the next start rather than lost. */
   private async deliverPendingContext(name: string): Promise<void> {
-    const context = this.pendingContext.get(name);
+    const context = readPendingContext(name);
     if (!context) return;
 
     const tracked = this.minds.get(name);
+    // Leave the queued context on disk for a later start if the mind isn't tracked yet.
     if (!tracked) return;
 
-    this.pendingContext.delete(name);
+    clearPendingContext(name);
 
     const content = await buildPendingContextMessage(name, context);
     const subtype = lifecycleSubtype(context.type);

--- a/packages/daemon/src/lib/daemon/pending-context.ts
+++ b/packages/daemon/src/lib/daemon/pending-context.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { stateDir } from "../mind/registry.js";
+import log from "../util/logger.js";
+
+const plog = log.child("pending-context");
+
+/**
+ * Durable per-mind "pending context" store.
+ *
+ * A mind's post-lifecycle continuity message — "you were merged, here's the
+ * summary/justification/memory", "you sprouted", "your upgrade landed" — is set
+ * just before the mind restarts and delivered on its next start. It used to live
+ * in an in-memory Map on MindManager, so a daemon crash between the merge and the
+ * restart-delivery lost the message permanently (#330). Backing it with a file
+ * under state/<mind>/ makes it survive a daemon restart: whatever start happens
+ * next (manual, boot, crash recovery) still delivers it.
+ *
+ * One file per mind, keyed by the raw name (variants have their own state dir), so
+ * a variant's split birth-context and its parent's merge context never collide.
+ */
+function pendingContextPath(name: string): string {
+  return resolve(stateDir(name), "pending-context.json");
+}
+
+/** Persist the context to deliver on this mind's next start. Overwrites any prior pending context. */
+export function setPendingContext(name: string, context: Record<string, unknown>): void {
+  const path = pendingContextPath(name);
+  try {
+    mkdirSync(stateDir(name), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(context)}\n`);
+  } catch (err) {
+    plog.warn(`failed to persist pending context for ${name}`, log.errorData(err));
+  }
+}
+
+/** Read the pending context for a mind, or null if none is queued (or it can't be read). */
+export function readPendingContext(name: string): Record<string, unknown> | null {
+  const path = pendingContextPath(name);
+  try {
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8").trim();
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      return data as Record<string, unknown>;
+    }
+    plog.warn(`ignoring malformed pending context for ${name}`);
+    return null;
+  } catch (err) {
+    plog.warn(`failed to read pending context for ${name}`, log.errorData(err));
+    return null;
+  }
+}
+
+/** Remove a mind's pending context. Idempotent. */
+export function clearPendingContext(name: string): void {
+  const path = pendingContextPath(name);
+  try {
+    if (existsSync(path)) unlinkSync(path);
+  } catch (err) {
+    plog.warn(`failed to clear pending context for ${name}`, log.errorData(err));
+  }
+}

--- a/packages/daemon/src/lib/mind/lifecycle.ts
+++ b/packages/daemon/src/lib/mind/lifecycle.ts
@@ -1,0 +1,1318 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import {
+  isAiConfigured,
+  missingCredentialWarning,
+  qualifyModelId,
+  resolveTemplate,
+  unqualifyModelId,
+} from "../ai-service.js";
+import { announceToCommons } from "../chat/commons-channel.js";
+import { getSpiritName } from "../config/setup.js";
+import { getMindManager } from "../daemon/mind-manager.js";
+import { getDb } from "../db.js";
+import { type ExportManifest, isHomeOnlyArchive } from "../mind/archive.js";
+import { TEMPLATE_BRANCH } from "../mind/upgrade.js";
+import { getMindPromptDefaults, getPrompt, getPromptIfCustom, substitute } from "../prompts.js";
+import { mindHistory } from "../schema.js";
+import { getStandardSkillsWithExtensions, installSkill, SEED_SKILLS } from "../skills.js";
+import { convertSession } from "../template/convert-session.js";
+import {
+  findOpenClawSession,
+  importOpenClawConnectors,
+  importPiSession,
+  parseNameFromIdentity,
+} from "../template/import-utils.js";
+import {
+  applyInitFiles,
+  composeTemplate,
+  copyTemplateToDir,
+  findTemplatesRoot,
+  listFiles,
+  type TemplateManifest,
+} from "../template/template.js";
+import { computeTemplateHash } from "../template/template-hash.js";
+import { exec, gitExec } from "../util/exec.js";
+import log from "../util/logger.js";
+import { fireWebhook } from "../webhook.js";
+import { consolidateMemory } from "./consolidate.js";
+import { defaultHeartbeatSchedule, setupDefaultDreaming } from "./default-autonomy.js";
+import { generateIdentity, publishPublicKey } from "./identity.js";
+import {
+  chownMindDir,
+  createMindUser,
+  ensureVoluteGroup,
+  isIsolationEnabled,
+  wrapForIsolation,
+} from "./isolation.js";
+import { npmInstallAsMind, npmInstallNeeded } from "./npm-install.js";
+import {
+  addMind,
+  addVariant,
+  countCappedMinds,
+  ensureVoluteHome,
+  findMind,
+  mindDir,
+  nextPort,
+  removeMind,
+  setMindTemplateHash,
+  stateDir,
+  validateMindName,
+} from "./registry.js";
+import { spawnServer } from "./spawn-server.js";
+import { configureGitIdentity } from "./upgrade.js";
+import { cleanupVariant } from "./variant-cleanup.js";
+import {
+  findUnresolvedHomeFiles,
+  formatUnresolvedHomeFilesMessage,
+  mergeVariantExcludingMemory,
+  type UnresolvedHomeFiles,
+  VariantMergeError,
+} from "./variants.js";
+import { verify } from "./verify.js";
+import { readVoluteConfig, writeVoluteConfig } from "./volute-config.js";
+
+const llog = log.child("lifecycle");
+
+/**
+ * The outcome of a lifecycle operation invoked from a thin route handler. `ok`
+ * carries the success payload verbatim (the route does `c.json(body)`); the
+ * failure form carries the HTTP status + error string the route maps to
+ * `c.json({ error }, status)`. Keeps create/import/split logic out of the HTTP
+ * layer while preserving each operation's exact response shapes (#330).
+ */
+export type LifecycleResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; status: 400 | 404 | 409 | 500; error: string };
+
+/**
+ * Create the volute/template tracking branch and main branch with shared history.
+ * Enables clean 3-way merges on the first `volute mind upgrade`. Called during
+ * mind creation and home-only archive import (both compose a fresh template).
+ */
+export async function initTemplateBranch(
+  projectRoot: string,
+  composedDir: string,
+  manifest: TemplateManifest,
+  mindName?: string,
+  env?: NodeJS.ProcessEnv,
+) {
+  const templateFiles = listFiles(composedDir)
+    .filter((f) => !f.startsWith(".init/") && !f.startsWith(".init\\"))
+    .filter((f) => (!f.startsWith("home/") && !f.startsWith("home\\")) || f === "home/VOLUTE.md")
+    .map((f) => manifest.rename[f] ?? f);
+
+  const opts = { cwd: projectRoot, mindName, env };
+
+  await gitExec(["checkout", "--orphan", TEMPLATE_BRANCH], opts);
+  await gitExec(["add", "--", ...templateFiles], opts);
+  await gitExec(["commit", "-m", "template update"], opts);
+
+  await gitExec(["checkout", "-b", "main"], opts);
+  await gitExec(["add", "-A"], opts);
+  await gitExec(["commit", "-m", "initial commit"], opts);
+}
+
+/**
+ * The single `type` a variant-join delivers as its post-merge continuity context.
+ * (The mind-initiated restart path historically stamped `"merge"` and the merge
+ * route `"merged"`; both map to the same lifecycle subtype and prompt, so the one
+ * value is behavior-identical for either caller — see buildPendingContextMessage.)
+ */
+export type VariantMergeContextType = "merged";
+
+/** Extra, caller-supplied fields folded into the merge continuity message. */
+export interface VariantMergeContextExtras {
+  summary?: string;
+  justification?: string;
+  memory?: string;
+  farewell?: string;
+}
+
+/**
+ * The outcome of {@link mergeVariant}. `merged` is the only success; the rest are
+ * distinct failure modes the two call sites map to their own semantics (an HTTP
+ * status for the merge route, a notice + restart-downgrade for the mind-initiated
+ * restart path). The variant is left fully intact on every non-`merged` outcome —
+ * cleanup runs only once the merge has landed and (unless discarded) no unresolved
+ * home/ files remain — so a failed join can always be retried.
+ */
+export type VariantMergeResult =
+  | { status: "merged"; memoryDelta: string; context: Record<string, unknown>; warning?: string }
+  | { status: "autocommit_failed"; side: "variant" | "main"; message: string }
+  | { status: "verify_failed"; message: string }
+  | { status: "conflict"; conflicts: string[]; abortFailed: boolean; message: string }
+  | { status: "unresolved"; message: string; unresolved: UnresolvedHomeFiles }
+  | { status: "check_failed"; message: string };
+
+export interface MergeVariantParams {
+  /** The base mind the variant merges into (owns projectRoot). */
+  parentName: string;
+  variantName: string;
+  projectRoot: string;
+  variantDir: string;
+  variantBranch: string;
+  /** Spawn the variant and run its self-check before merging (merge route: !skipVerify). */
+  verify: boolean;
+  /** Skip the unresolved-home/-files gate and clean up regardless (join --discard). */
+  discardUnresolved?: boolean;
+  /** The variant's own template — used to spawn it correctly during verify. */
+  variantTemplate?: string;
+  /** Parent's template — used to bump the stored template hash after an upgrade-named join. */
+  parentTemplate?: string;
+  contextType?: VariantMergeContextType;
+  contextExtras?: VariantMergeContextExtras;
+}
+
+/**
+ * Merge a variant back into its parent — the single implementation behind both the
+ * `POST /:name/variants/:variant/merge` route and the mind-initiated merge inside
+ * the restart handler (#330 collapsed two divergent copies into this).
+ *
+ * The shared spine: auto-commit both worktrees → optionally verify the variant →
+ * merge excluding the mind's living memory/journal (which rides back as
+ * `memoryDelta`, #440) → gate on unresolved home/ files → clean up the worktree +
+ * branch → reinstall deps only if the merge touched them. It never restarts the
+ * parent: the two callers differ there (the merge route does its own stop/start;
+ * the restart handler owns a last-known-good recovery path), so the caller sets
+ * the returned `context` as pending and restarts however it must.
+ *
+ * All git writes run as the daemon (root); the caller is responsible for restoring
+ * ownership on the failure paths it surfaces (chownMindDir), mirroring the pre-#330
+ * behavior. cleanupVariant already chowns projectRoot back on the success path.
+ */
+export async function mergeVariant(params: MergeVariantParams): Promise<VariantMergeResult> {
+  const {
+    parentName,
+    variantName,
+    projectRoot,
+    variantDir,
+    variantBranch,
+    discardUnresolved = false,
+    contextExtras = {},
+  } = params;
+
+  // Auto-commit any uncommitted changes in the variant worktree so they ride into
+  // the merge. A failure here is fatal to the join — surfacing it (rather than the
+  // old restart-path behavior of swallowing it with log.error) is one of the
+  // consistency wins of collapsing the two copies.
+  if (existsSync(variantDir)) {
+    const status = (await gitExec(["status", "--porcelain"], { cwd: variantDir })).trim();
+    if (status) {
+      try {
+        await gitExec(["add", "-A"], { cwd: variantDir });
+        await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
+          cwd: variantDir,
+        });
+      } catch (e) {
+        llog.warn(`failed to auto-commit variant worktree for ${parentName}`, log.errorData(e));
+        return {
+          status: "autocommit_failed",
+          side: "variant",
+          message:
+            "Failed to auto-commit variant changes. Commit or stash manually before merging.",
+        };
+      }
+    }
+  }
+
+  // Verify the variant boots and passes its self-check before it's merged and
+  // destroyed. The server is detached (its own process-group leader), so kill the
+  // whole group — under sandbox/isolation the real server is a wrapped grandchild.
+  if (params.verify) {
+    const result = await spawnServer(variantDir, 0, {
+      detached: true,
+      mindName: variantName,
+      template: params.variantTemplate,
+    });
+    if (!result) {
+      return {
+        status: "verify_failed",
+        message: "Failed to start server for verification. Use skipVerify to skip.",
+      };
+    }
+    const verified = await verify(result.actualPort);
+    try {
+      process.kill(-result.child.pid!, "SIGTERM");
+    } catch {}
+    if (!verified) {
+      return {
+        status: "verify_failed",
+        message: "Verification failed. Fix issues or use skipVerify to proceed.",
+      };
+    }
+  }
+
+  // Auto-commit any uncommitted changes in the main worktree before merging into it.
+  const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: projectRoot })).trim();
+  if (mainStatus) {
+    try {
+      await gitExec(["add", "-A"], { cwd: projectRoot });
+      await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
+        cwd: projectRoot,
+      });
+    } catch (e) {
+      llog.warn(`failed to auto-commit main worktree for ${parentName}`, log.errorData(e));
+      return {
+        status: "autocommit_failed",
+        side: "main",
+        message: "Failed to auto-commit main changes. Commit or stash manually before merging.",
+      };
+    }
+  }
+
+  // Merge, excluding the mind's living memory/journal — those ride back as
+  // `memoryDelta` (#440). A real code/config conflict aborts the merge and throws
+  // VariantMergeError; the variant is left intact so the conflict can be resolved
+  // there and the join retried.
+  const preMergeHead = (await gitExec(["rev-parse", "HEAD"], { cwd: projectRoot })).trim();
+  let memoryDelta = "";
+  try {
+    memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantBranch);
+  } catch (err) {
+    if (!(err instanceof VariantMergeError)) throw err;
+    return {
+      status: "conflict",
+      conflicts: err.conflicts,
+      abortFailed: err.abortFailed,
+      message: err.abortFailed
+        ? "Merge failed and the abort did not complete — the parent worktree may be left mid-merge with conflict markers; manual cleanup may be needed."
+        : "Merge failed. Resolve conflicts in the variant and retry the join.",
+    };
+  }
+
+  // The daemon can't know what's precious in a mind's home/ (a download, a cloned
+  // repo, a venv), so it never guesses. Checked right before the one genuinely
+  // destructive step (cleanupVariant's `git worktree remove`): the merge above
+  // already landed (it only pulls in what the variant committed), but cleanup —
+  // the point of no return — waits until this comes back clean.
+  if (existsSync(variantDir) && !discardUnresolved) {
+    let unresolved: UnresolvedHomeFiles;
+    try {
+      unresolved = await findUnresolvedHomeFiles(variantDir);
+    } catch (err) {
+      return {
+        status: "check_failed",
+        message: `Could not verify variant ${variantName} has no unresolved home/ files: ${err instanceof Error ? err.message : String(err)}. Variant left intact — retry the join.`,
+      };
+    }
+    if (unresolved.totalCount > 0) {
+      return {
+        status: "unresolved",
+        message: formatUnresolvedHomeFilesMessage(variantName, unresolved),
+        unresolved,
+      };
+    }
+  }
+
+  await cleanupVariant(variantName, parentName, projectRoot, variantDir, { stop: true });
+
+  // The merge/cleanup git ops ran as the daemon (root). Hand ownership of the
+  // parent worktree back to the mind user before the wrapped npm install (which
+  // runs as that user) and the caller's restart — otherwise the tree is left
+  // root-owned under isolation. (cleanupVariant already chowns, but a belt-and-
+  // suspenders chown here mirrors the merge route and precedes the install.)
+  await chownMindDir(projectRoot, parentName);
+
+  // Bump the stored template hash after an upgrade-named join so staleness tracking
+  // stays accurate (the variant merged the newer template into the parent).
+  if (variantName.endsWith("-upgrade") || variantName === "upgrade") {
+    try {
+      await setMindTemplateHash(parentName, computeTemplateHash(params.parentTemplate ?? "claude"));
+    } catch (err) {
+      llog.warn(`failed to update template hash for ${parentName}`, log.errorData(err));
+    }
+  }
+
+  // Reinstall dependencies only when the merge actually touched them — a no-op
+  // install still writes enough to stall slow storage for a minute.
+  let warning: string | undefined;
+  if (await npmInstallNeeded(projectRoot, preMergeHead)) {
+    try {
+      await npmInstallAsMind(projectRoot, parentName);
+    } catch (err) {
+      llog.warn(`npm install failed after merge for ${parentName}`, log.errorData(err));
+      warning = "npm install failed after merge — mind may have stale dependencies";
+    }
+  }
+
+  const context: Record<string, unknown> = {
+    type: params.contextType ?? "merged",
+    name: variantName,
+    ...(contextExtras.summary && { summary: contextExtras.summary }),
+    ...(contextExtras.justification && { justification: contextExtras.justification }),
+    ...(contextExtras.memory && { memory: contextExtras.memory }),
+    ...(memoryDelta && { memoryDelta }),
+    ...(contextExtras.farewell && { farewell: contextExtras.farewell }),
+  };
+
+  return { status: "merged", memoryDelta, context, warning };
+}
+
+/** Input for {@link createMind} — the validated create-mind request body. */
+export interface CreateMindInput {
+  name: string;
+  template?: string;
+  stage?: "seed" | "sprouted";
+  description?: string;
+  model?: string;
+  seedSoul?: string;
+  skills?: string[];
+  createdBy?: string;
+}
+
+/**
+ * Create a new mind: compose the template, generate identity, apply config/skill
+ * defaults, set up isolation + git + template branch, and register it. Moved out
+ * of the POST `/` route body verbatim (#330); the route parses/authorizes and maps
+ * the result to HTTP. `username` is the authenticated caller, used as the createdBy
+ * fallback.
+ */
+export async function createMind(
+  body: CreateMindInput,
+  opts: { username?: string },
+): Promise<LifecycleResult> {
+  const { name } = body;
+  const template = body.template ?? (await resolveTemplate(body.model));
+
+  const nameErr = validateMindName(name);
+  if (nameErr) return { ok: false, status: 400, error: nameErr };
+
+  if (await findMind(name))
+    return { ok: false, status: 409, error: `Mind already exists: ${name}` };
+
+  // Refuse to create a mind the system can't run. With no AI provider configured
+  // every mind spawns mute (no model to think with), so block creation here rather
+  // than leave an unusable mind behind (#606). Mirrors the dashboard banner's copy.
+  if (!isAiConfigured()) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        "Minds cannot think yet — no AI provider is configured. Add a provider in Settings before creating a mind.",
+    };
+  }
+
+  // Cap total minds to protect host resources. Central enforcement here covers
+  // `volute mind create`, `volute seed create`, and spirit-driven seeds alike;
+  // the error text is relayed verbatim to whoever asked.
+  {
+    const { mindLimitError, readGlobalConfig } = await import("../config/setup.js");
+    const limitError = mindLimitError(await countCappedMinds(), readGlobalConfig().maxMinds);
+    if (limitError) return { ok: false, status: 409, error: limitError };
+  }
+
+  ensureVoluteHome();
+  const dest = mindDir(name);
+
+  if (existsSync(dest)) return { ok: false, status: 409, error: "Mind directory already exists" };
+
+  let composedDir: string;
+  let manifest: TemplateManifest;
+  try {
+    const templatesRoot = findTemplatesRoot();
+    ({ composedDir, manifest } = composeTemplate(templatesRoot, template));
+  } catch (err) {
+    // A missing/broken template throws (rather than exiting — #330); surface it as
+    // a 500 instead of taking down the daemon.
+    return {
+      ok: false,
+      status: 500,
+      error: err instanceof Error ? err.message : "Failed to compose template",
+    };
+  }
+
+  try {
+    copyTemplateToDir(composedDir, dest, name, manifest);
+    applyInitFiles(dest);
+
+    // Generate Ed25519 keypair for mind identity
+    const { publicKeyPem } = generateIdentity(dest);
+
+    // The model the mind will actually run (request, or default cognition model),
+    // provider-qualified — feeds the credential warning below so pi minds created
+    // from defaults are checked too.
+    let effectiveModel: string | undefined = body.model;
+    // Merge default settings into volute.json and config.json
+    {
+      const { readGlobalConfig: readGlobal } = await import("../config/setup.js");
+      const mindDefaults = readGlobal().mindDefaults;
+      const config = readVoluteConfig(dest);
+      if (!config) throw new Error("Failed to read volute.json after identity generation");
+      if (body.description) {
+        config.profile = { ...config.profile, description: body.description };
+      }
+      if (!config.sleep) {
+        config.sleep = mindDefaults?.sleep ?? {
+          enabled: true,
+          schedule: { sleep: "0 0 * * *", wake: "0 8 * * *" },
+        };
+      }
+      if (!config.schedules || config.schedules.length === 0) {
+        config.schedules = mindDefaults?.schedules ?? [defaultHeartbeatSchedule()];
+      }
+      // Apply cognition defaults
+      const cog = mindDefaults?.cognition;
+      if (cog) {
+        if (cog.thinkingLevel != null && !config.thinkingLevel)
+          config.thinkingLevel = cog.thinkingLevel;
+        if (cog.tokenBudget != null && config.tokenBudget == null)
+          config.tokenBudget = cog.tokenBudget;
+        if (cog.tokenBudgetPeriodMinutes != null && config.tokenBudgetPeriodMinutes == null)
+          config.tokenBudgetPeriodMinutes = cog.tokenBudgetPeriodMinutes;
+      }
+      writeVoluteConfig(dest, config);
+
+      // Apply model (and compaction) to SDK config.json
+      const modelId = body.model ?? cog?.model;
+      effectiveModel = modelId ? qualifyModelId(modelId) : undefined;
+      const sdkConfigPath = resolve(dest, "home/.config/config.json");
+      if (modelId || cog?.compaction) {
+        const existing = existsSync(sdkConfigPath)
+          ? JSON.parse(readFileSync(sdkConfigPath, "utf-8"))
+          : {};
+        if (modelId) {
+          existing.model = template === "pi" ? qualifyModelId(modelId) : unqualifyModelId(modelId);
+        }
+        if (cog?.compaction && !existing.compaction) {
+          existing.compaction = cog.compaction;
+        }
+        writeFileSync(sdkConfigPath, `${JSON.stringify(existing, null, 2)}\n`);
+      }
+    }
+
+    // Stamp prompts.json with current DB defaults
+    const mindPrompts = await getMindPromptDefaults();
+    writeFileSync(
+      resolve(dest, "home/.config/prompts.json"),
+      `${JSON.stringify(mindPrompts, null, 2)}\n`,
+    );
+
+    const port = await nextPort();
+    // Use createdBy from body, or fall back to the authenticated user's username
+    const createdBy = body.createdBy ?? opts.username;
+    await addMind(name, port, body.stage, template, createdBy);
+    try {
+      await setMindTemplateHash(name, computeTemplateHash(template));
+    } catch (err) {
+      llog.warn(`failed to set template hash for ${name}`, log.errorData(err));
+    }
+
+    // Set up per-mind user isolation (no-ops if VOLUTE_ISOLATION !== "user")
+    const homeDir = resolve(dest, "home");
+    ensureVoluteGroup();
+    createMindUser(name, homeDir);
+    await chownMindDir(dest, name);
+
+    // Install dependencies as mind user (chown already ran above)
+    await npmInstallAsMind(dest, name);
+
+    // git init + template branch + initial commit (before seed modifications
+    // so that initTemplateBranch can git-add all template files)
+    let gitWarning: string | undefined;
+    try {
+      const env = isIsolationEnabled() ? { ...process.env, HOME: homeDir } : undefined;
+      await gitExec(["init"], { cwd: dest, mindName: name, env });
+      await configureGitIdentity(name, { cwd: dest, mindName: name, env });
+      await initTemplateBranch(dest, composedDir, manifest, name, env);
+    } catch (err) {
+      llog.error(`git setup failed for ${name}`, log.errorData(err));
+      rmSync(resolve(dest, ".git"), { recursive: true, force: true });
+      gitWarning =
+        "Git setup failed — variants and upgrades won't be available until git is initialized.";
+    }
+
+    if (body.stage === "seed") {
+      // Write orientation SOUL.md
+      const descLine = body.description
+        ? `\nYour creator described you as: "${body.description}"\n`
+        : "";
+      const seedSoulRaw =
+        body.seedSoul ?? (await getPrompt("seed_soul", { name, description: descLine }));
+      // getPrompt already substituted; custom seedSoul needs substitution too
+      const seedSoul = body.seedSoul
+        ? substitute(seedSoulRaw, { name, description: descLine })
+        : seedSoulRaw;
+      writeFileSync(resolve(dest, "home/SOUL.md"), seedSoul);
+    }
+
+    // Install skills from shared pool (after git init so installSkill can commit)
+    let skillSet =
+      body.skills ?? (body.stage === "seed" ? SEED_SKILLS : getStandardSkillsWithExtensions());
+
+    // Add imagegen skill for seeds when image generation is enabled
+    if (body.stage === "seed" && !body.skills) {
+      const { isImagegenEnabled } = await import("../config/setup.js");
+      if (isImagegenEnabled()) {
+        skillSet = [...skillSet, "imagegen"];
+      }
+    }
+    const skillWarnings: string[] = [];
+    for (const skillId of skillSet) {
+      try {
+        await installSkill(name, dest, skillId);
+      } catch (err) {
+        llog.error(`failed to install skill ${skillId} for ${name}`, log.errorData(err));
+        skillWarnings.push(`Failed to install skill: ${skillId}`);
+      }
+    }
+
+    // Default autonomy: minds created directly as full minds get working
+    // dreaming out of the box; seeds get it at sprout (#581)
+    if (body.stage !== "seed") {
+      skillWarnings.push(...setupDefaultDreaming(dest).warnings);
+    }
+
+    // Add nurture schedule to spirit if this is a seed
+    if (body.stage === "seed") {
+      try {
+        const spiritName = getSpiritName();
+        const spiritEntry = await findMind(spiritName);
+        if (spiritEntry) {
+          const { spiritDir } = await import("./spirit.js");
+          const sDir = spiritEntry.dir ?? spiritDir();
+          const spiritConfig = readVoluteConfig(sDir) ?? {};
+          const schedules = spiritConfig.schedules ?? [];
+          const nurtureId = `nurture-${name}`;
+          if (!schedules.some((s) => s.id === nurtureId)) {
+            schedules.push({
+              id: nurtureId,
+              cron: process.env.VOLUTE_NURTURE_CRON ?? "*/5 * * * *",
+              script: `volute seed check ${name} --nurture`,
+              enabled: true,
+              whileSleeping: "skip",
+            });
+            spiritConfig.schedules = schedules;
+            writeVoluteConfig(sDir, spiritConfig);
+            const { getScheduler } = await import("../daemon/scheduler.js");
+            getScheduler().loadSchedules(spiritName, sDir);
+          }
+        }
+      } catch (err) {
+        llog.warn(`failed to add nurture schedule for ${name}`, log.errorData(err));
+      }
+    }
+
+    // Overwrite SOUL.md / MEMORY.md if custom defaults are set in DB
+    if (body.stage !== "seed") {
+      const customSoul = await getPromptIfCustom("default_soul");
+      if (customSoul) {
+        writeFileSync(resolve(dest, "home/SOUL.md"), customSoul.replace(/\{\{name\}\}/g, name));
+      }
+      const customMemory = await getPromptIfCustom("default_memory");
+      if (customMemory) {
+        writeFileSync(resolve(dest, "home/MEMORY.md"), customMemory);
+      }
+    }
+
+    // Fix ownership after all root git/file operations (git objects, skill
+    // installs, and SOUL.md/MEMORY.md writes above must end up mind-owned so
+    // the mind can modify its own identity files under user isolation)
+    await chownMindDir(dest, name);
+
+    // Auto-publish public key to volute.systems (non-blocking)
+    publishPublicKey(name, publicKeyPem).catch((err: unknown) =>
+      llog.warn(`failed to publish key for ${name}`, { error: (err as Error).message }),
+    );
+
+    fireWebhook({
+      event: "mind_created",
+      mind: name,
+      data: {
+        name,
+        port,
+        stage: body.stage ?? "sprouted",
+        template,
+        description: body.description,
+      },
+    });
+
+    // Announce to the commons channel. Fire-and-forget, but surface failures — this is the
+    // primary producer of commons event rows, and announceToCommons propagates DB errors
+    // (ensureCommonsChannel/addMessage/getParticipants), so a silent swallow would make the
+    // join moment vanish without a trace.
+    announceToCommons(`${name} has joined`).catch((err) =>
+      llog.warn(`failed to announce ${name} joining the commons`, log.errorData(err)),
+    );
+
+    // Warn (don't block) when the mind will spawn without usable model credentials,
+    // so a mute-on-first-turn mind is caught at creation rather than in silence (#573).
+    // The mind is already created — an advisory check must never fail creation, so
+    // swallow any hiccup and just omit the warning.
+    const credentialWarning = await missingCredentialWarning(template, effectiveModel, name).catch(
+      (err) => {
+        llog.warn(`credential check failed for ${name}`, log.errorData(err));
+        return null;
+      },
+    );
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        name,
+        port,
+        stage: body.stage ?? "sprouted",
+        message: `Created mind: ${name} (port ${port})`,
+        ...(gitWarning && { warning: gitWarning }),
+        ...(credentialWarning && { credentialWarning }),
+        ...(skillWarnings.length > 0 && { skillWarnings }),
+      },
+    };
+  } catch (err) {
+    // Clean up partial state
+    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+    try {
+      await removeMind(name);
+    } catch (cleanupErr) {
+      llog.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
+    }
+    return {
+      ok: false,
+      status: 500,
+      error: err instanceof Error ? err.message : "Failed to create mind",
+    };
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+}
+
+/** Import a mind from a .volute archive (already extracted to tempDir by the CLI). */
+export async function importMindFromArchive(
+  tempDir: string,
+  nameOverride: string | undefined,
+  manifest: ExportManifest,
+): Promise<LifecycleResult> {
+  const extractedMindDir = resolve(tempDir, "mind");
+  if (!existsSync(extractedMindDir)) {
+    return { ok: false, status: 400, error: "Invalid archive: missing mind/ directory" };
+  }
+
+  if (!manifest?.includes || !manifest.name || !manifest.template) {
+    return { ok: false, status: 400, error: "Invalid archive manifest" };
+  }
+
+  // Route home-only archives through the template-composed import path
+  if (isHomeOnlyArchive(manifest)) {
+    return importFromHomeOnlyArchive(tempDir, extractedMindDir, nameOverride, manifest);
+  }
+
+  return importFromFullArchive(tempDir, extractedMindDir, nameOverride, manifest);
+}
+
+/** Import a full archive (contains src/, home/, .mind/) — original behavior. */
+async function importFromFullArchive(
+  tempDir: string,
+  extractedMindDir: string,
+  nameOverride: string | undefined,
+  manifest: ExportManifest,
+): Promise<LifecycleResult> {
+  const name = nameOverride ?? manifest.name;
+
+  const nameErr = validateMindName(name);
+  if (nameErr) return { ok: false, status: 400, error: nameErr };
+
+  if (await findMind(name))
+    return { ok: false, status: 409, error: `Mind already exists: ${name}` };
+
+  ensureVoluteHome();
+  const dest = mindDir(name);
+  if (existsSync(dest)) return { ok: false, status: 409, error: "Mind directory already exists" };
+
+  try {
+    // Copy extracted mind directory to final location
+    cpSync(extractedMindDir, dest, { recursive: true });
+
+    // Generate new identity if not included in archive
+    if (!manifest.includes.identity) {
+      generateIdentity(dest);
+    }
+
+    // Copy state files (env.json) to centralized state dir
+    const state = stateDir(name);
+    mkdirSync(state, { recursive: true });
+
+    const envJson = resolve(tempDir, "state/env.json");
+    if (existsSync(envJson)) {
+      cpSync(envJson, resolve(state, "env.json"));
+    }
+
+    // Assign port and register
+    const port = await nextPort();
+    await addMind(name, port, manifest.stage, manifest.template);
+    try {
+      await setMindTemplateHash(name, computeTemplateHash(manifest.template));
+    } catch (err) {
+      llog.warn(`failed to set template hash for ${name}`, log.errorData(err));
+    }
+
+    // Set up per-mind user isolation
+    const homeDir = resolve(dest, "home");
+    ensureVoluteGroup();
+    createMindUser(name, homeDir);
+    await chownMindDir(dest, name);
+
+    // Install dependencies
+    await npmInstallAsMind(dest, name);
+
+    // Import history and sessions
+    await importHistoryFromArchive(name, tempDir);
+    importSessionsFromArchive(dest, tempDir);
+
+    // git init if .git/ doesn't exist (non-fatal — mind works without git)
+    if (!existsSync(resolve(dest, ".git"))) {
+      try {
+        const env = isIsolationEnabled()
+          ? { ...process.env, HOME: resolve(dest, "home") }
+          : undefined;
+        await gitExec(["init"], { cwd: dest, mindName: name, env });
+        await configureGitIdentity(name, { cwd: dest, mindName: name, env });
+        await gitExec(["add", "-A"], { cwd: dest, mindName: name, env });
+        await gitExec(["commit", "-m", "import from archive"], { cwd: dest, mindName: name, env });
+      } catch (err) {
+        llog.error(`git setup failed for imported mind ${name}`, log.errorData(err));
+        rmSync(resolve(dest, ".git"), { recursive: true, force: true });
+      }
+    }
+
+    // Fix ownership
+    await chownMindDir(dest, name);
+
+    // Clean up temp dir
+    rmSync(tempDir, { recursive: true, force: true });
+
+    return {
+      ok: true,
+      body: { ok: true, name, port, message: `Imported mind: ${name} (port ${port})` },
+    };
+  } catch (err) {
+    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+    try {
+      await removeMind(name);
+    } catch (cleanupErr) {
+      llog.error(`Failed to clean up registry for ${name}`, log.errorData(cleanupErr));
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    return {
+      ok: false,
+      status: 500,
+      error: err instanceof Error ? err.message : "Failed to import mind",
+    };
+  }
+}
+
+/** Import a home-only archive by composing a fresh template and overlaying mind-owned files. */
+async function importFromHomeOnlyArchive(
+  tempDir: string,
+  extractedMindDir: string,
+  nameOverride: string | undefined,
+  manifest: ExportManifest,
+): Promise<LifecycleResult> {
+  const name = nameOverride ?? manifest.name;
+
+  const nameErr = validateMindName(name);
+  if (nameErr) return { ok: false, status: 400, error: nameErr };
+
+  if (await findMind(name))
+    return { ok: false, status: 409, error: `Mind already exists: ${name}` };
+
+  ensureVoluteHome();
+  const dest = mindDir(name);
+  if (existsSync(dest)) return { ok: false, status: 409, error: "Mind directory already exists" };
+
+  const templatesRoot = findTemplatesRoot();
+  const { composedDir, manifest: templateManifest } = composeTemplate(
+    templatesRoot,
+    manifest.template,
+  );
+
+  try {
+    // 1. Compose fresh template
+    copyTemplateToDir(composedDir, dest, name, templateManifest);
+    applyInitFiles(dest);
+
+    // 2. Overlay home/ from archive (archive files win over template defaults)
+    const extractedHome = resolve(extractedMindDir, "home");
+    if (existsSync(extractedHome)) {
+      cpSync(extractedHome, resolve(dest, "home"), { recursive: true });
+    }
+
+    // 3. Overlay .mind/ from archive (preserves schedules, etc.)
+    const extractedMindInternal = resolve(extractedMindDir, ".mind");
+    if (existsSync(extractedMindInternal)) {
+      cpSync(extractedMindInternal, resolve(dest, ".mind"), { recursive: true });
+    }
+
+    // 4. Generate new identity if not included in archive
+    const identityDir = resolve(dest, ".mind/identity");
+    let publicKeyPem: string;
+    if (!manifest.includes.identity || !existsSync(resolve(identityDir, "private.pem"))) {
+      ({ publicKeyPem } = generateIdentity(dest));
+    } else {
+      publicKeyPem = readFileSync(resolve(identityDir, "public.pem"), "utf-8");
+    }
+
+    // 5. Stamp prompts.json only if archive didn't provide one
+    const promptsPath = resolve(dest, "home/.config/prompts.json");
+    if (!existsSync(promptsPath)) {
+      const mindPrompts = await getMindPromptDefaults();
+      writeFileSync(promptsPath, `${JSON.stringify(mindPrompts, null, 2)}\n`);
+    }
+
+    // 6. Copy state files (env.json) to centralized state dir
+    const state = stateDir(name);
+    mkdirSync(state, { recursive: true });
+
+    const envJson = resolve(tempDir, "state/env.json");
+    if (existsSync(envJson)) {
+      cpSync(envJson, resolve(state, "env.json"));
+    }
+
+    // 7. Register with correct stage and template
+    const port = await nextPort();
+    await addMind(name, port, manifest.stage, manifest.template);
+
+    // 8. User isolation setup
+    const homeDir = resolve(dest, "home");
+    ensureVoluteGroup();
+    createMindUser(name, homeDir);
+    await chownMindDir(dest, name);
+
+    // 9. npm install
+    await npmInstallAsMind(dest, name);
+
+    // 10. Git init with template branch (enables upgrades)
+    let gitWarning: string | undefined;
+    try {
+      const env = isIsolationEnabled() ? { ...process.env, HOME: homeDir } : undefined;
+      await gitExec(["init"], { cwd: dest, mindName: name, env });
+      await configureGitIdentity(name, { cwd: dest, mindName: name, env });
+      await initTemplateBranch(dest, composedDir, templateManifest, name, env);
+    } catch (err) {
+      llog.error(`git setup failed for imported mind ${name}`, log.errorData(err));
+      rmSync(resolve(dest, ".git"), { recursive: true, force: true });
+      gitWarning =
+        "Git setup failed — variants and upgrades won't be available until git is initialized.";
+    }
+
+    // 11. Install skills based on stage
+    const skillSet = manifest.stage === "seed" ? SEED_SKILLS : getStandardSkillsWithExtensions();
+    const skillWarnings: string[] = [];
+    for (const skillId of skillSet) {
+      try {
+        await installSkill(name, dest, skillId);
+      } catch (err) {
+        llog.error(`failed to install skill ${skillId} for ${name}`, log.errorData(err));
+        skillWarnings.push(`Failed to install skill: ${skillId}`);
+      }
+    }
+
+    // 13. Import history and sessions from archive
+    await importHistoryFromArchive(name, tempDir);
+    importSessionsFromArchive(dest, tempDir);
+
+    // 14. Fix ownership, publish public key
+    await chownMindDir(dest, name);
+    publishPublicKey(name, publicKeyPem).catch((err: unknown) =>
+      llog.warn(`failed to publish key for ${name}`, { error: (err as Error).message }),
+    );
+
+    // 15. Clean up
+    rmSync(tempDir, { recursive: true, force: true });
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        name,
+        port,
+        stage: manifest.stage ?? "sprouted",
+        message: `Imported mind: ${name} (port ${port})`,
+        ...(gitWarning && { warning: gitWarning }),
+        ...(skillWarnings.length > 0 && { skillWarnings }),
+      },
+    };
+  } catch (err) {
+    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+    try {
+      await removeMind(name);
+    } catch (cleanupErr) {
+      llog.error(`Failed to clean up registry for ${name}`, log.errorData(cleanupErr));
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    return {
+      ok: false,
+      status: 500,
+      error: err instanceof Error ? err.message : "Failed to import mind",
+    };
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+}
+
+/** Import history rows from archive into the database. */
+async function importHistoryFromArchive(name: string, tempDir: string): Promise<void> {
+  const historyJsonl = resolve(tempDir, "history.jsonl");
+  if (!existsSync(historyJsonl)) return;
+
+  try {
+    const db = await getDb();
+    const lines = readFileSync(historyJsonl, "utf-8").trim().split("\n");
+    let imported = 0;
+    let failed = 0;
+    for (const line of lines) {
+      if (!line) continue;
+      try {
+        const row = JSON.parse(line);
+        if (!row.type) {
+          failed++;
+          continue;
+        }
+        await db.insert(mindHistory).values({
+          mind: name,
+          channel: row.channel ?? null,
+          // Archives are long-lived files: pre-rename exports carry `session`.
+          thread: row.thread ?? row.session ?? null,
+          sender: row.sender ?? null,
+          message_id: row.message_id ?? null,
+          type: row.type,
+          content: row.content ?? null,
+          metadata: row.metadata ?? null,
+          created_at: row.created_at ?? new Date().toISOString(),
+        });
+        imported++;
+      } catch (lineErr) {
+        llog.warn("Failed to import history line", log.errorData(lineErr));
+        failed++;
+      }
+    }
+    if (failed > 0) {
+      llog.warn(`History import: ${imported} imported, ${failed} failed`);
+    }
+  } catch (err) {
+    llog.error("Failed to open database for history import", log.errorData(err));
+  }
+}
+
+/** Import session files from archive into .mind/sessions/. Non-fatal on failure. */
+function importSessionsFromArchive(dest: string, tempDir: string): void {
+  const sessionsDir = resolve(tempDir, "sessions");
+  if (!existsSync(sessionsDir)) return;
+
+  try {
+    const destSessions = resolve(dest, ".mind/sessions");
+    mkdirSync(destSessions, { recursive: true });
+    for (const file of readdirSync(sessionsDir)) {
+      cpSync(resolve(sessionsDir, file), resolve(destSessions, file));
+    }
+  } catch (err) {
+    llog.error("Failed to import sessions from archive", log.errorData(err));
+  }
+}
+
+/** Input for {@link importOpenClawWorkspace}. */
+export interface ImportOpenClawInput {
+  workspacePath?: string;
+  name?: string;
+  template?: string;
+  sessionPath?: string;
+}
+
+/** Import a mind from an OpenClaw workspace directory (SOUL.md + IDENTITY.md + optional session). */
+export async function importOpenClawWorkspace(body: ImportOpenClawInput): Promise<LifecycleResult> {
+  const wsDir = body.workspacePath;
+  if (
+    !wsDir ||
+    !existsSync(resolve(wsDir, "SOUL.md")) ||
+    !existsSync(resolve(wsDir, "IDENTITY.md"))
+  ) {
+    return { ok: false, status: 400, error: "Invalid workspace: missing SOUL.md or IDENTITY.md" };
+  }
+
+  const soul = readFileSync(resolve(wsDir, "SOUL.md"), "utf-8");
+  const identity = readFileSync(resolve(wsDir, "IDENTITY.md"), "utf-8");
+  const userPath = resolve(wsDir, "USER.md");
+  const user = existsSync(userPath) ? readFileSync(userPath, "utf-8") : "";
+
+  const name = body.name ?? parseNameFromIdentity(identity) ?? "imported-mind";
+  const template = body.template ?? "claude";
+
+  const nameErr = validateMindName(name);
+  if (nameErr) return { ok: false, status: 400, error: nameErr };
+
+  if (await findMind(name))
+    return { ok: false, status: 409, error: `Mind already exists: ${name}` };
+
+  const mergedSoul = `${soul.trimEnd()}\n\n---\n\n${identity.trimEnd()}\n`;
+  const mergedMemoryExtra = user ? `\n\n---\n\n${user.trimEnd()}\n` : "";
+
+  ensureVoluteHome();
+  const dest = mindDir(name);
+
+  if (existsSync(dest)) return { ok: false, status: 409, error: "Mind directory already exists" };
+
+  const templatesRoot = findTemplatesRoot();
+  const { composedDir, manifest } = composeTemplate(templatesRoot, template);
+
+  try {
+    copyTemplateToDir(composedDir, dest, name, manifest);
+
+    applyInitFiles(dest);
+
+    // Generate Ed25519 keypair for mind identity
+    const { publicKeyPem: importPublicKey } = generateIdentity(dest);
+
+    // Write SOUL.md (with IDENTITY.md merged in)
+    writeFileSync(resolve(dest, "home/SOUL.md"), mergedSoul);
+
+    // Copy or create MEMORY.md
+    const wsMemoryPath = resolve(wsDir, "MEMORY.md");
+    const hasMemory = existsSync(wsMemoryPath);
+    if (hasMemory) {
+      const existingMemory = readFileSync(wsMemoryPath, "utf-8");
+      writeFileSync(
+        resolve(dest, "home/MEMORY.md"),
+        `${existingMemory.trimEnd()}${mergedMemoryExtra}`,
+      );
+    } else if (user) {
+      writeFileSync(resolve(dest, "home/MEMORY.md"), `${user.trimEnd()}\n`);
+    }
+
+    // Copy memory/*.md daily logs
+    const wsMemoryDir = resolve(wsDir, "memory");
+    let dailyLogCount = 0;
+    if (existsSync(wsMemoryDir)) {
+      const destMemoryDir = resolve(dest, "home/memory");
+      const files = readdirSync(wsMemoryDir).filter((f) => f.endsWith(".md"));
+      for (const file of files) {
+        cpSync(resolve(wsMemoryDir, file), resolve(destMemoryDir, file));
+      }
+      dailyLogCount = files.length;
+    }
+
+    // Assign port and register
+    const port = await nextPort();
+    await addMind(name, port, undefined, template);
+    try {
+      await setMindTemplateHash(name, computeTemplateHash(template));
+    } catch (err) {
+      llog.warn(`failed to set template hash for ${name}`, log.errorData(err));
+    }
+
+    // Set up per-mind user isolation (no-ops if VOLUTE_ISOLATION !== "user")
+    const homeDir = resolve(dest, "home");
+    ensureVoluteGroup();
+    createMindUser(name, homeDir);
+    await chownMindDir(dest, name);
+
+    // Install dependencies as mind user (chown already ran above)
+    await npmInstallAsMind(dest, name);
+
+    // Consolidate memory if no MEMORY.md but daily logs exist
+    if (!hasMemory && dailyLogCount > 0) {
+      await consolidateMemory(dest);
+    }
+
+    // git init + initial commit
+    const env = isIsolationEnabled() ? { ...process.env, HOME: resolve(dest, "home") } : undefined;
+    await gitExec(["init"], { cwd: dest, mindName: name, env });
+    await configureGitIdentity(name, { cwd: dest, mindName: name, env });
+    await gitExec(["add", "-A"], { cwd: dest, mindName: name, env });
+    await gitExec(["commit", "-m", "import from OpenClaw"], { cwd: dest, mindName: name, env });
+
+    // Import session
+    const sessionFile = body.sessionPath ? resolve(body.sessionPath) : findOpenClawSession(wsDir);
+    if (sessionFile && existsSync(sessionFile)) {
+      if (template === "pi") {
+        importPiSession(sessionFile, dest);
+      } else if (template === "claude") {
+        const sessionId = convertSession({ sessionPath: sessionFile, projectDir: dest });
+        const mindRuntimeDir = resolve(dest, ".mind");
+        mkdirSync(mindRuntimeDir, { recursive: true });
+        writeFileSync(resolve(mindRuntimeDir, "session.json"), JSON.stringify({ sessionId }));
+      }
+    }
+
+    // Import OpenClaw connectors as system bridges (non-fatal)
+    importOpenClawConnectors(name, dest);
+
+    // Fix ownership after root git/file operations
+    await chownMindDir(dest, name);
+
+    // Auto-publish public key to volute.systems (non-blocking)
+    publishPublicKey(name, importPublicKey).catch((err: unknown) =>
+      llog.warn(`failed to publish key for ${name}`, { error: (err as Error).message }),
+    );
+
+    return {
+      ok: true,
+      body: { ok: true, name, port, message: `Imported mind: ${name} (port ${port})` },
+    };
+  } catch (err) {
+    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+    try {
+      await removeMind(name);
+    } catch (cleanupErr) {
+      llog.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
+    }
+    return {
+      ok: false,
+      status: 500,
+      error: err instanceof Error ? err.message : "Failed to import mind",
+    };
+  } finally {
+    rmSync(composedDir, { recursive: true, force: true });
+  }
+}
+
+/** Input for {@link createVariant}. The caller validates the name and parent first. */
+export interface CreateVariantInput {
+  /** Base mind being split from (owns projectRoot). */
+  parentName: string;
+  projectRoot: string;
+  variantName: string;
+  soul?: string;
+  port?: number;
+  noStart?: boolean;
+  purpose?: string;
+}
+
+export type CreateVariantResult =
+  | {
+      ok: true;
+      variant: { name: string; branch: string; path: string; port: number; purpose?: string };
+    }
+  | { ok: false; status: 409 | 500; error: string };
+
+/**
+ * Split a variant off a base mind: create the git worktree, install deps, register
+ * it, and (unless noStart) start its server with birth context queued. Moved out of
+ * the POST `/:name/variants` route body verbatim (#330). Every step past worktree
+ * creation is rolled back on failure so a retry with the same name isn't blocked by
+ * a half-created variant (#444). The caller establishes the parent<->variant dialogue
+ * on success.
+ */
+export async function createVariant(input: CreateVariantInput): Promise<CreateVariantResult> {
+  const { parentName, projectRoot, variantName, purpose } = input;
+  const variantDir = resolve(projectRoot, ".variants", variantName);
+
+  if (existsSync(variantDir)) {
+    return { ok: false, status: 409, error: `Variant directory already exists: ${variantDir}` };
+  }
+
+  mkdirSync(resolve(projectRoot, ".variants"), { recursive: true });
+
+  // Create git worktree
+  try {
+    await gitExec(["worktree", "add", "-b", variantName, variantDir], { cwd: projectRoot });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // mkdirSync + `git worktree add` ran as the daemon (root) and may leave
+    // root-owned files under .variants/ in the mind's tree; hand ownership
+    // back before returning so the mind can retry. Surface a restore failure
+    // so a left-behind-root-files condition isn't hidden.
+    let error = `Failed to create worktree: ${msg}`;
+    try {
+      await chownMindDir(projectRoot, parentName);
+    } catch (err) {
+      llog.warn(
+        `failed to restore ownership after worktree-add failure for ${parentName}`,
+        log.errorData(err),
+      );
+      error += ` Restoring mind ownership also failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+    return { ok: false, status: 500, error };
+  }
+
+  // Everything after the worktree is created is rolled back on failure so a
+  // retry with the same name isn't blocked by a half-created variant (#444).
+  const rollbackSplit = async () => {
+    try {
+      await cleanupVariant(variantName, parentName, projectRoot, variantDir, { stop: true });
+    } catch (err) {
+      llog.warn(`failed to roll back split of ${variantName}`, log.errorData(err));
+    }
+  };
+
+  // Fix ownership before npm install so it runs as the mind user. This is the
+  // first step past worktree creation, so a throw here (chownMindDir re-throws
+  // under isolation) must also roll back or it strands the worktree+branch.
+  try {
+    await chownMindDir(projectRoot, parentName);
+  } catch (e: unknown) {
+    await rollbackSplit();
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, status: 500, error: `Failed to prepare variant ownership: ${msg}` };
+  }
+
+  // Install dependencies
+  try {
+    if (isIsolationEnabled()) {
+      const [cmd, args] = await wrapForIsolation("npm", ["install"], parentName);
+      await exec(cmd, args, {
+        cwd: variantDir,
+        env: { ...process.env, HOME: resolve(variantDir, "home") },
+      });
+    } else {
+      await exec("npm", ["install"], { cwd: variantDir });
+    }
+  } catch (e: unknown) {
+    await rollbackSplit();
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, status: 500, error: `npm install failed: ${msg}` };
+  }
+
+  // Write SOUL.md if provided
+  if (input.soul) {
+    writeFileSync(resolve(variantDir, "home/SOUL.md"), input.soul);
+  }
+
+  const variantPort = input.port ?? (await nextPort());
+
+  // Register variant in DB
+  try {
+    await addVariant(variantName, parentName, variantPort, variantDir, variantName, purpose);
+  } catch (e: unknown) {
+    await rollbackSplit();
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, status: 500, error: `Failed to register variant: ${msg}` };
+  }
+
+  // Queue the variant's birth context now, independent of --no-start: it's the
+  // variant's first message — who it is, where it came from, and why it was split
+  // off — and deliverPendingContext fires on whatever first start happens, so a
+  // variant started manually later still gets oriented. Pending context is
+  // persisted under state/<variant>/ (#330), so it survives a daemon restart
+  // before that first start too.
+  const manager = getMindManager();
+  manager.setPendingContext(variantName, { type: "split", parent: parentName, purpose });
+
+  if (!input.noStart) {
+    try {
+      await manager.startMind(variantName);
+    } catch (e: unknown) {
+      await rollbackSplit();
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false, status: 500, error: `Variant created but failed to start: ${msg}` };
+    }
+  }
+
+  return {
+    ok: true,
+    variant: {
+      name: variantName,
+      branch: variantName,
+      path: variantDir,
+      port: variantPort,
+      ...(purpose && { purpose }),
+    },
+  };
+}

--- a/packages/daemon/src/lib/template/template-hash.ts
+++ b/packages/daemon/src/lib/template/template-hash.ts
@@ -13,7 +13,7 @@ export function computeTemplateHash(templateName: string): string {
   const cached = hashCache.get(templateName);
   if (cached) return cached;
 
-  // Pre-validate to avoid process.exit() paths in composeTemplate/findTemplatesRoot
+  // Pre-validate for clearer errors than composeTemplate/findTemplatesRoot's generic throws
   const templatesRoot = findTemplatesRoot();
   const baseDir = resolve(templatesRoot, "_base");
   const templateDir = resolve(templatesRoot, templateName);

--- a/packages/daemon/src/lib/template/template.ts
+++ b/packages/daemon/src/lib/template/template.ts
@@ -71,19 +71,20 @@ export function locateTemplatesRoot(): string | null {
 export function findTemplatesRoot(): string {
   const root = locateTemplatesRoot();
   if (root) return root;
-  console.error(
-    "Templates directory not found. Searched up from:",
-    dirname(new URL(import.meta.url).pathname),
+  // Throw rather than exit: every caller runs inside the long-lived daemon (create,
+  // import, upgrade, staleness, spirit sync), where a process.exit(1) would take down
+  // every mind, bridge, and the web server that no try/catch could stop. Route handlers
+  // catch this and return 500.
+  throw new Error(
+    `Templates directory not found. Searched up from: ${dirname(new URL(import.meta.url).pathname)}`,
   );
-  process.exit(1);
 }
 
 export function findTemplatesDir(template: string): string {
   const root = findTemplatesRoot();
   const dir = resolve(root, template);
   if (!existsSync(dir)) {
-    console.error(`Template not found: ${template}`);
-    process.exit(1);
+    throw new Error(`Template not found: ${template}`);
   }
   return dir;
 }
@@ -100,12 +101,10 @@ export function composeTemplate(
   const templateDir = resolve(templatesRoot, templateName);
 
   if (!existsSync(baseDir)) {
-    console.error("Base template not found:", baseDir);
-    process.exit(1);
+    throw new Error(`Base template not found: ${baseDir}`);
   }
   if (!existsSync(templateDir)) {
-    console.error(`Template not found: ${templateName}`);
-    process.exit(1);
+    throw new Error(`Template not found: ${templateName}`);
   }
 
   // Create a unique temp staging directory. A timestamp suffix is not enough: two
@@ -132,8 +131,7 @@ export function composeTemplate(
   const baseManifestPath = resolve(baseDir, "volute-template.json");
   if (!existsSync(baseManifestPath)) {
     rmSync(composedDir, { recursive: true, force: true });
-    console.error("Base template manifest not found: _base/volute-template.json");
-    process.exit(1);
+    throw new Error("Base template manifest not found: _base/volute-template.json");
   }
   const baseManifest = JSON.parse(
     readFileSync(baseManifestPath, "utf-8"),
@@ -292,10 +290,10 @@ export function isInitInfrastructure(relPath: string): boolean {
  * upgrade's git merge.
  *
  * Throws rather than exiting when the template can't be composed. Both callers
- * run inside the daemon, and `composeTemplate`/`findTemplatesRoot` `process.exit(1)`
- * on a missing templates root, template dir, or manifest — uncatchable, and fatal
- * to every mind on the host. The pre-checks below cover exactly those exit paths
- * so a broken install degrades to one warning.
+ * run inside the daemon; the pre-checks below turn a missing templates root,
+ * template dir, or manifest into a specific error message (rather than
+ * composeTemplate/findTemplatesRoot's generic throw) so a broken install
+ * degrades to one clear warning.
  */
 export function backfillInitInfrastructure(
   homeDir: string,
@@ -308,8 +306,8 @@ export function backfillInitInfrastructure(
     throw new Error(`template "${template}" not found at ${root}`);
   }
   // _base ships the shared manifest that every template merges into; its absence is
-  // the manifest path composeTemplate process.exit(1)s on (a template's own manifest
-  // is now optional). Pre-check it so a broken install degrades to one warning.
+  // the manifest path composeTemplate throws on (a template's own manifest is now
+  // optional). Pre-check it so a broken install degrades to one clear warning.
   if (!existsSync(resolve(root, "_base", "volute-template.json"))) {
     throw new Error(`base template manifest missing at ${root}/_base`);
   }

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -1,30 +1,11 @@
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { zValidator } from "@hono/zod-validator";
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { z } from "zod";
-import {
-  isAiConfigured,
-  missingCredentialWarning,
-  qualifyModelId,
-  resolveTemplate,
-  unqualifyModelId,
-} from "../../lib/ai-service.js";
 import { deleteMindUser, getDisplayNames, withSenderDisplayNames } from "../../lib/auth.js";
-import {
-  announceSprout,
-  announceToCommons,
-  joinCommonsChannelForMind,
-} from "../../lib/chat/commons-channel.js";
+import { announceSprout, joinCommonsChannelForMind } from "../../lib/chat/commons-channel.js";
 import {
   drainEvents,
   eventLabel,
@@ -61,91 +42,51 @@ import {
   listConversationsForMind,
 } from "../../lib/events/conversations.js";
 import { subscribe as subscribeMindEvent } from "../../lib/events/mind-events.js";
-import { type ExportManifest, isHomeOnlyArchive } from "../../lib/mind/archive.js";
-import { consolidateMemory } from "../../lib/mind/consolidate.js";
-import { defaultHeartbeatSchedule, setupDefaultDreaming } from "../../lib/mind/default-autonomy.js";
-import { generateIdentity, publishPublicKey } from "../../lib/mind/identity.js";
-import {
-  chownMindDir,
-  createMindUser,
-  deleteMindUser as deleteIsolationUser,
-  ensureVoluteGroup,
-  isIsolationEnabled,
-} from "../../lib/mind/isolation.js";
+import type { ExportManifest } from "../../lib/mind/archive.js";
+import { setupDefaultDreaming } from "../../lib/mind/default-autonomy.js";
+import { deleteMindUser as deleteIsolationUser } from "../../lib/mind/isolation.js";
 import { commitSrcChanges, rollbackSrcChanges } from "../../lib/mind/last-known-good.js";
-import { getMemoryStatus } from "../../lib/mind/memory-size.js";
-import { npmInstallAsMind, npmInstallNeeded } from "../../lib/mind/npm-install.js";
 import {
-  addMind,
-  countCappedMinds,
-  ensureVoluteHome,
+  createMind,
+  importMindFromArchive,
+  importOpenClawWorkspace,
+  mergeVariant,
+} from "../../lib/mind/lifecycle.js";
+import { getMemoryStatus } from "../../lib/mind/memory-size.js";
+import {
   findMind,
   findVariants,
   getBaseName,
   type MindEntry,
   mindDir,
-  nextPort,
   readRegistry,
   removeMind,
   setMindStage,
-  setMindTemplateHash,
   stateDir,
-  validateMindName,
 } from "../../lib/mind/registry.js";
 import { evaluateSeedChecklist } from "../../lib/mind/seed-readiness.js";
 import { isTemplateStale } from "../../lib/mind/template-staleness.js";
 import { applyThinkingLevel, deriveThinkingLevel } from "../../lib/mind/thinking-config.js";
 import {
   abortUpgrade,
-  configureGitIdentity,
   continueUpgrade,
   runUpgrade,
-  TEMPLATE_BRANCH,
   UpgradeInProgressError,
   upgradeDiff,
   upgradeInProgress,
 } from "../../lib/mind/upgrade.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
-import {
-  findUnresolvedHomeFiles,
-  formatUnresolvedHomeFilesMessage,
-  mergeVariantExcludingMemory,
-  validateBranchName,
-} from "../../lib/mind/variants.js";
+import { validateBranchName } from "../../lib/mind/variants.js";
 import { readVoluteConfig, writeVoluteConfig } from "../../lib/mind/volute-config.js";
 import { PLATFORMS } from "../../lib/platforms.js";
-import {
-  getMindPromptDefaults,
-  getPrompt,
-  getPromptIfCustom,
-  substitute,
-} from "../../lib/prompts.js";
 import { mindHistory, summaries, turns } from "../../lib/schema.js";
 import {
   createImagegenJob,
   getImagegenJob,
   waitForImagegenJob,
 } from "../../lib/services/imagegen-jobs.js";
-import { getStandardSkillsWithExtensions, installSkill, SEED_SKILLS } from "../../lib/skills.js";
-import { convertSession } from "../../lib/template/convert-session.js";
-import {
-  findOpenClawSession,
-  importOpenClawConnectors,
-  importPiSession,
-  parseNameFromIdentity,
-} from "../../lib/template/import-utils.js";
-import {
-  applyInitFiles,
-  composeTemplate,
-  copyTemplateToDir,
-  findTemplatesRoot,
-  isKnownTemplate,
-  listFiles,
-  type TemplateManifest,
-} from "../../lib/template/template.js";
-import { computeTemplateHash } from "../../lib/template/template-hash.js";
+import { isKnownTemplate } from "../../lib/template/template.js";
 import { collectTurnContext } from "../../lib/turn-context.js";
-import { gitExec } from "../../lib/util/exec.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
 import { safeResolveWithinBase } from "../../lib/util/paths.js";
@@ -297,353 +238,6 @@ export function toPublicMind(
   };
 }
 
-/**
- * Create the volute/template tracking branch and main branch with shared history.
- * Enables clean 3-way merges on the first `volute mind upgrade`.
- */
-async function initTemplateBranch(
-  projectRoot: string,
-  composedDir: string,
-  manifest: TemplateManifest,
-  mindName?: string,
-  env?: NodeJS.ProcessEnv,
-) {
-  const templateFiles = listFiles(composedDir)
-    .filter((f) => !f.startsWith(".init/") && !f.startsWith(".init\\"))
-    .filter((f) => (!f.startsWith("home/") && !f.startsWith("home\\")) || f === "home/VOLUTE.md")
-    .map((f) => manifest.rename[f] ?? f);
-
-  const opts = { cwd: projectRoot, mindName, env };
-
-  await gitExec(["checkout", "--orphan", TEMPLATE_BRANCH], opts);
-  await gitExec(["add", "--", ...templateFiles], opts);
-  await gitExec(["commit", "-m", "template update"], opts);
-
-  await gitExec(["checkout", "-b", "main"], opts);
-  await gitExec(["add", "-A"], opts);
-  await gitExec(["commit", "-m", "initial commit"], opts);
-}
-
-/** Import a mind from a .volute archive (extracted to tempDir by CLI). */
-async function importFromArchive(
-  c: any,
-  tempDir: string,
-  nameOverride: string | undefined,
-  manifest: ExportManifest,
-) {
-  const extractedMindDir = resolve(tempDir, "mind");
-  if (!existsSync(extractedMindDir)) {
-    return c.json({ error: "Invalid archive: missing mind/ directory" }, 400);
-  }
-
-  if (!manifest?.includes || !manifest.name || !manifest.template) {
-    return c.json({ error: "Invalid archive manifest" }, 400);
-  }
-
-  // Route home-only archives through the template-composed import path
-  if (isHomeOnlyArchive(manifest)) {
-    return importFromHomeOnlyArchive(c, tempDir, extractedMindDir, nameOverride, manifest);
-  }
-
-  return importFromFullArchive(c, tempDir, extractedMindDir, nameOverride, manifest);
-}
-
-/** Import a full archive (contains src/, home/, .mind/) — original behavior. */
-async function importFromFullArchive(
-  c: any,
-  tempDir: string,
-  extractedMindDir: string,
-  nameOverride: string | undefined,
-  manifest: ExportManifest,
-) {
-  const name = nameOverride ?? manifest.name;
-
-  const nameErr = validateMindName(name);
-  if (nameErr) return c.json({ error: nameErr }, 400);
-
-  if (await findMind(name)) return c.json({ error: `Mind already exists: ${name}` }, 409);
-
-  ensureVoluteHome();
-  const dest = mindDir(name);
-  if (existsSync(dest)) return c.json({ error: "Mind directory already exists" }, 409);
-
-  try {
-    // Copy extracted mind directory to final location
-    cpSync(extractedMindDir, dest, { recursive: true });
-
-    // Generate new identity if not included in archive
-    if (!manifest.includes.identity) {
-      generateIdentity(dest);
-    }
-
-    // Copy state files (env.json) to centralized state dir
-    const state = stateDir(name);
-    mkdirSync(state, { recursive: true });
-
-    const envJson = resolve(tempDir, "state/env.json");
-    if (existsSync(envJson)) {
-      cpSync(envJson, resolve(state, "env.json"));
-    }
-
-    // Assign port and register
-    const port = await nextPort();
-    await addMind(name, port, manifest.stage, manifest.template);
-    try {
-      await setMindTemplateHash(name, computeTemplateHash(manifest.template));
-    } catch (err) {
-      log.warn(`failed to set template hash for ${name}`, log.errorData(err));
-    }
-
-    // Set up per-mind user isolation
-    const homeDir = resolve(dest, "home");
-    ensureVoluteGroup();
-    createMindUser(name, homeDir);
-    await chownMindDir(dest, name);
-
-    // Install dependencies
-    await npmInstallAsMind(dest, name);
-
-    // Import history and sessions
-    await importHistoryFromArchive(name, tempDir);
-    importSessionsFromArchive(dest, tempDir);
-
-    // git init if .git/ doesn't exist (non-fatal — mind works without git)
-    if (!existsSync(resolve(dest, ".git"))) {
-      try {
-        const env = isIsolationEnabled()
-          ? { ...process.env, HOME: resolve(dest, "home") }
-          : undefined;
-        await gitExec(["init"], { cwd: dest, mindName: name, env });
-        await configureGitIdentity(name, { cwd: dest, mindName: name, env });
-        await gitExec(["add", "-A"], { cwd: dest, mindName: name, env });
-        await gitExec(["commit", "-m", "import from archive"], { cwd: dest, mindName: name, env });
-      } catch (err) {
-        log.error(`git setup failed for imported mind ${name}`, log.errorData(err));
-        rmSync(resolve(dest, ".git"), { recursive: true, force: true });
-      }
-    }
-
-    // Fix ownership
-    await chownMindDir(dest, name);
-
-    // Clean up temp dir
-    rmSync(tempDir, { recursive: true, force: true });
-
-    return c.json({ ok: true, name, port, message: `Imported mind: ${name} (port ${port})` });
-  } catch (err) {
-    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
-    try {
-      await removeMind(name);
-    } catch (cleanupErr) {
-      log.error(`Failed to clean up registry for ${name}`, log.errorData(cleanupErr));
-    }
-    rmSync(tempDir, { recursive: true, force: true });
-    return c.json({ error: err instanceof Error ? err.message : "Failed to import mind" }, 500);
-  }
-}
-
-/** Import a home-only archive by composing a fresh template and overlaying mind-owned files. */
-async function importFromHomeOnlyArchive(
-  c: any,
-  tempDir: string,
-  extractedMindDir: string,
-  nameOverride: string | undefined,
-  manifest: ExportManifest,
-) {
-  const name = nameOverride ?? manifest.name;
-
-  const nameErr = validateMindName(name);
-  if (nameErr) return c.json({ error: nameErr }, 400);
-
-  if (await findMind(name)) return c.json({ error: `Mind already exists: ${name}` }, 409);
-
-  ensureVoluteHome();
-  const dest = mindDir(name);
-  if (existsSync(dest)) return c.json({ error: "Mind directory already exists" }, 409);
-
-  const templatesRoot = findTemplatesRoot();
-  const { composedDir, manifest: templateManifest } = composeTemplate(
-    templatesRoot,
-    manifest.template,
-  );
-
-  try {
-    // 1. Compose fresh template
-    copyTemplateToDir(composedDir, dest, name, templateManifest);
-    applyInitFiles(dest);
-
-    // 2. Overlay home/ from archive (archive files win over template defaults)
-    const extractedHome = resolve(extractedMindDir, "home");
-    if (existsSync(extractedHome)) {
-      cpSync(extractedHome, resolve(dest, "home"), { recursive: true });
-    }
-
-    // 3. Overlay .mind/ from archive (preserves schedules, etc.)
-    const extractedMindInternal = resolve(extractedMindDir, ".mind");
-    if (existsSync(extractedMindInternal)) {
-      cpSync(extractedMindInternal, resolve(dest, ".mind"), { recursive: true });
-    }
-
-    // 4. Generate new identity if not included in archive
-    const identityDir = resolve(dest, ".mind/identity");
-    let publicKeyPem: string;
-    if (!manifest.includes.identity || !existsSync(resolve(identityDir, "private.pem"))) {
-      ({ publicKeyPem } = generateIdentity(dest));
-    } else {
-      publicKeyPem = readFileSync(resolve(identityDir, "public.pem"), "utf-8");
-    }
-
-    // 5. Stamp prompts.json only if archive didn't provide one
-    const promptsPath = resolve(dest, "home/.config/prompts.json");
-    if (!existsSync(promptsPath)) {
-      const mindPrompts = await getMindPromptDefaults();
-      writeFileSync(promptsPath, `${JSON.stringify(mindPrompts, null, 2)}\n`);
-    }
-
-    // 6. Copy state files (env.json) to centralized state dir
-    const state = stateDir(name);
-    mkdirSync(state, { recursive: true });
-
-    const envJson = resolve(tempDir, "state/env.json");
-    if (existsSync(envJson)) {
-      cpSync(envJson, resolve(state, "env.json"));
-    }
-
-    // 7. Register with correct stage and template
-    const port = await nextPort();
-    await addMind(name, port, manifest.stage, manifest.template);
-
-    // 8. User isolation setup
-    const homeDir = resolve(dest, "home");
-    ensureVoluteGroup();
-    createMindUser(name, homeDir);
-    await chownMindDir(dest, name);
-
-    // 9. npm install
-    await npmInstallAsMind(dest, name);
-
-    // 10. Git init with template branch (enables upgrades)
-    let gitWarning: string | undefined;
-    try {
-      const env = isIsolationEnabled() ? { ...process.env, HOME: homeDir } : undefined;
-      await gitExec(["init"], { cwd: dest, mindName: name, env });
-      await configureGitIdentity(name, { cwd: dest, mindName: name, env });
-      await initTemplateBranch(dest, composedDir, templateManifest, name, env);
-    } catch (err) {
-      log.error(`git setup failed for imported mind ${name}`, log.errorData(err));
-      rmSync(resolve(dest, ".git"), { recursive: true, force: true });
-      gitWarning =
-        "Git setup failed — variants and upgrades won't be available until git is initialized.";
-    }
-
-    // 11. Install skills based on stage
-    const skillSet = manifest.stage === "seed" ? SEED_SKILLS : getStandardSkillsWithExtensions();
-    const skillWarnings: string[] = [];
-    for (const skillId of skillSet) {
-      try {
-        await installSkill(name, dest, skillId);
-      } catch (err) {
-        log.error(`failed to install skill ${skillId} for ${name}`, log.errorData(err));
-        skillWarnings.push(`Failed to install skill: ${skillId}`);
-      }
-    }
-
-    // 13. Import history and sessions from archive
-    await importHistoryFromArchive(name, tempDir);
-    importSessionsFromArchive(dest, tempDir);
-
-    // 14. Fix ownership, publish public key
-    await chownMindDir(dest, name);
-    publishPublicKey(name, publicKeyPem).catch((err: unknown) =>
-      log.warn(`failed to publish key for ${name}`, { error: (err as Error).message }),
-    );
-
-    // 15. Clean up
-    rmSync(tempDir, { recursive: true, force: true });
-
-    return c.json({
-      ok: true,
-      name,
-      port,
-      stage: manifest.stage ?? "sprouted",
-      message: `Imported mind: ${name} (port ${port})`,
-      ...(gitWarning && { warning: gitWarning }),
-      ...(skillWarnings.length > 0 && { skillWarnings }),
-    });
-  } catch (err) {
-    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
-    try {
-      await removeMind(name);
-    } catch (cleanupErr) {
-      log.error(`Failed to clean up registry for ${name}`, log.errorData(cleanupErr));
-    }
-    rmSync(tempDir, { recursive: true, force: true });
-    return c.json({ error: err instanceof Error ? err.message : "Failed to import mind" }, 500);
-  } finally {
-    rmSync(composedDir, { recursive: true, force: true });
-  }
-}
-
-/** Import history rows from archive into the database. */
-async function importHistoryFromArchive(name: string, tempDir: string): Promise<void> {
-  const historyJsonl = resolve(tempDir, "history.jsonl");
-  if (!existsSync(historyJsonl)) return;
-
-  try {
-    const db = await getDb();
-    const lines = readFileSync(historyJsonl, "utf-8").trim().split("\n");
-    let imported = 0;
-    let failed = 0;
-    for (const line of lines) {
-      if (!line) continue;
-      try {
-        const row = JSON.parse(line);
-        if (!row.type) {
-          failed++;
-          continue;
-        }
-        await db.insert(mindHistory).values({
-          mind: name,
-          channel: row.channel ?? null,
-          // Archives are long-lived files: pre-rename exports carry `session`.
-          thread: row.thread ?? row.session ?? null,
-          sender: row.sender ?? null,
-          message_id: row.message_id ?? null,
-          type: row.type,
-          content: row.content ?? null,
-          metadata: row.metadata ?? null,
-          created_at: row.created_at ?? new Date().toISOString(),
-        });
-        imported++;
-      } catch (lineErr) {
-        log.warn("Failed to import history line", log.errorData(lineErr));
-        failed++;
-      }
-    }
-    if (failed > 0) {
-      log.warn(`History import: ${imported} imported, ${failed} failed`);
-    }
-  } catch (err) {
-    log.error("Failed to open database for history import", log.errorData(err));
-  }
-}
-
-/** Import session files from archive into .mind/sessions/. Non-fatal on failure. */
-function importSessionsFromArchive(dest: string, tempDir: string): void {
-  const sessionsDir = resolve(tempDir, "sessions");
-  if (!existsSync(sessionsDir)) return;
-
-  try {
-    const destSessions = resolve(dest, ".mind/sessions");
-    mkdirSync(destSessions, { recursive: true });
-    for (const file of readdirSync(sessionsDir)) {
-      cpSync(resolve(sessionsDir, file), resolve(destSessions, file));
-    }
-  } catch (err) {
-    log.error("Failed to import sessions from archive", log.errorData(err));
-  }
-}
-
 const createMindSchema = z.object({
   name: z.string(),
   template: z.string().optional(),
@@ -703,295 +297,9 @@ async function proxyToMind(c: Context<AuthEnv>, path: string) {
 
 const app = new Hono<AuthEnv>()
   .post("/", requireAdminOrSystem, zValidator("json", createMindSchema), async (c) => {
-    const body = c.req.valid("json");
-
-    const { name } = body;
-    const template = body.template ?? (await resolveTemplate(body.model));
-
-    const nameErr = validateMindName(name);
-    if (nameErr) return c.json({ error: nameErr }, 400);
-
-    if (await findMind(name)) return c.json({ error: `Mind already exists: ${name}` }, 409);
-
-    // Refuse to create a mind the system can't run. With no AI provider configured
-    // every mind spawns mute (no model to think with), so block creation here rather
-    // than leave an unusable mind behind (#606). Mirrors the dashboard banner's copy.
-    if (!isAiConfigured()) {
-      return c.json(
-        {
-          error:
-            "Minds cannot think yet — no AI provider is configured. Add a provider in Settings before creating a mind.",
-        },
-        409,
-      );
-    }
-
-    // Cap total minds to protect host resources. Central enforcement here covers
-    // `volute mind create`, `volute seed create`, and spirit-driven seeds alike;
-    // the error text is relayed verbatim to whoever asked.
-    {
-      const { mindLimitError, readGlobalConfig } = await import("../../lib/config/setup.js");
-      const limitError = mindLimitError(await countCappedMinds(), readGlobalConfig().maxMinds);
-      if (limitError) return c.json({ error: limitError }, 409);
-    }
-
-    ensureVoluteHome();
-    const dest = mindDir(name);
-
-    if (existsSync(dest)) return c.json({ error: "Mind directory already exists" }, 409);
-
-    const templatesRoot = findTemplatesRoot();
-    const { composedDir, manifest } = composeTemplate(templatesRoot, template);
-
-    try {
-      copyTemplateToDir(composedDir, dest, name, manifest);
-      applyInitFiles(dest);
-
-      // Generate Ed25519 keypair for mind identity
-      const { publicKeyPem } = generateIdentity(dest);
-
-      // The model the mind will actually run (request, or default cognition model),
-      // provider-qualified — feeds the credential warning below so pi minds created
-      // from defaults are checked too.
-      let effectiveModel: string | undefined = body.model;
-      // Merge default settings into volute.json and config.json
-      {
-        const { readGlobalConfig: readGlobal } = await import("../../lib/config/setup.js");
-        const mindDefaults = readGlobal().mindDefaults;
-        const config = readVoluteConfig(dest);
-        if (!config) throw new Error("Failed to read volute.json after identity generation");
-        if (body.description) {
-          config.profile = { ...config.profile, description: body.description };
-        }
-        if (!config.sleep) {
-          config.sleep = mindDefaults?.sleep ?? {
-            enabled: true,
-            schedule: { sleep: "0 0 * * *", wake: "0 8 * * *" },
-          };
-        }
-        if (!config.schedules || config.schedules.length === 0) {
-          config.schedules = mindDefaults?.schedules ?? [defaultHeartbeatSchedule()];
-        }
-        // Apply cognition defaults
-        const cog = mindDefaults?.cognition;
-        if (cog) {
-          if (cog.thinkingLevel != null && !config.thinkingLevel)
-            config.thinkingLevel = cog.thinkingLevel;
-          if (cog.tokenBudget != null && config.tokenBudget == null)
-            config.tokenBudget = cog.tokenBudget;
-          if (cog.tokenBudgetPeriodMinutes != null && config.tokenBudgetPeriodMinutes == null)
-            config.tokenBudgetPeriodMinutes = cog.tokenBudgetPeriodMinutes;
-        }
-        writeVoluteConfig(dest, config);
-
-        // Apply model (and compaction) to SDK config.json
-        const modelId = body.model ?? cog?.model;
-        effectiveModel = modelId ? qualifyModelId(modelId) : undefined;
-        const sdkConfigPath = resolve(dest, "home/.config/config.json");
-        if (modelId || cog?.compaction) {
-          const existing = existsSync(sdkConfigPath)
-            ? JSON.parse(readFileSync(sdkConfigPath, "utf-8"))
-            : {};
-          if (modelId) {
-            existing.model =
-              template === "pi" ? qualifyModelId(modelId) : unqualifyModelId(modelId);
-          }
-          if (cog?.compaction && !existing.compaction) {
-            existing.compaction = cog.compaction;
-          }
-          writeFileSync(sdkConfigPath, `${JSON.stringify(existing, null, 2)}\n`);
-        }
-      }
-
-      // Stamp prompts.json with current DB defaults
-      const mindPrompts = await getMindPromptDefaults();
-      writeFileSync(
-        resolve(dest, "home/.config/prompts.json"),
-        `${JSON.stringify(mindPrompts, null, 2)}\n`,
-      );
-
-      const port = await nextPort();
-      // Use createdBy from body, or fall back to the authenticated user's username
-      const createdBy = body.createdBy ?? c.get("user")?.username;
-      await addMind(name, port, body.stage, template, createdBy);
-      try {
-        await setMindTemplateHash(name, computeTemplateHash(template));
-      } catch (err) {
-        log.warn(`failed to set template hash for ${name}`, log.errorData(err));
-      }
-
-      // Set up per-mind user isolation (no-ops if VOLUTE_ISOLATION !== "user")
-      const homeDir = resolve(dest, "home");
-      ensureVoluteGroup();
-      createMindUser(name, homeDir);
-      await chownMindDir(dest, name);
-
-      // Install dependencies as mind user (chown already ran above)
-      await npmInstallAsMind(dest, name);
-
-      // git init + template branch + initial commit (before seed modifications
-      // so that initTemplateBranch can git-add all template files)
-      let gitWarning: string | undefined;
-      try {
-        const env = isIsolationEnabled() ? { ...process.env, HOME: homeDir } : undefined;
-        await gitExec(["init"], { cwd: dest, mindName: name, env });
-        await configureGitIdentity(name, { cwd: dest, mindName: name, env });
-        await initTemplateBranch(dest, composedDir, manifest, name, env);
-      } catch (err) {
-        log.error(`git setup failed for ${name}`, log.errorData(err));
-        rmSync(resolve(dest, ".git"), { recursive: true, force: true });
-        gitWarning =
-          "Git setup failed — variants and upgrades won't be available until git is initialized.";
-      }
-
-      if (body.stage === "seed") {
-        // Write orientation SOUL.md
-        const descLine = body.description
-          ? `\nYour creator described you as: "${body.description}"\n`
-          : "";
-        const seedSoulRaw =
-          body.seedSoul ?? (await getPrompt("seed_soul", { name, description: descLine }));
-        // getPrompt already substituted; custom seedSoul needs substitution too
-        const seedSoul = body.seedSoul
-          ? substitute(seedSoulRaw, { name, description: descLine })
-          : seedSoulRaw;
-        writeFileSync(resolve(dest, "home/SOUL.md"), seedSoul);
-      }
-
-      // Install skills from shared pool (after git init so installSkill can commit)
-      let skillSet =
-        body.skills ?? (body.stage === "seed" ? SEED_SKILLS : getStandardSkillsWithExtensions());
-
-      // Add imagegen skill for seeds when image generation is enabled
-      if (body.stage === "seed" && !body.skills) {
-        const { isImagegenEnabled } = await import("../../lib/config/setup.js");
-        if (isImagegenEnabled()) {
-          skillSet = [...skillSet, "imagegen"];
-        }
-      }
-      const skillWarnings: string[] = [];
-      for (const skillId of skillSet) {
-        try {
-          await installSkill(name, dest, skillId);
-        } catch (err) {
-          log.error(`failed to install skill ${skillId} for ${name}`, log.errorData(err));
-          skillWarnings.push(`Failed to install skill: ${skillId}`);
-        }
-      }
-
-      // Default autonomy: minds created directly as full minds get working
-      // dreaming out of the box; seeds get it at sprout (#581)
-      if (body.stage !== "seed") {
-        skillWarnings.push(...setupDefaultDreaming(dest).warnings);
-      }
-
-      // Add nurture schedule to spirit if this is a seed
-      if (body.stage === "seed") {
-        try {
-          const spiritName = getSpiritName();
-          const spiritEntry = await findMind(spiritName);
-          if (spiritEntry) {
-            const { spiritDir } = await import("../../lib/mind/spirit.js");
-            const sDir = spiritEntry.dir ?? spiritDir();
-            const spiritConfig = readVoluteConfig(sDir) ?? {};
-            const schedules = spiritConfig.schedules ?? [];
-            const nurtureId = `nurture-${name}`;
-            if (!schedules.some((s) => s.id === nurtureId)) {
-              schedules.push({
-                id: nurtureId,
-                cron: process.env.VOLUTE_NURTURE_CRON ?? "*/5 * * * *",
-                script: `volute seed check ${name} --nurture`,
-                enabled: true,
-                whileSleeping: "skip",
-              });
-              spiritConfig.schedules = schedules;
-              writeVoluteConfig(sDir, spiritConfig);
-              const { getScheduler } = await import("../../lib/daemon/scheduler.js");
-              getScheduler().loadSchedules(spiritName, sDir);
-            }
-          }
-        } catch (err) {
-          log.warn(`failed to add nurture schedule for ${name}`, log.errorData(err));
-        }
-      }
-
-      // Overwrite SOUL.md / MEMORY.md if custom defaults are set in DB
-      if (body.stage !== "seed") {
-        const customSoul = await getPromptIfCustom("default_soul");
-        if (customSoul) {
-          writeFileSync(resolve(dest, "home/SOUL.md"), customSoul.replace(/\{\{name\}\}/g, name));
-        }
-        const customMemory = await getPromptIfCustom("default_memory");
-        if (customMemory) {
-          writeFileSync(resolve(dest, "home/MEMORY.md"), customMemory);
-        }
-      }
-
-      // Fix ownership after all root git/file operations (git objects, skill
-      // installs, and SOUL.md/MEMORY.md writes above must end up mind-owned so
-      // the mind can modify its own identity files under user isolation)
-      await chownMindDir(dest, name);
-
-      // Auto-publish public key to volute.systems (non-blocking)
-      publishPublicKey(name, publicKeyPem).catch((err: unknown) =>
-        log.warn(`failed to publish key for ${name}`, { error: (err as Error).message }),
-      );
-
-      fireWebhook({
-        event: "mind_created",
-        mind: name,
-        data: {
-          name,
-          port,
-          stage: body.stage ?? "sprouted",
-          template,
-          description: body.description,
-        },
-      });
-
-      // Announce to the commons channel. Fire-and-forget, but surface failures — this is the
-      // primary producer of commons event rows, and announceToCommons propagates DB errors
-      // (ensureCommonsChannel/addMessage/getParticipants), so a silent swallow would make the
-      // join moment vanish without a trace.
-      announceToCommons(`${name} has joined`).catch((err) =>
-        log.warn(`failed to announce ${name} joining the commons`, log.errorData(err)),
-      );
-
-      // Warn (don't block) when the mind will spawn without usable model credentials,
-      // so a mute-on-first-turn mind is caught at creation rather than in silence (#573).
-      // The mind is already created — an advisory check must never fail creation, so
-      // swallow any hiccup and just omit the warning.
-      const credentialWarning = await missingCredentialWarning(
-        template,
-        effectiveModel,
-        name,
-      ).catch((err) => {
-        log.warn(`credential check failed for ${name}`, log.errorData(err));
-        return null;
-      });
-
-      return c.json({
-        ok: true,
-        name,
-        port,
-        stage: body.stage ?? "sprouted",
-        message: `Created mind: ${name} (port ${port})`,
-        ...(gitWarning && { warning: gitWarning }),
-        ...(credentialWarning && { credentialWarning }),
-        ...(skillWarnings.length > 0 && { skillWarnings }),
-      });
-    } catch (err) {
-      // Clean up partial state
-      if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
-      try {
-        await removeMind(name);
-      } catch (cleanupErr) {
-        log.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
-      }
-      return c.json({ error: err instanceof Error ? err.message : "Failed to create mind" }, 500);
-    } finally {
-      rmSync(composedDir, { recursive: true, force: true });
-    }
+    const result = await createMind(c.req.valid("json"), { username: c.get("user")?.username });
+    if (!result.ok) return c.json({ error: result.error }, result.status);
+    return c.json(result.body);
   })
   // Import mind from OpenClaw workspace or .volute archive — admin only
   .post("/import", requireAdmin, async (c) => {
@@ -1009,148 +317,12 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Invalid JSON" }, 400);
     }
 
-    // Route to archive import if archivePath + manifest are present
-    if (body.archivePath && body.manifest) {
-      return importFromArchive(c, body.archivePath, body.name, body.manifest);
-    }
-
-    const wsDir = body.workspacePath;
-    if (
-      !wsDir ||
-      !existsSync(resolve(wsDir, "SOUL.md")) ||
-      !existsSync(resolve(wsDir, "IDENTITY.md"))
-    ) {
-      return c.json({ error: "Invalid workspace: missing SOUL.md or IDENTITY.md" }, 400);
-    }
-
-    const soul = readFileSync(resolve(wsDir, "SOUL.md"), "utf-8");
-    const identity = readFileSync(resolve(wsDir, "IDENTITY.md"), "utf-8");
-    const userPath = resolve(wsDir, "USER.md");
-    const user = existsSync(userPath) ? readFileSync(userPath, "utf-8") : "";
-
-    const name = body.name ?? parseNameFromIdentity(identity) ?? "imported-mind";
-    const template = body.template ?? "claude";
-
-    const nameErr = validateMindName(name);
-    if (nameErr) return c.json({ error: nameErr }, 400);
-
-    if (await findMind(name)) return c.json({ error: `Mind already exists: ${name}` }, 409);
-
-    const mergedSoul = `${soul.trimEnd()}\n\n---\n\n${identity.trimEnd()}\n`;
-    const mergedMemoryExtra = user ? `\n\n---\n\n${user.trimEnd()}\n` : "";
-
-    ensureVoluteHome();
-    const dest = mindDir(name);
-
-    if (existsSync(dest)) return c.json({ error: "Mind directory already exists" }, 409);
-
-    const templatesRoot = findTemplatesRoot();
-    const { composedDir, manifest } = composeTemplate(templatesRoot, template);
-
-    try {
-      copyTemplateToDir(composedDir, dest, name, manifest);
-
-      applyInitFiles(dest);
-
-      // Generate Ed25519 keypair for mind identity
-      const { publicKeyPem: importPublicKey } = generateIdentity(dest);
-
-      // Write SOUL.md (with IDENTITY.md merged in)
-      writeFileSync(resolve(dest, "home/SOUL.md"), mergedSoul);
-
-      // Copy or create MEMORY.md
-      const wsMemoryPath = resolve(wsDir, "MEMORY.md");
-      const hasMemory = existsSync(wsMemoryPath);
-      if (hasMemory) {
-        const existingMemory = readFileSync(wsMemoryPath, "utf-8");
-        writeFileSync(
-          resolve(dest, "home/MEMORY.md"),
-          `${existingMemory.trimEnd()}${mergedMemoryExtra}`,
-        );
-      } else if (user) {
-        writeFileSync(resolve(dest, "home/MEMORY.md"), `${user.trimEnd()}\n`);
-      }
-
-      // Copy memory/*.md daily logs
-      const wsMemoryDir = resolve(wsDir, "memory");
-      let dailyLogCount = 0;
-      if (existsSync(wsMemoryDir)) {
-        const destMemoryDir = resolve(dest, "home/memory");
-        const files = readdirSync(wsMemoryDir).filter((f) => f.endsWith(".md"));
-        for (const file of files) {
-          cpSync(resolve(wsMemoryDir, file), resolve(destMemoryDir, file));
-        }
-        dailyLogCount = files.length;
-      }
-
-      // Assign port and register
-      const port = await nextPort();
-      await addMind(name, port, undefined, template);
-      try {
-        await setMindTemplateHash(name, computeTemplateHash(template));
-      } catch (err) {
-        log.warn(`failed to set template hash for ${name}`, log.errorData(err));
-      }
-
-      // Set up per-mind user isolation (no-ops if VOLUTE_ISOLATION !== "user")
-      const homeDir = resolve(dest, "home");
-      ensureVoluteGroup();
-      createMindUser(name, homeDir);
-      await chownMindDir(dest, name);
-
-      // Install dependencies as mind user (chown already ran above)
-      await npmInstallAsMind(dest, name);
-
-      // Consolidate memory if no MEMORY.md but daily logs exist
-      if (!hasMemory && dailyLogCount > 0) {
-        await consolidateMemory(dest);
-      }
-
-      // git init + initial commit
-      const env = isIsolationEnabled()
-        ? { ...process.env, HOME: resolve(dest, "home") }
-        : undefined;
-      await gitExec(["init"], { cwd: dest, mindName: name, env });
-      await configureGitIdentity(name, { cwd: dest, mindName: name, env });
-      await gitExec(["add", "-A"], { cwd: dest, mindName: name, env });
-      await gitExec(["commit", "-m", "import from OpenClaw"], { cwd: dest, mindName: name, env });
-
-      // Import session
-      const sessionFile = body.sessionPath ? resolve(body.sessionPath) : findOpenClawSession(wsDir);
-      if (sessionFile && existsSync(sessionFile)) {
-        if (template === "pi") {
-          importPiSession(sessionFile, dest);
-        } else if (template === "claude") {
-          const sessionId = convertSession({ sessionPath: sessionFile, projectDir: dest });
-          const mindRuntimeDir = resolve(dest, ".mind");
-          mkdirSync(mindRuntimeDir, { recursive: true });
-          writeFileSync(resolve(mindRuntimeDir, "session.json"), JSON.stringify({ sessionId }));
-        }
-      }
-
-      // Import OpenClaw connectors as system bridges (non-fatal)
-      importOpenClawConnectors(name, dest);
-
-      // Fix ownership after root git/file operations
-      await chownMindDir(dest, name);
-
-      // Auto-publish public key to volute.systems (non-blocking)
-      publishPublicKey(name, importPublicKey).catch((err: unknown) =>
-        log.warn(`failed to publish key for ${name}`, { error: (err as Error).message }),
-      );
-
-      return c.json({ ok: true, name, port, message: `Imported mind: ${name} (port ${port})` });
-    } catch (err) {
-      if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
-      try {
-        await removeMind(name);
-      } catch (cleanupErr) {
-        log.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
-      }
-      return c.json({ error: err instanceof Error ? err.message : "Failed to import mind" }, 500);
-    } finally {
-      rmSync(composedDir, { recursive: true, force: true });
-    }
+    const result =
+      body.archivePath && body.manifest
+        ? await importMindFromArchive(body.archivePath, body.name, body.manifest)
+        : await importOpenClawWorkspace(body);
+    if (!result.ok) return c.json({ error: result.error }, result.status);
+    return c.json(result.body);
   })
   // List all minds
   .get("/", async (c) => {
@@ -1353,98 +525,46 @@ const app = new Hono<AuthEnv>()
           variantEntry.branch
         ) {
           const projectRoot = mindDir(baseName);
-          const discardUnresolved = context.discardUnresolvedHomeFiles === true;
 
-          // Auto-commit variant worktree
-          if (existsSync(variantEntry.dir)) {
-            const status = (
-              await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })
-            ).trim();
-            if (status) {
-              try {
-                await gitExec(["add", "-A"], { cwd: variantEntry.dir });
-                await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
-                  cwd: variantEntry.dir,
-                });
-              } catch (e) {
-                log.error(
-                  `failed to auto-commit variant worktree for ${baseName}`,
-                  log.errorData(e),
-                );
-              }
-            }
-          }
+          // Delegate to the one shared merge implementation (#330). The parent isn't
+          // restarted here — that happens below, through the last-known-good recovery
+          // path — so mergeVariant only does the merge + cleanup + reinstall and hands
+          // back the result to fold into the pending context.
+          const merge = await mergeVariant({
+            parentName: baseName,
+            variantName: mergeVariantName,
+            projectRoot,
+            variantDir: variantEntry.dir,
+            variantBranch: variantEntry.branch,
+            verify: false,
+            discardUnresolved: context.discardUnresolvedHomeFiles === true,
+            parentTemplate: entry.template ?? undefined,
+          });
 
-          // Auto-commit main worktree
-          const mainStatus = (
-            await gitExec(["status", "--porcelain"], { cwd: projectRoot })
-          ).trim();
-          if (mainStatus) {
-            try {
-              await gitExec(["add", "-A"], { cwd: projectRoot });
-              await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
-                cwd: projectRoot,
-              });
-            } catch (e) {
-              log.error(`failed to auto-commit main worktree for ${baseName}`, log.errorData(e));
-            }
-          }
-
-          // Merge (excluding the mind's living memory/journal — #440); clean up
-          // worktree/branch and reinstall if the merge touched dependencies, and
-          // narrate the memory delta — but only once cleanup actually happens (see
-          // below). Telling the parent "your variant has returned, merged into you"
-          // (the merge_message prompt, keyed off context.type === "merge") while
-          // the variant is still sitting there unresolved would be a straight-up lie.
-          const preMergeHead = (await gitExec(["rev-parse", "HEAD"], { cwd: projectRoot })).trim();
-          const memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantEntry.branch);
-
-          // The daemon can't know what's precious in a mind's home/, so it never
-          // guesses. Checked here, right before the one genuinely destructive step
-          // (`cleanupVariant`'s `git worktree remove`) — the merge above already
-          // landed (it only pulls in what the variant committed, so it's safe
-          // regardless), but cleanup waits until this comes back clean. If anything
-          // is found, skip cleanup, leave the variant fully intact, and tell the
-          // parent why via a notice instead of falsely claiming the join finished (#656).
-          let unresolvedNotice: string | undefined;
-          if (existsSync(variantEntry.dir) && !discardUnresolved) {
-            try {
-              const unresolved = await findUnresolvedHomeFiles(variantEntry.dir);
-              if (unresolved.totalCount > 0) {
-                unresolvedNotice = formatUnresolvedHomeFilesMessage(mergeVariantName, unresolved);
-              }
-            } catch (err) {
-              unresolvedNotice = `Could not verify variant ${mergeVariantName} has no unresolved home/ files: ${err instanceof Error ? err.message : String(err)}. Variant left intact — retry the join.`;
-            }
-          }
-
-          if (unresolvedNotice) {
+          if (merge.status === "merged") {
+            if (merge.memoryDelta && context) context.memoryDelta = merge.memoryDelta;
+          } else {
+            // Merge blocked (unresolved home/ files, a merge conflict, or a failed
+            // pre-merge commit): the variant is left fully intact. Tell the parent why
+            // via a notice, and downgrade to a plain restart so buildPendingContextMessage
+            // doesn't fire the "your variant has returned, merged into you" prompt for a
+            // join that didn't finish (#656). The join_blocked notice is the real story.
             log.warn(
-              `variant join blocked for ${baseName}: ${mergeVariantName} — ${unresolvedNotice}`,
+              `variant join blocked for ${baseName}: ${mergeVariantName} — ${merge.message}`,
             );
             await recordNotice({
               mind: baseName,
               thread: "main",
               kind: "join_blocked",
-              reason: "unresolved_variant_files",
-              detail: unresolvedNotice,
+              reason:
+                merge.status === "unresolved" || merge.status === "check_failed"
+                  ? "unresolved_variant_files"
+                  : "merge_conflict",
+              detail: merge.message,
             });
-            // Downgrade to a plain restart so buildPendingContextMessage doesn't fire
-            // the "your variant has returned, merged into you" prompt — nothing merged
-            // or cleaned up. The join_blocked notice above is the real story here.
             if (context) {
               context.type = "restart";
               context.name = undefined;
-            }
-          } else {
-            if (memoryDelta && context) context.memoryDelta = memoryDelta;
-            await cleanupVariant(mergeVariantName, baseName, projectRoot, variantEntry.dir);
-            if (await npmInstallNeeded(projectRoot, preMergeHead)) {
-              try {
-                await npmInstallAsMind(projectRoot, baseName);
-              } catch (e) {
-                log.error(`npm install failed after merge for ${baseName}`, log.errorData(e));
-              }
             }
           }
         }
@@ -2030,8 +1150,8 @@ const app = new Hono<AuthEnv>()
     const oldTemplate = entry.template ?? "claude";
     const template = body.template ?? oldTemplate;
     // `template` is request-controllable and flows into fs paths, composeTemplate
-    // (which process.exit()s on an unknown template), and the registry — validate
-    // against the known set before any of that.
+    // (which throws on an unknown template), and the registry — validate against
+    // the known set before any of that.
     if (!isKnownTemplate(template)) {
       return c.json({ error: `Unknown template: ${template}` }, 400);
     }

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -1,31 +1,14 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { Hono } from "hono";
 import { getOrCreateMindUser } from "../../lib/auth.js";
 import { deliverEvent } from "../../lib/chat/system-events.js";
 import { getMindManager, tryGetMindManager } from "../../lib/daemon/mind-manager.js";
 import { createConversation, findDMConversation } from "../../lib/events/conversations.js";
 import { runFarewellTurn } from "../../lib/mind/farewell.js";
-import { chownMindDir, isIsolationEnabled, wrapForIsolation } from "../../lib/mind/isolation.js";
-import {
-  addVariant,
-  findMind,
-  findVariants,
-  mindDir,
-  nextPort,
-  setMindRunning,
-} from "../../lib/mind/registry.js";
-import { spawnServer } from "../../lib/mind/spawn-server.js";
+import { chownMindDir } from "../../lib/mind/isolation.js";
+import { createVariant, mergeVariant } from "../../lib/mind/lifecycle.js";
+import { findMind, findVariants, mindDir, setMindRunning } from "../../lib/mind/registry.js";
 import { cleanupVariant } from "../../lib/mind/variant-cleanup.js";
-import {
-  findUnresolvedHomeFiles,
-  formatUnresolvedHomeFilesMessage,
-  mergeVariantExcludingMemory,
-  VariantMergeError,
-  validateBranchName,
-} from "../../lib/mind/variants.js";
-import { verify } from "../../lib/mind/verify.js";
-import { exec, gitExec } from "../../lib/util/exec.js";
+import { validateBranchName } from "../../lib/mind/variants.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
 import { type AuthEnv, requireSelf } from "../middleware/auth.js";
@@ -125,108 +108,17 @@ const app = new Hono<AuthEnv>()
     }
 
     const projectRoot = entry.dir ?? mindDir(mindName);
-    const variantDir = resolve(projectRoot, ".variants", variantName);
 
-    if (existsSync(variantDir)) {
-      return c.json({ error: `Variant directory already exists: ${variantDir}` }, 409);
-    }
-
-    mkdirSync(resolve(projectRoot, ".variants"), { recursive: true });
-
-    // Create git worktree
-    try {
-      await gitExec(["worktree", "add", "-b", variantName, variantDir], { cwd: projectRoot });
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      // mkdirSync + `git worktree add` ran as the daemon (root) and may leave
-      // root-owned files under .variants/ in the mind's tree; hand ownership
-      // back before returning so the mind can retry. Surface a restore failure
-      // so a left-behind-root-files condition isn't hidden.
-      let error = `Failed to create worktree: ${msg}`;
-      try {
-        await chownMindDir(projectRoot, mindName);
-      } catch (err) {
-        log.warn(
-          `failed to restore ownership after worktree-add failure for ${mindName}`,
-          log.errorData(err),
-        );
-        error += ` Restoring mind ownership also failed: ${err instanceof Error ? err.message : String(err)}`;
-      }
-      return c.json({ error }, 500);
-    }
-
-    // Everything after the worktree is created is rolled back on failure so a
-    // retry with the same name isn't blocked by a half-created variant (#444).
-    const rollbackSplit = async () => {
-      try {
-        await cleanupVariant(variantName, mindName, projectRoot, variantDir, { stop: true });
-      } catch (err) {
-        log.warn(`failed to roll back split of ${variantName}`, log.errorData(err));
-      }
-    };
-
-    // Fix ownership before npm install so it runs as the mind user. This is the
-    // first step past worktree creation, so a throw here (chownMindDir re-throws
-    // under isolation) must also roll back or it strands the worktree+branch.
-    try {
-      await chownMindDir(projectRoot, mindName);
-    } catch (e: unknown) {
-      await rollbackSplit();
-      const msg = e instanceof Error ? e.message : String(e);
-      return c.json({ error: `Failed to prepare variant ownership: ${msg}` }, 500);
-    }
-
-    // Install dependencies
-    try {
-      if (isIsolationEnabled()) {
-        const [cmd, args] = await wrapForIsolation("npm", ["install"], mindName);
-        await exec(cmd, args, {
-          cwd: variantDir,
-          env: { ...process.env, HOME: resolve(variantDir, "home") },
-        });
-      } else {
-        await exec("npm", ["install"], { cwd: variantDir });
-      }
-    } catch (e: unknown) {
-      await rollbackSplit();
-      const msg = e instanceof Error ? e.message : String(e);
-      return c.json({ error: `npm install failed: ${msg}` }, 500);
-    }
-
-    // Write SOUL.md if provided
-    if (body.soul) {
-      writeFileSync(resolve(variantDir, "home/SOUL.md"), body.soul);
-    }
-
-    const variantPort = body.port ?? (await nextPort());
-
-    // Register variant in DB
-    try {
-      await addVariant(variantName, mindName, variantPort, variantDir, variantName, purpose);
-    } catch (e: unknown) {
-      await rollbackSplit();
-      const msg = e instanceof Error ? e.message : String(e);
-      return c.json({ error: `Failed to register variant: ${msg}` }, 500);
-    }
-
-    // Queue the variant's birth context now, independent of --no-start: it's the
-    // variant's first message — who it is, where it came from, and why it was split
-    // off — and deliverPendingContext fires on whatever first start happens, so a
-    // variant started manually later still gets oriented. (pendingContext is an
-    // in-memory map, so a daemon restart before that start drops this transient
-    // orientation — acceptable; the variant just starts without the birth message.)
-    const manager = getMindManager();
-    manager.setPendingContext(variantName, { type: "split", parent: mindName, purpose });
-
-    if (!body.noStart) {
-      try {
-        await manager.startMind(variantName);
-      } catch (e: unknown) {
-        await rollbackSplit();
-        const msg = e instanceof Error ? e.message : String(e);
-        return c.json({ error: `Variant created but failed to start: ${msg}` }, 500);
-      }
-    }
+    const result = await createVariant({
+      parentName: mindName,
+      projectRoot,
+      variantName,
+      soul: body.soul,
+      port: body.port,
+      noStart: body.noStart,
+      purpose,
+    });
+    if (!result.ok) return c.json({ error: result.error }, result.status);
 
     // The split has now cleared every rollback point. Establish the parent↔variant
     // relationship as a conversation: open a DM the two can talk in during the
@@ -238,16 +130,7 @@ const app = new Hono<AuthEnv>()
       log.error(`failed to establish variant dialogue for ${variantName}`, log.errorData(e)),
     );
 
-    return c.json({
-      ok: true,
-      variant: {
-        name: variantName,
-        branch: variantName,
-        path: variantDir,
-        port: variantPort,
-        ...(purpose && { purpose }),
-      },
-    });
+    return c.json({ ok: true, variant: result.variant });
   })
   // Merge variant — admin only
   .post("/:name/variants/:variant/merge", requireSelf(), async (c) => {
@@ -339,176 +222,53 @@ const app = new Hono<AuthEnv>()
     // ownership, leaving the parent (and the nested variant tree) root-owned under
     // isolation. The catch funnels those through the same restore path.
     try {
-      // Auto-commit any uncommitted changes in the variant worktree
-      if (existsSync(variantEntry.dir)) {
-        const status = (await gitExec(["status", "--porcelain"], { cwd: variantEntry.dir })).trim();
-        if (status) {
-          try {
-            await gitExec(["add", "-A"], { cwd: variantEntry.dir });
-            await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
-              cwd: variantEntry.dir,
-            });
-          } catch (_e) {
-            return failAfterGitWrite(
-              "Failed to auto-commit variant changes. Commit or stash manually before merging.",
-            );
-          }
-        }
-      }
-
-      // Verify variant before merge
-      if (!body.skipVerify) {
-        const result = await spawnServer(variantEntry.dir, 0, {
-          detached: true,
-          mindName: variantName,
-          template: variantEntry.template,
-        });
-        if (!result) {
-          return failAfterGitWrite(
-            "Failed to start server for verification. Use skipVerify to skip.",
-          );
-        }
-
-        const verified = await verify(result.actualPort);
-
-        try {
-          // The verify server is detached (its own process-group leader), so kill
-          // the whole group — under sandbox/isolation the real server is a wrapped
-          // grandchild that a single-PID SIGTERM would leave running.
-          process.kill(-result.child.pid!, "SIGTERM");
-        } catch {}
-
-        if (!verified) {
-          return failAfterGitWrite("Verification failed. Fix issues or use skipVerify to proceed.");
-        }
-      }
-
-      // Auto-commit any uncommitted changes in the main worktree
-      const mainStatus = (await gitExec(["status", "--porcelain"], { cwd: projectRoot })).trim();
-      if (mainStatus) {
-        try {
-          await gitExec(["add", "-A"], { cwd: projectRoot });
-          await gitExec(["commit", "-m", "Auto-commit uncommitted changes before merge"], {
-            cwd: projectRoot,
-          });
-        } catch (_e) {
-          return failAfterGitWrite(
-            "Failed to auto-commit main changes. Commit or stash manually before merging.",
-          );
-        }
-      }
-
-      // Merge the variant into the parent, excluding the mind's living memory and
-      // journal — those ride to the parent as `memoryDelta` (#440) instead of
-      // being line-merged. A real code/config conflict (or a failed restore)
-      // aborts the merge and throws VariantMergeError; route it through
-      // failAfterGitWrite so ownership is restored and the conflicts are reported.
-      let memoryDelta = "";
-      try {
-        memoryDelta = await mergeVariantExcludingMemory(projectRoot, variantEntry.branch);
-      } catch (err) {
-        if (!(err instanceof VariantMergeError)) throw err;
-        // Leave the variant intact so the conflict can be resolved in the variant
-        // and the join retried. If the abort itself failed, the parent is left
-        // mid-merge with conflict markers on disk — say so, since the still-running
-        // mind could auto-commit them.
-        return failAfterGitWrite(
-          err.abortFailed
-            ? "Merge failed and the abort did not complete — the parent worktree may be left mid-merge with conflict markers; manual cleanup may be needed."
-            : "Merge failed. Resolve conflicts in the variant and retry the join.",
-          { conflicts: err.conflicts },
-        );
-      }
-
-      // The daemon can't know what's precious in a mind's home/ — a download, a cloned
-      // repo, a venv could all be exactly what the mind wants kept, so it never guesses.
-      // Checked here, right before the one genuinely destructive step (`cleanupVariant`'s
-      // `git worktree remove`), so it also catches anything the farewell turn above just
-      // wrote — an earlier check, before the farewell turn ran, could miss those. The
-      // merge above already landed (it only pulls in what the variant committed, so it's
-      // safe regardless), but cleanup — and with it, the point of no return — waits until
-      // this comes back clean. Retrying the same join later resumes cleanly: a no-op
-      // merge next time, then cleanup, once the files are resolved.
-      if (existsSync(variantEntry.dir) && !body.discardUnresolved) {
-        let unresolved: Awaited<ReturnType<typeof findUnresolvedHomeFiles>>;
-        try {
-          unresolved = await findUnresolvedHomeFiles(variantEntry.dir);
-        } catch (err) {
-          return failAfterGitWrite(
-            `Could not verify variant ${variantName} has no unresolved home/ files: ${err instanceof Error ? err.message : String(err)}. Variant left intact — retry the join.`,
-          );
-        }
-        if (unresolved.totalCount > 0) {
-          return failAfterGitWrite(
-            formatUnresolvedHomeFilesMessage(variantName, unresolved),
-            {
-              unresolvedFiles: unresolved.files,
-              unresolvedCount: unresolved.totalCount,
-              unresolvedBytes: unresolved.totalBytes,
-            },
-            409,
-          );
-        }
-      }
-
-      await cleanupVariant(variantName, mindName, projectRoot, variantEntry.dir, { stop: true });
-
-      // The merge and cleanup git ops ran as the daemon (root). Hand ownership of
-      // the parent worktree back to the mind user before the wrapped npm install
-      // (which runs as that user) and the restart — otherwise the tree is left
-      // root-owned under isolation. Mirrors the split/create path.
-      await chownMindDir(projectRoot, mindName);
-
-      // Update template hash after upgrade merge
-      if (variantName.endsWith("-upgrade") || variantName === "upgrade") {
-        try {
-          const { computeTemplateHash } = await import("../../lib/template/template-hash.js");
-          const { setMindTemplateHash } = await import("../../lib/mind/registry.js");
-          const tmpl = parentEntry.template ?? "claude";
-          await setMindTemplateHash(mindName, computeTemplateHash(tmpl));
-        } catch (err) {
-          log.warn(`failed to update template hash for ${mindName}`, log.errorData(err));
-        }
-      }
-
-      // Reinstall dependencies
-      let restartWarning: string | undefined;
-      try {
-        if (isIsolationEnabled()) {
-          const [cmd, args] = await wrapForIsolation("npm", ["install"], mindName);
-          await exec(cmd, args, {
-            cwd: projectRoot,
-            env: { ...process.env, HOME: resolve(projectRoot, "home") },
-          });
-        } else {
-          await exec("npm", ["install"], { cwd: projectRoot });
-        }
-      } catch (err) {
-        log.warn(`npm install failed after merge for ${mindName}`, log.errorData(err));
-        restartWarning = `npm install failed after merge — mind may have stale dependencies`;
-      }
-
-      // Restart mind via mind manager with merge context
-      const manager = getMindManager();
       // Fall back to the purpose captured at split so the parent's merge message can
       // recall why the variant existed even when no justification is passed at join.
       // Normalize like the split path so an explicit "" (or whitespace) still falls back.
       const justification = body.justification?.trim() || variantEntry.purpose;
-      const context = {
-        type: "merged",
-        name: variantName,
-        ...(body.summary && { summary: body.summary }),
-        ...(justification && { justification }),
-        ...(body.memory && { memory: body.memory }),
-        ...(memoryDelta && { memoryDelta }),
-        ...(farewell && { farewell }),
-      };
 
+      const merge = await mergeVariant({
+        parentName: mindName,
+        variantName,
+        projectRoot,
+        variantDir: variantEntry.dir,
+        variantBranch: variantEntry.branch,
+        verify: !body.skipVerify,
+        discardUnresolved: body.discardUnresolved === true,
+        variantTemplate: variantEntry.template ?? undefined,
+        parentTemplate: parentEntry.template ?? undefined,
+        contextExtras: { summary: body.summary, justification, memory: body.memory, farewell },
+      });
+
+      switch (merge.status) {
+        case "autocommit_failed":
+        case "verify_failed":
+        case "check_failed":
+          return failAfterGitWrite(merge.message);
+        case "conflict":
+          return failAfterGitWrite(merge.message, { conflicts: merge.conflicts });
+        case "unresolved":
+          return failAfterGitWrite(
+            merge.message,
+            {
+              unresolvedFiles: merge.unresolved.files,
+              unresolvedCount: merge.unresolved.totalCount,
+              unresolvedBytes: merge.unresolved.totalBytes,
+            },
+            409,
+          );
+      }
+
+      // Restart the parent with the merge context. A failed restart (or a stale-deps
+      // npm warning surfaced by mergeVariant) is a warning, not a failure — the merge
+      // and cleanup already landed.
+      let restartWarning = merge.warning;
+      const manager = getMindManager();
       try {
         if (manager.isRunning(mindName)) {
           await manager.stopMind(mindName);
         }
-        manager.setPendingContext(mindName, context);
+        manager.setPendingContext(mindName, merge.context);
         await manager.startMind(mindName);
       } catch (e) {
         restartWarning = `Merge succeeded but mind restart failed: ${e instanceof Error ? e.message : String(e)}`;

--- a/test/merge-variant.test.ts
+++ b/test/merge-variant.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { mergeVariant } from "../packages/daemon/src/lib/mind/lifecycle.js";
+
+// #330: the single mergeVariant() behind both the merge route (verify:true) and the
+// mind-initiated restart merge (verify:false). These drive the collapsed spine on a
+// real git repo — auto-commit both sides, merge-excluding-memory, unresolved gate,
+// cleanup — and assert each former call site's outcome is reproduced. verify:true's
+// happy path (spawn + self-check) needs a bootable mind server and is exercised
+// end-to-end by daemon-e2e; here we cover its fast failure branch.
+
+let counter = 0;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t",
+    },
+  }).trim();
+}
+
+/**
+ * A parent mind repo (main) with a variant worktree branched off it. `home/MEMORY.md`
+ * is tracked so the memory-exclusion path has something to diff; a stub `node_modules`
+ * keeps npmInstallNeeded from shelling out to `npm install` in the fixture.
+ */
+function setupRepo(): {
+  baseDir: string;
+  variantDir: string;
+  variantName: string;
+  variantBranch: string;
+} {
+  const n = ++counter;
+  const variantName = `mv-test-variant-${Date.now()}-${n}`;
+  const variantBranch = variantName;
+  const baseDir = mkdtempSync(resolve(tmpdir(), "mv-test-base-"));
+
+  git(baseDir, "init", "-q");
+  mkdirSync(resolve(baseDir, "home"), { recursive: true });
+  mkdirSync(resolve(baseDir, "node_modules"), { recursive: true });
+  writeFileSync(resolve(baseDir, "app.txt"), "v1\n");
+  writeFileSync(resolve(baseDir, "home/MEMORY.md"), "parent memory v1\n");
+  writeFileSync(resolve(baseDir, ".gitignore"), "node_modules/\nhome/downloads/\n");
+  git(baseDir, "add", "-A");
+  git(baseDir, "commit", "-q", "-m", "initial");
+
+  mkdirSync(resolve(baseDir, ".variants"), { recursive: true });
+  const variantDir = resolve(baseDir, ".variants", variantName);
+  git(baseDir, "worktree", "add", "-q", "-b", variantBranch, variantDir);
+
+  return { baseDir, variantDir, variantName, variantBranch };
+}
+
+describe("mergeVariant (#330 unified merge)", () => {
+  it("merges a clean variant, folds in the memory delta, and cleans up (verify:false)", async () => {
+    const { baseDir, variantDir, variantName, variantBranch } = setupRepo();
+    try {
+      // Variant commits new code and edits its living memory.
+      writeFileSync(resolve(variantDir, "feature.txt"), "from variant\n");
+      writeFileSync(resolve(variantDir, "home/MEMORY.md"), "variant learned something\n");
+      git(variantDir, "add", "-A");
+      git(variantDir, "commit", "-q", "-m", "variant work");
+
+      const result = await mergeVariant({
+        parentName: "mv-parent",
+        variantName,
+        projectRoot: baseDir,
+        variantDir,
+        variantBranch,
+        verify: false,
+        contextExtras: { summary: "did work", justification: "why", memory: "carry this" },
+      });
+
+      assert.equal(result.status, "merged");
+      if (result.status !== "merged") return; // narrow
+
+      // Code merged into the parent...
+      assert.ok(existsSync(resolve(baseDir, "feature.txt")));
+      // ...but the mind's living memory is NOT line-merged — parent keeps its own,
+      // the variant's version rides back as memoryDelta (#440).
+      assert.equal(git(baseDir, "show", "HEAD:home/MEMORY.md"), "parent memory v1");
+      assert.ok(result.memoryDelta.includes("variant learned something"));
+
+      // Context is the ready-to-deliver merge message payload.
+      assert.equal(result.context.type, "merged");
+      assert.equal(result.context.name, variantName);
+      assert.equal(result.context.summary, "did work");
+      assert.equal(result.context.justification, "why");
+      assert.equal(result.context.memory, "carry this");
+      assert.ok(String(result.context.memoryDelta).includes("variant learned something"));
+
+      // Cleanup landed: worktree gone, branch deleted.
+      assert.ok(!existsSync(variantDir));
+      assert.throws(() => git(baseDir, "rev-parse", "--verify", variantBranch));
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a conflict and leaves the variant intact (verify:false)", async () => {
+    const { baseDir, variantDir, variantName, variantBranch } = setupRepo();
+    try {
+      // Both sides edit the same tracked file → real merge conflict.
+      writeFileSync(resolve(variantDir, "app.txt"), "variant change\n");
+      git(variantDir, "add", "-A");
+      git(variantDir, "commit", "-q", "-m", "variant edits app");
+      writeFileSync(resolve(baseDir, "app.txt"), "parent change\n");
+      git(baseDir, "add", "-A");
+      git(baseDir, "commit", "-q", "-m", "parent edits app");
+
+      const result = await mergeVariant({
+        parentName: "mv-parent",
+        variantName,
+        projectRoot: baseDir,
+        variantDir,
+        variantBranch,
+        verify: false,
+      });
+
+      assert.equal(result.status, "conflict");
+      // Variant left fully intact for retry — worktree and branch still there.
+      assert.ok(existsSync(variantDir));
+      assert.equal(git(baseDir, "rev-parse", "--verify", variantBranch).length, 40);
+      // Parent worktree restored — no lingering merge state.
+      assert.equal(git(baseDir, "show", "HEAD:app.txt"), "parent change");
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks on unresolved ignored home/ files, and --discard overrides it (verify:false)", async () => {
+    // Blocked case.
+    {
+      const { baseDir, variantDir, variantName, variantBranch } = setupRepo();
+      try {
+        writeFileSync(resolve(variantDir, "feature.txt"), "x\n");
+        git(variantDir, "add", "-A");
+        git(variantDir, "commit", "-q", "-m", "variant work");
+        // An ignored, untracked file under home/ — gitignore would silently drop it.
+        mkdirSync(resolve(variantDir, "home/downloads"), { recursive: true });
+        writeFileSync(resolve(variantDir, "home/downloads/movie.bin"), "precious\n");
+
+        const result = await mergeVariant({
+          parentName: "mv-parent",
+          variantName,
+          projectRoot: baseDir,
+          variantDir,
+          variantBranch,
+          verify: false,
+        });
+
+        assert.equal(result.status, "unresolved");
+        if (result.status === "unresolved") {
+          assert.equal(result.unresolved.totalCount, 1);
+        }
+        // Variant not cleaned up — the join can be retried after resolving.
+        assert.ok(existsSync(variantDir));
+      } finally {
+        rmSync(baseDir, { recursive: true, force: true });
+      }
+    }
+
+    // Same setup, but discardUnresolved bypasses the gate and merges.
+    {
+      const { baseDir, variantDir, variantName, variantBranch } = setupRepo();
+      try {
+        writeFileSync(resolve(variantDir, "feature.txt"), "x\n");
+        git(variantDir, "add", "-A");
+        git(variantDir, "commit", "-q", "-m", "variant work");
+        mkdirSync(resolve(variantDir, "home/downloads"), { recursive: true });
+        writeFileSync(resolve(variantDir, "home/downloads/movie.bin"), "precious\n");
+
+        const result = await mergeVariant({
+          parentName: "mv-parent",
+          variantName,
+          projectRoot: baseDir,
+          variantDir,
+          variantBranch,
+          verify: false,
+          discardUnresolved: true,
+        });
+
+        assert.equal(result.status, "merged");
+        assert.ok(existsSync(resolve(baseDir, "feature.txt")));
+        assert.ok(!existsSync(variantDir));
+      } finally {
+        rmSync(baseDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("returns verify_failed when the variant can't boot (verify:true)", async () => {
+    const { baseDir, variantDir, variantName, variantBranch } = setupRepo();
+    try {
+      // No src/server.ts in the fixture, so the spawned server exits immediately and
+      // spawnServer resolves null → verify_failed, before any merge is attempted.
+      const result = await mergeVariant({
+        parentName: "mv-parent",
+        variantName,
+        projectRoot: baseDir,
+        variantDir,
+        variantBranch,
+        verify: true,
+      });
+
+      assert.equal(result.status, "verify_failed");
+      // Nothing merged — variant and branch untouched.
+      assert.ok(existsSync(variantDir));
+      assert.equal(git(baseDir, "rev-parse", "--verify", variantBranch).length, 40);
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/pending-context.test.ts
+++ b/test/pending-context.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  clearPendingContext,
+  readPendingContext,
+  setPendingContext,
+} from "../packages/daemon/src/lib/daemon/pending-context.js";
+import { stateDir } from "../packages/daemon/src/lib/mind/registry.js";
+
+describe("pending context persistence (#330)", () => {
+  it("survives a simulated daemon restart and is cleared after delivery", () => {
+    const name = `pending-ctx-${Date.now()}`;
+    const context = {
+      type: "merged",
+      name: "explorer-variant",
+      summary: "refactored the router",
+      justification: "cleaner batching",
+      memory: "keep the batching notes",
+    };
+
+    setPendingContext(name, context);
+
+    // A daemon restart drops all in-memory state — reading fresh from disk (there
+    // is no in-process Map to fall back on) is exactly what the next start does.
+    // If this store regressed to an in-memory Map, the read below would be null.
+    const afterRestart = readPendingContext(name);
+    assert.deepEqual(afterRestart, context);
+
+    // Delivery clears it, so a subsequent start doesn't redeliver the same message.
+    clearPendingContext(name);
+    assert.equal(readPendingContext(name), null);
+    assert.ok(!existsSync(resolve(stateDir(name), "pending-context.json")));
+  });
+
+  it("returns null when nothing is queued", () => {
+    assert.equal(readPendingContext(`never-set-${Date.now()}`), null);
+  });
+
+  it("overwrites a prior pending context rather than merging", () => {
+    const name = `pending-ctx-overwrite-${Date.now()}`;
+    setPendingContext(name, { type: "split", parent: "root", purpose: "explore A" });
+    setPendingContext(name, { type: "merged", name });
+    assert.deepEqual(readPendingContext(name), { type: "merged", name });
+    clearPendingContext(name);
+  });
+});

--- a/test/template-throws.test.ts
+++ b/test/template-throws.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import {
+  type GlobalConfig,
+  readGlobalConfig,
+  writeGlobalConfig,
+} from "../packages/daemon/src/lib/config/setup.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { sessions, users } from "../packages/daemon/src/lib/schema.js";
+import {
+  composeTemplate,
+  findTemplatesDir,
+  findTemplatesRoot,
+} from "../packages/daemon/src/lib/template/template.js";
+import mindsApp from "../packages/daemon/src/web/api/minds.js";
+import { type AuthEnv, authMiddleware } from "../packages/daemon/src/web/middleware/auth.js";
+
+// The whole point of #330 part 4: these locators throw instead of process.exit(1),
+// so a route handler catches → 500 rather than the throw killing the daemon (and
+// every mind on it). If any of these still called process.exit, this test *file*
+// would abort the whole run — surviving to make an assertion is itself the proof.
+describe("template locators throw instead of exiting", () => {
+  it("composeTemplate throws on an unknown template", () => {
+    const root = findTemplatesRoot();
+    assert.throws(() => composeTemplate(root, "no-such-template-xyz"), /Template not found/);
+  });
+
+  it("findTemplatesDir throws on an unknown template", () => {
+    assert.throws(() => findTemplatesDir("no-such-template-xyz"), /Template not found/);
+  });
+});
+
+describe("create route returns 500 (not a process exit) on a broken template", () => {
+  const adminUser = "template-throws-admin";
+  let adminCookie: string;
+  let savedConfig: GlobalConfig;
+
+  function createApp() {
+    const app = new Hono<AuthEnv>();
+    app.use("/*", authMiddleware);
+    app.route("/minds", mindsApp);
+    return app;
+  }
+
+  before(async () => {
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, adminUser));
+    const [user] = await db
+      .insert(users)
+      .values({ username: adminUser, password_hash: "x", role: "admin" })
+      .returning();
+    const sessionId = crypto.randomUUID();
+    await db.insert(sessions).values({ id: sessionId, userId: user.id, createdAt: Date.now() });
+    adminCookie = `volute_session=${sessionId}`;
+
+    // The create route refuses (409) when no AI provider is configured, before it
+    // ever reaches composeTemplate — give it an enabled model so it gets that far.
+    savedConfig = readGlobalConfig();
+    writeGlobalConfig({ ...savedConfig, ai: { ...savedConfig.ai, models: ["anthropic/x"] } });
+  });
+
+  after(async () => {
+    writeGlobalConfig(savedConfig);
+    const db = await getDb();
+    await db.delete(users).where(eq(users.username, adminUser));
+  });
+
+  it("maps a composeTemplate throw to HTTP 500", async () => {
+    const app = createApp();
+    const res = await app.request("/minds", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: adminCookie },
+      body: JSON.stringify({ name: "template-throws-mind", template: "no-such-template-xyz" }),
+    });
+    assert.equal(res.status, 500);
+  });
+});


### PR DESCRIPTION
## Summary

Implements parts 1–4 of #330 (part 5 deferred as a follow-up).

**Part 1 — lifecycle.ts extraction.** New `packages/daemon/src/lib/mind/lifecycle.ts` owns `createMind`, `importMindFromArchive`/`importOpenClawWorkspace`, `createVariant`, `mergeVariant`, and `initTemplateBranch`. Routes become thin (parse/authorize → lifecycle → HTTP via `LifecycleResult`). **minds.ts 3050→2170, variants.ts 551→310.**

**Part 2 — one mergeVariant().** The two divergent variant-join merges (merge route WITH verification, restart-handler merge WITHOUT) now delegate to a single function taking `verify`/`contextType`/`discardUnresolved`. The upgrade merge (`mergeUpgradeAndRestart`) was NOT folded in — it uses a different algorithm (no memory exclusion) with template-switch/backfill steps.

**Part 3 — durable pendingContext.** `state/<mind>/pending-context.json` replaces the in-memory Map. Survives daemon restarts.

**Part 4 — template.ts throws.** All 5 `process.exit(1)` sites now throw, so broken templates → 500, not dead daemon.

**Part 5 DEFERRED.** Long-ops-as-async-jobs + CLI timeout restoration is a behavioral/API change for a separate PR. Left `headersTimeout:0` with a TODO marker.

Tests: `merge-variant.test.ts`, `pending-context.test.ts` (survives restart), `template-throws.test.ts` (create route → 500). Full suite 3307/3307 green, e2e 70/70.

Closes #330

## Test plan

- [x] npm run typecheck
- [x] npm test (3307 tests)
- [x] npm run test:e2e (70 tests)
- [ ] After merge: spot-check mind create/upgrade/variant-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
