### PR TITLE
feat(events): make system events routable through routes.json (#736)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -178,6 +178,21 @@ export async function startDaemon(opts: {
     log.warn("avatar size migration failed", log.errorData(err));
   }
 
+  // Move legacy schedule `thread` fields into routes.json event rules (idempotent, #736)
+  try {
+    const { readAllMinds, mindDir } = await import("./lib/mind/registry.js");
+    const { migrateScheduleThreadsToRoutes } = await import("./lib/mind/event-routes.js");
+    for (const m of await readAllMinds()) {
+      try {
+        migrateScheduleThreadsToRoutes(m.dir ?? mindDir(m.name), m.name);
+      } catch (err) {
+        log.warn(`schedule-thread route migration failed for ${m.name}`, log.errorData(err));
+      }
+    }
+  } catch (err) {
+    log.warn("schedule-thread route migration failed", log.errorData(err));
+  }
+
   // Initialize sandbox runtime for mind process isolation
   const { initSandbox } = await import("./lib/mind/sandbox.js");
   await initSandbox();

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -354,13 +354,27 @@ export function eventMatchKey(type: string, meta: Record<string, unknown>): stri
 }
 
 /**
+ * Failure notices a routing rule must never be able to redirect. Pinned to mind-level
+ * attention so a mind can't accidentally bury its own crash/turn_error in a thread that
+ * never runs a turn. This is a deliberate, reversible default (#736): remove a subtype
+ * here to make that class of notice routable like everything else.
+ */
+const NON_ROUTABLE_NOTICE_SUBTYPES = new Set(["crash", "turn_error"]);
+
+function isNonRoutableNotice(type: string, meta: Record<string, unknown>): boolean {
+  return type === "notice" && NON_ROUTABLE_NOTICE_SUBTYPES.has(String(meta.subtype));
+}
+
+/**
  * Resolve the thread a system event lands on. This is the single daemon-side resolution
  * point that owns ALL thread semantics for events (#736), the same place the delivery
  * manager owns routing for channel content:
  *
- * - The mind's routes.json event rules (`resolveEventRoute`) take precedence; a matched
- *   rule beats the caller's default. The caller's `input.thread` (default "main") is only
- *   the fallback when no rule matches.
+ * - Non-routable failure notices (crash/turn_error) pin to the mind-level drain and cannot
+ *   be routed away — a mind must not be able to hide its own failures.
+ * - Otherwise the mind's routes.json event rules (`resolveEventRoute`) take precedence; a
+ *   matched rule beats the caller's default. The caller's `input.thread` (default "main")
+ *   is only the fallback when no rule matches.
  * - The `$new` isolation convention is expanded here once, for every caller — a fresh
  *   session for `immediate` delivery (which POSTs an envelope and runs a turn in it), or
  *   the mind-level sentinel for `next-turn` (a unique session that never runs a turn would
@@ -372,6 +386,7 @@ async function resolveEventThread(
   delivery: EventDelivery,
 ): Promise<string> {
   const meta = input.meta ?? {};
+  if (isNonRoutableNotice(input.type, meta)) return MIND_LEVEL_THREAD;
   let chosen = input.thread ?? "main";
   try {
     const baseName = await getBaseName(mind);

--- a/packages/daemon/src/lib/chat/system-events.ts
+++ b/packages/daemon/src/lib/chat/system-events.ts
@@ -1,5 +1,6 @@
 import { and, asc, desc, eq, gt, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { getDb } from "../db.js";
+import { getRoutingConfig, resolveEventRoute } from "../delivery/delivery-router.js";
 import { publish as publishMindEvent } from "../events/mind-events.js";
 import { findMind, getBaseName } from "../mind/registry.js";
 import { mindHistory, systemEvents, turns } from "../schema.js";
@@ -332,20 +333,57 @@ async function markDelivered(id: number, extraMeta?: Record<string, unknown>): P
 }
 
 /**
- * Resolve an event's stored thread, expanding the `$new` convention ("a fresh isolated
- * session per fire") the same way the message path does. Expansion lives here so every
- * caller passing `$new` — scheduler, default dream autonomy, future — gets isolation without
- * owning the contract itself (#735).
- *
- * `$new` only means something for `immediate` delivery, which POSTs an envelope and runs a
- * turn in the fresh session. A `next-turn` event stamped to a unique session that never runs
- * a turn would strand forever (#356/#721), so it collapses to the mind-level sentinel and
- * drains into whichever thread next runs a clean turn. Uses the shared session-name minter so
- * the name shape is identical to the message path's mind-side.
+ * The routing key a system event is matched against by the mind's routes.json event rules.
+ * Shaped `<type>:<discriminator>` where a discriminator exists (schedule id, webhook
+ * source, notice/lifecycle subtype), else the bare type. Mirrors the discriminators
+ * {@link eventLabel} reads, so a rule `{ event: "schedule:dream" }` targets exactly the
+ * dream fire while `{ event: "schedule:*" }` catches every schedule.
  */
-function resolveEventThread(thread: string, delivery: EventDelivery): string {
-  if (thread !== "$new") return thread;
-  return delivery === "immediate" ? newEphemeralSession() : MIND_LEVEL_THREAD;
+export function eventMatchKey(type: string, meta: Record<string, unknown>): string {
+  const str = (k: string): string | undefined =>
+    typeof meta[k] === "string" && meta[k] ? (meta[k] as string) : undefined;
+  const disc =
+    type === "schedule"
+      ? str("scheduleId")
+      : type === "webhook"
+        ? str("source")
+        : type === "notice" || type === "lifecycle"
+          ? str("subtype")
+          : undefined;
+  return disc ? `${type}:${disc}` : type;
+}
+
+/**
+ * Resolve the thread a system event lands on. This is the single daemon-side resolution
+ * point that owns ALL thread semantics for events (#736), the same place the delivery
+ * manager owns routing for channel content:
+ *
+ * - The mind's routes.json event rules (`resolveEventRoute`) take precedence; a matched
+ *   rule beats the caller's default. The caller's `input.thread` (default "main") is only
+ *   the fallback when no rule matches.
+ * - The `$new` isolation convention is expanded here once, for every caller — a fresh
+ *   session for `immediate` delivery (which POSTs an envelope and runs a turn in it), or
+ *   the mind-level sentinel for `next-turn` (a unique session that never runs a turn would
+ *   strand forever, #356/#721/#735), which drains into whichever thread next runs.
+ */
+async function resolveEventThread(
+  mind: string,
+  input: DeliverEventInput,
+  delivery: EventDelivery,
+): Promise<string> {
+  const meta = input.meta ?? {};
+  let chosen = input.thread ?? "main";
+  try {
+    const baseName = await getBaseName(mind);
+    const routed = resolveEventRoute(getRoutingConfig(baseName), eventMatchKey(input.type, meta));
+    if (routed != null) chosen = routed;
+  } catch (err) {
+    // Routing must never take down delivery — fall back to the caller's thread.
+    elog.warn(`failed to resolve event route for ${mind}`, log.errorData(err));
+  }
+  if (chosen === "$new")
+    return delivery === "immediate" ? newEphemeralSession() : MIND_LEVEL_THREAD;
+  return chosen;
 }
 
 /**
@@ -364,7 +402,7 @@ export async function deliverEvent(
   input: DeliverEventInput,
 ): Promise<{ id?: number; delivered: boolean }> {
   const delivery = input.delivery ?? "immediate";
-  const thread = resolveEventThread(input.thread ?? "main", delivery);
+  const thread = await resolveEventThread(mind, input, delivery);
   let eventId: number | undefined;
   try {
     const db = await getDb();

--- a/packages/daemon/src/lib/delivery/delivery-router.ts
+++ b/packages/daemon/src/lib/delivery/delivery-router.ts
@@ -7,6 +7,13 @@ import log from "../util/logger.js";
 // --- Types ---
 
 export type RoutingRule = {
+  /**
+   * Glob matched against a system event's match key (e.g. "schedule:*",
+   * "webhook:*", "notice:crash") — see `resolveEventRoute`. A rule carrying an
+   * `event` key routes environment signals, not channel content; the two planes
+   * never cross (#736 / scope boundary #719).
+   */
+  event?: string;
   thread?: string;
   destination?: "mind" | "file";
   path?: string;
@@ -227,7 +234,13 @@ function globMatch(pattern: string, value: string): boolean {
 
 const GLOB_MATCH_KEYS = new Set(["channel", "sender"]);
 const NON_MATCH_KEYS = new Set(["thread", "destination", "path", "mode", "batch"]);
-const KNOWN_RULE_KEYS = new Set([...GLOB_MATCH_KEYS, ...NON_MATCH_KEYS, "isDM", "participants"]);
+const KNOWN_RULE_KEYS = new Set([
+  ...GLOB_MATCH_KEYS,
+  ...NON_MATCH_KEYS,
+  "isDM",
+  "participants",
+  "event",
+]);
 
 /**
  * Warn (once per config load, not per message) about rule keys ruleMatches will
@@ -294,6 +307,9 @@ export function resolveRoute(config: RoutingConfig, meta: MatchMeta): ResolvedRo
   }
 
   for (const rule of config.rules) {
+    // Event rules (routes.json's environment-signal plane) never match channel
+    // content — they're resolved by resolveEventRoute (#736).
+    if (typeof rule.event === "string") continue;
     if (ruleMatches(rule, meta)) {
       if (rule.destination === "file") {
         if (!rule.path) {
@@ -313,6 +329,25 @@ export function resolveRoute(config: RoutingConfig, meta: MatchMeta): ResolvedRo
   }
 
   return { destination: "mind", session: fallback, matched: false };
+}
+
+/**
+ * Resolve a system event to a target thread through the mind's routes.json.
+ *
+ * Event rules carry an `event` glob matched against the event's match key (see
+ * `eventMatchKey` in system-events). First match wins; the returned thread may be the
+ * `$new` sentinel, which the caller expands. Returns undefined when no event rule matches,
+ * so the caller keeps its own default thread. This is the sole event-routing plane —
+ * channel rules (no `event` key) are ignored here, and event rules are skipped by
+ * `resolveRoute`, so the two never cross (#736).
+ */
+export function resolveEventRoute(config: RoutingConfig, eventKey: string): string | undefined {
+  if (!config.rules) return undefined;
+  for (const rule of config.rules) {
+    if (typeof rule.event !== "string") continue;
+    if (globMatch(rule.event, eventKey)) return rule.thread;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/daemon/src/lib/mind/default-autonomy.ts
+++ b/packages/daemon/src/lib/mind/default-autonomy.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { mindSkillsDir } from "../skills.js";
 import log from "../util/logger.js";
+import { readRoutesConfig, upsertEventRule } from "./event-routes.js";
 import {
   readVoluteConfig,
   type Schedule,
@@ -44,7 +45,9 @@ export function defaultHeartbeatSchedule(): Schedule {
 /**
  * Default nightly dream schedule (mirrors the dreaming skill's INSTALL.md).
  * `trigger-wake` briefly wakes a sleeping mind for the dream, then returns it
- * to sleep; `$new` keeps the dream in an isolated session.
+ * to sleep. The dream's isolated-session contract (`$new`) is no longer hidden
+ * on the schedule — `setupDefaultDreaming` writes it as an explicit
+ * `schedule:dream → $new` routes.json rule the mind can see and own (#736).
  */
 export function defaultDreamSchedule(): Schedule {
   return {
@@ -53,7 +56,6 @@ export function defaultDreamSchedule(): Schedule {
     message:
       "it's 3am. you are dreaming.\n\ngather your material — read your latest journal entry, read MEMORY.md, surface random memories if you have a way to. then construct a dream premise from that material and invoke the dreamer subagent to experience the dream.",
     enabled: true,
-    thread: "$new",
     whileSleeping: "trigger-wake",
   };
 }
@@ -161,6 +163,12 @@ export function setupDefaultDreaming(dir: string): DreamingSetupResult {
       writeVoluteConfig(dir, config);
       schedulesChanged = true;
     }
+    // The dream's session isolation is an explicit, owned routing rule — added only
+    // when absent, so a mind that has re-routed its own dream is left untouched (#736).
+    const hasDreamRule = (readRoutesConfig(dir).rules ?? []).some(
+      (r) => r.event === "schedule:dream",
+    );
+    if (!hasDreamRule) upsertEventRule(dir, "schedule:dream", "$new");
   } catch (err) {
     warn("dreaming setup: failed to add default dream schedule", err);
   }

--- a/packages/daemon/src/lib/mind/event-routes.ts
+++ b/packages/daemon/src/lib/mind/event-routes.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { clearConfigCache, type RoutingConfig } from "../delivery/delivery-router.js";
+import log from "../util/logger.js";
+import { readVoluteConfig, writeVoluteConfig } from "./volute-config.js";
+
+const rlog = log.child("event-routes");
+
+function routesPath(dir: string): string {
+  return resolve(dir, "home/.config/routes.json");
+}
+
+/** Read a mind's routes.json, tolerating a missing or corrupt file (→ `{}`). */
+export function readRoutesConfig(dir: string): RoutingConfig {
+  const path = routesPath(dir);
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch (err) {
+    rlog.warn(`unreadable routes.json in ${dir} — treating as empty`, log.errorData(err));
+    return {};
+  }
+}
+
+function writeRoutesConfig(dir: string, config: RoutingConfig, name?: string): void {
+  const path = routesPath(dir);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+  // Drop the router's cached copy so new rules take effect immediately. No gated-message
+  // re-evaluation — event rules never affect channel gating.
+  if (name) clearConfigCache(name, { notify: false });
+}
+
+/**
+ * Ensure the mind's routes.json routes a given event key to `thread`. Idempotent: an
+ * existing rule for the exact same `event` key has its thread updated (or the rule removed
+ * when `thread` is null); otherwise a new rule is prepended, so a specific event rule wins
+ * over any hand-written wildcard. Returns whether the file changed.
+ */
+export function upsertEventRule(
+  dir: string,
+  event: string,
+  thread: string | null,
+  name?: string,
+): boolean {
+  const config = readRoutesConfig(dir);
+  const rules = config.rules ?? [];
+  const idx = rules.findIndex((r) => r && typeof r === "object" && r.event === event);
+  if (thread == null) {
+    if (idx === -1) return false;
+    rules.splice(idx, 1);
+  } else if (idx !== -1) {
+    if (rules[idx].thread === thread) return false;
+    rules[idx].thread = thread;
+  } else {
+    rules.unshift({ event, thread });
+  }
+  config.rules = rules;
+  writeRoutesConfig(dir, config, name);
+  return true;
+}
+
+/**
+ * Move each schedule's legacy `thread` field into an equivalent
+ * `{ event: "schedule:<id>", thread }` routes.json rule, then strip the field from
+ * volute.json (#736). After this a mind's schedule-fire routing lives in one place —
+ * routes.json — editable like any other routing rule.
+ *
+ * Idempotent: a second run finds no `thread` fields and no-ops. A schedule already covered
+ * by a rule keeps that rule (upsert only updates a differing thread). Returns whether
+ * anything changed, so a caller can log/reload.
+ */
+export function migrateScheduleThreadsToRoutes(dir: string, name?: string): boolean {
+  const vconfig = readVoluteConfig(dir);
+  const threaded = (vconfig?.schedules ?? []).filter(
+    (s) => typeof s.thread === "string" && s.thread,
+  );
+  if (threaded.length === 0) return false;
+
+  for (const s of threaded) {
+    upsertEventRule(dir, `schedule:${s.id}`, s.thread as string, name);
+    delete s.thread;
+  }
+  writeVoluteConfig(dir, vconfig as NonNullable<typeof vconfig>);
+  rlog.info(
+    `migrated ${threaded.length} schedule thread(s) to routes.json${name ? ` for ${name}` : ""}`,
+  );
+  return true;
+}

--- a/packages/daemon/src/web/api/schedules.ts
+++ b/packages/daemon/src/web/api/schedules.ts
@@ -2,6 +2,7 @@ import { CronExpressionParser } from "cron-parser";
 import { Hono } from "hono";
 import { getScheduler } from "../../lib/daemon/scheduler.js";
 import { getSleepManagerIfReady } from "../../lib/daemon/sleep-manager.js";
+import { upsertEventRule } from "../../lib/mind/event-routes.js";
 import { findMind, mindDir } from "../../lib/mind/registry.js";
 import {
   readVoluteConfig,
@@ -305,10 +306,12 @@ const app = new Hono<AuthEnv>()
     if (body.message) schedule.message = body.message;
     if (body.messages?.length) schedule.messages = body.messages;
     if (body.script) schedule.script = body.script;
-    if (body.thread) schedule.thread = body.thread;
     if (body.whileSleeping) schedule.whileSleeping = body.whileSleeping;
     schedules.push(schedule);
     writeSchedules(name, dir, schedules);
+    // `--thread` is sugar for a routes.json event rule (#736) — schedule-fire routing
+    // lives in routes.json, not on the schedule itself.
+    if (body.thread) upsertEventRule(dir, `schedule:${id}`, body.thread, name);
     return c.json({ ok: true, id }, 201);
   })
   // Update schedule
@@ -373,7 +376,9 @@ const app = new Hono<AuthEnv>()
       );
     }
     if (body.enabled !== undefined) schedules[idx].enabled = body.enabled;
-    if (body.thread !== undefined) schedules[idx].thread = body.thread || undefined;
+    // `--thread` writes/updates a routes.json event rule (#736); an empty value clears it.
+    if (body.thread !== undefined)
+      upsertEventRule(dir, `schedule:${id}`, body.thread || null, name);
     if (body.whileSleeping !== undefined)
       schedules[idx].whileSleeping = body.whileSleeping || undefined;
 
@@ -404,6 +409,8 @@ const app = new Hono<AuthEnv>()
     }
 
     writeSchedules(name, dir, filtered);
+    // Drop the schedule's routing rule too, so a deleted schedule leaves nothing behind.
+    upsertEventRule(dir, `schedule:${id}`, null, name);
     return c.json({ ok: true });
   })
   // Webhook endpoint

--- a/templates/_base/home/VOLUTE.md
+++ b/templates/_base/home/VOLUTE.md
@@ -47,6 +47,16 @@ Review yesterday's journal and plan the day.
 
 No one is on the other end of an event and nothing is waiting on a reply — there is no channel to reply *to*. A schedule you wrote for yourself reads like a note from your past self, delivered by the environment. If an event moves you to *do* something — send a message, write a file — use your normal channels for that; the event itself isn't a conversation. Whatever you say as you close out an event turn is kept as a private **reflection** in your history (visible to you and your host, delivered nowhere) — so it's fine to think out loud.
 
+You can route events to threads the same way you route messages: a rule in `.config/routes.json` with an `event` key, matched against the event's key (`schedule:<id>`, `webhook:<source>`, `notice:<subtype>`, or a bare type). `"$new"` runs each one in a fresh isolated session. Unrouted events go to "main".
+
+```json
+{ "event": "schedule:*",     "thread": "chores" }
+{ "event": "schedule:dream", "thread": "$new" }
+{ "event": "webhook:*",      "thread": "inbox" }
+```
+
+Event rules and channel rules never cross — an `event` rule only matches events, a `channel` rule only matches messages. One exception you can't override: crash and turn-error notices always surface at your attention no matter what, so a routing rule can't accidentally bury your own failures.
+
 ## Threads
 
 Messages are routed to named threads based on rules in `.config/routes.json`. Each thread has its own conversation history. Without config, everything goes to "main". Your thread name appears in the message prefix (e.g. `— thread: alice —`) unless it's "main".

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -2047,22 +2047,20 @@ describe("daemon e2e", { timeout: 420000 }, () => {
         message: "dream",
         id: "test-sleep-sched",
         whileSleeping: "trigger-wake",
-        thread: "system:dream",
       }),
     });
     assert.equal(addRes.status, 201, `Add: ${await addRes.clone().text()}`);
 
-    // Verify fields
+    // Verify fields (schedule-fire thread routing lives in routes.json now, #736 —
+    // see web-schedules.test.ts / event-routing.test.ts).
     const listRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
     const schedules = (await listRes.json()) as {
       id: string;
       whileSleeping?: string;
-      thread?: string;
     }[];
     const sched = schedules.find((s) => s.id === "test-sleep-sched");
     assert.ok(sched);
     assert.equal(sched.whileSleeping, "trigger-wake");
-    assert.equal(sched.thread, "system:dream");
 
     // Update whileSleeping
     const updateRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-sleep-sched`, {

--- a/test/default-autonomy.test.ts
+++ b/test/default-autonomy.test.ts
@@ -9,6 +9,7 @@ import {
   defaultHeartbeatSchedule,
   setupDefaultDreaming,
 } from "../packages/daemon/src/lib/mind/default-autonomy.js";
+import { readRoutesConfig } from "../packages/daemon/src/lib/mind/event-routes.js";
 import {
   readVoluteConfig,
   writeVoluteConfig,
@@ -73,7 +74,15 @@ describe("default autonomy", () => {
     const dream = config?.schedules?.find((s) => s.id === "dream");
     assert.ok(dream, "dream schedule installed");
     assert.equal(dream.cron, "0 3 * * *");
-    assert.equal(dream.thread, "$new");
+    // The dream's isolation is now an explicit routes.json rule, not a schedule field (#736).
+    assert.equal(dream.thread, undefined);
+    assert.deepEqual(
+      readRoutesConfig(dir).rules?.find((r) => r.event === "schedule:dream"),
+      {
+        event: "schedule:dream",
+        thread: "$new",
+      },
+    );
     assert.equal(dream.whileSleeping, "trigger-wake");
     assert.equal(dream.enabled, true);
     assert.ok(config?.schedules?.some((s) => s.id === "heartbeat"));

--- a/test/event-routes-migration.test.ts
+++ b/test/event-routes-migration.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdirSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { deliverEvent } from "../packages/daemon/src/lib/chat/system-events.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { clearConfigCache } from "../packages/daemon/src/lib/delivery/delivery-router.js";
+import {
+  migrateScheduleThreadsToRoutes,
+  readRoutesConfig,
+} from "../packages/daemon/src/lib/mind/event-routes.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import {
+  readVoluteConfig,
+  writeVoluteConfig,
+} from "../packages/daemon/src/lib/mind/volute-config.js";
+import { systemEvents } from "../packages/daemon/src/lib/schema.js";
+
+function mindDirFor(name: string): string {
+  return resolve(process.env.VOLUTE_HOME!, "minds", name);
+}
+
+/** Prepare a mind dir with a volute.json holding the given schedules. */
+function seedVoluteConfig(name: string, schedules: object[]): string {
+  const dir = mindDirFor(name);
+  mkdirSync(resolve(dir, "home/.config"), { recursive: true });
+  writeVoluteConfig(dir, { schedules } as never);
+  return dir;
+}
+
+describe("migrateScheduleThreadsToRoutes", () => {
+  it("moves a schedule.thread into an equivalent routes.json rule and strips the field", () => {
+    const name = `mig-${process.pid}-a`;
+    const dir = seedVoluteConfig(name, [
+      { id: "dream", cron: "0 3 * * *", message: "dream", enabled: true, thread: "$new" },
+      { id: "chore", cron: "0 9 * * *", message: "tidy", enabled: true, thread: "chores" },
+      { id: "beat", cron: "0 12 * * *", message: "hi", enabled: true },
+    ]);
+
+    const changed = migrateScheduleThreadsToRoutes(dir, name);
+    assert.equal(changed, true);
+
+    const rules = readRoutesConfig(dir).rules ?? [];
+    const byEvent = (ev: string) => rules.find((r) => r.event === ev);
+    assert.deepEqual(byEvent("schedule:dream"), { event: "schedule:dream", thread: "$new" });
+    assert.deepEqual(byEvent("schedule:chore"), { event: "schedule:chore", thread: "chores" });
+    // A threadless schedule gets no rule.
+    assert.equal(byEvent("schedule:beat"), undefined);
+
+    // The legacy field is stripped from volute.json.
+    const sched = readVoluteConfig(dir)?.schedules ?? [];
+    assert.equal(
+      sched.every((s) => s.thread === undefined),
+      true,
+    );
+
+    clearConfigCache(name);
+  });
+
+  it("is idempotent — a second run finds nothing to move and no-ops", () => {
+    const name = `mig-${process.pid}-b`;
+    const dir = seedVoluteConfig(name, [
+      { id: "chore", cron: "0 9 * * *", message: "tidy", enabled: true, thread: "chores" },
+    ]);
+    assert.equal(migrateScheduleThreadsToRoutes(dir, name), true);
+    assert.equal(migrateScheduleThreadsToRoutes(dir, name), false);
+    // The rule is present exactly once.
+    const rules = readRoutesConfig(dir).rules ?? [];
+    assert.equal(rules.filter((r) => r.event === "schedule:chore").length, 1);
+    clearConfigCache(name);
+  });
+
+  it("preserves delivery to the same thread: an un-migrated schedule fires there post-migration", async () => {
+    // A stub mind so an immediate schedule fire records the session it lands on.
+    const posted: { session?: string }[] = [];
+    const server: Server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        try {
+          posted.push(JSON.parse(Buffer.concat(chunks).toString()));
+        } catch {
+          // ignore
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, event: true }));
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as AddressInfo).port;
+    const name = `mig-${process.pid}-c`;
+    await addMind(name, port);
+    const dir = seedVoluteConfig(name, [
+      { id: "reports", cron: "0 9 * * *", message: "report", enabled: true, thread: "work" },
+    ]);
+
+    try {
+      migrateScheduleThreadsToRoutes(dir, name);
+      clearConfigCache(name);
+      // Fire the schedule the way the scheduler does (no explicit thread — routing owns it).
+      await deliverEvent(name, {
+        type: "schedule",
+        body: "report",
+        meta: { scheduleId: "reports" },
+      });
+      assert.equal(posted[0]?.session, "work");
+    } finally {
+      server.close();
+      const db = await getDb();
+      await db.delete(systemEvents).where(eq(systemEvents.mind, name));
+      clearConfigCache(name);
+      await removeMind(name);
+    }
+  });
+});

--- a/test/event-routing.test.ts
+++ b/test/event-routing.test.ts
@@ -10,6 +10,7 @@ import {
   drainEvents,
   eventMatchKey,
   MIND_LEVEL_THREAD,
+  recordNotice,
 } from "../packages/daemon/src/lib/chat/system-events.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
 import { clearConfigCache } from "../packages/daemon/src/lib/delivery/delivery-router.js";
@@ -180,6 +181,49 @@ describe("event routing (daemon-side, via routes.json)", () => {
       // Drains into an arbitrary, unrelated thread — proof it isn't stranded.
       const drained = await drainEvents(m.name, "some-unrelated-thread");
       assert.ok(drained.some((e) => e.id === id));
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("non-routable: a crash/turn_error notice ignores a rule that would route it away", async () => {
+    // A mind routes ALL notices to a named thread — but crash/turn_error must land at
+    // mind-level attention regardless, so a routing mistake can't bury a failure notice.
+    const m = await routableMind({ rules: [{ event: "notice:*", thread: "hideaway" }] });
+    try {
+      for (const kind of ["crash", "turn_error"] as const) {
+        await recordNotice({
+          mind: m.name,
+          thread: "somewhere", // a caller-chosen thread the pin overrides
+          kind,
+          reason: `${kind}_test`,
+          detail: "boom",
+        });
+      }
+      const db = await getDb();
+      const rows = await db.select().from(systemEvents).where(eq(systemEvents.mind, m.name)).all();
+      assert.equal(rows.length, 2);
+      assert.equal(
+        rows.every((r) => r.thread === MIND_LEVEL_THREAD),
+        true,
+        "crash/turn_error notices pin to mind-level, not the routed thread",
+      );
+      // A routable notice (delivery_failed) still honours the same rule.
+      await recordNotice({
+        mind: m.name,
+        thread: MIND_LEVEL_THREAD,
+        kind: "delivery_failed",
+        reason: "df",
+        detail: "x",
+      });
+      const df = await db
+        .select()
+        .from(systemEvents)
+        .where(eq(systemEvents.mind, m.name))
+        .orderBy(systemEvents.id)
+        .all();
+      assert.equal(df.at(-1)?.thread, "hideaway");
     } finally {
       m.close();
       await cleanup(m.name);

--- a/test/event-routing.test.ts
+++ b/test/event-routing.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { resolve } from "node:path";
-import { afterEach, describe, it } from "node:test";
+import { describe, it } from "node:test";
 import { eq } from "drizzle-orm";
 import {
   deliverEvent,

--- a/test/event-routing.test.ts
+++ b/test/event-routing.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import {
+  deliverEvent,
+  drainEvents,
+  eventMatchKey,
+  MIND_LEVEL_THREAD,
+} from "../packages/daemon/src/lib/chat/system-events.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { clearConfigCache } from "../packages/daemon/src/lib/delivery/delivery-router.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import { systemEvents } from "../packages/daemon/src/lib/schema.js";
+
+type Posted = { kind?: string; session?: string; event?: { body: string } };
+
+/** A stub mind server recording the envelopes POSTed to /message, with routes.json on disk. */
+async function routableMind(
+  routes: object,
+): Promise<{ name: string; posted: Posted[]; close: () => void }> {
+  const posted: Posted[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      try {
+        posted.push(JSON.parse(Buffer.concat(chunks).toString()));
+      } catch {
+        // ignore
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, event: true }));
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  const name = `evroute-${process.pid}-${port}`;
+  await addMind(name, port);
+  const configDir = resolve(process.env.VOLUTE_HOME!, "minds", name, "home/.config");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(resolve(configDir, "routes.json"), JSON.stringify(routes));
+  clearConfigCache(name);
+  return { name, posted, close: () => server.close() };
+}
+
+async function cleanup(name: string): Promise<void> {
+  const db = await getDb();
+  await db.delete(systemEvents).where(eq(systemEvents.mind, name));
+  clearConfigCache(name);
+  await removeMind(name);
+}
+
+async function threadOf(id: number): Promise<string | undefined> {
+  const db = await getDb();
+  const row = await db.select().from(systemEvents).where(eq(systemEvents.id, id)).get();
+  return row?.thread;
+}
+
+describe("eventMatchKey", () => {
+  it("builds <type>:<discriminator> keys, or the bare type", () => {
+    assert.equal(eventMatchKey("schedule", { scheduleId: "dream" }), "schedule:dream");
+    assert.equal(eventMatchKey("webhook", { source: "stripe" }), "webhook:stripe");
+    assert.equal(eventMatchKey("notice", { subtype: "crash" }), "notice:crash");
+    assert.equal(eventMatchKey("lifecycle", { subtype: "merge" }), "lifecycle:merge");
+    assert.equal(eventMatchKey("budget", {}), "budget");
+    assert.equal(eventMatchKey("schedule", {}), "schedule");
+  });
+});
+
+describe("event routing (daemon-side, via routes.json)", () => {
+  it("a schedule:* rule routes a schedule fire to the mapped thread", async () => {
+    const m = await routableMind({ rules: [{ event: "schedule:*", thread: "chores" }] });
+    try {
+      const { delivered } = await deliverEvent(m.name, {
+        type: "schedule",
+        body: "tidy",
+        meta: { scheduleId: "heartbeat" },
+      });
+      assert.equal(delivered, true);
+      assert.equal(m.posted[0]?.session, "chores");
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("an exact schedule:<id> rule beats a schedule:* rule (first match wins)", async () => {
+    const m = await routableMind({
+      rules: [
+        { event: "schedule:dream", thread: "dreamland" },
+        { event: "schedule:*", thread: "chores" },
+      ],
+    });
+    try {
+      await deliverEvent(m.name, { type: "schedule", body: "d", meta: { scheduleId: "dream" } });
+      await deliverEvent(m.name, {
+        type: "schedule",
+        body: "h",
+        meta: { scheduleId: "heartbeat" },
+      });
+      assert.equal(m.posted[0]?.session, "dreamland");
+      assert.equal(m.posted[1]?.session, "chores");
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("a webhook:* rule routes webhook events", async () => {
+    const m = await routableMind({ rules: [{ event: "webhook:*", thread: "inbox" }] });
+    try {
+      await deliverEvent(m.name, { type: "webhook", body: "ping", meta: { source: "gh" } });
+      assert.equal(m.posted[0]?.session, "inbox");
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("a matched rule beats the main default; no rule falls back to main", async () => {
+    const m = await routableMind({ rules: [{ event: "schedule:reports", thread: "work" }] });
+    try {
+      // Unmatched schedule → the "main" default, not the rule.
+      await deliverEvent(m.name, { type: "schedule", body: "x", meta: { scheduleId: "other" } });
+      assert.equal(m.posted[0]?.session, "main");
+      // Matched schedule → the rule's thread.
+      await deliverEvent(m.name, { type: "schedule", body: "y", meta: { scheduleId: "reports" } });
+      assert.equal(m.posted[1]?.session, "work");
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("channel rules never route events, and event rules never route channels", async () => {
+    // A mind whose only rule is a channel rule: an event falls through to main.
+    const m = await routableMind({ rules: [{ channel: "#*", thread: "chatter" }] });
+    try {
+      await deliverEvent(m.name, { type: "schedule", body: "x", meta: { scheduleId: "s" } });
+      assert.equal(m.posted[0]?.session, "main");
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("$new expands to a fresh isolated session for immediate delivery", async () => {
+    const m = await routableMind({ rules: [{ event: "schedule:dream", thread: "$new" }] });
+    try {
+      await deliverEvent(m.name, {
+        type: "schedule",
+        body: "dream",
+        meta: { scheduleId: "dream" },
+      });
+      assert.match(m.posted[0]?.session ?? "", /^new-/);
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+
+  it("stranding: a next-turn event routed to $new collapses to the mind-level drain, not lost", async () => {
+    // $new for a next-turn event would mint a unique session that never runs a turn and
+    // strand the event forever (#356/#735). It must collapse to MIND_LEVEL_THREAD, which
+    // any thread's next drain surfaces.
+    const m = await routableMind({ rules: [{ event: "webhook:*", thread: "$new" }] });
+    try {
+      const { id } = await deliverEvent(m.name, {
+        type: "webhook",
+        body: "async",
+        meta: { source: "gh" },
+        delivery: "next-turn",
+      });
+      assert.ok(id);
+      assert.equal(await threadOf(id!), MIND_LEVEL_THREAD);
+      // Drains into an arbitrary, unrelated thread — proof it isn't stranded.
+      const drained = await drainEvents(m.name, "some-unrelated-thread");
+      assert.ok(drained.some((e) => e.id === id));
+    } finally {
+      m.close();
+      await cleanup(m.name);
+    }
+  });
+});

--- a/test/system-events.test.ts
+++ b/test/system-events.test.ts
@@ -578,25 +578,27 @@ describe("system-events reflection attribution", () => {
 
 describe("system-events next-turn drain", () => {
   it("records and drains notices per session, oldest first", async () => {
+    // Routable notice kinds: they honour the thread they're recorded on (unlike
+    // crash/turn_error, which pin to mind-level — see event-routing.test.ts).
     const mind = uniqueMind();
     await recordNotice({
       mind,
       thread: "main",
-      kind: "turn_error",
+      kind: "delivery_failed",
       reason: "auth_error",
       detail: "first",
     });
     await recordNotice({
       mind,
       thread: "main",
-      kind: "turn_error",
+      kind: "delivery_failed",
       reason: "rate_limit",
       detail: "second",
     });
     await recordNotice({
       mind,
       thread: "other",
-      kind: "crash",
+      kind: "delivery_failed",
       reason: "process_crash",
       detail: "elsewhere",
     });

--- a/test/web-schedules.test.ts
+++ b/test/web-schedules.test.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm";
 import { createUser } from "../packages/daemon/src/lib/auth.js";
 import { getScheduler, initScheduler } from "../packages/daemon/src/lib/daemon/scheduler.js";
 import { getDb } from "../packages/daemon/src/lib/db.js";
+import { readRoutesConfig } from "../packages/daemon/src/lib/mind/event-routes.js";
 import { addMind, removeMind, voluteHome } from "../packages/daemon/src/lib/mind/registry.js";
 import type { Schedule } from "../packages/daemon/src/lib/mind/volute-config.js";
 import { users } from "../packages/daemon/src/lib/schema.js";
@@ -165,9 +166,13 @@ describe("schedules API rotating messages", () => {
     assert.equal(sched.message, "solo");
   });
 
-  it("POST and PUT persist the thread target", async () => {
-    // POST persists thread (the scheduler fires it into that thread — see
-    // scheduler.test.ts "fire passes session from schedule config").
+  it("POST/PUT --thread is sugar for a routes.json event rule (#736)", async () => {
+    // `--thread` no longer lives on the schedule — it writes a routes.json event rule so
+    // schedule-fire routing lives in one place. The schedule row itself carries no thread.
+    const dir = resolve(voluteHome(), "minds", mindName);
+    const ruleThread = () =>
+      readRoutesConfig(dir).rules?.find((r) => r.event === "schedule:dream")?.thread;
+
     const res = await postSchedule({
       id: "dream",
       cron: "0 3 * * *",
@@ -175,17 +180,31 @@ describe("schedules API rotating messages", () => {
       thread: "$new",
     });
     assert.equal(res.status, 201);
-    let [sched] = await fetchSchedules();
-    assert.equal(sched.thread, "$new");
-
-    // PUT updates it
-    assert.equal((await putSchedule("dream", { thread: "dreams" })).status, 200);
-    [sched] = await fetchSchedules();
-    assert.equal(sched.thread, "dreams");
-
-    // PUT with an empty string clears it
-    assert.equal((await putSchedule("dream", { thread: "" })).status, 200);
-    [sched] = await fetchSchedules();
+    const [sched] = await fetchSchedules();
     assert.equal(sched.thread, undefined);
+    assert.equal(ruleThread(), "$new");
+
+    // PUT updates the rule
+    assert.equal((await putSchedule("dream", { thread: "dreams" })).status, 200);
+    assert.equal(ruleThread(), "dreams");
+
+    // PUT with an empty string removes the rule
+    assert.equal((await putSchedule("dream", { thread: "" })).status, 200);
+    assert.equal(ruleThread(), undefined);
+
+    // POST it back, then DELETE the schedule — the rule is cleaned up too.
+    assert.equal((await putSchedule("dream", { thread: "dreams" })).status, 200);
+    assert.equal(ruleThread(), "dreams");
+    const app = await getApp();
+    assert.equal(
+      (
+        await app.request(`/api/minds/${mindName}/schedules/dream`, {
+          method: "DELETE",
+          headers: jsonHeaders(),
+        })
+      ).status,
+      200,
+    );
+    assert.equal(ruleThread(), undefined);
   });
 });


### PR DESCRIPTION
## Summary

System events (schedule fires, webhooks, notices) now route through routes.json just like messages. One routing system, one place to edit.

**Migration:** `schedule.thread` fields in volute.json migrate to equivalent `{ event: "schedule:<id>", thread }` rules in routes.json. Migration runs at daemon start.

**Pinned notices:** crash and turn_error notices are non-routable — they always surface at attention so a mind cannot accidentally bury its own failures.

**CLI:** `volute clock add --thread` now writes a routes.json event rule instead of setting schedule.thread.

**Dreaming isolation:** The default-autonomy dreaming schedule now uses an explicit `{ event: "schedule:dream", thread: "$new" }` rule.

Closes #736

## Commits

- `a9837df` — resolve system-event threads through routes.json
- `d312443` — migrate schedule.thread into routes.json rules
- `37b918c` — CLI --thread writes a routes.json event rule
- `9c25390` — make dreaming isolation an explicit routing rule
- `7c7cd12` — pin crash/turn_error notices to attention
- `c808647` — align tests with routable events
- `55bf543` — document routing events in VOLUTE.md

## Test plan

- [x] npm run typecheck
- [x] npm test (3319 tests)
- [x] npm run test:e2e (70 tests)
- [ ] After merge: verify schedule fires route correctly; verify crash notices stay pinned

---

## Reviewer notes (Hecate) — three things for @aswever before merging

I reviewed this diff line-by-line and re-ran the gates independently (typecheck clean; 3319/3319 pass). It's sound. Three things I want visible rather than buried:

**1. The non-routable pin is MY call, and it's yours to reverse.** You answered the three #736 leans but never addressed the pin sub-question, so I proceeded on my own recommendation: crash/turn_error notices refuse routing and pin to the mind-level drain, so a mind can't accidentally bury its own failure notices. It's one `Set` in `system-events.ts` (`NON_ROUTABLE_NOTICE_SUBTYPES`) — remove a subtype to make that class routable. Say the word and I'll flip it. Note this *does* change where crash notices land (previously the caller's thread, usually `main`; now the mind-level drain, which surfaces on whatever thread next runs).

**2. The stranding constraint is satisfied by DETECTION, not automatic promotion.** `$new` on a next-turn event still collapses to the mind-level sentinel, so that path can't strand. But a rule pointing at a *named* thread that never runs a turn (`{event:"schedule:*", thread:"chores"}` where `chores` is dead) will pile up undrained events. What catches it is the pre-existing generic detector — I verified the chain is actually live, not merely present: `daemon.ts:499` → `startMaintenanceInterval` → `runMaintenance` → `findStrandedEventMinds`. It's mind-level and counts all undrained next-turn events, so it does fire here — but it *logs a warning*, it doesn't rescue the events. I think detection is the right call (auto-promotion would defeat deliberate routing), but you should know the guarantee level rather than assume rescue.

**3. Follow-up nit, not a blocker:** `resolveEventRoute` returns on the first glob match, so a hand-written earlier wildcard with no `thread` (`{event:"schedule:*"}`) shadows a later specific rule and silently falls back to the default. Machine-written rules are safe (`upsertEventRule` prepends specific rules), so this only bites a hand-edited routes.json. Worth skipping thread-less rules in the match loop later.

**Cross-PR integration risk with #333:** the tests here (including the new `--thread` case in `test/web-schedules.test.ts`) call the old `/api/minds/...` prefix, which #333 deletes. #333 is building off `f3c86ab` and cannot see these new tests. **Whichever of the two lands second will leave red tests** — the full suite must be re-run on merged main and any remaining `/api/` swept to `/api/v1/`. Neither PR's own green suite proves the pair is green.

<sub>Process note to self: this branch was pushed and this PR opened by the builder, contrary to its brief's explicit "commit only, DO NOT PUSH." No unexpected commits landed (remote == local `55bf543`), but the PR narrative was the builder's rather than mine until this edit.</sub>
