### PR TITLE
refactor(api): uniform request validation with zValidator (#333 part B)

### DIFF
--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -35,14 +35,14 @@ curl -sf -X PUT -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -d "{\"value\":\"$ANTHROPIC_API_KEY\"}" \
-  "http://localhost:$HOST_PORT/api/env/ANTHROPIC_API_KEY"
+  "http://localhost:$HOST_PORT/api/v1/env/ANTHROPIC_API_KEY"
 
 # For pi template minds:
 curl -sf -X PUT -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -d "{\"value\":\"$OPENROUTER_API_KEY\"}" \
-  "http://localhost:$HOST_PORT/api/env/OPENROUTER_API_KEY"
+  "http://localhost:$HOST_PORT/api/v1/env/OPENROUTER_API_KEY"
 ```
 
 ### 3. Restart for Spirit Creation
@@ -66,7 +66,7 @@ curl -sf -X POST -H "Content-Type: application/json" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -c /tmp/volute-cookies.txt \
   -d '{"username":"tester","password":"tester"}' \
-  "http://localhost:$HOST_PORT/api/auth/login"
+  "http://localhost:$HOST_PORT/api/v1/auth/login"
 ```
 
 ### 5. Create Minds
@@ -78,13 +78,13 @@ Create minds with different templates to test cross-template compatibility:
 curl -sf -X POST -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" -H "Origin: http://localhost:$HOST_PORT" \
   -d '{"name":"lyra","template":"claude","model":"claude-sonnet-4-6"}' \
-  "http://localhost:$HOST_PORT/api/minds"
+  "http://localhost:$HOST_PORT/api/v1/minds"
 
 # Pi template
 curl -sf -X POST -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" -H "Origin: http://localhost:$HOST_PORT" \
   -d '{"name":"atlas","template":"pi","model":"openrouter:anthropic/claude-sonnet-4"}' \
-  "http://localhost:$HOST_PORT/api/minds"
+  "http://localhost:$HOST_PORT/api/v1/minds"
 ```
 
 Write SOUL.md files to give minds personality, then start them.
@@ -108,7 +108,7 @@ docker logs "$CONTAINER" 2>&1 | grep "exited with code" | grep -v "code 0"
 Use the `--full` flag on mind history to see all entry types:
 
 ```bash
-curl -sf "http://localhost:$HOST_PORT/api/minds/<name>/history?limit=50&full=true" \
+curl -sf "http://localhost:$HOST_PORT/api/v1/minds/<name>/history?limit=50&full=true" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Origin: http://localhost:$HOST_PORT"
 ```

--- a/.claude/skills/integration-testing/references/test-checklist.md
+++ b/.claude/skills/integration-testing/references/test-checklist.md
@@ -21,7 +21,7 @@ Reusable checklist for verifying new features end-to-end.
 - [ ] Spirit can discover and use the feature
 - [ ] Minds on claude template can use the feature
 - [ ] Minds on pi template can use the feature
-- [ ] Activity events published (check `/api/activity/events`)
+- [ ] Activity events published (check `/api/v1/activity/events`)
 
 ## Mind Behavior (Organic)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Unified `users` table with `user_type` discrimination (`"human"` or `"mind"`) st
 - Fields: `display_name`, `description`, `avatar`
 - Mind profiles configured in `volute.json` under `profile: { displayName, description, avatar }`
 - `syncMindProfile()` syncs mind config to users table on mind start
-- Mind avatars served at `GET /api/minds/:name/avatar`, human avatars at `GET /api/auth/avatars/:filename`
+- Mind avatars served at `GET /api/v1/minds/:name/avatar`, human avatars at `GET /api/v1/auth/avatars/:filename`
 - `enrichWithProfiles()` in delivery-manager loads participant profiles + avatar images on first message per channel per session
 - `profile_updated` broadcast event triggers frontend refresh on profile changes
 
@@ -313,7 +313,7 @@ Rules with a canonical helper or enforcing test hold up; prose-only rules drift.
 - `volute setup` is the required first-run command; CLI commands are gated on `isSetupComplete()` with auto-migration for existing users via `migrateSetupConfig()`
 - Built-in skills live in `skills/` at repo root and are synced to the shared pool (`~/.volute/skills/`) on daemon startup via `syncBuiltinSkills()`. Extensions contribute skills via `skillsDir` in their manifest; skills with `standardSkill: true` are added to the configurable default skill set. The default skill set is stored in `~/.volute/system/config.json` (`defaultSkills` array) and initialized on first daemon start from `STANDARD_SKILLS` + extension standard skills. Admins can manage defaults via the web UI (Settings → Skills) or `volute skill defaults` CLI. `SEED_SKILLS` (orientation, memory) are installed for seed minds. Skills are installed from the shared pool with upstream tracking (`.upstream.json`) for independent updates.
 - Seed nurture: when a seed is created, a `nurture-<name>` schedule is added to the spirit's `volute.json`. The schedule runs `volute seed check <name>` which queries the daemon API for seed readiness (SOUL.md, MEMORY.md, display name, avatar). The spirit receives the output and can DM the seed encouragement. Thresholds are configurable via `VOLUTE_NURTURE_CRON`, `VOLUTE_NURTURE_CREATOR_MINUTES`, `VOLUTE_NURTURE_SPIRIT_MINUTES`, `VOLUTE_NURTURE_NUDGE_MINUTES` (nudge backoff, default 30). The check stays quiet while the seed sleeps. On sprout, the nurture schedule is cleaned up.
-- Image generation toggle: `isImagegenEnabled()` in `setup.ts` reads `imagegen.enabled` from global config. Controls whether seeds are asked to generate avatars and whether sprouting requires one. Configurable via Settings UI or `PUT /api/system/imagegen`.
+- Image generation toggle: `isImagegenEnabled()` in `setup.ts` reads `imagegen.enabled` from global config. Controls whether seeds are asked to generate avatars and whether sprouting requires one. Configurable via Settings UI or `PUT /api/v1/system/imagegen`.
 
 ## Security conventions
 

--- a/packages/cli/src/commands/chat/accept.ts
+++ b/packages/cli/src/commands/chat/accept.ts
@@ -13,7 +13,7 @@ const cmd = command({
   async run({ args, flags }) {
     const mind = resolveMindName(flags);
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/files/accept`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/files/accept`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: args.id, dest: flags.dest }),

--- a/packages/cli/src/commands/chat/bridge.ts
+++ b/packages/cli/src/commands/chat/bridge.ts
@@ -22,7 +22,7 @@ const bridgeAddCmd = command({
       process.exit(1);
     }
 
-    const res = await daemonFetch(`/api/bridges/${encodeURIComponent(platform)}`, {
+    const res = await daemonFetch(`/api/v1/bridges/${encodeURIComponent(platform)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ defaultMind }),
@@ -57,7 +57,7 @@ const bridgeRemoveCmd = command({
   run: async ({ args }) => {
     const platform = args.platform!;
 
-    const res = await daemonFetch(`/api/bridges/${encodeURIComponent(platform)}`, {
+    const res = await daemonFetch(`/api/v1/bridges/${encodeURIComponent(platform)}`, {
       method: "DELETE",
     });
 
@@ -76,7 +76,7 @@ const bridgeListCmd = command({
   args: [],
   flags: {},
   run: async () => {
-    const res = await daemonFetch("/api/bridges");
+    const res = await daemonFetch("/api/v1/bridges");
     if (!res.ok) {
       console.error(`Failed to list bridges: ${res.status}`);
       process.exit(1);
@@ -123,7 +123,7 @@ const bridgeMapCmd = command({
     const platform = target.slice(0, colonIdx);
     const externalChannel = target.slice(colonIdx + 1);
 
-    const res = await daemonFetch(`/api/bridges/${encodeURIComponent(platform)}/mappings`, {
+    const res = await daemonFetch(`/api/v1/bridges/${encodeURIComponent(platform)}/mappings`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ externalChannel, voluteChannel }),
@@ -157,7 +157,7 @@ const bridgeUnmapCmd = command({
     const externalChannel = target.slice(colonIdx + 1);
 
     const res = await daemonFetch(
-      `/api/bridges/${encodeURIComponent(platform)}/mappings/${encodeURIComponent(externalChannel)}`,
+      `/api/v1/bridges/${encodeURIComponent(platform)}/mappings/${encodeURIComponent(externalChannel)}`,
       { method: "DELETE" },
     );
 
@@ -179,7 +179,7 @@ const bridgeMappingsCmd = command({
     const platform = args.platform;
 
     if (platform) {
-      const res = await daemonFetch(`/api/bridges/${encodeURIComponent(platform)}/mappings`);
+      const res = await daemonFetch(`/api/v1/bridges/${encodeURIComponent(platform)}/mappings`);
       if (!res.ok) {
         console.error(`Failed to get mappings: ${res.status}`);
         process.exit(1);
@@ -196,7 +196,7 @@ const bridgeMappingsCmd = command({
       }
     } else {
       // List all bridges' mappings
-      const res = await daemonFetch("/api/bridges");
+      const res = await daemonFetch("/api/v1/bridges");
       if (!res.ok) {
         console.error(`Failed to list bridges: ${res.status}`);
         process.exit(1);

--- a/packages/cli/src/commands/chat/channels.ts
+++ b/packages/cli/src/commands/chat/channels.ts
@@ -13,7 +13,7 @@ const channelsListCmd = command({
   run: async ({ flags }) => {
     const mind = resolveMindName(flags);
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/delivery/pending`);
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/delivery/pending`);
     if (!res.ok) {
       const data = (await res.json().catch(() => ({}))) as { error?: string };
       console.error(data.error ?? `Failed to list gated channels: ${res.status}`);
@@ -59,7 +59,7 @@ const channelsDeclineCmd = command({
     const mind = resolveMindName(flags);
     const channel = args.channel!;
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/gates/decline`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/gates/decline`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ channel }),
@@ -88,7 +88,7 @@ const channelsAcceptCmd = command({
     const mind = resolveMindName(flags);
     const channel = args.channel!;
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/gates/accept`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/gates/accept`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ channel, thread: flags.thread }),
@@ -142,7 +142,7 @@ const channelsPeekCmd = command({
     const channel = args.channel!;
 
     const res = await daemonFetch(
-      `/api/minds/${encodeURIComponent(mind)}/gates/peek?channel=${encodeURIComponent(channel)}`,
+      `/api/v1/minds/${encodeURIComponent(mind)}/gates/peek?channel=${encodeURIComponent(channel)}`,
     );
 
     if (!res.ok) {

--- a/packages/cli/src/commands/chat/create.ts
+++ b/packages/cli/src/commands/chat/create.ts
@@ -48,7 +48,7 @@ const cmd = command({
       const conv = (await res.json()) as { id: string };
       console.log(`Created channel #${flags.channel}: ${conv.id}`);
     } else {
-      const res = await daemonFetch(`/api/minds/${encodeURIComponent(mindName)}/conversations`, {
+      const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mindName)}/conversations`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/cli/src/commands/chat/files.ts
+++ b/packages/cli/src/commands/chat/files.ts
@@ -12,7 +12,7 @@ const cmd = command({
   async run({ flags }) {
     const mind = resolveMindName(flags);
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/files/pending`);
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/files/pending`);
 
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };

--- a/packages/cli/src/commands/chat/list.ts
+++ b/packages/cli/src/commands/chat/list.ts
@@ -12,7 +12,7 @@ const cmd = command({
   async run({ flags }) {
     const mindName = resolveMindName(flags);
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mindName)}/conversations`);
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mindName)}/conversations`);
     if (!res.ok) {
       console.error(`Failed to list conversations: ${res.status}`);
       process.exit(1);

--- a/packages/cli/src/commands/chat/read.ts
+++ b/packages/cli/src/commands/chat/read.ts
@@ -17,7 +17,7 @@ async function resolveConversationId(mindName: string, input: string): Promise<s
   }
 
   // Fetch conversation list and try to match
-  const res = await daemonFetch(`/api/minds/${encodeURIComponent(mindName)}/conversations`);
+  const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mindName)}/conversations`);
   if (!res.ok) {
     return input; // Fall through to the original behavior
   }
@@ -69,7 +69,7 @@ const cmd = command({
     const limit = String(flags.limit ?? 50);
 
     const res = await daemonFetch(
-      `/api/minds/${encodeURIComponent(mindName)}/conversations/${encodeURIComponent(conversationId)}/messages?limit=${limit}`,
+      `/api/v1/minds/${encodeURIComponent(mindName)}/conversations/${encodeURIComponent(conversationId)}/messages?limit=${limit}`,
     );
     if (!res.ok) {
       console.error(`Failed to read conversation: ${res.status}`);

--- a/packages/cli/src/commands/chat/reject.ts
+++ b/packages/cli/src/commands/chat/reject.ts
@@ -12,7 +12,7 @@ const cmd = command({
   async run({ args, flags }) {
     const mind = resolveMindName(flags);
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(mind)}/files/reject`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/files/reject`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: args.id }),

--- a/packages/cli/src/commands/clock.ts
+++ b/packages/cli/src/commands/clock.ts
@@ -52,7 +52,7 @@ const clockStatusCmd = command({
     const client = getClient();
 
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].clock.status.$url({ param: { name: mind } })),
+      urlOf(client.api.v1.minds[":name"].clock.status.$url({ param: { name: mind } })),
     );
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };
@@ -209,7 +209,7 @@ const listSchedulesCmd = command({
 
     // clock/status carries both stores (schedules[] and sleep.schedule) in one call.
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].clock.status.$url({ param: { name: mind } })),
+      urlOf(client.api.v1.minds[":name"].clock.status.$url({ param: { name: mind } })),
     );
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };
@@ -333,7 +333,7 @@ const addScheduleCmd = command({
 
     const client = getClient();
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].schedules.$url({ param: { name: mind } })),
+      urlOf(client.api.v1.minds[":name"].schedules.$url({ param: { name: mind } })),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -374,7 +374,7 @@ const removeScheduleCmd = command({
     const client = getClient();
     const res = await daemonFetch(
       urlOf(
-        client.api.minds[":name"].schedules[":id"].$url({
+        client.api.v1.minds[":name"].schedules[":id"].$url({
           param: { name: mind, id: flags.id },
         }),
       ),

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -2,7 +2,7 @@ import { subcommands } from "../lib/command.js";
 
 async function listModels() {
   const { daemonFetch } = await import("../lib/daemon-client.js");
-  const res = await daemonFetch("/api/config/models");
+  const res = await daemonFetch("/api/v1/config/models");
   if (!res.ok) {
     console.error(`Failed to fetch models (HTTP ${res.status})`);
     process.exit(1);
@@ -25,7 +25,7 @@ async function listModels() {
 
 async function listProviders() {
   const { daemonFetch } = await import("../lib/daemon-client.js");
-  const res = await daemonFetch("/api/config/providers");
+  const res = await daemonFetch("/api/v1/config/providers");
   if (!res.ok) {
     console.error(`Failed to fetch providers (HTTP ${res.status})`);
     process.exit(1);
@@ -46,7 +46,7 @@ async function listProviders() {
 
 async function showStatus() {
   const { daemonFetch } = await import("../lib/daemon-client.js");
-  const res = await daemonFetch("/api/config/status");
+  const res = await daemonFetch("/api/v1/config/status");
   if (!res.ok) {
     console.error(`Failed to fetch config (HTTP ${res.status})`);
     process.exit(1);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -26,7 +26,7 @@ const cmd = command({
     const { getClient, urlOf } = await import("../lib/api-client.js");
     const client = getClient();
 
-    const res = await daemonFetch(urlOf(client.api.minds.$url()), {
+    const res = await daemonFetch(urlOf(client.api.v1.minds.$url()), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, template, skills }),

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -16,7 +16,7 @@ const cmd = command({
     const client = getClient();
 
     const url =
-      urlOf(client.api.minds[":name"].$url({ param: { name } })) +
+      urlOf(client.api.v1.minds[":name"].$url({ param: { name } })) +
       (flags.force ? "?force=true" : "");
 
     const res = await daemonFetch(url, { method: "DELETE" });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -280,7 +280,7 @@ async function runDiagnostics(): Promise<Diagnostics> {
   }
 
   // --- Per-mind process status ---
-  const daemonMinds = await fetchDaemonJson<DaemonMind[]>("/api/minds");
+  const daemonMinds = await fetchDaemonJson<DaemonMind[]>("/api/v1/minds");
   if (daemonMinds) {
     if (daemonMinds.length === 0) {
       checks.push({ label: "Minds", state: "pass", detail: "none configured" });

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -28,7 +28,7 @@ const envSetCmd = command({
     if (flags.mind) {
       res = await daemonFetch(
         urlOf(
-          client.api.minds[":name"].env[":key"].$url({
+          client.api.v1.minds[":name"].env[":key"].$url({
             param: { name: flags.mind, key },
           }),
         ),
@@ -39,7 +39,7 @@ const envSetCmd = command({
         },
       );
     } else {
-      res = await daemonFetch(urlOf(client.api.env[":key"].$url({ param: { key } })), {
+      res = await daemonFetch(urlOf(client.api.v1.env[":key"].$url({ param: { key } })), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ value }),
@@ -68,7 +68,7 @@ const envGetCmd = command({
     if (flags.mind) {
       const res = await daemonFetch(
         urlOf(
-          client.api.minds[":name"].env[":key"].$url({
+          client.api.v1.minds[":name"].env[":key"].$url({
             param: { name: flags.mind, key },
           }),
         ),
@@ -81,7 +81,7 @@ const envGetCmd = command({
       const data = (await res.json()) as { value: string };
       console.log(data.value);
     } else {
-      const res = await daemonFetch(urlOf(client.api.env.$url()));
+      const res = await daemonFetch(urlOf(client.api.v1.env.$url()));
       if (!res.ok) {
         console.error(`Failed to read shared env`);
         process.exit(1);
@@ -110,7 +110,7 @@ const envListCmd = command({
     const compact = isCompact();
     if (flags.mind) {
       const res = await daemonFetch(
-        urlOf(client.api.minds[":name"].env.$url({ param: { name: flags.mind } })),
+        urlOf(client.api.v1.minds[":name"].env.$url({ param: { name: flags.mind } })),
       );
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
@@ -133,7 +133,7 @@ const envListCmd = command({
         console.log(compact ? `${key}=${value}` : `${key}=${value} [${scope}]`);
       }
     } else {
-      const res = await daemonFetch(urlOf(client.api.env.$url()));
+      const res = await daemonFetch(urlOf(client.api.v1.env.$url()));
       if (!res.ok) {
         console.error("Failed to list shared env");
         process.exit(1);
@@ -167,14 +167,14 @@ const envRemoveCmd = command({
     if (flags.mind) {
       res = await daemonFetch(
         urlOf(
-          client.api.minds[":name"].env[":key"].$url({
+          client.api.v1.minds[":name"].env[":key"].$url({
             param: { name: flags.mind, key },
           }),
         ),
         { method: "DELETE" },
       );
     } else {
-      res = await daemonFetch(urlOf(client.api.env[":key"].$url({ param: { key } })), {
+      res = await daemonFetch(urlOf(client.api.v1.env[":key"].$url({ param: { key } })), {
         method: "DELETE",
       });
     }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -60,7 +60,7 @@ const cmd = command({
         const { getClient, urlOf } = await import("../lib/api-client.js");
         const client = getClient();
         const res = await daemonFetch(
-          urlOf(client.api.minds[":name"].history.export.$url({ param: { name } })),
+          urlOf(client.api.v1.minds[":name"].history.export.$url({ param: { name } })),
         );
         if (!res.ok) {
           const text = await res.text().catch(() => "");

--- a/packages/cli/src/commands/extension.ts
+++ b/packages/cli/src/commands/extension.ts
@@ -17,7 +17,7 @@ type ExtensionListItem = {
 
 async function listExtensions(args: string[]) {
   const detail = args.includes("--detail");
-  const url = detail ? "/api/extensions/all?detail=true" : "/api/extensions/all";
+  const url = detail ? "/api/v1/extensions/all?detail=true" : "/api/v1/extensions/all";
   const res = await daemonFetch(url);
   if (!res.ok) {
     const body = (await res.json().catch(() => ({ error: "Unknown error" }))) as {
@@ -72,7 +72,7 @@ async function installExtension(args: string[]) {
       `with full API access. Only install extensions you trust.`,
   );
   console.log(`Installing "${pkg}"...`);
-  const res = await daemonFetch("/api/extensions/install", {
+  const res = await daemonFetch("/api/v1/extensions/install", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ package: pkg }),
@@ -97,7 +97,7 @@ async function uninstallExtension(args: string[]) {
     process.exit(1);
   }
 
-  const res = await daemonFetch(`/api/extensions/uninstall/${encodeURIComponent(pkg)}`, {
+  const res = await daemonFetch(`/api/v1/extensions/uninstall/${encodeURIComponent(pkg)}`, {
     method: "DELETE",
   });
 

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -33,7 +33,7 @@ export async function run(args: string[]) {
   const { getClient, urlOf } = await import("../lib/api-client.js");
   const client = getClient();
 
-  const res = await daemonFetch(urlOf((client.api.minds as any).import.$url()), {
+  const res = await daemonFetch(urlOf((client.api.v1.minds as any).import.$url()), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -104,7 +104,7 @@ async function importArchive(archivePath: string, nameOverride?: string): Promis
     const { getClient, urlOf } = await import("../lib/api-client.js");
     const client = getClient();
 
-    const res = await daemonFetch(urlOf((client.api.minds as any).import.$url()), {
+    const res = await daemonFetch(urlOf((client.api.v1.minds as any).import.$url()), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -28,7 +28,7 @@ const cmd = command({
     // The API endpoint still uses the parent mind name + variant name
     // So we need to resolve the variant's parent first
     const statusRes = await daemonFetch(
-      urlOf(client.api.minds[":name"].$url({ param: { name: variantName } })),
+      urlOf(client.api.v1.minds[":name"].$url({ param: { name: variantName } })),
     );
 
     if (!statusRes.ok) {
@@ -47,7 +47,7 @@ const cmd = command({
 
     const res = await daemonFetch(
       urlOf(
-        client.api.minds[":name"].variants[":variant"].merge.$url({
+        client.api.v1.minds[":name"].variants[":variant"].merge.$url({
           param: { name: parentName, variant: variantName },
         }),
       ),

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -13,7 +13,7 @@ const cmd = command({
     // The first account is created in the browser setup wizard. If no account
     // exists yet, there is nothing to log in as — steer the user there instead
     // of prompting for credentials that can't work.
-    const statusRes = await daemonFetch("/api/setup/status");
+    const statusRes = await daemonFetch("/api/v1/setup/status");
     if (statusRes.ok) {
       const status = (await statusRes.json().catch(() => ({}))) as {
         complete?: boolean;
@@ -28,7 +28,7 @@ const cmd = command({
     const username = await promptLine("Username: ");
     const password = await promptPassword("Password: ");
 
-    const res = await daemonFetch("/api/auth/login", {
+    const res = await daemonFetch("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -26,7 +26,7 @@ const cmd = command({
 
     if (sessionId) {
       try {
-        await daemonFetch("/api/auth/logout", {
+        await daemonFetch("/api/v1/auth/logout", {
           method: "POST",
           headers: { Authorization: `Bearer ${sessionId}` },
         });

--- a/packages/cli/src/commands/mind-contacts.ts
+++ b/packages/cli/src/commands/mind-contacts.ts
@@ -30,7 +30,7 @@ const cmd = command({
     const name = resolveMindName(flags);
     const client = getClient();
 
-    const url = client.api.minds[":name"].history.contacts.$url({ param: { name } });
+    const url = client.api.v1.minds[":name"].history.contacts.$url({ param: { name } });
     if (flags.hours) url.searchParams.set("hours", flags.hours);
 
     const res = await daemonFetch(urlOf(url));

--- a/packages/cli/src/commands/mind-history.ts
+++ b/packages/cli/src/commands/mind-history.ts
@@ -326,7 +326,7 @@ const cmd = command({
       }
 
       const client = getClient();
-      const url = client.api.minds[":name"]["turn-summaries"].$url({ param: { name } });
+      const url = client.api.v1.minds[":name"]["turn-summaries"].$url({ param: { name } });
       const res = await daemonFetch(urlOf(url), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -440,7 +440,7 @@ const cmd = command({
     const name = resolveMindName(flags);
     const client = getClient();
 
-    const url = client.api.minds[":name"].history.$url({ param: { name } });
+    const url = client.api.v1.minds[":name"].history.$url({ param: { name } });
     if (flags.channel) url.searchParams.set("channel", flags.channel);
     if (flags.thread) url.searchParams.set("session", flags.thread);
     if (flags.preset) url.searchParams.set("preset", flags.preset);

--- a/packages/cli/src/commands/mind-list.ts
+++ b/packages/cli/src/commands/mind-list.ts
@@ -24,7 +24,7 @@ const cmd = command({
   description: "List all minds",
   flags: {},
   async run() {
-    const res = await daemonFetch("/api/minds");
+    const res = await daemonFetch("/api/v1/minds");
     if (!res.ok) {
       const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
         error: string;

--- a/packages/cli/src/commands/mind-profile.ts
+++ b/packages/cli/src/commands/mind-profile.ts
@@ -31,7 +31,7 @@ const cmd = command({
     if (description) body.description = description;
     if (avatar) body.avatar = avatar;
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/profile`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(name)}/profile`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),

--- a/packages/cli/src/commands/mind-sleep.ts
+++ b/packages/cli/src/commands/mind-sleep.ts
@@ -63,7 +63,7 @@ const cmd = command({
       body.wakeAt = wakeAt;
     }
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/sleep`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(name)}/sleep`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),

--- a/packages/cli/src/commands/mind-status.ts
+++ b/packages/cli/src/commands/mind-status.ts
@@ -15,7 +15,7 @@ const cmd = command({
       process.exit(1);
     }
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}`);
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(name)}`);
     if (!res.ok) {
       if (res.status === 404) {
         console.error(`Mind "${name}" not found`);
@@ -101,7 +101,7 @@ const cmd = command({
     // Surface unrouted (gated) channels holding messages, so a months-long silence
     // is visible without reading the DB. #537
     const pendingRes = await daemonFetch(
-      `/api/minds/${encodeURIComponent(name)}/delivery/pending`,
+      `/api/v1/minds/${encodeURIComponent(name)}/delivery/pending`,
     ).catch(() => null);
     if (pendingRes?.ok) {
       const pending = (await pendingRes.json().catch(() => [])) as Array<{

--- a/packages/cli/src/commands/mind-wake.ts
+++ b/packages/cli/src/commands/mind-wake.ts
@@ -16,7 +16,7 @@ const cmd = command({
       process.exit(1);
     }
 
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/wake`, {
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(name)}/wake`, {
       method: "POST",
     });
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -14,7 +14,7 @@ const cmd = command({
     const client = getClient();
 
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].restart.$url({ param: { name } })),
+      urlOf(client.api.v1.minds[":name"].restart.$url({ param: { name } })),
       { method: "POST" },
     );
 

--- a/packages/cli/src/commands/seed-check.ts
+++ b/packages/cli/src/commands/seed-check.ts
@@ -22,7 +22,7 @@ const cmd = command({
     const query = flags.nurture ? "" : "?force=1";
 
     const { daemonFetch } = await import("../lib/daemon-client.js");
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}/seed-check${query}`);
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(name)}/seed-check${query}`);
 
     if (!res.ok) {
       // Non-zero exit so the scheduler surfaces failures instead of logging

--- a/packages/cli/src/commands/seed-create.ts
+++ b/packages/cli/src/commands/seed-create.ts
@@ -12,7 +12,7 @@ type ModelInfo = {
 async function chooseModel(
   daemonFetch: (path: string, options?: RequestInit) => Promise<Response>,
 ): Promise<string | undefined> {
-  const res = await daemonFetch("/api/system/ai/models");
+  const res = await daemonFetch("/api/v1/system/ai/models");
   if (!res.ok) {
     console.error(`Failed to fetch AI models (HTTP ${res.status}). Is the daemon running?`);
     process.exit(1);
@@ -90,7 +90,7 @@ const cmd = command({
     }
 
     // Create mind as seed
-    const createRes = await daemonFetch(urlOf(client.api.minds.$url()), {
+    const createRes = await daemonFetch(urlOf(client.api.v1.minds.$url()), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -121,7 +121,7 @@ const cmd = command({
 
     // Start the mind
     const startRes = await daemonFetch(
-      urlOf(client.api.minds[":name"].start.$url({ param: { name } })),
+      urlOf(client.api.v1.minds[":name"].start.$url({ param: { name } })),
       { method: "POST" },
     );
 

--- a/packages/cli/src/commands/seed-sprout.ts
+++ b/packages/cli/src/commands/seed-sprout.ts
@@ -17,7 +17,7 @@ const cmd = command({
       process.exit(1);
     }
 
-    const mindRes = await daemonFetch(`/api/minds/${encodeURIComponent(mindName)}`);
+    const mindRes = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mindName)}`);
     if (!mindRes.ok) {
       console.error(`Mind "${mindName}" not found`);
       process.exit(1);
@@ -70,7 +70,7 @@ const cmd = command({
       const skillDir = resolve(mindSkillsDir(dir), skillId);
       if (!existsSync(skillDir)) {
         const installRes = await daemonFetch(
-          urlOf(client.api.minds[":name"].skills.install.$url({ param: { name: mindName } })),
+          urlOf(client.api.v1.minds[":name"].skills.install.$url({ param: { name: mindName } })),
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -94,7 +94,7 @@ const cmd = command({
     if (existsSync(orientationDir)) {
       const delRes = await daemonFetch(
         urlOf(
-          client.api.minds[":name"].skills[":skill"].$url({
+          client.api.v1.minds[":name"].skills[":skill"].$url({
             param: { name: mindName, skill: "orientation" },
           }),
         ),
@@ -113,7 +113,7 @@ const cmd = command({
     }
 
     const sproutRes = await daemonFetch(
-      urlOf(client.api.minds[":name"].sprout.$url({ param: { name: mindName } })),
+      urlOf(client.api.v1.minds[":name"].sprout.$url({ param: { name: mindName } })),
       { method: "POST" },
     );
     if (!sproutRes.ok) {
@@ -124,7 +124,7 @@ const cmd = command({
 
     // Restart with sprouted context
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].restart.$url({ param: { name: mindName } })),
+      urlOf(client.api.v1.minds[":name"].restart.$url({ param: { name: mindName } })),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -341,10 +341,13 @@ const cmd = command({
       // For mind senders, use the daemon file-send API (reads from mind's home/)
       const mindSelf = process.env.VOLUTE_MIND;
       if (mindSelf) {
-        const staged = await postStaging(`/api/minds/${encodeURIComponent(mindSelf)}/files/send`, {
-          targetMind: targetName,
-          filePath,
-        });
+        const staged = await postStaging(
+          `/api/v1/minds/${encodeURIComponent(mindSelf)}/files/send`,
+          {
+            targetMind: targetName,
+            filePath,
+          },
+        );
         printStaged(targetName, staged);
       } else {
         // For CLI (human) senders, read file locally and stage via daemon API
@@ -361,7 +364,7 @@ const cmd = command({
 
         const content = readFileSync(filePath);
         const staged = await postStaging(
-          `/api/minds/${encodeURIComponent(targetName)}/files/stage`,
+          `/api/v1/minds/${encodeURIComponent(targetName)}/files/stage`,
           {
             sender: flags.sender || userInfo().username,
             filename: basename(filePath),
@@ -412,7 +415,7 @@ const cmd = command({
 
       // Create/find conversation via daemon
       const createRes = await daemonFetch(
-        urlOf(client.api.minds[":name"].channels.create.$url({ param: { name: contextMind } })),
+        urlOf(client.api.v1.minds[":name"].channels.create.$url({ param: { name: contextMind } })),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -15,7 +15,7 @@ import { readStdin } from "../lib/read-stdin.js";
 /** Check if a name is a registered mind via the daemon API (avoids direct DB access). */
 async function isMind(name: string): Promise<boolean> {
   try {
-    const res = await daemonFetch(`/api/minds/${encodeURIComponent(name)}`);
+    const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(name)}`);
     return res.ok;
   } catch {
     return false;
@@ -53,7 +53,7 @@ async function waitForResponse(
 ): Promise<void> {
   const client = getClient();
   const eventPath = urlOf(
-    client.api.minds[":name"].conversations[":id"].events.$url({
+    client.api.v1.minds[":name"].conversations[":id"].events.$url({
       param: { name: mindName, id: conversationId },
     }),
   );

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -14,7 +14,7 @@ const listSkillsCmd = command({
     if (flags.mind || process.env.VOLUTE_MIND) {
       const mindName = resolveMindName(flags);
       const client = getClient();
-      const url = urlOf(client.api.minds[":name"].skills.$url({ param: { name: mindName } }));
+      const url = urlOf(client.api.v1.minds[":name"].skills.$url({ param: { name: mindName } }));
       const res = await daemonFetch(url);
       if (!res.ok) {
         const body = (await res.json().catch(() => ({ error: "Unknown error" }))) as {
@@ -45,7 +45,7 @@ const listSkillsCmd = command({
       }
     } else {
       const client = getClient();
-      const url = urlOf(client.api.skills.$url());
+      const url = urlOf(client.api.v1.skills.$url());
       const res = await daemonFetch(url);
       if (!res.ok) {
         const body = (await res.json().catch(() => ({ error: "Unknown error" }))) as {
@@ -87,7 +87,7 @@ const infoSkillCmd = command({
     const id = args.name!;
 
     const client = getClient();
-    const url = urlOf(client.api.skills[":id"].$url({ param: { id } }));
+    const url = urlOf(client.api.v1.skills[":id"].$url({ param: { id } }));
     const res = await daemonFetch(url);
     if (!res.ok) {
       const body = (await res.json().catch(() => ({ error: "Unknown error" }))) as {
@@ -128,7 +128,9 @@ const installSkillCmd = command({
     const skillId = args.name!;
 
     const client = getClient();
-    const url = urlOf(client.api.minds[":name"].skills.install.$url({ param: { name: mindName } }));
+    const url = urlOf(
+      client.api.v1.minds[":name"].skills.install.$url({ param: { name: mindName } }),
+    );
     const res = await daemonFetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -162,7 +164,7 @@ const installSkillCmd = command({
 /** Returns true on success, false on failure (for --all loop) */
 async function doUpdate(mindName: string, skillId: string): Promise<boolean> {
   const client = getClient();
-  const url = urlOf(client.api.minds[":name"].skills.update.$url({ param: { name: mindName } }));
+  const url = urlOf(client.api.v1.minds[":name"].skills.update.$url({ param: { name: mindName } }));
   const res = await daemonFetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -214,7 +216,9 @@ const updateSkillCmd = command({
     if (flags.all) {
       // Update all skills
       const client = getClient();
-      const listUrl = urlOf(client.api.minds[":name"].skills.$url({ param: { name: mindName } }));
+      const listUrl = urlOf(
+        client.api.v1.minds[":name"].skills.$url({ param: { name: mindName } }),
+      );
       const listRes = await daemonFetch(listUrl);
       if (!listRes.ok) {
         const body = (await listRes.json().catch(() => ({ error: "Unknown error" }))) as {
@@ -268,7 +272,9 @@ const publishSkillCmd = command({
     const skillId = args.name!;
 
     const client = getClient();
-    const url = urlOf(client.api.minds[":name"].skills.publish.$url({ param: { name: mindName } }));
+    const url = urlOf(
+      client.api.v1.minds[":name"].skills.publish.$url({ param: { name: mindName } }),
+    );
     const res = await daemonFetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -297,7 +303,7 @@ const removeSkillCmd = command({
     const id = args.name!;
 
     const client = getClient();
-    const url = urlOf(client.api.skills[":id"].$url({ param: { id } }));
+    const url = urlOf(client.api.v1.skills[":id"].$url({ param: { id } }));
     const res = await daemonFetch(url, { method: "DELETE" });
 
     if (!res.ok) {
@@ -325,7 +331,7 @@ const uninstallSkillCmd = command({
 
     const client = getClient();
     const url = urlOf(
-      client.api.minds[":name"].skills[":skill"].$url({
+      client.api.v1.minds[":name"].skills[":skill"].$url({
         param: { name: mindName, skill: skillId },
       }),
     );
@@ -348,7 +354,7 @@ const defaultsListCmd = command({
   description: "List default skills for new minds",
   flags: {},
   run: async () => {
-    const res = await daemonFetch("/api/skills/defaults/list");
+    const res = await daemonFetch("/api/v1/skills/defaults/list");
     if (!res.ok) {
       const body = (await res.json().catch(() => ({ error: "Unknown error" }))) as {
         error: string;
@@ -371,7 +377,7 @@ const defaultsAddCmd = command({
   flags: {},
   run: async ({ args }) => {
     const skillId = args.name!;
-    const res = await daemonFetch("/api/skills/defaults/list", {
+    const res = await daemonFetch("/api/v1/skills/defaults/list", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skill: skillId }),
@@ -394,7 +400,7 @@ const defaultsRemoveCmd = command({
   flags: {},
   run: async ({ args }) => {
     const skillId = args.name!;
-    const res = await daemonFetch(`/api/skills/defaults/list/${encodeURIComponent(skillId)}`, {
+    const res = await daemonFetch(`/api/v1/skills/defaults/list/${encodeURIComponent(skillId)}`, {
       method: "DELETE",
     });
     if (!res.ok) {

--- a/packages/cli/src/commands/split.ts
+++ b/packages/cli/src/commands/split.ts
@@ -26,7 +26,7 @@ const cmd = command({
 
     const client = getClient();
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].variants.$url({ param: { name: mindName } })),
+      urlOf(client.api.v1.minds[":name"].variants.$url({ param: { name: mindName } })),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -13,7 +13,7 @@ const cmd = command({
     const client = getClient();
 
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].start.$url({ param: { name } })),
+      urlOf(client.api.v1.minds[":name"].start.$url({ param: { name } })),
       { method: "POST" },
     );
 

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -13,9 +13,12 @@ const cmd = command({
 
     const client = getClient();
 
-    const res = await daemonFetch(urlOf(client.api.minds[":name"].stop.$url({ param: { name } })), {
-      method: "POST",
-    });
+    const res = await daemonFetch(
+      urlOf(client.api.v1.minds[":name"].stop.$url({ param: { name } })),
+      {
+        method: "POST",
+      },
+    );
 
     const data = (await res.json()) as { ok?: boolean; error?: string };
 

--- a/packages/cli/src/commands/systems.ts
+++ b/packages/cli/src/commands/systems.ts
@@ -2,7 +2,7 @@ import { subcommands } from "../lib/command.js";
 import { daemonFetch } from "../lib/daemon-client.js";
 
 async function showStatus() {
-  const res = await daemonFetch("/api/system/info");
+  const res = await daemonFetch("/api/v1/system/info");
   if (!res.ok) {
     const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
       error: string;

--- a/packages/cli/src/commands/systems/login.ts
+++ b/packages/cli/src/commands/systems/login.ts
@@ -22,7 +22,7 @@ const cmd = command({
       }
     }
 
-    const res = await daemonFetch("/api/system/login", {
+    const res = await daemonFetch("/api/v1/system/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key }),

--- a/packages/cli/src/commands/systems/logout.ts
+++ b/packages/cli/src/commands/systems/logout.ts
@@ -6,7 +6,7 @@ const cmd = command({
   description: "Remove stored volute.systems credentials",
   flags: {},
   run: async () => {
-    const res = await daemonFetch("/api/system/logout", { method: "POST" });
+    const res = await daemonFetch("/api/v1/system/logout", { method: "POST" });
 
     if (!res.ok) {
       const body = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {

--- a/packages/cli/src/commands/systems/register.ts
+++ b/packages/cli/src/commands/systems/register.ts
@@ -22,7 +22,7 @@ const cmd = command({
       }
     }
 
-    const res = await daemonFetch("/api/system/register", {
+    const res = await daemonFetch("/api/v1/system/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -19,7 +19,7 @@ const cmd = command({
     const client = getClient();
 
     const res = await daemonFetch(
-      urlOf(client.api.minds[":name"].upgrade.$url({ param: { name: mindName } })),
+      urlOf(client.api.v1.minds[":name"].upgrade.$url({ param: { name: mindName } })),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -173,9 +173,13 @@ export async function daemonFetch(path: string, options?: RequestInit): Promise<
       headers,
       dispatcher: daemonDispatcher,
     } as RequestInit & { dispatcher: Agent });
-    // /api/auth/ and /api/setup/ are public endpoints — a 401 from them is not
-    // a session problem, and "run `volute login`" would be nonsense mid-login.
-    if (res.status === 401 && !path.startsWith("/api/auth/") && !path.startsWith("/api/setup/")) {
+    // /api/v1/auth/ and /api/v1/setup/ are public endpoints — a 401 from them is
+    // not a session problem, and "run `volute login`" would be nonsense mid-login.
+    if (
+      res.status === 401 &&
+      !path.startsWith("/api/v1/auth/") &&
+      !path.startsWith("/api/v1/setup/")
+    ) {
       if (cliSession) {
         console.error("Session expired. Run `volute login` again.");
       } else {

--- a/packages/daemon/src/lib/bridges/bridge-sdk.ts
+++ b/packages/daemon/src/lib/bridges/bridge-sdk.ts
@@ -58,7 +58,7 @@ export async function sendToBridge(
   env: BridgeEnv,
   message: BridgeMessage,
 ): Promise<{ ok: boolean; error?: string; conversationId?: string }> {
-  const url = `${env.daemonUrl}/api/bridges/${env.platform}/inbound`;
+  const url = `${env.daemonUrl}/api/v1/bridges/${env.platform}/inbound`;
 
   try {
     const res = await fetch(url, {

--- a/packages/daemon/src/lib/bridges/sdk.ts
+++ b/packages/daemon/src/lib/bridges/sdk.ts
@@ -25,7 +25,7 @@ export function loadEnv(): ConnectorEnv {
   const daemonToken = process.env.VOLUTE_DAEMON_TOKEN;
 
   const baseUrl = daemonUrl
-    ? `${daemonUrl}/api/minds/${encodeURIComponent(mindName)}`
+    ? `${daemonUrl}/api/v1/minds/${encodeURIComponent(mindName)}`
     : `http://127.0.0.1:${mindPort}`;
 
   return { mindPort, mindName, mindDir, baseUrl, daemonUrl, daemonToken };

--- a/packages/daemon/src/lib/daemon/turn-lifecycle.ts
+++ b/packages/daemon/src/lib/daemon/turn-lifecycle.ts
@@ -224,7 +224,7 @@ export async function handleMindEvent(
   }
 
   // Fallback/activity linking via correlation markers. Outbound turn attribution is now
-  // primary via the session header at send time (see volute/chat.ts); linkToolResultToTurn
+  // primary via the session header at send time (see api/chat.ts); linkToolResultToTurn
   // is idempotent (won't re-publish an already-attributed outbound) and still links
   // extension activities and any outbound the direct path couldn't attribute.
   if (event.type === "tool_result" && turnId && event.content) {

--- a/packages/daemon/src/lib/extensions.ts
+++ b/packages/daemon/src/lib/extensions.ts
@@ -92,7 +92,7 @@ export function enrichActivityMetadata(
 }
 
 /**
- * The command definition as the CLI sees it over `/api/extensions/commands`:
+ * The command definition as the CLI sees it over `/api/v1/extensions/commands`:
  * everything except the handler, which cannot cross the wire. Metadata the CLI
  * acts on before dispatch — notably `stdin` (#872) — reaches it only through here.
  */
@@ -708,7 +708,7 @@ export async function loadAllExtensions(app: Hono, authMw: MiddlewareHandler): P
   await pruneOrphanedExtensionSkills();
 
   // Discovery endpoint for CLI dynamic dispatch
-  app.get("/api/extensions/commands", (c) => {
+  app.get("/api/v1/extensions/commands", (c) => {
     const result: Record<string, { commands: Record<string, ExtensionCommandInfo> }> = {};
     for (const { manifest } of loaded) {
       if (!manifest.commands) continue;
@@ -724,7 +724,7 @@ export async function loadAllExtensions(app: Hono, authMw: MiddlewareHandler): P
   // Mind-facing digest for session-start orientation: what extensions exist and how a
   // mind reaches them. Reflects only what's actually loaded, so third-party and disabled
   // extensions are handled automatically.
-  app.get("/api/extensions/mind-docs", (c) => {
+  app.get("/api/v1/extensions/mind-docs", (c) => {
     const result = loaded
       .filter(({ manifest }) => manifest.mindDoc || manifest.commands)
       .map(({ manifest }) => ({

--- a/packages/daemon/src/lib/mind/lifecycle.ts
+++ b/packages/daemon/src/lib/mind/lifecycle.ts
@@ -422,11 +422,12 @@ export async function createMind(
     ({ composedDir, manifest } = composeTemplate(templatesRoot, template));
   } catch (err) {
     // A missing/broken template throws (rather than exiting — #330); surface it as
-    // a 500 instead of taking down the daemon.
+    // a 500 instead of taking down the daemon. The detail is logged, not returned.
+    llog.error(`failed to compose template ${template}`, log.errorData(err));
     return {
       ok: false,
       status: 500,
-      error: err instanceof Error ? err.message : "Failed to compose template",
+      error: "Failed to compose template",
     };
   }
 
@@ -675,10 +676,11 @@ export async function createMind(
     } catch (cleanupErr) {
       llog.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
     }
+    llog.error(`failed to create mind ${name}`, log.errorData(err));
     return {
       ok: false,
       status: 500,
-      error: err instanceof Error ? err.message : "Failed to create mind",
+      error: "Failed to create mind",
     };
   } finally {
     rmSync(composedDir, { recursive: true, force: true });
@@ -801,10 +803,11 @@ async function importFromFullArchive(
       llog.error(`Failed to clean up registry for ${name}`, log.errorData(cleanupErr));
     }
     rmSync(tempDir, { recursive: true, force: true });
+    llog.error(`failed to import mind ${name}`, log.errorData(err));
     return {
       ok: false,
       status: 500,
-      error: err instanceof Error ? err.message : "Failed to import mind",
+      error: "Failed to import mind",
     };
   }
 }
@@ -948,10 +951,11 @@ async function importFromHomeOnlyArchive(
       llog.error(`Failed to clean up registry for ${name}`, log.errorData(cleanupErr));
     }
     rmSync(tempDir, { recursive: true, force: true });
+    llog.error(`failed to import mind ${name}`, log.errorData(err));
     return {
       ok: false,
       status: 500,
-      error: err instanceof Error ? err.message : "Failed to import mind",
+      error: "Failed to import mind",
     };
   } finally {
     rmSync(composedDir, { recursive: true, force: true });
@@ -1163,10 +1167,11 @@ export async function importOpenClawWorkspace(body: ImportOpenClawInput): Promis
     } catch (cleanupErr) {
       llog.warn(`failed to clean up registry for ${name}`, log.errorData(cleanupErr));
     }
+    llog.error(`failed to import mind ${name}`, log.errorData(err));
     return {
       ok: false,
       status: 500,
-      error: err instanceof Error ? err.message : "Failed to import mind",
+      error: "Failed to import mind",
     };
   } finally {
     rmSync(composedDir, { recursive: true, force: true });

--- a/packages/daemon/src/lib/platforms/volute.ts
+++ b/packages/daemon/src/lib/platforms/volute.ts
@@ -60,7 +60,7 @@ export async function read(
   if (token) headers.Authorization = `Bearer ${token}`;
 
   const res = await fetch(
-    `${url}/api/minds/${encodeURIComponent(mindName)}/conversations/${encodeURIComponent(conversationId)}/messages`,
+    `${url}/api/v1/minds/${encodeURIComponent(mindName)}/conversations/${encodeURIComponent(conversationId)}/messages`,
     { headers },
   );
   if (!res.ok) {
@@ -141,7 +141,7 @@ export async function listConversations(
   const headers: Record<string, string> = { Origin: url };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(`${url}/api/minds/${encodeURIComponent(mindName)}/conversations`, {
+  const res = await fetch(`${url}/api/v1/minds/${encodeURIComponent(mindName)}/conversations`, {
     headers,
   });
   if (!res.ok) {
@@ -188,7 +188,7 @@ export async function listUsers(_env: Record<string, string>): Promise<PlatformU
   const headers: Record<string, string> = { Origin: url };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(`${url}/api/auth/users`, { headers });
+  const res = await fetch(`${url}/api/v1/auth/users`, { headers });
   if (!res.ok) {
     throw new Error(`Failed to list users: ${res.status} ${res.statusText}`);
   }
@@ -219,7 +219,7 @@ export async function createConversation(
   };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(`${url}/api/minds/${encodeURIComponent(mindName)}/conversations`, {
+  const res = await fetch(`${url}/api/v1/minds/${encodeURIComponent(mindName)}/conversations`, {
     method: "POST",
     headers,
     body: JSON.stringify({ participantNames: participants }),

--- a/packages/daemon/src/lib/util/query-params.ts
+++ b/packages/daemon/src/lib/util/query-params.ts
@@ -1,3 +1,6 @@
+import type { CursorResponse } from "@volute/api/pagination";
+import { z } from "zod";
+
 /**
  * Parse an optional non-negative integer query param.
  *
@@ -25,4 +28,34 @@ export function parseIntParam(raw: string | undefined): number | undefined | nul
   const n = Number(raw);
   // A digit run longer than 2^53 parses fine but no longer round-trips as an id.
   return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * A single cursor param: absent (`undefined`) or an exact run of safe-integer digits.
+ * Deliberately built on `parseIntParam` rather than `z.coerce.number()` — coercion
+ * salvages a leading numeric prefix and would serve the wrong page for an ISO
+ * timestamp (see the `parseIntParam` note, #868).
+ */
+const cursorInt = z
+  .string()
+  .optional()
+  .transform((raw, ctx) => {
+    const n = parseIntParam(raw);
+    if (n === null) {
+      ctx.addIssue({ code: "custom", message: "must be a non-negative integer" });
+      return z.NEVER;
+    }
+    return n;
+  });
+
+/**
+ * Shared validator for cursor-paginated endpoints (`?before=&limit=`). Mount with
+ * `zValidator("query", cursorParamsSchema)`; a malformed value yields a structured
+ * 400, and `c.req.valid("query")` is a `CursorParams` with numeric/undefined fields.
+ */
+export const cursorParamsSchema = z.object({ before: cursorInt, limit: cursorInt });
+
+/** Build the canonical cursor-paginated response envelope. */
+export function cursorResponse<T>(items: T[], hasMore: boolean): CursorResponse<T> {
+  return { items, hasMore };
 }

--- a/packages/daemon/src/web/api/channels.ts
+++ b/packages/daemon/src/web/api/channels.ts
@@ -1,4 +1,6 @@
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod";
 import { loadMergedEnv } from "../../lib/config/env.js";
 import { findMind, mindDir } from "../../lib/mind/registry.js";
 import { getPlatformDriver } from "../../lib/platforms.js";
@@ -8,36 +10,38 @@ function buildEnv(name: string): Record<string, string> {
   return { ...loadMergedEnv(name), VOLUTE_MIND: name, VOLUTE_MIND_DIR: mindDir(name) };
 }
 
-const app = new Hono<AuthEnv>().post("/:name/channels/create", requireSelf(), async (c) => {
-  const name = c.req.param("name");
-  if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
-
-  const {
-    platform,
-    participants,
-    name: convName,
-    sender,
-  } = await c.req.json<{
-    platform: string;
-    participants: string[];
-    name?: string;
-    sender?: string;
-  }>();
-
-  const driver = getPlatformDriver(platform);
-  if (!driver?.createConversation) {
-    return c.json({ error: `Platform ${platform} does not support creating conversations` }, 400);
-  }
-
-  const env = buildEnv(name);
-  if (sender) env.VOLUTE_SENDER = sender;
-  try {
-    const slug = await driver.createConversation(env, participants, convName);
-    // For volute, the slug is the bare conversationId — return both for callers that need the ID
-    return c.json({ slug, conversationId: slug });
-  } catch (err) {
-    return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
-  }
+const createChannelSchema = z.object({
+  platform: z.string(),
+  participants: z.array(z.string()),
+  name: z.string().optional(),
+  sender: z.string().optional(),
 });
+
+const app = new Hono<AuthEnv>().post(
+  "/:name/channels/create",
+  requireSelf(),
+  zValidator("json", createChannelSchema),
+  async (c) => {
+    const name = c.req.param("name");
+    if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
+
+    const { platform, participants, name: convName, sender } = c.req.valid("json");
+
+    const driver = getPlatformDriver(platform);
+    if (!driver?.createConversation) {
+      return c.json({ error: `Platform ${platform} does not support creating conversations` }, 400);
+    }
+
+    const env = buildEnv(name);
+    if (sender) env.VOLUTE_SENDER = sender;
+    try {
+      const slug = await driver.createConversation(env, participants, convName);
+      // For volute, the slug is the bare conversationId — return both for callers that need the ID
+      return c.json({ slug, conversationId: slug });
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
+    }
+  },
+);
 
 export default app;

--- a/packages/daemon/src/web/api/chat.ts
+++ b/packages/daemon/src/web/api/chat.ts
@@ -3,21 +3,21 @@ import { isLocalMind, isMind, isSystemSpirit } from "@volute/api/user-type";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
-import { getOrCreateMindUser, getOrCreateSystemUser } from "../../../lib/auth.js";
-import { routeOutboundBridge } from "../../../lib/bridges/bridge-outbound.js";
-import { checkChannelLimits } from "../../../lib/chat/channel-limits.js";
-import { formatFileSize, stageFile, validateFilePath } from "../../../lib/chat/file-sharing.js";
+import { getOrCreateMindUser, getOrCreateSystemUser } from "../../lib/auth.js";
+import { routeOutboundBridge } from "../../lib/bridges/bridge-outbound.js";
+import { checkChannelLimits } from "../../lib/chat/channel-limits.js";
+import { formatFileSize, stageFile, validateFilePath } from "../../lib/chat/file-sharing.js";
 import {
   ensureSpiritAvailable,
   SPIRIT_NOTICE_PREFIX,
   type SpiritStatus,
-} from "../../../lib/chat/spirit-availability.js";
-import { getActiveTurnId } from "../../../lib/daemon/turn-tracker.js";
-import { extractTextContent } from "../../../lib/delivery/delivery-router.js";
-import { fanOutToMinds } from "../../../lib/delivery/fan-out.js";
-import { recordOutbound } from "../../../lib/delivery/message-delivery.js";
-import { checkStaleSend, formatHoldNotice } from "../../../lib/delivery/send-gate.js";
-import { subscribe } from "../../../lib/events/conversation-events.js";
+} from "../../lib/chat/spirit-availability.js";
+import { getActiveTurnId } from "../../lib/daemon/turn-tracker.js";
+import { extractTextContent } from "../../lib/delivery/delivery-router.js";
+import { fanOutToMinds } from "../../lib/delivery/fan-out.js";
+import { recordOutbound } from "../../lib/delivery/message-delivery.js";
+import { checkStaleSend, formatHoldNotice } from "../../lib/delivery/send-gate.js";
+import { subscribe } from "../../lib/events/conversation-events.js";
 import {
   addMessage,
   type ContentBlock,
@@ -28,14 +28,14 @@ import {
   getLastMessageBySender,
   getParticipants,
   isParticipantOrOwner,
-} from "../../../lib/events/conversations.js";
-import { publish as publishMindEvent } from "../../../lib/events/mind-events.js";
-import { findMind, getBaseName, isSpiritName, resolveMindDir } from "../../../lib/mind/registry.js";
-import { readVoluteConfig } from "../../../lib/mind/volute-config.js";
-import { fixModelEscapes } from "../../../lib/util/fix-model-escapes.js";
-import log from "../../../lib/util/logger.js";
-import { buildVoluteSlug } from "../../../lib/util/slugify.js";
-import type { AuthEnv } from "../../middleware/auth.js";
+} from "../../lib/events/conversations.js";
+import { publish as publishMindEvent } from "../../lib/events/mind-events.js";
+import { findMind, getBaseName, isSpiritName, resolveMindDir } from "../../lib/mind/registry.js";
+import { readVoluteConfig } from "../../lib/mind/volute-config.js";
+import { fixModelEscapes } from "../../lib/util/fix-model-escapes.js";
+import log from "../../lib/util/logger.js";
+import { buildVoluteSlug } from "../../lib/util/slugify.js";
+import type { AuthEnv } from "../middleware/auth.js";
 
 const fileSchema = z.object({
   filename: z.string(),
@@ -407,7 +407,7 @@ export const chatApp = new Hono<AuthEnv>().post("/", zValidator("json", chatSche
   });
 });
 
-// Default export: SSE endpoint only (keeps existing mount points at /api/minds and /api/v1/minds)
+// Default export: SSE endpoint only, mounted on /api/v1/minds.
 const app = new Hono<AuthEnv>().get("/:name/conversations/:id/events", async (c) => {
   const conversationId = c.req.param("id");
   const user = c.get("user");

--- a/packages/daemon/src/web/api/env.ts
+++ b/packages/daemon/src/web/api/env.ts
@@ -13,7 +13,7 @@ import { type AuthEnv, requireAdmin, requireSelf } from "../middleware/auth.js";
 
 const envValueSchema = z.object({ value: z.string() });
 
-// Mind-scoped env routes (mounted at /api/minds)
+// Mind-scoped env routes (mounted at /api/v1/minds)
 const app = new Hono<AuthEnv>()
   .get("/:name/env", requireSelf(), async (c) => {
     const name = c.req.param("name");
@@ -54,7 +54,7 @@ const app = new Hono<AuthEnv>()
     return c.json({ ok: true });
   });
 
-// Shared env routes (mounted at /api/env)
+// Shared env routes (mounted at /api/v1/env)
 export const sharedEnvApp = new Hono<AuthEnv>()
   .get("/", requireAdmin, (c) => {
     return c.json(readEnv(sharedEnvPath()));

--- a/packages/daemon/src/web/api/env.ts
+++ b/packages/daemon/src/web/api/env.ts
@@ -1,4 +1,6 @@
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   loadMergedEnv,
   mindEnvPath,
@@ -8,6 +10,8 @@ import {
 } from "../../lib/config/env.js";
 import { findMind } from "../../lib/mind/registry.js";
 import { type AuthEnv, requireAdmin, requireSelf } from "../middleware/auth.js";
+
+const envValueSchema = z.object({ value: z.string() });
 
 // Mind-scoped env routes (mounted at /api/minds)
 const app = new Hono<AuthEnv>()
@@ -27,22 +31,14 @@ const app = new Hono<AuthEnv>()
     if (value === undefined) return c.json({ error: "Key not found" }, 404);
     return c.json({ value });
   })
-  .put("/:name/env/:key", requireSelf(), async (c) => {
+  .put("/:name/env/:key", requireSelf(), zValidator("json", envValueSchema), async (c) => {
     const name = c.req.param("name");
     if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
     const key = c.req.param("key");
-    let body: { value?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    if (typeof body.value !== "string") {
-      return c.json({ error: "Missing required field: value" }, 400);
-    }
+    const { value } = c.req.valid("json");
     const path = mindEnvPath(name);
     const env = readEnv(path);
-    env[key] = body.value;
+    env[key] = value;
     writeEnv(path, env);
     return c.json({ ok: true });
   })
@@ -63,20 +59,12 @@ export const sharedEnvApp = new Hono<AuthEnv>()
   .get("/", requireAdmin, (c) => {
     return c.json(readEnv(sharedEnvPath()));
   })
-  .put("/:key", requireAdmin, async (c) => {
+  .put("/:key", requireAdmin, zValidator("json", envValueSchema), async (c) => {
     const key = c.req.param("key");
-    let body: { value?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    if (typeof body.value !== "string") {
-      return c.json({ error: "Missing required field: value" }, 400);
-    }
+    const { value } = c.req.valid("json");
     const path = sharedEnvPath();
     const env = readEnv(path);
-    env[key] = body.value;
+    env[key] = value;
     writeEnv(path, env);
     return c.json({ ok: true });
   })

--- a/packages/daemon/src/web/api/extensions.ts
+++ b/packages/daemon/src/web/api/extensions.ts
@@ -1,4 +1,6 @@
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   getAllDiscoveredExtensions,
   getAllDiscoveredExtensionsDetailed,
@@ -22,37 +24,43 @@ const app = new Hono<AuthEnv>()
   })
 
   // Toggle enable/disable
-  .put("/:id/enabled", requireAdmin, async (c) => {
-    const { id } = c.req.param();
-    const body = await c.req.json<{ enabled: boolean }>().catch(() => null);
-    if (!body || typeof body.enabled !== "boolean") {
-      return c.json({ error: "enabled must be a boolean" }, 400);
-    }
-    try {
-      setExtensionEnabled(id, body.enabled);
-    } catch (err) {
-      return c.json({ error: (err as Error).message }, 404);
-    }
-    return c.json({ ok: true, requiresRestart: true });
-  })
+  .put(
+    "/:id/enabled",
+    requireAdmin,
+    zValidator("json", z.object({ enabled: z.boolean() })),
+    async (c) => {
+      const { id } = c.req.param();
+      const { enabled } = c.req.valid("json");
+      try {
+        setExtensionEnabled(id, enabled);
+      } catch (err) {
+        return c.json({ error: (err as Error).message }, 404);
+      }
+      return c.json({ ok: true, requiresRestart: true });
+    },
+  )
 
   // Install npm extension
-  .post("/install", requireAdmin, async (c) => {
-    const body = await c.req.json<{ package: string }>();
-    const pkg = body.package?.trim();
-    if (!pkg) {
-      return c.json({ error: "package is required" }, 400);
-    }
-    try {
-      await installNpmExtension(pkg);
-      return c.json({ ok: true, requiresRestart: true });
-    } catch (err) {
-      const message = (err as Error).message;
-      const isValidation =
-        message.includes("already installed") || message.includes("Invalid package");
-      return c.json({ error: message }, isValidation ? 400 : 500);
-    }
-  })
+  .post(
+    "/install",
+    requireAdmin,
+    zValidator("json", z.object({ package: z.string() })),
+    async (c) => {
+      const pkg = c.req.valid("json").package.trim();
+      if (!pkg) {
+        return c.json({ error: "package is required" }, 400);
+      }
+      try {
+        await installNpmExtension(pkg);
+        return c.json({ ok: true, requiresRestart: true });
+      } catch (err) {
+        const message = (err as Error).message;
+        const isValidation =
+          message.includes("already installed") || message.includes("Invalid package");
+        return c.json({ error: message }, isValidation ? 400 : 500);
+      }
+    },
+  )
 
   // Uninstall npm extension
   .delete("/uninstall/:package", requireAdmin, async (c) => {

--- a/packages/daemon/src/web/api/file-sharing.ts
+++ b/packages/daemon/src/web/api/file-sharing.ts
@@ -1,6 +1,8 @@
 import { readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   acceptPending,
   formatFileSize,
@@ -41,63 +43,65 @@ async function notifyMind(mindName: string, message: string): Promise<boolean> {
 
 const app = new Hono<AuthEnv>()
   // Send a file to another mind
-  .post("/:name/files/send", requireSelf(), async (c) => {
-    const senderName = c.req.param("name");
-    const senderEntry = await findMind(senderName);
-    if (!senderEntry) return c.json({ error: "Sender mind not found" }, 404);
+  .post(
+    "/:name/files/send",
+    requireSelf(),
+    zValidator("json", z.object({ targetMind: z.string().min(1), filePath: z.string().min(1) })),
+    async (c) => {
+      const senderName = c.req.param("name");
+      const senderEntry = await findMind(senderName);
+      if (!senderEntry) return c.json({ error: "Sender mind not found" }, 404);
 
-    const body = (await c.req.json()) as { targetMind?: string; filePath?: string };
-    if (!body.targetMind || !body.filePath) {
-      return c.json({ error: "targetMind and filePath are required" }, 400);
-    }
+      const body = c.req.valid("json");
 
-    const receiverEntry = await findMind(body.targetMind);
-    if (!receiverEntry) return c.json({ error: "Target mind not found" }, 404);
+      const receiverEntry = await findMind(body.targetMind);
+      if (!receiverEntry) return c.json({ error: "Target mind not found" }, 404);
 
-    const pathErr = validateFilePath(body.filePath);
-    if (pathErr) return c.json({ error: pathErr }, 400);
+      const pathErr = validateFilePath(body.filePath);
+      if (pathErr) return c.json({ error: pathErr }, 400);
 
-    // Read file from sender's home directory
-    const senderDir = mindDir(senderName);
-    const filePath = resolve(senderDir, "home", body.filePath);
+      // Read file from sender's home directory
+      const senderDir = mindDir(senderName);
+      const filePath = resolve(senderDir, "home", body.filePath);
 
-    const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
-    const stat = statSync(filePath, { throwIfNoEntry: false });
-    if (!stat) return c.json({ error: `File not found: ${body.filePath}` }, 404);
-    if (stat.size > MAX_FILE_SIZE) {
-      return c.json(
-        {
-          error: `File too large (${formatFileSize(stat.size)}, max ${formatFileSize(MAX_FILE_SIZE)})`,
-        },
-        413,
-      );
-    }
-
-    let content: Buffer;
-    try {
-      content = readFileSync(filePath);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") {
-        return c.json({ error: `File not found: ${body.filePath}` }, 404);
+      const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+      const stat = statSync(filePath, { throwIfNoEntry: false });
+      if (!stat) return c.json({ error: `File not found: ${body.filePath}` }, 404);
+      if (stat.size > MAX_FILE_SIZE) {
+        return c.json(
+          {
+            error: `File too large (${formatFileSize(stat.size)}, max ${formatFileSize(MAX_FILE_SIZE)})`,
+          },
+          413,
+        );
       }
-      return c.json({ error: `Failed to read file: ${code ?? (err as Error).message}` }, 500);
-    }
 
-    const filename = body.filePath;
-    const sizeStr = formatFileSize(content.length);
+      let content: Buffer;
+      try {
+        content = readFileSync(filePath);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          return c.json({ error: `File not found: ${body.filePath}` }, 404);
+        }
+        return c.json({ error: `Failed to read file: ${code ?? (err as Error).message}` }, 500);
+      }
 
-    // Always stage for approval
-    const { id } = stageFile(body.targetMind, senderName, filename, content, body.filePath);
+      const filename = body.filePath;
+      const sizeStr = formatFileSize(content.length);
 
-    // Notify receiver
-    const notified = await notifyMind(
-      body.targetMind,
-      `[file] ${senderName} sent ${filename} (${sizeStr}) — run: volute chat accept ${id}`,
-    );
+      // Always stage for approval
+      const { id } = stageFile(body.targetMind, senderName, filename, content, body.filePath);
 
-    return c.json({ status: "pending", id, notified }, 200);
-  })
+      // Notify receiver
+      const notified = await notifyMind(
+        body.targetMind,
+        `[file] ${senderName} sent ${filename} (${sizeStr}) — run: volute chat accept ${id}`,
+      );
+
+      return c.json({ status: "pending", id, notified }, 200);
+    },
+  )
 
   // List pending incoming files
   .get("/:name/files/pending", requireSelf(), async (c) => {
@@ -107,102 +111,121 @@ const app = new Hono<AuthEnv>()
   })
 
   // Accept a pending file
-  .post("/:name/files/accept", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const entry = await findMind(name);
-    if (!entry) return c.json({ error: "Mind not found" }, 404);
+  .post(
+    "/:name/files/accept",
+    requireSelf(),
+    zValidator("json", z.object({ id: z.string().min(1), dest: z.string().optional() })),
+    async (c) => {
+      const name = c.req.param("name");
+      const entry = await findMind(name);
+      if (!entry) return c.json({ error: "Mind not found" }, 404);
 
-    const body = (await c.req.json()) as { id?: string; dest?: string };
-    if (!body.id) return c.json({ error: "id is required" }, 400);
+      const body = c.req.valid("json");
 
-    if (body.dest) {
-      const destErr = validateFilePath(body.dest);
-      if (destErr) return c.json({ error: `Invalid dest: ${destErr}` }, 400);
-    }
-
-    let result: { sender: string; filename: string; destPath: string };
-    try {
-      result = acceptPending(name, body.id, mindDir(name), body.dest);
-    } catch (err) {
-      const message = (err as Error).message;
-      if (message.includes("not found") || message.includes("Invalid pending")) {
-        return c.json({ error: message }, 404);
+      if (body.dest) {
+        const destErr = validateFilePath(body.dest);
+        if (destErr) return c.json({ error: `Invalid dest: ${destErr}` }, 400);
       }
-      return c.json({ error: `Failed to accept file: ${message}` }, 500);
-    }
 
-    // Notify sender that file was accepted
-    const notified = await notifyMind(result.sender, `[file] ${name} accepted ${result.filename}`);
+      let result: { sender: string; filename: string; destPath: string };
+      try {
+        result = acceptPending(name, body.id, mindDir(name), body.dest);
+      } catch (err) {
+        const message = (err as Error).message;
+        if (message.includes("not found") || message.includes("Invalid pending")) {
+          return c.json({ error: message }, 404);
+        }
+        return c.json({ error: `Failed to accept file: ${message}` }, 500);
+      }
 
-    return c.json({ ok: true, destPath: result.destPath, notified });
-  })
+      // Notify sender that file was accepted
+      const notified = await notifyMind(
+        result.sender,
+        `[file] ${name} accepted ${result.filename}`,
+      );
+
+      return c.json({ ok: true, destPath: result.destPath, notified });
+    },
+  )
 
   // Reject a pending file
-  .post("/:name/files/reject", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
+  .post(
+    "/:name/files/reject",
+    requireSelf(),
+    zValidator("json", z.object({ id: z.string().min(1) })),
+    async (c) => {
+      const name = c.req.param("name");
+      if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
 
-    const body = (await c.req.json()) as { id?: string };
-    if (!body.id) return c.json({ error: "id is required" }, 400);
+      const body = c.req.valid("json");
 
-    let result: { sender: string; filename: string };
-    try {
-      result = rejectPending(name, body.id);
-    } catch (err) {
-      const message = (err as Error).message;
-      if (message.includes("not found") || message.includes("Invalid pending")) {
-        return c.json({ error: message }, 404);
+      let result: { sender: string; filename: string };
+      try {
+        result = rejectPending(name, body.id);
+      } catch (err) {
+        const message = (err as Error).message;
+        if (message.includes("not found") || message.includes("Invalid pending")) {
+          return c.json({ error: message }, 404);
+        }
+        return c.json({ error: `Failed to reject file: ${message}` }, 500);
       }
-      return c.json({ error: `Failed to reject file: ${message}` }, 500);
-    }
 
-    // Notify sender that file was rejected
-    const notified = await notifyMind(result.sender, `[file] ${name} rejected ${result.filename}`);
+      // Notify sender that file was rejected
+      const notified = await notifyMind(
+        result.sender,
+        `[file] ${name} rejected ${result.filename}`,
+      );
 
-    return c.json({ ok: true, notified });
-  })
+      return c.json({ ok: true, notified });
+    },
+  )
 
   // Stage a file from an external sender (CLI user, not a mind).
   // requireSelf restricts staging into a mind's queue to that mind or an admin
   // (the CLI human-sender path uses the daemon admin token, which is allowed).
-  .post("/:name/files/stage", requireSelf(), async (c) => {
-    const receiverName = c.req.param("name");
-    const receiverEntry = await findMind(receiverName);
-    if (!receiverEntry) return c.json({ error: "Mind not found" }, 404);
+  .post(
+    "/:name/files/stage",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({
+        sender: z.string().min(1),
+        filename: z.string().min(1),
+        data: z.string().min(1),
+      }),
+    ),
+    async (c) => {
+      const receiverName = c.req.param("name");
+      const receiverEntry = await findMind(receiverName);
+      if (!receiverEntry) return c.json({ error: "Mind not found" }, 404);
 
-    const body = (await c.req.json()) as {
-      sender?: string;
-      filename?: string;
-      data?: string;
-    };
-    if (!body.sender || !body.filename || !body.data) {
-      return c.json({ error: "sender, filename, and data are required" }, 400);
-    }
+      const body = c.req.valid("json");
 
-    const pathErr = validateFilePath(body.filename);
-    if (pathErr) return c.json({ error: pathErr }, 400);
+      const pathErr = validateFilePath(body.filename);
+      if (pathErr) return c.json({ error: pathErr }, 400);
 
-    const content = Buffer.from(body.data, "base64");
-    const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
-    if (content.length > MAX_FILE_SIZE) {
-      return c.json(
-        {
-          error: `File too large (${formatFileSize(content.length)}, max ${formatFileSize(MAX_FILE_SIZE)})`,
-        },
-        413,
+      const content = Buffer.from(body.data, "base64");
+      const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+      if (content.length > MAX_FILE_SIZE) {
+        return c.json(
+          {
+            error: `File too large (${formatFileSize(content.length)}, max ${formatFileSize(MAX_FILE_SIZE)})`,
+          },
+          413,
+        );
+      }
+
+      const sizeStr = formatFileSize(content.length);
+      const { id } = stageFile(receiverName, body.sender, body.filename, content, body.filename);
+
+      // Notify receiver
+      const notified = await notifyMind(
+        receiverName,
+        `[file] ${body.sender} sent ${body.filename} (${sizeStr}) — run: volute chat accept ${id}`,
       );
-    }
 
-    const sizeStr = formatFileSize(content.length);
-    const { id } = stageFile(receiverName, body.sender, body.filename, content, body.filename);
-
-    // Notify receiver
-    const notified = await notifyMind(
-      receiverName,
-      `[file] ${body.sender} sent ${body.filename} (${sizeStr}) — run: volute chat accept ${id}`,
-    );
-
-    return c.json({ status: "pending", id, notified }, 200);
-  });
+      return c.json({ status: "pending", id, notified }, 200);
+    },
+  );
 
 export default app;

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -456,7 +456,8 @@ const app = new Hono<AuthEnv>()
       await startMindFullService(name);
       return c.json({ ok: true, port: targetPort });
     } catch (err) {
-      return c.json({ error: err instanceof Error ? err.message : "Failed to start mind" }, 500);
+      log.error(`failed to start mind ${name}`, log.errorData(err));
+      return c.json({ error: "Failed to start mind" }, 500);
     }
   })
   // Restart mind (supports variants) — admin or self
@@ -639,7 +640,7 @@ const app = new Hono<AuthEnv>()
       return c.json({ ok: true, port: targetPort });
     } catch (err) {
       log.error(`failed to restart mind ${name}`, log.errorData(err));
-      return c.json({ error: err instanceof Error ? err.message : "Failed to restart mind" }, 500);
+      return c.json({ error: "Failed to restart mind" }, 500);
     }
   })
   // Stop mind (supports variants) — admin only
@@ -659,7 +660,7 @@ const app = new Hono<AuthEnv>()
       return c.json({ ok: true });
     } catch (err) {
       log.error(`failed to stop mind ${name}`, log.errorData(err));
-      return c.json({ error: err instanceof Error ? err.message : "Failed to stop mind" }, 500);
+      return c.json({ error: "Failed to stop mind" }, 500);
     }
   })
   // Get sleep state
@@ -1164,10 +1165,8 @@ const app = new Hono<AuthEnv>()
         await abortUpgrade(mindName);
         return c.json({ ok: true });
       } catch (err) {
-        return c.json(
-          { error: err instanceof Error ? err.message : "Failed to abort upgrade" },
-          500,
-        );
+        log.error(`failed to abort upgrade for ${mindName}`, log.errorData(err));
+        return c.json({ error: "Failed to abort upgrade" }, 500);
       }
     }
 
@@ -1206,10 +1205,8 @@ const app = new Hono<AuthEnv>()
         const diff = await upgradeDiff(mindName, template);
         return c.json({ ok: true, diff: diff || "(no changes)" });
       } catch (err) {
-        return c.json(
-          { error: err instanceof Error ? err.message : "Failed to generate diff" },
-          500,
-        );
+        log.error(`failed to generate upgrade diff for ${mindName}`, log.errorData(err));
+        return c.json({ error: "Failed to generate diff" }, 500);
       }
     }
 
@@ -1232,7 +1229,8 @@ const app = new Hono<AuthEnv>()
       if (err instanceof UpgradeInProgressError) {
         return c.json({ error: err.message }, 409);
       }
-      return c.json({ error: err instanceof Error ? err.message : "Failed to merge upgrade" }, 500);
+      log.error(`failed to merge upgrade for ${mindName}`, log.errorData(err));
+      return c.json({ error: "Failed to merge upgrade" }, 500);
     }
   })
   // All conversations for a mind (across all channels)

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -14,7 +14,6 @@ import {
   latestFailureEvent,
   listEvents,
   MIND_LEVEL_THREAD,
-  type NoticeKind,
   parseMeta,
   recordNotice,
 } from "../../lib/chat/system-events.js";
@@ -302,28 +301,32 @@ const app = new Hono<AuthEnv>()
     return c.json(result.body);
   })
   // Import mind from OpenClaw workspace or .volute archive — admin only
-  .post("/import", requireAdmin, async (c) => {
-    let body: {
-      workspacePath?: string;
-      name?: string;
-      template?: string;
-      sessionPath?: string;
-      archivePath?: string;
-      manifest?: ExportManifest;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
+  .post(
+    "/import",
+    requireAdmin,
+    zValidator(
+      "json",
+      z.object({
+        workspacePath: z.string().optional(),
+        name: z.string().optional(),
+        template: z.string().optional(),
+        sessionPath: z.string().optional(),
+        archivePath: z.string().optional(),
+        // The archive manifest is validated downstream by importMindFromArchive.
+        manifest: z.custom<ExportManifest>().optional(),
+      }),
+    ),
+    async (c) => {
+      const body = c.req.valid("json");
 
-    const result =
-      body.archivePath && body.manifest
-        ? await importMindFromArchive(body.archivePath, body.name, body.manifest)
-        : await importOpenClawWorkspace(body);
-    if (!result.ok) return c.json({ error: result.error }, result.status);
-    return c.json(result.body);
-  })
+      const result =
+        body.archivePath && body.manifest
+          ? await importMindFromArchive(body.archivePath, body.name, body.manifest)
+          : await importOpenClawWorkspace(body);
+      if (!result.ok) return c.json({ error: result.error }, result.status);
+      return c.json(result.body);
+    },
+  )
   // List all minds
   .get("/", async (c) => {
     const entries = await readRegistry();
@@ -739,49 +742,57 @@ const app = new Hono<AuthEnv>()
     return c.json({ ok: true, flushed });
   })
   // Update mind profile — admin or self
-  .patch("/:name/profile", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const entry = await findMind(name);
-    if (!entry) return c.json({ error: "Mind not found" }, 404);
+  .patch(
+    "/:name/profile",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({
+        displayName: z.string().optional(),
+        description: z.string().optional(),
+        avatar: z.string().optional(),
+      }),
+    ),
+    async (c) => {
+      const name = c.req.param("name");
+      const entry = await findMind(name);
+      if (!entry) return c.json({ error: "Mind not found" }, 404);
 
-    const body = (await c.req.json()) as {
-      displayName?: string;
-      description?: string;
-      avatar?: string;
-    };
+      const body = c.req.valid("json");
 
-    const dir = entry.dir ?? mindDir(name);
-    const config = readVoluteConfig(dir) ?? {};
-    const profile = config.profile ?? {};
+      const dir = entry.dir ?? mindDir(name);
+      const config = readVoluteConfig(dir) ?? {};
+      const profile = config.profile ?? {};
 
-    if (body.displayName !== undefined) profile.displayName = body.displayName;
-    if (body.description !== undefined) profile.description = body.description;
-    // Store a home-relative path — never persist a value that escapes home/,
-    // since it's later used in filesystem operations (avatar serving/deletion).
-    if (body.avatar !== undefined) {
-      const homeDir = resolve(dir, "home");
-      const avatarPath = safeResolveWithinBase(homeDir, body.avatar);
-      if (!avatarPath) {
-        return c.json({ error: "Avatar path must be inside the mind's home directory" }, 400);
+      if (body.displayName !== undefined) profile.displayName = body.displayName;
+      if (body.description !== undefined) profile.description = body.description;
+      // Store a home-relative path — never persist a value that escapes home/,
+      // since it's later used in filesystem operations (avatar serving/deletion).
+      if (body.avatar !== undefined) {
+        const homeDir = resolve(dir, "home");
+        const avatarPath = safeResolveWithinBase(homeDir, body.avatar);
+        if (!avatarPath) {
+          return c.json({ error: "Avatar path must be inside the mind's home directory" }, 400);
+        }
+        if (!existsSync(avatarPath)) {
+          return c.json({ error: `Avatar file not found: ${relative(homeDir, avatarPath)}` }, 400);
+        }
+        profile.avatar = relative(homeDir, avatarPath);
       }
-      if (!existsSync(avatarPath)) {
-        return c.json({ error: `Avatar file not found: ${relative(homeDir, avatarPath)}` }, 400);
-      }
-      profile.avatar = relative(homeDir, avatarPath);
-    }
 
-    config.profile = profile;
-    writeVoluteConfig(dir, config);
+      config.profile = profile;
+      writeVoluteConfig(dir, config);
 
-    // Sync to users table
-    const { syncMindProfile } = await import("../../lib/auth.js");
-    await syncMindProfile(name, profile);
+      // Sync to users table
+      const { syncMindProfile } = await import("../../lib/auth.js");
+      await syncMindProfile(name, profile);
 
-    // Broadcast profile update
-    broadcast({ type: "profile_updated", mind: name, summary: `${name} profile updated` });
+      // Broadcast profile update
+      broadcast({ type: "profile_updated", mind: name, summary: `${name} profile updated` });
 
-    return c.json({ ok: true });
-  })
+      return c.json({ ok: true });
+    },
+  )
   // Start a background image-generation job. Returns a job id immediately; the
   // daemon generates, writes home/images/<filename>.png, and wakes the mind on
   // completion. requireSelf: a mind may only run jobs for itself.
@@ -1486,49 +1497,58 @@ const app = new Hono<AuthEnv>()
   // Decline an unrouted (gated) channel: stops invites and archives the held backlog.
   // The channel is passed in the body (not the path) since channel slugs can contain
   // slashes (e.g. "discord:server/general") that a path param can't carry.
-  .post("/:name/gates/decline", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const body = (await c.req.json().catch(() => ({}))) as { channel?: string };
-    const channel = body.channel?.trim();
-    if (!channel) return c.json({ error: "channel required" }, 400);
-    try {
-      const archived = await getDeliveryManager().declineChannel(name, channel);
-      return c.json({ ok: true, channel, archived });
-    } catch (err) {
-      if (err instanceof Error && err.message.includes("not initialized")) {
-        return c.json({ error: "Delivery manager not available" }, 503);
+  .post(
+    "/:name/gates/decline",
+    requireSelf(),
+    zValidator("json", z.object({ channel: z.string() })),
+    async (c) => {
+      const name = c.req.param("name");
+      const channel = c.req.valid("json").channel.trim();
+      if (!channel) return c.json({ error: "channel required" }, 400);
+      try {
+        const archived = await getDeliveryManager().declineChannel(name, channel);
+        return c.json({ ok: true, channel, archived });
+      } catch (err) {
+        if (err instanceof Error && err.message.includes("not initialized")) {
+          return c.json({ error: "Delivery manager not available" }, 503);
+        }
+        // A name that matches no real channel is caller error, not a server fault.
+        if (err instanceof UnknownChannelError) return c.json({ error: err.message }, 400);
+        log.error(`failed to decline channel ${channel} for ${name}`, log.errorData(err));
+        return c.json({ error: "Failed to decline channel" }, 500);
       }
-      // A name that matches no real channel is caller error, not a server fault.
-      if (err instanceof UnknownChannelError) return c.json({ error: err.message }, 400);
-      log.error(`failed to decline channel ${channel} for ${name}`, log.errorData(err));
-      return c.json({ error: "Failed to decline channel" }, 500);
-    }
-  })
+    },
+  )
   // Accept an unrouted (gated) channel: adds a routing rule and releases the held backlog
   // immediately. Channel is in the body for the same reason as decline (slugs contain slashes).
-  .post("/:name/gates/accept", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const body = (await c.req.json().catch(() => ({}))) as { channel?: string; thread?: string };
-    const channel = body.channel?.trim();
-    if (!channel) return c.json({ error: "channel required" }, 400);
-    // Accept writes to the mind's home directory — refuse rather than fabricate a path.
-    if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
-    try {
-      const result = await getDeliveryManager().acceptChannel(name, channel, body.thread?.trim());
-      return c.json({ ok: true, channel, ...result });
-    } catch (err) {
-      if (err instanceof Error && err.message.includes("not initialized")) {
-        return c.json({ error: "Delivery manager not available" }, 503);
+  .post(
+    "/:name/gates/accept",
+    requireSelf(),
+    zValidator("json", z.object({ channel: z.string(), thread: z.string().optional() })),
+    async (c) => {
+      const name = c.req.param("name");
+      const body = c.req.valid("json");
+      const channel = body.channel.trim();
+      if (!channel) return c.json({ error: "channel required" }, 400);
+      // Accept writes to the mind's home directory — refuse rather than fabricate a path.
+      if (!(await findMind(name))) return c.json({ error: "Mind not found" }, 404);
+      try {
+        const result = await getDeliveryManager().acceptChannel(name, channel, body.thread?.trim());
+        return c.json({ ok: true, channel, ...result });
+      } catch (err) {
+        if (err instanceof Error && err.message.includes("not initialized")) {
+          return c.json({ error: "Delivery manager not available" }, 503);
+        }
+        if (err instanceof Error && err.message.includes("malformed")) {
+          return c.json({ error: err.message }, 409);
+        }
+        // A name that matches no real channel is caller error, not a server fault.
+        if (err instanceof UnknownChannelError) return c.json({ error: err.message }, 400);
+        log.error(`failed to accept channel ${channel} for ${name}`, log.errorData(err));
+        return c.json({ error: "Failed to accept channel" }, 500);
       }
-      if (err instanceof Error && err.message.includes("malformed")) {
-        return c.json({ error: err.message }, 409);
-      }
-      // A name that matches no real channel is caller error, not a server fault.
-      if (err instanceof UnknownChannelError) return c.json({ error: err.message }, 400);
-      log.error(`failed to accept channel ${channel} for ${name}`, log.errorData(err));
-      return c.json({ error: "Failed to accept channel" }, 500);
-    }
-  })
+    },
+  )
   // Read the messages held on a gated channel, without changing anything. Gated rows have no
   // conversation, so `volute chat read` can't reach them.
   .get("/:name/gates/peek", requireSelf(), async (c) => {
@@ -1548,51 +1568,62 @@ const app = new Hono<AuthEnv>()
     }
   })
   // AI completion proxy for minds
-  .post("/:name/ai/complete", requireSelf(), async (c) => {
-    const body = (await c.req.json()) as { systemPrompt: string; message: string; model?: string };
-    if (!body.systemPrompt || !body.message) {
-      return c.json({ error: "systemPrompt and message required" }, 400);
-    }
-    const { aiComplete: aiCompleteFn, isAiConfigured } = await import("../../lib/ai-service.js");
-    if (!isAiConfigured()) {
-      return c.json({ error: "AI service not configured" }, 503);
-    }
-    const text = await aiCompleteFn(body.systemPrompt, body.message, body.model);
-    if (text == null) {
-      return c.json({ error: "AI completion failed" }, 502);
-    }
-    return c.json({ text });
-  })
+  .post(
+    "/:name/ai/complete",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({ systemPrompt: z.string(), message: z.string(), model: z.string().optional() }),
+    ),
+    async (c) => {
+      const body = c.req.valid("json");
+      if (!body.systemPrompt || !body.message) {
+        return c.json({ error: "systemPrompt and message required" }, 400);
+      }
+      const { aiComplete: aiCompleteFn, isAiConfigured } = await import("../../lib/ai-service.js");
+      if (!isAiConfigured()) {
+        return c.json({ error: "AI service not configured" }, 503);
+      }
+      const text = await aiCompleteFn(body.systemPrompt, body.message, body.model);
+      if (text == null) {
+        return c.json({ error: "AI completion failed" }, 502);
+      }
+      return c.json({ text });
+    },
+  )
   // Receive events from mind, persist to mind_history, publish to pub-sub
-  .post("/:name/events", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const baseName = await getBaseName(name);
+  .post(
+    "/:name/events",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({
+        type: z.string(),
+        session: z.string().optional(),
+        channel: z.string().optional(),
+        messageId: z.string().optional(),
+        content: z.string().optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      }),
+    ),
+    async (c) => {
+      const name = c.req.param("name");
+      const baseName = await getBaseName(name);
 
-    let body: {
-      type: string;
-      session?: string;
-      channel?: string;
-      messageId?: string;
-      content?: string;
-      metadata?: Record<string, unknown>;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
+      const body = c.req.valid("json");
 
-    if (!body.type) {
-      return c.json({ error: "type required" }, 400);
-    }
-    if (DAEMON_AUTHORED_TYPES.has(body.type)) {
-      return c.json({ error: `type "${body.type}" is daemon-authored` }, 400);
-    }
+      if (!body.type) {
+        return c.json({ error: "type required" }, 400);
+      }
+      if (DAEMON_AUTHORED_TYPES.has(body.type)) {
+        return c.json({ error: `type "${body.type}" is daemon-authored` }, 400);
+      }
 
-    await handleMindEvent(baseName, body);
+      await handleMindEvent(baseName, body);
 
-    return c.json({ ok: true });
-  })
+      return c.json({ ok: true });
+    },
+  )
   // SSE endpoint for mind events
   .get("/:name/events", requireSelf(), async (c) => {
     const name = c.req.param("name");
@@ -1660,43 +1691,46 @@ const app = new Hono<AuthEnv>()
     });
   })
   // Persist external channel send to mind_history
-  .post("/:name/history", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const baseName = await getBaseName(name);
+  .post(
+    "/:name/history",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({ channel: z.string(), content: z.string(), sender: z.string().optional() }),
+    ),
+    async (c) => {
+      const name = c.req.param("name");
+      const baseName = await getBaseName(name);
 
-    let body: { channel: string; content: string; sender?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
+      const body = c.req.valid("json");
 
-    if (!body.channel || !body.content) {
-      return c.json({ error: "channel and content required" }, 400);
-    }
+      if (!body.channel || !body.content) {
+        return c.json({ error: "channel and content required" }, 400);
+      }
 
-    // Best-effort turn lookup for external bridge sends (these don't go through
-    // volute chat send, so they won't have tool_result correlation markers).
-    const mindSession = c.get("mindSession");
-    const outboundTurnId = getActiveTurnId(baseName, mindSession);
+      // Best-effort turn lookup for external bridge sends (these don't go through
+      // volute chat send, so they won't have tool_result correlation markers).
+      const mindSession = c.get("mindSession");
+      const outboundTurnId = getActiveTurnId(baseName, mindSession);
 
-    const db = await getDb();
-    try {
-      await db.insert(mindHistory).values({
-        mind: baseName,
-        type: "outbound",
-        channel: body.channel,
-        sender: body.sender ?? baseName,
-        content: body.content,
-        turn_id: outboundTurnId ?? null,
-      });
-    } catch (err) {
-      log.error(`failed to persist external send for ${baseName}`, log.errorData(err));
-      return c.json({ error: "Failed to persist" }, 500);
-    }
+      const db = await getDb();
+      try {
+        await db.insert(mindHistory).values({
+          mind: baseName,
+          type: "outbound",
+          channel: body.channel,
+          sender: body.sender ?? baseName,
+          content: body.content,
+          turn_id: outboundTurnId ?? null,
+        });
+      } catch (err) {
+        log.error(`failed to persist external send for ${baseName}`, log.errorData(err));
+        return c.json({ error: "Failed to persist" }, 500);
+      }
 
-    return c.json({ ok: true });
-  })
+      return c.json({ ok: true });
+    },
+  )
   // Get sessions summary
   .get("/:name/history/sessions", requireSelf(), async (c) => {
     const name = c.req.param("name");
@@ -1929,38 +1963,40 @@ const app = new Hono<AuthEnv>()
   // latestFailureEvent (the host's "last turn failed" surface) and budget becomes a
   // budget event — daemon-authored semantics a mind must not be able to forge about
   // itself (mirrors the DAEMON_AUTHORED_TYPES guard on POST /:name/events).
-  .post("/:name/notices", requireSelf(), async (c) => {
-    const MIND_POSTABLE_KINDS: NoticeKind[] = ["context_lost", "delivery_failed"];
-    const name = c.req.param("name");
-    const baseName = await getBaseName(name);
+  .post(
+    "/:name/notices",
+    requireSelf(),
+    // Deliberately narrower than NOTICE_KINDS: only these two are mind-postable
+    // (see the route comment) — the enum enforces that a mind can't forge a
+    // daemon-authored kind about itself.
+    zValidator(
+      "json",
+      z.object({
+        kind: z.enum(["context_lost", "delivery_failed"]),
+        message: z.string(),
+        thread: z.string().optional(),
+      }),
+    ),
+    async (c) => {
+      const name = c.req.param("name");
+      const baseName = await getBaseName(name);
 
-    let body: { thread?: unknown; kind?: unknown; message?: unknown };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const kind = body.kind;
-    if (typeof kind !== "string" || !(MIND_POSTABLE_KINDS as string[]).includes(kind)) {
-      return c.json({ error: `kind must be one of: ${MIND_POSTABLE_KINDS.join(", ")}` }, 400);
-    }
-    const message = typeof body.message === "string" ? body.message.trim() : "";
-    if (!message) return c.json({ error: "message is required" }, 400);
-    if (body.thread !== undefined && typeof body.thread !== "string") {
-      return c.json({ error: "thread must be a string" }, 400);
-    }
+      const body = c.req.valid("json");
+      const message = body.message.trim();
+      if (!message) return c.json({ error: "message is required" }, 400);
 
-    await recordNotice({
-      mind: baseName,
-      thread: (body.thread as string | undefined) ?? MIND_LEVEL_THREAD,
-      kind: kind as NoticeKind,
-      reason: kind,
-      // Bound the size (the body is injected into turn context) without dropping
-      // the notice — a truncated explanation beats a silent 400.
-      detail: message.length > 4000 ? `${message.slice(0, 4000)}…` : message,
-    });
-    return c.json({ ok: true });
-  })
+      await recordNotice({
+        mind: baseName,
+        thread: body.thread ?? MIND_LEVEL_THREAD,
+        kind: body.kind,
+        reason: body.kind,
+        // Bound the size (the body is injected into turn context) without dropping
+        // the notice — a truncated explanation beats a silent 400.
+        detail: message.length > 4000 ? `${message.slice(0, 4000)}…` : message,
+      });
+      return c.json({ ok: true });
+    },
+  )
   // List system events for a mind (schedule fires, wake summaries, lifecycle, notices…)
   // with their reflections. Self-or-admin only. Named /system-events because
   // GET /:name/events is the live SSE stream above.
@@ -1989,48 +2025,44 @@ const app = new Hono<AuthEnv>()
     });
   })
   // Supersede provisional turn summaries with the mind's own words. Self-or-admin only.
-  .put("/:name/turn-summaries", requireSelf(), async (c) => {
-    const name = c.req.param("name");
-    const baseName = await getBaseName(name);
+  .put(
+    "/:name/turn-summaries",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({
+        summaries: z
+          .array(z.object({ turnId: z.string().min(1), content: z.string() }))
+          .min(1, "summaries must be a non-empty array"),
+      }),
+    ),
+    async (c) => {
+      const name = c.req.param("name");
+      const baseName = await getBaseName(name);
 
-    let body: { summaries?: Array<{ turnId?: string; content?: string }> };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
+      const items = c.req.valid("json").summaries;
 
-    const items = body.summaries;
-    if (!Array.isArray(items) || items.length === 0) {
-      return c.json({ error: "summaries must be a non-empty array" }, 400);
-    }
-
-    let updated = 0;
-    let created = 0;
-    for (const item of items) {
-      if (!item || typeof item.turnId !== "string" || !item.turnId) {
-        return c.json({ error: "each summary needs a turnId" }, 400);
+      let updated = 0;
+      let created = 0;
+      for (const item of items) {
+        const result = await supersedeTurnSummary(baseName, item.turnId, item.content);
+        switch (result.status) {
+          case "invalid":
+            return c.json({ error: result.error }, 400);
+          case "not_found":
+            return c.json({ error: "Turn not found" }, 404);
+          case "forbidden":
+            return c.json({ error: "Forbidden" }, 403);
+          case "ok":
+            if (result.created) created++;
+            else updated++;
+            break;
+        }
       }
-      if (typeof item.content !== "string") {
-        return c.json({ error: "each summary needs content" }, 400);
-      }
-      const result = await supersedeTurnSummary(baseName, item.turnId, item.content);
-      switch (result.status) {
-        case "invalid":
-          return c.json({ error: result.error }, 400);
-        case "not_found":
-          return c.json({ error: "Turn not found" }, 404);
-        case "forbidden":
-          return c.json({ error: "Forbidden" }, 403);
-        case "ok":
-          if (result.created) created++;
-          else updated++;
-          break;
-      }
-    }
 
-    return c.json({ ok: true, updated, created });
-  })
+      return c.json({ ok: true, updated, created });
+    },
+  )
   .get("/:name/history", requireSelf(), async (c) => {
     const name = c.req.param("name");
     const channel = c.req.query("channel");

--- a/packages/daemon/src/web/api/minds.ts
+++ b/packages/daemon/src/web/api/minds.ts
@@ -90,7 +90,7 @@ import { collectTurnContext } from "../../lib/turn-context.js";
 import { checkHealth } from "../../lib/util/health.js";
 import log from "../../lib/util/logger.js";
 import { safeResolveWithinBase } from "../../lib/util/paths.js";
-import { parseIntParam } from "../../lib/util/query-params.js";
+import { cursorParamsSchema, cursorResponse } from "../../lib/util/query-params.js";
 import { parseDbTimestamp } from "../../lib/util/time.js";
 import { fireWebhook } from "../../lib/webhook.js";
 import {
@@ -1252,47 +1252,42 @@ const app = new Hono<AuthEnv>()
     return c.json(filtered);
   })
   // Read messages from a mind's conversation (privacy-enforced)
-  .get("/:name/conversations/:convId/messages", async (c) => {
-    const name = c.req.param("name");
-    const convId = c.req.param("convId");
-    const entry = await findMind(name);
-    if (!entry) return c.json({ error: "Mind not found" }, 404);
-    // Verify conversation belongs to this mind
-    const belongs = await isConversationForMind(name, convId);
-    if (!belongs) {
-      return c.json({ error: "Conversation not found" }, 404);
-    }
-    // Enforce privacy: if conversation is private, require participant or admin
-    const conv = await getConversation(convId);
-    if (!conv) {
-      return c.json({ error: "Conversation not found" }, 404);
-    }
-    if (conv.private === 1) {
-      const user = c.get("user");
-      if (user.role !== "admin") {
-        const participant = await isParticipant(convId, user.id);
-        if (!participant) {
-          return c.json({ error: "This is a private conversation" }, 403);
+  .get(
+    "/:name/conversations/:convId/messages",
+    zValidator("query", cursorParamsSchema),
+    async (c) => {
+      const name = c.req.param("name");
+      const convId = c.req.param("convId");
+      const entry = await findMind(name);
+      if (!entry) return c.json({ error: "Mind not found" }, 404);
+      // Verify conversation belongs to this mind
+      const belongs = await isConversationForMind(name, convId);
+      if (!belongs) {
+        return c.json({ error: "Conversation not found" }, 404);
+      }
+      // Enforce privacy: if conversation is private, require participant or admin
+      const conv = await getConversation(convId);
+      if (!conv) {
+        return c.json({ error: "Conversation not found" }, 404);
+      }
+      if (conv.private === 1) {
+        const user = c.get("user");
+        if (user.role !== "admin") {
+          const participant = await isParticipant(convId, user.id);
+          if (!participant) {
+            return c.json({ error: "This is a private conversation" }, 403);
+          }
         }
       }
-    }
-    const beforeStr = c.req.query("before");
-    const limitStr = c.req.query("limit");
-    if (!beforeStr && !limitStr) {
-      const msgs = await getMessages(convId);
-      return c.json({ items: await withSenderDisplayNames(msgs), hasMore: false });
-    }
-    const before = parseIntParam(beforeStr);
-    const limit = parseIntParam(limitStr);
-    if (before === null || limit === null) {
-      return c.json({ error: "Invalid pagination parameters" }, 400);
-    }
-    const result = await getMessagesPaginated(convId, { before, limit });
-    return c.json({
-      items: await withSenderDisplayNames(result.messages),
-      hasMore: result.hasMore,
-    });
-  })
+      const { before, limit } = c.req.valid("query");
+      if (before === undefined && limit === undefined) {
+        const msgs = await getMessages(convId);
+        return c.json(cursorResponse(await withSenderDisplayNames(msgs), false));
+      }
+      const result = await getMessagesPaginated(convId, { before, limit });
+      return c.json(cursorResponse(await withSenderDisplayNames(result.messages), result.hasMore));
+    },
+  )
   // Budget status
   .get("/:name/budget", requireSelf(), async (c) => {
     const name = c.req.param("name");

--- a/packages/daemon/src/web/api/schedules.ts
+++ b/packages/daemon/src/web/api/schedules.ts
@@ -1,5 +1,7 @@
+import { zValidator } from "@hono/zod-validator";
 import { CronExpressionParser } from "cron-parser";
 import { Hono } from "hono";
+import { z } from "zod";
 import { getScheduler } from "../../lib/daemon/scheduler.js";
 import { getSleepManagerIfReady } from "../../lib/daemon/sleep-manager.js";
 import { upsertEventRule } from "../../lib/mind/event-routes.js";
@@ -14,6 +16,35 @@ import { fireWebhook } from "../../lib/webhook.js";
 import { type AuthEnv, requireSelf } from "../middleware/auth.js";
 
 const slog = log.child("schedules");
+
+// Validates the body shape only (types + the whileSleeping enum). Every cross-field
+// rule (cron/fireAt mutual exclusion, cron parse, fireAt date, action-required,
+// non-empty messages) stays in the handler, so the accepted set is unchanged for
+// valid input — malformed *types* now 400 structurally instead of flowing through.
+const scheduleBodySchema = z.object({
+  id: z.string().optional(),
+  cron: z.string().optional(),
+  fireAt: z.string().optional(),
+  message: z.string().optional(),
+  messages: z.array(z.string()).optional(),
+  script: z.string().optional(),
+  enabled: z.boolean().optional(),
+  whileSleeping: z.enum(["skip", "queue", "trigger-wake"]).optional(),
+  thread: z.string().optional(),
+});
+
+const sleepConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+  schedule: z.object({ sleep: z.string(), wake: z.string() }).optional(),
+  wakeTriggers: z
+    .object({
+      mentions: z.boolean().optional(),
+      dms: z.boolean().optional(),
+      channels: z.array(z.string()).optional(),
+      senders: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
 
 function readSchedules(dir: string): Schedule[] {
   return readVoluteConfig(dir)?.schedules ?? [];
@@ -195,21 +226,12 @@ const app = new Hono<AuthEnv>()
     return c.json(config?.sleep ?? { enabled: false });
   })
   // Update sleep config
-  .put("/:name/sleep/config", requireSelf(), async (c) => {
+  .put("/:name/sleep/config", requireSelf(), zValidator("json", sleepConfigSchema), async (c) => {
     const name = c.req.param("name");
     const entry = await findMind(name);
     if (!entry) return c.json({ error: "Mind not found" }, 404);
 
-    const body = (await c.req.json()) as {
-      enabled?: boolean;
-      schedule?: { sleep: string; wake: string };
-      wakeTriggers?: {
-        mentions?: boolean;
-        dms?: boolean;
-        channels?: string[];
-        senders?: string[];
-      };
-    };
+    const body = c.req.valid("json");
 
     // Validate cron expressions if provided
     if (body.schedule) {
@@ -247,14 +269,14 @@ const app = new Hono<AuthEnv>()
     return c.json(readSchedules(entry.dir ?? mindDir(name)));
   })
   // Add schedule
-  .post("/:name/schedules", requireSelf(), async (c) => {
+  .post("/:name/schedules", requireSelf(), zValidator("json", scheduleBodySchema), async (c) => {
     const name = c.req.param("name");
     const entry = await findMind(name);
     if (!entry) return c.json({ error: "Mind not found" }, 404);
     if (entry.stage === "seed")
       return c.json({ error: "Seed minds cannot use schedules — sprout first" }, 403);
 
-    const body = (await c.req.json()) as Partial<Schedule>;
+    const body = c.req.valid("json");
     if (!body.id) {
       return c.json({ error: "id is required (a descriptive name for this schedule)" }, 400);
     }
@@ -283,14 +305,6 @@ const app = new Hono<AuthEnv>()
     if (body.fireAt && Number.isNaN(new Date(body.fireAt).getTime())) {
       return c.json({ error: `Invalid fireAt date: ${body.fireAt}` }, 400);
     }
-    if (body.whileSleeping && !["skip", "queue", "trigger-wake"].includes(body.whileSleeping)) {
-      return c.json(
-        {
-          error: `Invalid whileSleeping value: ${body.whileSleeping} (must be skip, queue, or trigger-wake)`,
-        },
-        400,
-      );
-    }
 
     const dir = entry.dir ?? mindDir(name);
     const schedules = readSchedules(dir);
@@ -315,7 +329,7 @@ const app = new Hono<AuthEnv>()
     return c.json({ ok: true, id }, 201);
   })
   // Update schedule
-  .put("/:name/schedules/:id", requireSelf(), async (c) => {
+  .put("/:name/schedules/:id", requireSelf(), zValidator("json", scheduleBodySchema), async (c) => {
     const name = c.req.param("name");
     const id = c.req.param("id");
     const entry = await findMind(name);
@@ -326,7 +340,7 @@ const app = new Hono<AuthEnv>()
     const idx = schedules.findIndex((s) => s.id === id);
     if (idx === -1) return c.json({ error: "Schedule not found" }, 404);
 
-    const body = (await c.req.json()) as Partial<Schedule>;
+    const body = c.req.valid("json");
     const messagesErr = validateMessages(body.messages);
     if (messagesErr) return c.json({ error: messagesErr }, 400);
     if ([body.message, body.messages?.length, body.script].filter(Boolean).length > 1) {
@@ -366,14 +380,6 @@ const app = new Hono<AuthEnv>()
       schedules[idx].script = body.script;
       delete schedules[idx].message;
       delete schedules[idx].messages;
-    }
-    if (body.whileSleeping && !["skip", "queue", "trigger-wake"].includes(body.whileSleeping)) {
-      return c.json(
-        {
-          error: `Invalid whileSleeping value: ${body.whileSleeping} (must be skip, queue, or trigger-wake)`,
-        },
-        400,
-      );
     }
     if (body.enabled !== undefined) schedules[idx].enabled = body.enabled;
     // `--thread` writes/updates a routes.json event rule (#736); an empty value clears it.

--- a/packages/daemon/src/web/api/setup.ts
+++ b/packages/daemon/src/web/api/setup.ts
@@ -1,8 +1,10 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, resolve } from "node:path";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
+import { z } from "zod";
 import {
   type GlobalConfig,
   getSpiritName,
@@ -23,6 +25,36 @@ import log from "../../lib/util/logger.js";
 import { createSession, SESSION_MAX_AGE } from "../middleware/auth.js";
 
 const DEFAULT_API_URL = "https://volute.systems";
+
+// Schemas enforce the declared body types; the semantic checks each route already
+// runs (non-empty-after-trim, spirit-name validation, avatar format) stay inline so
+// the accepted set for valid input is unchanged — only malformed bodies now 400
+// structurally instead of throwing (which surfaced as a 500) or flowing through.
+const systemBodySchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  remote: z.boolean().optional(),
+  service: z.boolean().optional(),
+  tailscale: z.boolean().optional(),
+});
+const registerBodySchema = z.object({ slug: z.string() });
+const loginBodySchema = z.object({ key: z.string() });
+const accountBodySchema = z.object({
+  username: z.string(),
+  password: z.string(),
+  displayName: z.string().optional(),
+});
+const modelsBodySchema = z.object({
+  models: z.array(z.string()),
+  spiritModel: z.string(),
+  utilityModel: z.string().optional(),
+});
+const spiritBodySchema = z.object({
+  name: z.string(),
+  temperament: z.string().optional(),
+  description: z.string().optional(),
+  avatar: z.string().optional(),
+});
 
 const setup = new Hono();
 
@@ -91,25 +123,14 @@ setup.get("/status", async (c) => {
 });
 
 // Step 1: Configure system (name + description + remote access)
-setup.post("/system", async (c) => {
+setup.post("/system", zValidator("json", systemBodySchema), async (c) => {
   if (isSetupComplete()) {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: {
-    name: string;
-    description?: string;
-    remote?: boolean;
-    service?: boolean;
-    tailscale?: boolean;
-  };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
-  }
+  const body = c.req.valid("json");
 
-  if (!body.name?.trim()) {
+  if (!body.name.trim()) {
     return c.json({ error: "System name is required" }, 400);
   }
 
@@ -151,19 +172,14 @@ setup.post("/system", async (c) => {
 });
 
 // Register with volute.systems during setup
-setup.post("/system/register", async (c) => {
+setup.post("/system/register", zValidator("json", registerBodySchema), async (c) => {
   if (isSetupComplete()) {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: { slug: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
-  }
+  const body = c.req.valid("json");
 
-  if (!body.slug?.trim()) {
+  if (!body.slug.trim()) {
     return c.json({ error: "System slug is required" }, 400);
   }
 
@@ -214,19 +230,14 @@ setup.post("/system/register", async (c) => {
 });
 
 // Login to volute.systems with existing API key during setup
-setup.post("/system/login", async (c) => {
+setup.post("/system/login", zValidator("json", loginBodySchema), async (c) => {
   if (isSetupComplete()) {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: { key: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
-  }
+  const body = c.req.valid("json");
 
-  if (!body.key?.trim()) {
+  if (!body.key.trim()) {
     return c.json({ error: "API key is required" }, 400);
   }
 
@@ -283,23 +294,14 @@ setup.get("/system/systems-status", (c) => {
 });
 
 // Step 2: Create account (user only, system already configured)
-setup.post("/account", async (c) => {
+setup.post("/account", zValidator("json", accountBodySchema), async (c) => {
   if (isSetupComplete()) {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: {
-    username: string;
-    password: string;
-    displayName?: string;
-  };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
-  }
+  const body = c.req.valid("json");
 
-  if (!body.username?.trim()) {
+  if (!body.username.trim()) {
     return c.json({ error: "Username is required" }, 400);
   }
   if (!body.password || body.password.length < 1) {
@@ -354,22 +356,17 @@ setup.post("/account", async (c) => {
 });
 
 // Step 3: Configure models
-setup.post("/models", async (c) => {
+setup.post("/models", zValidator("json", modelsBodySchema), async (c) => {
   if (isSetupComplete()) {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: { models: string[]; spiritModel: string; utilityModel?: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
-  }
+  const body = c.req.valid("json");
 
-  if (!Array.isArray(body.models) || body.models.length === 0) {
+  if (body.models.length === 0) {
     return c.json({ error: "At least one model must be selected" }, 400);
   }
-  if (!body.spiritModel?.trim()) {
+  if (!body.spiritModel.trim()) {
     return c.json({ error: "Spirit model is required" }, 400);
   }
 
@@ -395,19 +392,14 @@ setup.post("/models", async (c) => {
 });
 
 // Step 4: Name the spirit
-setup.post("/spirit", async (c) => {
+setup.post("/spirit", zValidator("json", spiritBodySchema), async (c) => {
   if (isSetupComplete()) {
     return c.json({ error: "Setup already complete" }, 400);
   }
 
-  let body: { name: string; temperament?: string; description?: string; avatar?: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid JSON in request body" }, 400);
-  }
+  const body = c.req.valid("json");
 
-  const name = body.name?.trim() ?? "";
+  const name = body.name.trim();
   const nameErr = validateSpiritName(name);
   if (nameErr) {
     return c.json({ error: nameErr }, 400);

--- a/packages/daemon/src/web/api/skills.ts
+++ b/packages/daemon/src/web/api/skills.ts
@@ -1,8 +1,10 @@
 import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { zValidator } from "@hono/zod-validator";
 import AdmZip from "adm-zip";
 import { Hono } from "hono";
+import { z } from "zod";
 import { readGlobalConfig, writeGlobalConfig } from "../../lib/config/setup.js";
 import { getExtensionStandardSkills } from "../../lib/extensions.js";
 import {
@@ -27,42 +29,46 @@ const app = new Hono<AuthEnv>()
   .get("/defaults/list", async (c) => {
     return c.json({ skills: getStandardSkillsWithExtensions() });
   })
-  .put("/defaults/list", requireAdmin, async (c) => {
-    const body = await c.req.json<{ skills: string[] }>();
-    if (!Array.isArray(body.skills) || !body.skills.every((s) => typeof s === "string")) {
-      return c.json({ error: "body.skills must be a string array" }, 400);
-    }
-    const config = readGlobalConfig();
-    // Track which standard/extension skills were explicitly removed
-    const allStandard = new Set([...STANDARD_SKILLS, ...getExtensionStandardSkills()]);
-    const newSet = new Set(body.skills);
-    const removed = [...allStandard].filter((s) => !newSet.has(s));
-    const prevRemoved = new Set(config.removedDefaultSkills ?? []);
-    for (const s of removed) prevRemoved.add(s);
-    // Re-added skills should be cleared from the removed list
-    for (const s of body.skills) prevRemoved.delete(s);
-    writeGlobalConfig({
-      ...config,
-      defaultSkills: body.skills,
-      removedDefaultSkills: [...prevRemoved],
-    });
-    return c.json({ skills: body.skills });
-  })
-  .post("/defaults/list", requireAdmin, async (c) => {
-    const body = await c.req.json<{ skill: string }>();
-    if (typeof body.skill !== "string" || !body.skill) {
-      return c.json({ error: "body.skill must be a non-empty string" }, 400);
-    }
-    const current = getStandardSkillsWithExtensions();
-    if (current.includes(body.skill)) {
-      return c.json({ error: `"${body.skill}" is already a default skill` }, 409);
-    }
-    const config = readGlobalConfig();
-    const updated = [...current, body.skill];
-    const removed = (config.removedDefaultSkills ?? []).filter((s) => s !== body.skill);
-    writeGlobalConfig({ ...config, defaultSkills: updated, removedDefaultSkills: removed });
-    return c.json({ skills: updated });
-  })
+  .put(
+    "/defaults/list",
+    requireAdmin,
+    zValidator("json", z.object({ skills: z.array(z.string()) })),
+    async (c) => {
+      const body = c.req.valid("json");
+      const config = readGlobalConfig();
+      // Track which standard/extension skills were explicitly removed
+      const allStandard = new Set([...STANDARD_SKILLS, ...getExtensionStandardSkills()]);
+      const newSet = new Set(body.skills);
+      const removed = [...allStandard].filter((s) => !newSet.has(s));
+      const prevRemoved = new Set(config.removedDefaultSkills ?? []);
+      for (const s of removed) prevRemoved.add(s);
+      // Re-added skills should be cleared from the removed list
+      for (const s of body.skills) prevRemoved.delete(s);
+      writeGlobalConfig({
+        ...config,
+        defaultSkills: body.skills,
+        removedDefaultSkills: [...prevRemoved],
+      });
+      return c.json({ skills: body.skills });
+    },
+  )
+  .post(
+    "/defaults/list",
+    requireAdmin,
+    zValidator("json", z.object({ skill: z.string().min(1) })),
+    async (c) => {
+      const body = c.req.valid("json");
+      const current = getStandardSkillsWithExtensions();
+      if (current.includes(body.skill)) {
+        return c.json({ error: `"${body.skill}" is already a default skill` }, 409);
+      }
+      const config = readGlobalConfig();
+      const updated = [...current, body.skill];
+      const removed = (config.removedDefaultSkills ?? []).filter((s) => s !== body.skill);
+      writeGlobalConfig({ ...config, defaultSkills: updated, removedDefaultSkills: removed });
+      return c.json({ skills: updated });
+    },
+  )
   .delete("/defaults/list/:skill", requireAdmin, async (c) => {
     const skill = c.req.param("skill");
     const current = getStandardSkillsWithExtensions();
@@ -79,15 +85,17 @@ const app = new Hono<AuthEnv>()
   .get("/auto-update", (c) => {
     return c.json({ enabled: isAutoUpdateSkillsEnabled() });
   })
-  .put("/auto-update", requireAdmin, async (c) => {
-    const body = await c.req.json<{ enabled: boolean }>();
-    if (typeof body.enabled !== "boolean") {
-      return c.json({ error: "body.enabled must be a boolean" }, 400);
-    }
-    const config = readGlobalConfig();
-    writeGlobalConfig({ ...config, autoUpdateSkills: body.enabled });
-    return c.json({ enabled: body.enabled });
-  })
+  .put(
+    "/auto-update",
+    requireAdmin,
+    zValidator("json", z.object({ enabled: z.boolean() })),
+    async (c) => {
+      const { enabled } = c.req.valid("json");
+      const config = readGlobalConfig();
+      writeGlobalConfig({ ...config, autoUpdateSkills: enabled });
+      return c.json({ enabled });
+    },
+  )
   .post("/upload", requireAdmin, async (c) => {
     const body = await c.req.parseBody();
     const file = body.file;

--- a/packages/daemon/src/web/api/v1/conversations.ts
+++ b/packages/daemon/src/web/api/v1/conversations.ts
@@ -53,7 +53,7 @@ const app = new Hono<AuthEnv>()
     const id = c.req.param("id");
     const user = c.get("user");
     // Non-private conversations are readable by any authenticated user — deliberate;
-    // powers the home feed transcript modal (mirrors GET /api/minds/:name/
+    // powers the home feed transcript modal (mirrors GET /api/v1/minds/:name/
     // conversations/:convId/messages, AUTHZ_EXEMPT). Private conversations stay
     // scoped to participants (or admin/system).
     if (!(await canReadConversation(id, user))) {

--- a/packages/daemon/src/web/api/v1/conversations.ts
+++ b/packages/daemon/src/web/api/v1/conversations.ts
@@ -18,7 +18,7 @@ import {
   setConversationPrivate,
 } from "../../../lib/events/conversations.js";
 import { findMind } from "../../../lib/mind/registry.js";
-import { parseIntParam } from "../../../lib/util/query-params.js";
+import { cursorParamsSchema, cursorResponse } from "../../../lib/util/query-params.js";
 import { type AuthEnv, authMiddleware } from "../../middleware/auth.js";
 
 const createSchema = z.object({
@@ -49,7 +49,7 @@ const app = new Hono<AuthEnv>()
     const convs = await listConversationsWithParticipants(user.id);
     return c.json(convs);
   })
-  .get("/:id/messages", async (c) => {
+  .get("/:id/messages", zValidator("query", cursorParamsSchema), async (c) => {
     const id = c.req.param("id");
     const user = c.get("user");
     // Non-private conversations are readable by any authenticated user — deliberate;
@@ -60,14 +60,9 @@ const app = new Hono<AuthEnv>()
       return c.json({ error: "Conversation not found" }, 404);
     }
 
-    const before = parseIntParam(c.req.query("before"));
-    const limit = parseIntParam(c.req.query("limit"));
-    if (before === null || limit === null) {
-      return c.json({ error: "Invalid cursor params: before and limit must be integers" }, 400);
-    }
-
+    const { before, limit } = c.req.valid("query");
     const result = await getMessagesPaginated(id, { before, limit });
-    return c.json({ items: result.messages, hasMore: result.hasMore });
+    return c.json(cursorResponse(result.messages, result.hasMore));
   })
   .get("/:id/participants", async (c) => {
     const id = c.req.param("id");

--- a/packages/daemon/src/web/api/v1/feed.ts
+++ b/packages/daemon/src/web/api/v1/feed.ts
@@ -18,7 +18,7 @@ const app = new Hono<AuthEnv>()
   .use("*", authMiddleware)
   // The home feed. Any authenticated principal — including minds — sees bursts of
   // NON-private conversations plus whitelisted lifecycle events. This transparency
-  // is deliberate (mirrors GET /api/minds/:name/conversations/:convId/messages).
+  // is deliberate (mirrors GET /api/v1/minds/:name/conversations/:convId/messages).
   // Private conversations never appear; mind_error detail is redacted for
   // non-admin/system callers (#503).
   .get("/", async (c) => {

--- a/packages/daemon/src/web/api/variants.ts
+++ b/packages/daemon/src/web/api/variants.ts
@@ -1,4 +1,6 @@
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod";
 import { getOrCreateMindUser } from "../../lib/auth.js";
 import { deliverEvent } from "../../lib/chat/system-events.js";
 import { getMindManager, tryGetMindManager } from "../../lib/daemon/mind-manager.js";
@@ -75,63 +77,69 @@ const app = new Hono<AuthEnv>()
     return c.json(results);
   })
   // Create variant — admin only
-  .post("/:name/variants", requireSelf(), async (c) => {
-    const mindName = c.req.param("name");
-    const entry = await findMind(mindName);
-    if (!entry) return c.json({ error: "Mind not found" }, 404);
-    if (entry.stage === "seed")
-      return c.json({ error: "Seed minds cannot create variants — sprout first" }, 403);
-    if (entry.parent)
-      return c.json(
-        { error: "Cannot split from a variant — split from the base mind instead" },
-        403,
+  .post(
+    "/:name/variants",
+    requireSelf(),
+    zValidator(
+      "json",
+      z.object({
+        name: z.string().min(1),
+        soul: z.string().optional(),
+        port: z.number().optional(),
+        noStart: z.boolean().optional(),
+        purpose: z.string().optional(),
+      }),
+    ),
+    async (c) => {
+      const mindName = c.req.param("name");
+      const entry = await findMind(mindName);
+      if (!entry) return c.json({ error: "Mind not found" }, 404);
+      if (entry.stage === "seed")
+        return c.json({ error: "Seed minds cannot create variants — sprout first" }, 403);
+      if (entry.parent)
+        return c.json(
+          { error: "Cannot split from a variant — split from the base mind instead" },
+          403,
+        );
+
+      const body = c.req.valid("json");
+      const variantName = body.name;
+      const purpose = body.purpose?.trim() || undefined;
+
+      const err = validateBranchName(variantName);
+      if (err) return c.json({ error: err }, 400);
+
+      // Check name isn't already taken
+      if (await findMind(variantName)) {
+        return c.json({ error: `Name already in use: ${variantName}` }, 409);
+      }
+
+      const projectRoot = entry.dir ?? mindDir(mindName);
+
+      const result = await createVariant({
+        parentName: mindName,
+        projectRoot,
+        variantName,
+        soul: body.soul,
+        port: body.port,
+        noStart: body.noStart,
+        purpose,
+      });
+      if (!result.ok) return c.json({ error: result.error }, result.status);
+
+      // The split has now cleared every rollback point. Establish the parent↔variant
+      // relationship as a conversation: open a DM the two can talk in during the
+      // variant's life, and tell the parent it has a variant to check in on. Placed
+      // after the last rollback so a failed split never strands a DM or a stale notice.
+      // Best-effort, but logged at error level — a silent failure means the dialogue
+      // this feature exists for never happens.
+      await establishVariantDialogue(mindName, variantName, purpose).catch((e: unknown) =>
+        log.error(`failed to establish variant dialogue for ${variantName}`, log.errorData(e)),
       );
 
-    let body: { name: string; soul?: string; port?: number; noStart?: boolean; purpose?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
-
-    const variantName = body.name;
-    if (!variantName) return c.json({ error: "Variant name required" }, 400);
-
-    const purpose = body.purpose?.trim() || undefined;
-
-    const err = validateBranchName(variantName);
-    if (err) return c.json({ error: err }, 400);
-
-    // Check name isn't already taken
-    if (await findMind(variantName)) {
-      return c.json({ error: `Name already in use: ${variantName}` }, 409);
-    }
-
-    const projectRoot = entry.dir ?? mindDir(mindName);
-
-    const result = await createVariant({
-      parentName: mindName,
-      projectRoot,
-      variantName,
-      soul: body.soul,
-      port: body.port,
-      noStart: body.noStart,
-      purpose,
-    });
-    if (!result.ok) return c.json({ error: result.error }, result.status);
-
-    // The split has now cleared every rollback point. Establish the parent↔variant
-    // relationship as a conversation: open a DM the two can talk in during the
-    // variant's life, and tell the parent it has a variant to check in on. Placed
-    // after the last rollback so a failed split never strands a DM or a stale notice.
-    // Best-effort, but logged at error level — a silent failure means the dialogue
-    // this feature exists for never happens.
-    await establishVariantDialogue(mindName, variantName, purpose).catch((e: unknown) =>
-      log.error(`failed to establish variant dialogue for ${variantName}`, log.errorData(e)),
-    );
-
-    return c.json({ ok: true, variant: result.variant });
-  })
+      return c.json({ ok: true, variant: result.variant });
+    },
+  )
   // Merge variant — admin only
   .post("/:name/variants/:variant/merge", requireSelf(), async (c) => {
     const mindName = c.req.param("name");

--- a/packages/daemon/src/web/api/volute/chat.ts
+++ b/packages/daemon/src/web/api/volute/chat.ts
@@ -122,297 +122,290 @@ async function persistSpiritNotice(
   }
 }
 
-export const unifiedChatApp = new Hono<AuthEnv>().post(
-  "/chat",
-  zValidator("json", chatSchema),
-  async (c) => {
-    const user = c.get("user");
-    const body = c.req.valid("json");
+// Mounted at /api/v1/chat, so the route path is bare "/". See app.ts.
+export const chatApp = new Hono<AuthEnv>().post("/", zValidator("json", chatSchema), async (c) => {
+  const user = c.get("user");
+  const body = c.req.valid("json");
 
-    // Validate content
-    if (
-      !body.message &&
-      (!body.images || body.images.length === 0) &&
-      (!body.files || body.files.length === 0)
-    ) {
-      return c.json({ error: "message, images, or files required" }, 400);
-    }
+  // Validate content
+  if (
+    !body.message &&
+    (!body.images || body.images.length === 0) &&
+    (!body.files || body.files.length === 0)
+  ) {
+    return c.json({ error: "message, images, or files required" }, 400);
+  }
 
-    // Must have conversationId or targetMind
-    if (!body.conversationId && !body.targetMind) {
-      return c.json({ error: "conversationId or targetMind required" }, 400);
-    }
+  // Must have conversationId or targetMind
+  if (!body.conversationId && !body.targetMind) {
+    return c.json({ error: "conversationId or targetMind required" }, 400);
+  }
 
-    // Resolve sender: daemon token + body.sender → override, else user.username
-    const senderName = user.id === 0 && body.sender ? body.sender : user.username;
+  // Resolve sender: daemon token + body.sender → override, else user.username
+  const senderName = user.id === 0 && body.sender ? body.sender : user.username;
 
-    // Detect if sender is a mind. The spirit authenticates with its
-    // mind token but resolves to the shared system user (user_type "spirit"), so
-    // classify a system principal whose username is a registered mind as a mind
-    // sender too — this matches only the spirit, never a plain system principal.
-    const senderIsMind =
-      (user.id === 0 && body.sender && (await findMind(body.sender))) ||
-      isMind(user) ||
-      (isSystemSpirit(user) && !!(await findMind(user.username)));
+  // Detect if sender is a mind. The spirit authenticates with its
+  // mind token but resolves to the shared system user (user_type "spirit"), so
+  // classify a system principal whose username is a registered mind as a mind
+  // sender too — this matches only the spirit, never a plain system principal.
+  const senderIsMind =
+    (user.id === 0 && body.sender && (await findMind(body.sender))) ||
+    isMind(user) ||
+    (isSystemSpirit(user) && !!(await findMind(user.username)));
 
-    // Track baseName and variant-aware targetName callback for the targetMind flow
-    let baseName: string | undefined;
-    let variantName: string | undefined;
+  // Track baseName and variant-aware targetName callback for the targetMind flow
+  let baseName: string | undefined;
+  let variantName: string | undefined;
 
-    let conversationId = body.conversationId;
+  let conversationId = body.conversationId;
 
-    if (body.targetMind) {
-      // --- targetMind flow (was mind-scoped endpoint) ---
-      variantName = body.targetMind;
-      baseName = await getBaseName(body.targetMind);
+  if (body.targetMind) {
+    // --- targetMind flow (was mind-scoped endpoint) ---
+    variantName = body.targetMind;
+    baseName = await getBaseName(body.targetMind);
 
-      const entry = await findMind(baseName);
-      if (!entry) return c.json({ error: "Mind not found" }, 404);
+    const entry = await findMind(baseName);
+    if (!entry) return c.json({ error: "Mind not found" }, 404);
 
-      if (conversationId) {
-        // Daemon token (id: 0) can access any conversation
-        if (user.id !== 0 && !(await isParticipantOrOwner(conversationId, user.id))) {
-          return c.json({ error: "Conversation not found" }, 404);
-        }
-      } else {
-        // Auto-create/reuse DM conversation
-        const mindUser = await getOrCreateMindUser(baseName);
-        const participantIds: number[] = [];
-        if (user.id !== 0) {
-          participantIds.push(user.id);
-        } else if (body.sender) {
-          if (isSpiritName(body.sender)) {
-            const systemUser = await getOrCreateSystemUser();
-            participantIds.push(systemUser.id);
-          } else {
-            const senderMind = await findMind(body.sender);
-            if (senderMind) {
-              const senderMindUser = await getOrCreateMindUser(body.sender);
-              participantIds.push(senderMindUser.id);
-            }
-          }
-        }
-        participantIds.push(mindUser.id);
-
-        // DM reuse: if exactly 2 participants, look for an existing conversation
-        if (participantIds.length === 2) {
-          const existing = await findDMConversation(participantIds as [number, number]);
-          if (existing) {
-            conversationId = existing;
-          }
-        }
-
-        if (!conversationId) {
-          const conv = await createConversation({
-            userId: user.id !== 0 ? user.id : undefined,
-            participantIds,
-          });
-          conversationId = conv.id;
-        }
-      }
-    } else {
-      // --- conversationId-only flow (was unified endpoint) ---
-      if (user.id !== 0 && !(await isParticipantOrOwner(conversationId!, user.id))) {
+    if (conversationId) {
+      // Daemon token (id: 0) can access any conversation
+      if (user.id !== 0 && !(await isParticipantOrOwner(conversationId, user.id))) {
         return c.json({ error: "Conversation not found" }, 404);
       }
-    }
-
-    const conv = await getConversation(conversationId!);
-    if (!conv) return c.json({ error: "Conversation not found" }, 404);
-    const convName = conv.type === "channel" ? await getChannelName(conversationId!) : null;
-    const participants = await getParticipants(conversationId!);
-
-    // Normalize the sender's own text first: fixModelEscapes changes its length, and the
-    // channel's character limit has to measure the text that will actually be stored.
-    let messageText = body.message ?? "";
-    if (senderIsMind && messageText) {
-      const vCfg = readVoluteConfig(await resolveMindDir(baseName ?? senderName));
-      messageText = fixModelEscapes(messageText, vCfg?.unescapeNewlines === true);
-    }
-
-    // Enforce the channel's character and rate limits before anything is written or staged.
-    // Ordering matters: staging persists a pending file offer per recipient, so checking
-    // after it would leave minds holding offers for a message that was never sent — and
-    // every retry would stage another copy.
-    if (conv.type === "channel" && convName) {
-      const rejection = await checkChannelLimits({
-        conversationId: conversationId!,
-        channelName: convName,
-        text: messageText,
-      });
-      if (rejection) return c.json({ error: rejection.error }, rejection.status);
-    }
-
-    // Stage files
-    const fileNotifications: string[] = [];
-    if (body.files && body.files.length > 0) {
-      let fileTargets: string[];
-      if (baseName) {
-        fileTargets = [baseName];
-      } else {
-        fileTargets = participants
-          .filter((p) => isMind(p) && p.username !== senderName)
-          .map((p) => p.username);
+    } else {
+      // Auto-create/reuse DM conversation
+      const mindUser = await getOrCreateMindUser(baseName);
+      const participantIds: number[] = [];
+      if (user.id !== 0) {
+        participantIds.push(user.id);
+      } else if (body.sender) {
+        if (isSpiritName(body.sender)) {
+          const systemUser = await getOrCreateSystemUser();
+          participantIds.push(systemUser.id);
+        } else {
+          const senderMind = await findMind(body.sender);
+          if (senderMind) {
+            const senderMindUser = await getOrCreateMindUser(body.sender);
+            participantIds.push(senderMindUser.id);
+          }
+        }
       }
-      const { notifications, error } = stageFilesForMinds(body.files, fileTargets, senderName);
-      if (error) return c.json({ error: error.message }, error.status);
-      fileNotifications.push(...notifications);
-    }
+      participantIds.push(mindUser.id);
 
-    // Build content blocks. The file-share notifications are system-generated text appended
-    // alongside the sender's message — deliberately not part of what the character limit
-    // measured above, since the sender didn't write them.
-    const contentBlocks: ContentBlock[] = [];
-    if (messageText) contentBlocks.push({ type: "text", text: messageText });
-    for (const note of fileNotifications) {
-      contentBlocks.push({ type: "text", text: note });
-    }
-    if (body.images) {
-      for (const img of body.images) {
-        contentBlocks.push({ type: "image", media_type: img.media_type, data: img.data });
+      // DM reuse: if exactly 2 participants, look for an existing conversation
+      if (participantIds.length === 2) {
+        const existing = await findDMConversation(participantIds as [number, number]);
+        if (existing) {
+          conversationId = existing;
+        }
       }
-    }
 
-    // Resolve the sending mind's active turn from the per-request X-Volute-Thread header
-    // (captured into context as `mindSession`). This is the primary turn-attribution path:
-    // it records turn_id directly on send, replacing the racy process-global VOLUTE_SESSION
-    // lookup and the marker-only correlation that ran after the fact.
-    let outboundTurnId: string | undefined;
-    let senderBase: string | undefined;
-    if (senderIsMind) {
-      senderBase = await getBaseName(senderName);
-      outboundTurnId = getActiveTurnId(senderBase, c.get("mindSession"));
-    }
-
-    // Stale-send hold: if a peer posted to this conversation after this mind's turn began,
-    // don't post — return a plain notice (surfaced as the send command's stdout) so the mind
-    // can revise or re-send. Held at most once per turn. Replaces the destructive mid-turn
-    // interrupt that produced the "tool use rejected" message.
-    if (senderIsMind && senderBase) {
-      const gate = await checkStaleSend(senderBase, conversationId!, [senderName, senderBase]);
-      if (gate.held && gate.unseen) {
-        const label = buildVoluteSlug({
-          participants,
-          mindUsername: senderName,
-          conversationId: conversationId!,
-          convType: conv.type as "dm" | "channel",
-          convName,
+      if (!conversationId) {
+        const conv = await createConversation({
+          userId: user.id !== 0 ? user.id : undefined,
+          participantIds,
         });
-        return c.json({ ok: true, held: true, notice: formatHoldNotice(label, gate.unseen) });
+        conversationId = conv.id;
       }
     }
+  } else {
+    // --- conversationId-only flow (was unified endpoint) ---
+    if (user.id !== 0 && !(await isParticipantOrOwner(conversationId!, user.id))) {
+      return c.json({ error: "Conversation not found" }, 404);
+    }
+  }
 
-    // Save message. turn_id is attributed directly for mind senders (see above); when the
-    // turn can't be resolved it stays null and is linked later via the tool_result marker.
-    const message = await addMessage(conversationId!, "user", senderName, contentBlocks, {
-      turnId: outboundTurnId,
+  const conv = await getConversation(conversationId!);
+  if (!conv) return c.json({ error: "Conversation not found" }, 404);
+  const convName = conv.type === "channel" ? await getChannelName(conversationId!) : null;
+  const participants = await getParticipants(conversationId!);
+
+  // Normalize the sender's own text first: fixModelEscapes changes its length, and the
+  // channel's character limit has to measure the text that will actually be stored.
+  let messageText = body.message ?? "";
+  if (senderIsMind && messageText) {
+    const vCfg = readVoluteConfig(await resolveMindDir(baseName ?? senderName));
+    messageText = fixModelEscapes(messageText, vCfg?.unescapeNewlines === true);
+  }
+
+  // Enforce the channel's character and rate limits before anything is written or staged.
+  // Ordering matters: staging persists a pending file offer per recipient, so checking
+  // after it would leave minds holding offers for a message that was never sent — and
+  // every retry would stage another copy.
+  if (conv.type === "channel" && convName) {
+    const rejection = await checkChannelLimits({
+      conversationId: conversationId!,
+      channelName: convName,
+      text: messageText,
     });
+    if (rejection) return c.json({ error: rejection.error }, rejection.status);
+  }
 
-    let outboundId: number | undefined;
-    if (senderIsMind) {
-      routeOutboundBridge(conversationId!, senderName, contentBlocks).catch((err) => {
-        log.warn("outbound bridge routing failed", log.errorData(err));
-      });
-      const channel = buildVoluteSlug({
+  // Stage files
+  const fileNotifications: string[] = [];
+  if (body.files && body.files.length > 0) {
+    let fileTargets: string[];
+    if (baseName) {
+      fileTargets = [baseName];
+    } else {
+      fileTargets = participants
+        .filter((p) => isMind(p) && p.username !== senderName)
+        .map((p) => p.username);
+    }
+    const { notifications, error } = stageFilesForMinds(body.files, fileTargets, senderName);
+    if (error) return c.json({ error: error.message }, error.status);
+    fileNotifications.push(...notifications);
+  }
+
+  // Build content blocks. The file-share notifications are system-generated text appended
+  // alongside the sender's message — deliberately not part of what the character limit
+  // measured above, since the sender didn't write them.
+  const contentBlocks: ContentBlock[] = [];
+  if (messageText) contentBlocks.push({ type: "text", text: messageText });
+  for (const note of fileNotifications) {
+    contentBlocks.push({ type: "text", text: note });
+  }
+  if (body.images) {
+    for (const img of body.images) {
+      contentBlocks.push({ type: "image", media_type: img.media_type, data: img.data });
+    }
+  }
+
+  // Resolve the sending mind's active turn from the per-request X-Volute-Thread header
+  // (captured into context as `mindSession`). This is the primary turn-attribution path:
+  // it records turn_id directly on send, replacing the racy process-global VOLUTE_SESSION
+  // lookup and the marker-only correlation that ran after the fact.
+  let outboundTurnId: string | undefined;
+  let senderBase: string | undefined;
+  if (senderIsMind) {
+    senderBase = await getBaseName(senderName);
+    outboundTurnId = getActiveTurnId(senderBase, c.get("mindSession"));
+  }
+
+  // Stale-send hold: if a peer posted to this conversation after this mind's turn began,
+  // don't post — return a plain notice (surfaced as the send command's stdout) so the mind
+  // can revise or re-send. Held at most once per turn. Replaces the destructive mid-turn
+  // interrupt that produced the "tool use rejected" message.
+  if (senderIsMind && senderBase) {
+    const gate = await checkStaleSend(senderBase, conversationId!, [senderName, senderBase]);
+    if (gate.held && gate.unseen) {
+      const label = buildVoluteSlug({
         participants,
         mindUsername: senderName,
         conversationId: conversationId!,
         convType: conv.type as "dm" | "channel",
         convName,
       });
-      const text = extractTextContent(contentBlocks);
-      try {
-        outboundId = await recordOutbound(senderName, channel, text, {
-          messageId: message?.id != null ? String(message.id) : undefined,
+      return c.json({ ok: true, held: true, notice: formatHoldNotice(label, gate.unseen) });
+    }
+  }
+
+  // Save message. turn_id is attributed directly for mind senders (see above); when the
+  // turn can't be resolved it stays null and is linked later via the tool_result marker.
+  const message = await addMessage(conversationId!, "user", senderName, contentBlocks, {
+    turnId: outboundTurnId,
+  });
+
+  let outboundId: number | undefined;
+  if (senderIsMind) {
+    routeOutboundBridge(conversationId!, senderName, contentBlocks).catch((err) => {
+      log.warn("outbound bridge routing failed", log.errorData(err));
+    });
+    const channel = buildVoluteSlug({
+      participants,
+      mindUsername: senderName,
+      conversationId: conversationId!,
+      convType: conv.type as "dm" | "channel",
+      convName,
+    });
+    const text = extractTextContent(contentBlocks);
+    try {
+      outboundId = await recordOutbound(senderName, channel, text, {
+        messageId: message?.id != null ? String(message.id) : undefined,
+        turnId: outboundTurnId,
+      });
+      // When the turn is known, publish the outbound to SSE now (correctly tagged).
+      // Otherwise linkToolResultToTurn publishes it when the marker arrives.
+      if (outboundTurnId) {
+        const mindKey = senderBase ?? senderName;
+        publishMindEvent(mindKey, {
+          mind: mindKey,
+          type: "outbound",
+          channel,
+          content: text,
           turnId: outboundTurnId,
         });
-        // When the turn is known, publish the outbound to SSE now (correctly tagged).
-        // Otherwise linkToolResultToTurn publishes it when the marker arrives.
-        if (outboundTurnId) {
-          const mindKey = senderBase ?? senderName;
-          publishMindEvent(mindKey, {
-            mind: mindKey,
-            type: "outbound",
-            channel,
-            content: text,
-            turnId: outboundTurnId,
-          });
-        }
-      } catch (err) {
-        log.warn(`recordOutbound failed for ${senderName}`, log.errorData(err));
-      }
-    }
-
-    // On-demand spirit start + availability surfacing (#434). ADVISORY: this must never
-    // block or break message delivery — any error degrades to "no status, no notice" and
-    // fan-out proceeds. Only a DM whose sole mind-ish recipient is the spirit awaits the
-    // start: fan-out only delivers to running/sleeping minds, so for the DM case the await
-    // IS the delivery guarantee. Channels/groups never block on a spirit start — there,
-    // fan-out's skip path starts a stopped spirit fire-and-forget and this message is
-    // missed, same as for any stopped mind. A sleeping spirit is left alone: its queue
-    // covers the message (don't force-wake, per #418).
-    let spiritStatus: SpiritStatus | undefined;
-    let spiritName: string | undefined;
-    try {
-      const mindishRecipients = participants.filter(
-        (p) => isLocalMind(p) && p.username !== senderName,
-      );
-      const spiritRecipient =
-        conv.type === "dm" && mindishRecipients.length === 1 && isSystemSpirit(mindishRecipients[0])
-          ? mindishRecipients[0]
-          : undefined;
-      if (spiritRecipient) {
-        const availability = await ensureSpiritAvailable();
-        if (availability) {
-          spiritStatus = availability.status;
-          spiritName = spiritRecipient.username;
-          if (availability.status === "unavailable" && availability.notice) {
-            await persistSpiritNotice(
-              conversationId!,
-              spiritRecipient.username,
-              availability.notice,
-            );
-          }
-        }
       }
     } catch (err) {
-      log.error("spirit availability check failed — proceeding with delivery", log.errorData(err));
+      log.warn(`recordOutbound failed for ${senderName}`, log.errorData(err));
     }
+  }
 
-    // Fan out to running mind participants
-    const isDM = conv.type === "dm";
-    const { gatedRecipients } = await fanOutToMinds({
-      conversationId: conversationId!,
-      contentBlocks,
-      senderName,
-      participants,
-      isDM,
-      slugExtra: { convType: conv.type as "dm" | "channel", convName },
-      // Variant-aware targeting: when targetMind is a variant, route to the variant name
-      targetName: baseName
-        ? (username) => (username === baseName ? variantName! : username)
-        : undefined,
-    });
-
-    // The message is saved, but a recipient whose routing gates this channel won't see it
-    // until they accept the channel — say so in the 200 instead of a bare "sent" (#723).
-    const notice =
-      gatedRecipients.length > 0
-        ? `Note: your message is held for ${gatedRecipients.join(", ")} pending channel ` +
-          `approval — they haven't routed this channel yet. It will be delivered if they ` +
-          `accept the channel.`
+  // On-demand spirit start + availability surfacing (#434). ADVISORY: this must never
+  // block or break message delivery — any error degrades to "no status, no notice" and
+  // fan-out proceeds. Only a DM whose sole mind-ish recipient is the spirit awaits the
+  // start: fan-out only delivers to running/sleeping minds, so for the DM case the await
+  // IS the delivery guarantee. Channels/groups never block on a spirit start — there,
+  // fan-out's skip path starts a stopped spirit fire-and-forget and this message is
+  // missed, same as for any stopped mind. A sleeping spirit is left alone: its queue
+  // covers the message (don't force-wake, per #418).
+  let spiritStatus: SpiritStatus | undefined;
+  let spiritName: string | undefined;
+  try {
+    const mindishRecipients = participants.filter(
+      (p) => isLocalMind(p) && p.username !== senderName,
+    );
+    const spiritRecipient =
+      conv.type === "dm" && mindishRecipients.length === 1 && isSystemSpirit(mindishRecipients[0])
+        ? mindishRecipients[0]
         : undefined;
+    if (spiritRecipient) {
+      const availability = await ensureSpiritAvailable();
+      if (availability) {
+        spiritStatus = availability.status;
+        spiritName = spiritRecipient.username;
+        if (availability.status === "unavailable" && availability.notice) {
+          await persistSpiritNotice(conversationId!, spiritRecipient.username, availability.notice);
+        }
+      }
+    }
+  } catch (err) {
+    log.error("spirit availability check failed — proceeding with delivery", log.errorData(err));
+  }
 
-    return c.json({
-      ok: true,
-      conversationId,
-      outboundId,
-      spirit: spiritStatus,
-      spiritName,
-      ...(notice ? { notice } : {}),
-    });
-  },
-);
+  // Fan out to running mind participants
+  const isDM = conv.type === "dm";
+  const { gatedRecipients } = await fanOutToMinds({
+    conversationId: conversationId!,
+    contentBlocks,
+    senderName,
+    participants,
+    isDM,
+    slugExtra: { convType: conv.type as "dm" | "channel", convName },
+    // Variant-aware targeting: when targetMind is a variant, route to the variant name
+    targetName: baseName
+      ? (username) => (username === baseName ? variantName! : username)
+      : undefined,
+  });
+
+  // The message is saved, but a recipient whose routing gates this channel won't see it
+  // until they accept the channel — say so in the 200 instead of a bare "sent" (#723).
+  const notice =
+    gatedRecipients.length > 0
+      ? `Note: your message is held for ${gatedRecipients.join(", ")} pending channel ` +
+        `approval — they haven't routed this channel yet. It will be delivered if they ` +
+        `accept the channel.`
+      : undefined;
+
+  return c.json({
+    ok: true,
+    conversationId,
+    outboundId,
+    spirit: spiritStatus,
+    spiritName,
+    ...(notice ? { notice } : {}),
+  });
+});
 
 // Default export: SSE endpoint only (keeps existing mount points at /api/minds and /api/v1/minds)
 const app = new Hono<AuthEnv>().get("/:name/conversations/:id/events", async (c) => {

--- a/packages/daemon/src/web/api/volute/conversations.ts
+++ b/packages/daemon/src/web/api/volute/conversations.ts
@@ -19,7 +19,7 @@ import {
   listConversationsForUser,
 } from "../../../lib/events/conversations.js";
 import { findMind } from "../../../lib/mind/registry.js";
-import { parseIntParam } from "../../../lib/util/query-params.js";
+import { cursorParamsSchema, cursorResponse } from "../../../lib/util/query-params.js";
 import type { AuthEnv } from "../../middleware/auth.js";
 
 const createConvSchema = z.object({
@@ -126,28 +126,19 @@ const app = new Hono<AuthEnv>()
 
     return c.json(conv, 201);
   })
-  .get("/:name/conversations/:id/messages", async (c) => {
+  .get("/:name/conversations/:id/messages", zValidator("query", cursorParamsSchema), async (c) => {
     const id = c.req.param("id");
     const user = c.get("user");
     if (user.id !== 0 && !(await isParticipantOrOwner(id, user.id))) {
       return c.json({ error: "Conversation not found" }, 404);
     }
-    const limitStr = c.req.query("limit");
-    const beforeStr = c.req.query("before");
-    if (!limitStr && !beforeStr) {
+    const { before, limit } = c.req.valid("query");
+    if (before === undefined && limit === undefined) {
       const msgs = await getMessages(id);
-      return c.json({ items: await withSenderDisplayNames(msgs), hasMore: false });
-    }
-    const limit = parseIntParam(limitStr);
-    const before = parseIntParam(beforeStr);
-    if (limit === null || before === null) {
-      return c.json({ error: "Invalid pagination parameters" }, 400);
+      return c.json(cursorResponse(await withSenderDisplayNames(msgs), false));
     }
     const result = await getMessagesPaginated(id, { before, limit });
-    return c.json({
-      items: await withSenderDisplayNames(result.messages),
-      hasMore: result.hasMore,
-    });
+    return c.json(cursorResponse(await withSenderDisplayNames(result.messages), result.hasMore));
   })
   .get("/:name/conversations/:id/participants", async (c) => {
     const id = c.req.param("id");

--- a/packages/daemon/src/web/app.ts
+++ b/packages/daemon/src/web/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { cors } from "hono/cors";
 import { csrf } from "hono/csrf";
+import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import { normalizeTrailingSlash } from "../lib/extensions.js";
 import { checkForUpdateCached, getCurrentVersion } from "../lib/update-check.js";
@@ -11,6 +12,7 @@ import auth from "./api/auth.js";
 import backupRoutes from "./api/backup.js";
 import bridges from "./api/bridges.js";
 import channels from "./api/channels.js";
+import chat, { chatApp } from "./api/chat.js";
 import configRoutes from "./api/config.js";
 import envRoutes, { sharedEnvApp } from "./api/env.js";
 import extensionsRoutes from "./api/extensions.js";
@@ -33,7 +35,6 @@ import v1Events from "./api/v1/events.js";
 import v1Feed from "./api/v1/feed.js";
 import variants from "./api/variants.js";
 import voluteChannels from "./api/volute/channels.js";
-import chat, { chatApp } from "./api/volute/chat.js";
 import conversations from "./api/volute/conversations.js";
 import { type AuthEnv, authMiddleware } from "./middleware/auth.js";
 
@@ -113,28 +114,30 @@ app.get("/api/health", (c) => {
   });
 });
 
-// Extension routes 404 on a trailing slash without this (#792).
+// Extension routes 404 on a trailing slash without this (#792). Extension apps
+// mount at /api/ext/* dynamically (see extensions.ts), outside the /api/v1 surface,
+// so this normalizer stays on the bare /api/ext prefix.
 app.use("/api/ext/*", normalizeTrailingSlash(app));
 
-// Protected API routes. The canonical surface is /api/v1/*; the remaining bare
-// /api/* namespaces below are routes that were never dual-mounted under v1
-// (admin/system tooling + the mind-scoped file-sharing/channels/conversations
-// modules), plus the pre-auth /api/setup and /api/auth handled elsewhere.
-app.use("/api/activity/*", authMiddleware);
-app.use("/api/minds/*", authMiddleware);
-app.use("/api/extensions/*", authMiddleware);
-app.use("/api/bridges/*", authMiddleware);
-app.use("/api/config/*", authMiddleware);
-app.use("/api/backup/*", authMiddleware);
-
-// v1 API auth
-app.use("/api/v1/*", authMiddleware);
-
-// Setup routes (no auth — needed before first user exists)
-app.route("/api/setup", setup);
-
-// Config routes (authenticated, no admin required — accessible to minds)
-app.route("/api/config", configRoutes);
+// Authentication for the canonical /api/v1 surface. A few sub-surfaces were
+// unauthenticated at their former bare mounts and must stay reachable without a
+// session — exempt them so this move doesn't silently gate them:
+//   /api/v1/setup — first-run setup, runs before the first user exists
+//   /api/v1/auth  — login/register/me/logout/avatars are public; the protected
+//                   routes self-guard via their own authMiddleware (see auth.ts)
+//   /api/v1/keys  — public identity-key lookup used for signature verification
+// Everything else under /api/v1 requires auth.
+const V1_PUBLIC_PREFIXES = ["/api/v1/setup", "/api/v1/auth", "/api/v1/keys"];
+app.use(
+  "/api/v1/*",
+  createMiddleware<AuthEnv>(async (c, next) => {
+    const path = c.req.path;
+    if (V1_PUBLIC_PREFIXES.some((p) => path === p || path.startsWith(`${p}/`))) {
+      return next();
+    }
+    return authMiddleware(c, next);
+  }),
+);
 
 // The canonical /api/v1 surface, composed as a single sub-app mounted once. This
 // keeps AppType's per-module route schemas merged under one `v1` key rather than
@@ -153,6 +156,9 @@ const v1 = new Hono<AuthEnv>()
   .route("/minds", files)
   .route("/minds", envRoutes)
   .route("/minds", mindSkills)
+  .route("/minds", fileSharing)
+  .route("/minds", channels)
+  .route("/minds", conversations)
   .route("/env", sharedEnvApp)
   .route("/prompts", prompts)
   .route("/skills", skills)
@@ -161,25 +167,21 @@ const v1 = new Hono<AuthEnv>()
   .route("/feed", v1Feed)
   .route("/chat", chatApp)
   .route("/channels", voluteChannels)
-  .route("/history", historyRoutes);
+  .route("/history", historyRoutes)
+  .route("/activity", activityRoutes)
+  .route("/keys", keys)
+  .route("/auth", auth)
+  .route("/backup", backupRoutes)
+  .route("/bridges", bridges)
+  .route("/extensions", extensionsRoutes)
+  .route("/config", configRoutes)
+  .route("/setup", setup);
 
-// Single chained registration — one mount per module, so AppType captures the
-// whole surface with no un-chained duplicates. The canonical prefix is /api/v1;
-// the bare /api mounts below are the modules that never had a v1 alias (admin
-// tooling + the mind-scoped file-sharing/channels/conversations routes).
-const routes = app
-  .route("/api/activity", activityRoutes)
-  .route("/api/keys", keys)
-  .route("/api/auth", auth)
-  .route("/api/backup", backupRoutes)
-  .route("/api/bridges", bridges)
-  .route("/api/extensions", extensionsRoutes)
-  // Mind-scoped modules that stay on the bare /api prefix (no v1 alias existed).
-  .route("/api/minds", fileSharing)
-  .route("/api/minds", channels)
-  .route("/api/minds", conversations)
-  // v1 API — the canonical surface.
-  .route("/api/v1", v1);
+// Single chained registration — every module mounted exactly once under the
+// canonical /api/v1 prefix, so AppType captures the whole surface with no bare
+// /api aliases and no un-chained duplicates. The only bare /api routes that
+// remain are /api/health (above) and the /api/ext/* extension mounts.
+const routes = app.route("/api/v1", v1);
 
 export default app;
 export type AppType = typeof routes;

--- a/packages/daemon/src/web/app.ts
+++ b/packages/daemon/src/web/app.ts
@@ -33,9 +33,9 @@ import v1Events from "./api/v1/events.js";
 import v1Feed from "./api/v1/feed.js";
 import variants from "./api/variants.js";
 import voluteChannels from "./api/volute/channels.js";
-import chat, { unifiedChatApp } from "./api/volute/chat.js";
+import chat, { chatApp } from "./api/volute/chat.js";
 import conversations from "./api/volute/conversations.js";
-import { authMiddleware } from "./middleware/auth.js";
+import { type AuthEnv, authMiddleware } from "./middleware/auth.js";
 
 const httpLog = log.child("http");
 
@@ -116,14 +116,12 @@ app.get("/api/health", (c) => {
 // Extension routes 404 on a trailing slash without this (#792).
 app.use("/api/ext/*", normalizeTrailingSlash(app));
 
-// Protected API routes
+// Protected API routes. The canonical surface is /api/v1/*; the remaining bare
+// /api/* namespaces below are routes that were never dual-mounted under v1
+// (admin/system tooling + the mind-scoped file-sharing/channels/conversations
+// modules), plus the pre-auth /api/setup and /api/auth handled elsewhere.
 app.use("/api/activity/*", authMiddleware);
 app.use("/api/minds/*", authMiddleware);
-app.use("/api/conversations/*", authMiddleware);
-app.use("/api/system/*", authMiddleware);
-app.use("/api/env/*", authMiddleware);
-app.use("/api/prompts/*", authMiddleware);
-app.use("/api/skills/*", authMiddleware);
 app.use("/api/extensions/*", authMiddleware);
 app.use("/api/bridges/*", authMiddleware);
 app.use("/api/config/*", authMiddleware);
@@ -138,55 +136,50 @@ app.route("/api/setup", setup);
 // Config routes (authenticated, no admin required — accessible to minds)
 app.route("/api/config", configRoutes);
 
-// Chain route registrations to capture types
+// The canonical /api/v1 surface, composed as a single sub-app mounted once. This
+// keeps AppType's per-module route schemas merged under one `v1` key rather than
+// piling every module directly onto the root app — the latter overwhelms Hono's
+// RPC type merge and silently collapses `AppType["api"]["v1"]` to a partial type,
+// breaking the CLI's typed client.
+const v1 = new Hono<AuthEnv>()
+  .route("/system", system)
+  .route("/system", update)
+  .route("/minds", minds)
+  .route("/minds", chat)
+  .route("/minds", schedules)
+  .route("/minds", logs)
+  .route("/minds", typing)
+  .route("/minds", variants)
+  .route("/minds", files)
+  .route("/minds", envRoutes)
+  .route("/minds", mindSkills)
+  .route("/env", sharedEnvApp)
+  .route("/prompts", prompts)
+  .route("/skills", skills)
+  .route("/conversations", v1Conversations)
+  .route("/events", v1Events)
+  .route("/feed", v1Feed)
+  .route("/chat", chatApp)
+  .route("/channels", voluteChannels)
+  .route("/history", historyRoutes);
+
+// Single chained registration — one mount per module, so AppType captures the
+// whole surface with no un-chained duplicates. The canonical prefix is /api/v1;
+// the bare /api mounts below are the modules that never had a v1 alias (admin
+// tooling + the mind-scoped file-sharing/channels/conversations routes).
 const routes = app
   .route("/api/activity", activityRoutes)
   .route("/api/keys", keys)
   .route("/api/auth", auth)
-  .route("/api/system", system)
-  .route("/api/system", update)
   .route("/api/backup", backupRoutes)
-  .route("/api/minds", minds)
-  .route("/api/minds", chat)
-  .route("/api/minds", schedules)
-  .route("/api/minds", logs)
-  .route("/api/minds", typing)
-  .route("/api/minds", variants)
-  .route("/api/minds", fileSharing)
-  .route("/api/minds", files)
-  .route("/api/minds", channels)
-  .route("/api/minds", envRoutes)
-  .route("/api/minds", mindSkills)
-  .route("/api/minds", conversations)
-  .route("/api/env", sharedEnvApp)
-  .route("/api/prompts", prompts)
-  .route("/api/skills", skills)
   .route("/api/bridges", bridges)
   .route("/api/extensions", extensionsRoutes)
-  // v1 API routes
-  .route("/api/v1/conversations", v1Conversations)
-  .route("/api/v1/events", v1Events)
-  .route("/api/v1/feed", v1Feed)
-  .route("/api/v1", unifiedChatApp)
-  .route("/api/v1/channels", voluteChannels)
-  .route("/api/v1/history", historyRoutes);
-
-// v1 re-mounts of existing modules (not chained to preserve AppType)
-app.route("/api/v1/minds", minds);
-app.route("/api/v1/minds", chat);
-app.route("/api/v1/minds", typing);
-app.route("/api/v1/minds", variants);
-app.route("/api/v1/minds", files);
-app.route("/api/v1/minds", envRoutes);
-app.route("/api/v1/minds", mindSkills);
-app.route("/api/v1/minds", schedules);
-app.route("/api/v1/minds", logs);
-app.route("/api/v1/system", system);
-app.route("/api/v1/system", update);
-app.route("/api/v1/prompts", prompts);
-app.route("/api/v1/skills", skills);
-app.route("/api/v1/env", sharedEnvApp);
-app.route("/api/conversations", v1Conversations);
+  // Mind-scoped modules that stay on the bare /api prefix (no v1 alias existed).
+  .route("/api/minds", fileSharing)
+  .route("/api/minds", channels)
+  .route("/api/minds", conversations)
+  // v1 API — the canonical surface.
+  .route("/api/v1", v1);
 
 export default app;
 export type AppType = typeof routes;

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -130,7 +130,7 @@ function daemonFetch(path: string, init?: RequestInit): Promise<Response> {
 
 async function fetchMinds(): Promise<MindInfo[]> {
   try {
-    const res = await daemonFetch("/api/minds");
+    const res = await daemonFetch("/api/v1/minds");
     if (!res.ok) {
       console.warn(`Failed to fetch minds: ${res.status} ${res.statusText}`);
       return [];
@@ -146,7 +146,7 @@ async function fetchMinds(): Promise<MindInfo[]> {
 async function toggleMind(name: string, currentStatus: string) {
   const action = currentStatus === "running" || currentStatus === "starting" ? "stop" : "start";
   try {
-    const res = await daemonFetch(`/api/minds/${name}/${action}`, { method: "POST" });
+    const res = await daemonFetch(`/api/v1/minds/${name}/${action}`, { method: "POST" });
     if (!res.ok) {
       console.error(`Failed to ${action} mind "${name}": ${res.status} ${res.statusText}`);
     }

--- a/packages/extensions/pages/ui/src/lib/api.ts
+++ b/packages/extensions/pages/ui/src/lib/api.ts
@@ -103,7 +103,7 @@ export async function fetchPagesData(): Promise<{
 
 export async function fetchCurrentUser(): Promise<CurrentUser> {
   try {
-    const res = await fetch("/api/auth/me");
+    const res = await fetch("/api/v1/auth/me");
     if (!res.ok) {
       console.warn(`Failed to fetch current user: HTTP ${res.status}`);
       return { username: "", avatarUrl: null };
@@ -111,7 +111,7 @@ export async function fetchCurrentUser(): Promise<CurrentUser> {
     const data = await res.json();
     return {
       username: data?.username ?? "",
-      avatarUrl: data?.avatar ? `/api/auth/avatars/${encodeURIComponent(data.avatar)}` : null,
+      avatarUrl: data?.avatar ? `/api/v1/auth/avatars/${encodeURIComponent(data.avatar)}` : null,
     };
   } catch (err) {
     console.warn("Failed to fetch current user:", err);

--- a/packages/web/src/ui/App.svelte
+++ b/packages/web/src/ui/App.svelte
@@ -408,7 +408,7 @@ $effect(() => {
   if (!auth.user) return;
   fetchMe()
     .then((me) => {
-      userAvatar = me?.avatar ? `/api/auth/avatars/${me.avatar}` : null;
+      userAvatar = me?.avatar ? `/api/v1/auth/avatars/${me.avatar}` : null;
     })
     .catch((err) => {
       console.warn("Failed to fetch user profile:", err);

--- a/packages/web/src/ui/components/ChannelMembersPanel.svelte
+++ b/packages/web/src/ui/components/ChannelMembersPanel.svelte
@@ -71,7 +71,7 @@ function isBrainIridescent(username: string): boolean {
           name: mind.name,
           displayName: mind.displayName,
           description: mind.description,
-          avatarUrl: mind.avatar ? `/api/minds/${encodeURIComponent(mind.name)}/avatar` : null,
+          avatarUrl: mind.avatar ? `/api/v1/minds/${encodeURIComponent(mind.name)}/avatar` : null,
           userType: "mind",
           created: mind.created,
         }}>

--- a/packages/web/src/ui/components/ChannelMembersPanel.svelte
+++ b/packages/web/src/ui/components/ChannelMembersPanel.svelte
@@ -100,7 +100,7 @@ function isBrainIridescent(username: string): boolean {
         name: participant.username,
         displayName: participant.displayName,
         description: participant.description,
-        avatarUrl: participant.avatar ? `/api/auth/avatars/${encodeURIComponent(participant.avatar)}` : null,
+        avatarUrl: participant.avatar ? `/api/v1/auth/avatars/${encodeURIComponent(participant.avatar)}` : null,
         userType: participant.userType,
       }}>
         {#snippet children()}

--- a/packages/web/src/ui/components/chat/MessageEntry.svelte
+++ b/packages/web/src/ui/components/chat/MessageEntry.svelte
@@ -56,7 +56,7 @@ function profileForSender(name: string): HoverProfile | null {
       name: mind.name,
       displayName: mind.displayName,
       description: mind.description,
-      avatarUrl: mind.avatar ? `/api/minds/${encodeURIComponent(mind.name)}/avatar` : null,
+      avatarUrl: mind.avatar ? `/api/v1/minds/${encodeURIComponent(mind.name)}/avatar` : null,
       userType: "mind",
       created: mind.created,
     };

--- a/packages/web/src/ui/components/chat/MessageEntry.svelte
+++ b/packages/web/src/ui/components/chat/MessageEntry.svelte
@@ -67,7 +67,7 @@ function profileForSender(name: string): HoverProfile | null {
       name: p.username,
       displayName: p.displayName,
       description: p.description,
-      avatarUrl: p.avatar ? `/api/auth/avatars/${encodeURIComponent(p.avatar)}` : null,
+      avatarUrl: p.avatar ? `/api/v1/auth/avatars/${encodeURIComponent(p.avatar)}` : null,
       userType: p.userType,
     };
   }

--- a/packages/web/src/ui/components/home/AvatarStack.svelte
+++ b/packages/web/src/ui/components/home/AvatarStack.svelte
@@ -18,7 +18,7 @@ let overflow = $derived(Math.max(0, participants.length - max));
 function avatarUrl(p: AvatarParticipant): string | null {
   if (!p.avatar) return null;
   return isMind(p)
-    ? `/api/minds/${encodeURIComponent(p.username)}/avatar`
+    ? `/api/v1/minds/${encodeURIComponent(p.username)}/avatar`
     : `/api/auth/avatars/${encodeURIComponent(p.avatar)}`;
 }
 

--- a/packages/web/src/ui/components/home/AvatarStack.svelte
+++ b/packages/web/src/ui/components/home/AvatarStack.svelte
@@ -19,7 +19,7 @@ function avatarUrl(p: AvatarParticipant): string | null {
   if (!p.avatar) return null;
   return isMind(p)
     ? `/api/v1/minds/${encodeURIComponent(p.username)}/avatar`
-    : `/api/auth/avatars/${encodeURIComponent(p.avatar)}`;
+    : `/api/v1/auth/avatars/${encodeURIComponent(p.avatar)}`;
 }
 
 function initial(p: AvatarParticipant): string {

--- a/packages/web/src/ui/components/home/MindPresenceStrip.svelte
+++ b/packages/web/src/ui/components/home/MindPresenceStrip.svelte
@@ -22,7 +22,7 @@ const STATE_LABEL: Record<PresenceState, string> = {
 };
 
 function avatarUrl(mind: Mind): string | null {
-  return mind.avatar ? `/api/minds/${encodeURIComponent(mind.name)}/avatar` : null;
+  return mind.avatar ? `/api/v1/minds/${encodeURIComponent(mind.name)}/avatar` : null;
 }
 
 function initial(mind: Mind): string {

--- a/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
+++ b/packages/web/src/ui/components/layout/UnifiedSidebar.svelte
@@ -273,7 +273,7 @@ let isSystemActive = $derived(
                   name: mind.name,
                   displayName: mind.displayName,
                   description: mind.description,
-                  avatarUrl: mind.avatar ? `/api/minds/${encodeURIComponent(mind.name)}/avatar` : null,
+                  avatarUrl: mind.avatar ? `/api/v1/minds/${encodeURIComponent(mind.name)}/avatar` : null,
                   userType: "mind",
                   created: mind.created,
                 }}>

--- a/packages/web/src/ui/components/mind/MindRightPanel.svelte
+++ b/packages/web/src/ui/components/mind/MindRightPanel.svelte
@@ -64,7 +64,7 @@ let memoryBadge = $derived.by(() => {
     <div class="profile-section">
       {#if mind.avatar}
         <img
-          src={`/api/minds/${encodeURIComponent(mind.name)}/avatar`}
+          src={`/api/v1/minds/${encodeURIComponent(mind.name)}/avatar`}
           alt=""
           class="profile-avatar"
           loading="lazy"

--- a/packages/web/src/ui/components/mind/MindSettingsProfile.svelte
+++ b/packages/web/src/ui/components/mind/MindSettingsProfile.svelte
@@ -60,7 +60,7 @@ async function saveDescription() {
       <button type="button" class="avatar-wrapper" onclick={() => fileInput?.click()}>
         {#if mind.avatar}
           <img
-            src={`/api/minds/${encodeURIComponent(mind.name)}/avatar`}
+            src={`/api/v1/minds/${encodeURIComponent(mind.name)}/avatar`}
             alt=""
             class="avatar-img"
             loading="lazy"

--- a/packages/web/src/ui/components/modals/UserSettingsModal.svelte
+++ b/packages/web/src/ui/components/modals/UserSettingsModal.svelte
@@ -34,7 +34,7 @@ async function loadProfile() {
     if (me) {
       displayName = me.display_name ?? "";
       description = me.description ?? "";
-      avatarUrl = me.avatar ? `/api/auth/avatars/${me.avatar}` : null;
+      avatarUrl = me.avatar ? `/api/v1/auth/avatars/${me.avatar}` : null;
     }
   } catch {
     profileError = "Failed to load profile";
@@ -73,7 +73,7 @@ async function handleUploadAvatar() {
   profileError = "";
   try {
     const filename = await uploadAvatar(avatarFile);
-    avatarUrl = `/api/auth/avatars/${filename}`;
+    avatarUrl = `/api/v1/auth/avatars/${filename}`;
     avatarFile = null;
     avatarPreview = null;
   } catch (err) {

--- a/packages/web/src/ui/components/system/NoProviderBanner.svelte
+++ b/packages/web/src/ui/components/system/NoProviderBanner.svelte
@@ -11,7 +11,7 @@ $effect(() => {
 
   async function poll() {
     try {
-      const res = await fetch("/api/system/info");
+      const res = await fetch("/api/v1/system/info");
       if (!res.ok) {
         console.debug("[provider] poll returned", res.status);
         return;

--- a/packages/web/src/ui/components/system/PublicFiles.svelte
+++ b/packages/web/src/ui/components/system/PublicFiles.svelte
@@ -42,7 +42,7 @@ async function loadDir() {
   fileContent = null;
   try {
     const dirPath = path.length > 0 ? `${path.join("/")}/` : "";
-    const res = await fetch(`/api/minds/${encodeURIComponent(name)}/files/${dirPath}`);
+    const res = await fetch(`/api/v1/minds/${encodeURIComponent(name)}/files/${dirPath}`);
     if (!res.ok) throw new Error("Failed to load directory");
     entries = await res.json();
   } catch (e) {
@@ -76,7 +76,7 @@ async function selectFile(entry: Entry) {
 
   try {
     const filePath = currentDir + entry.name;
-    const res = await fetch(`/api/minds/${encodeURIComponent(name)}/files/${filePath}`);
+    const res = await fetch(`/api/v1/minds/${encodeURIComponent(name)}/files/${filePath}`);
     if (!res.ok) throw new Error("Failed to load file");
 
     fileMime = res.headers.get("content-type") ?? "";
@@ -168,7 +168,7 @@ let sortedEntries = $derived(
             <span class="preview-filename">{currentDir}{selectedFile}</span>
             <a
               class="preview-link"
-              href="/api/minds/{encodeURIComponent(name)}/files/{currentDir}{selectedFile}"
+              href="/api/v1/minds/{encodeURIComponent(name)}/files/{currentDir}{selectedFile}"
               target="_blank"
               rel="noopener"
             >open</a>
@@ -190,7 +190,7 @@ let sortedEntries = $derived(
               <span class="preview-mime">{fileMime || "unknown type"}</span>
               <a
                 class="download-link"
-                href="/api/minds/{encodeURIComponent(name)}/files/{currentDir}{selectedFile}"
+                href="/api/v1/minds/{encodeURIComponent(name)}/files/{currentDir}{selectedFile}"
                 target="_blank"
                 rel="noopener"
               >Download</a>

--- a/packages/web/src/ui/components/system/UpdateBanner.svelte
+++ b/packages/web/src/ui/components/system/UpdateBanner.svelte
@@ -39,7 +39,7 @@ $effect(() => {
 async function handleUpdate() {
   updating = true;
   try {
-    const res = await fetch("/api/system/update", { method: "POST" });
+    const res = await fetch("/api/v1/system/update", { method: "POST" });
     if (!res.ok) {
       updating = false;
       error = "Update failed";

--- a/packages/web/src/ui/lib/auth.ts
+++ b/packages/web/src/ui/lib/auth.ts
@@ -47,42 +47,42 @@ async function authPost<T>(path: string, body?: unknown): Promise<T> {
 }
 
 export async function fetchMe(): Promise<AuthUser | null> {
-  const res = await fetch("/api/auth/me");
+  const res = await fetch("/api/v1/auth/me");
   if (!res.ok) return null;
   return res.json();
 }
 
 export function login(username: string, password: string): Promise<AuthUser> {
-  return authPost("/api/auth/login", { username, password });
+  return authPost("/api/v1/auth/login", { username, password });
 }
 
 export function register(username: string, password: string): Promise<AuthUser> {
-  return authPost("/api/auth/register", { username, password });
+  return authPost("/api/v1/auth/register", { username, password });
 }
 
 export async function logout(): Promise<void> {
-  await fetch("/api/auth/logout", { method: "POST" });
+  await fetch("/api/v1/auth/logout", { method: "POST" });
 }
 
 export function fetchUsers(): Promise<AuthUser[]> {
-  return authGet("/api/auth/users");
+  return authGet("/api/v1/auth/users");
 }
 
 export function fetchPendingUsers(): Promise<AuthUser[]> {
-  return authGet("/api/auth/users/pending");
+  return authGet("/api/v1/auth/users/pending");
 }
 
 export function changePassword(currentPassword: string, newPassword: string): Promise<void> {
-  return authPost("/api/auth/change-password", { currentPassword, newPassword });
+  return authPost("/api/v1/auth/change-password", { currentPassword, newPassword });
 }
 
 export async function approveUser(id: number): Promise<void> {
-  const res = await fetch(`/api/auth/users/${id}/approve`, { method: "POST" });
+  const res = await fetch(`/api/v1/auth/users/${id}/approve`, { method: "POST" });
   if (!res.ok) throw new Error("Failed to approve user");
 }
 
 export async function setUserRole(id: number, role: "admin" | "user"): Promise<void> {
-  const res = await fetch(`/api/auth/users/${id}/role`, {
+  const res = await fetch(`/api/v1/auth/users/${id}/role`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ role }),
@@ -97,7 +97,7 @@ export async function updateUserProfile(
   id: number,
   profile: { display_name?: string | null; description?: string | null },
 ): Promise<void> {
-  const res = await fetch(`/api/auth/users/${id}/profile`, {
+  const res = await fetch(`/api/v1/auth/users/${id}/profile`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(profile),
@@ -122,19 +122,19 @@ export function registerExternalMind(body: {
   // The response also carries the created `user`, deliberately left off this type:
   // the server builds it without the `external` flag, so typing it as AuthUser
   // would hand callers a mind that reads as local. Re-read it from the users list.
-  return authPost("/api/auth/minds", body);
+  return authPost("/api/v1/auth/minds", body);
 }
 
 export function fetchUserTokens(id: number): Promise<ApiToken[]> {
-  return authGet(`/api/auth/users/${id}/tokens`);
+  return authGet(`/api/v1/auth/users/${id}/tokens`);
 }
 
 export function issueUserToken(id: number, label?: string): Promise<IssuedToken> {
-  return authPost(`/api/auth/users/${id}/tokens`, { label });
+  return authPost(`/api/v1/auth/users/${id}/tokens`, { label });
 }
 
 export async function revokeUserToken(id: number, tokenId: number): Promise<void> {
-  const res = await fetch(`/api/auth/users/${id}/tokens/${tokenId}`, { method: "DELETE" });
+  const res = await fetch(`/api/v1/auth/users/${id}/tokens/${tokenId}`, { method: "DELETE" });
   if (!res.ok) {
     const data = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(data.error || "Failed to revoke token");
@@ -142,7 +142,7 @@ export async function revokeUserToken(id: number, tokenId: number): Promise<void
 }
 
 export async function deleteUser(id: number): Promise<void> {
-  const res = await fetch(`/api/auth/users/${id}`, { method: "DELETE" });
+  const res = await fetch(`/api/v1/auth/users/${id}`, { method: "DELETE" });
   if (!res.ok) {
     const data = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(data.error || "Failed to delete user");
@@ -153,7 +153,7 @@ export async function updateProfile(profile: {
   display_name?: string | null;
   description?: string | null;
 }): Promise<void> {
-  const res = await fetch("/api/auth/profile", {
+  const res = await fetch("/api/v1/auth/profile", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(profile),
@@ -167,7 +167,7 @@ export async function updateProfile(profile: {
 export async function uploadAvatar(file: File): Promise<string> {
   const form = new FormData();
   form.append("file", file);
-  const res = await fetch("/api/auth/avatar", { method: "POST", body: form });
+  const res = await fetch("/api/v1/auth/avatar", { method: "POST", body: form });
   if (!res.ok) {
     const data = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(data.error || "Failed to upload avatar");
@@ -177,7 +177,7 @@ export async function uploadAvatar(file: File): Promise<string> {
 }
 
 export async function deleteAvatar(): Promise<void> {
-  const res = await fetch("/api/auth/avatar", { method: "DELETE" });
+  const res = await fetch("/api/v1/auth/avatar", { method: "DELETE" });
   if (!res.ok) {
     const data = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(data.error || "Failed to delete avatar");

--- a/packages/web/src/ui/lib/client.ts
+++ b/packages/web/src/ui/lib/client.ts
@@ -834,30 +834,30 @@ export type BackupSnapshot = {
 };
 
 export function fetchBackupStatus(): Promise<BackupStatus> {
-  return get("/api/backup/status");
+  return get("/api/v1/backup/status");
 }
 
 export function saveBackupConfig(config: BackupConfigUpdate): Promise<void> {
-  return put("/api/backup/config", config);
+  return put("/api/v1/backup/config", config);
 }
 
 export function initBackupRepo(): Promise<{ ok: true; password: string | null }> {
-  return post("/api/backup/init");
+  return post("/api/v1/backup/init");
 }
 
 export function runBackupNow(): Promise<BackupRunSummary> {
-  return post("/api/backup/run");
+  return post("/api/v1/backup/run");
 }
 
 export function listBackupSnapshots(): Promise<BackupSnapshot[]> {
-  return get("/api/backup/snapshots");
+  return get("/api/v1/backup/snapshots");
 }
 
-// --- Auth (these stay on /api/ since they're not mind-scoped) ---
+// --- Auth ---
 
 export function fetchAvailableUsers(type?: string): Promise<AvailableUser[]> {
   const qs = type ? `?type=${enc(type)}` : "";
-  return get(`/api/auth/users${qs}`);
+  return get(`/api/v1/auth/users${qs}`);
 }
 
 // --- Upload ---
@@ -978,8 +978,8 @@ export function deleteSchedule(name: string, id: string): Promise<void> {
 }
 
 // --- Pending incoming files ---
-// This route lives under /api/minds (not /api/v1), guarded by requireSelf.
-// Read-only by design: accepting or rejecting a file is the mind's decision,
+// Guarded by requireSelf. Read-only by design: accepting or rejecting a file
+// is the mind's decision,
 // made via its own tools (volute chat accept/reject) — the web UI only
 // provides visibility into the queue.
 
@@ -993,7 +993,7 @@ export type PendingFile = {
 };
 
 export function fetchPendingFiles(mind: string): Promise<PendingFile[]> {
-  return get(`/api/minds/${enc(mind)}/files/pending`);
+  return get(`/api/v1/minds/${enc(mind)}/files/pending`);
 }
 
 // --- Profile ---
@@ -1029,19 +1029,19 @@ export async function uploadMindAvatar(name: string, file: File): Promise<void> 
 // --- Extensions management ---
 
 export function fetchAllExtensions(): Promise<ExtensionManagementInfo[]> {
-  return get("/api/extensions/all");
+  return get("/api/v1/extensions/all");
 }
 
 export async function setExtensionEnabled(id: string, enabled: boolean): Promise<void> {
-  await put(`/api/extensions/${enc(id)}/enabled`, { enabled });
+  await put(`/api/v1/extensions/${enc(id)}/enabled`, { enabled });
 }
 
 export async function installExtension(pkg: string): Promise<void> {
-  await post("/api/extensions/install", { package: pkg });
+  await post("/api/v1/extensions/install", { package: pkg });
 }
 
 export async function uninstallExtension(pkg: string): Promise<void> {
-  await del(`/api/extensions/uninstall/${enc(pkg)}`);
+  await del(`/api/v1/extensions/uninstall/${enc(pkg)}`);
 }
 
 // --- Helpers ---

--- a/packages/web/src/ui/lib/daemon-connection.svelte.ts
+++ b/packages/web/src/ui/lib/daemon-connection.svelte.ts
@@ -70,7 +70,7 @@ export async function remoteLogin(
   username: string,
   password: string,
 ): Promise<{ token: string; user: { id: number; username: string; role: string } }> {
-  const url = `${daemonUrl.replace(/\/$/, "")}/api/auth/login`;
+  const url = `${daemonUrl.replace(/\/$/, "")}/api/v1/auth/login`;
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/packages/web/src/ui/lib/extensions.ts
+++ b/packages/web/src/ui/lib/extensions.ts
@@ -10,7 +10,7 @@ export type ExtensionInfo = {
 };
 
 export async function fetchExtensions(): Promise<ExtensionInfo[]> {
-  const res = await fetch("/api/extensions");
+  const res = await fetch("/api/v1/extensions");
   if (!res.ok) {
     console.warn(`Failed to fetch extensions: HTTP ${res.status}`);
     return [];

--- a/packages/web/src/ui/lib/stores.svelte.ts
+++ b/packages/web/src/ui/lib/stores.svelte.ts
@@ -34,7 +34,7 @@ export const auth = $state({
 
 export async function checkSetup() {
   try {
-    const res = await fetch("/api/setup/status");
+    const res = await fetch("/api/v1/setup/status");
     if (res.ok) {
       const data = await res.json();
       auth.setupComplete = data.complete;

--- a/packages/web/src/ui/lib/streams.ts
+++ b/packages/web/src/ui/lib/streams.ts
@@ -57,12 +57,12 @@ export function createLogStream(
   onLine: (line: string) => void,
   onError?: (msg: string) => void,
 ) {
-  return createSSEStream(`/api/minds/${name}/logs`, onLine, onError);
+  return createSSEStream(`/api/v1/minds/${name}/logs`, onLine, onError);
 }
 
 export function createSystemLogStream(
   onLine: (line: string) => void,
   onError?: (msg: string) => void,
 ) {
-  return createSSEStream("/api/system/logs", onLine, onError);
+  return createSSEStream("/api/v1/system/logs", onLine, onError);
 }

--- a/packages/web/src/ui/lib/user-kind.ts
+++ b/packages/web/src/ui/lib/user-kind.ts
@@ -16,7 +16,7 @@ export { isExternal };
 export function avatarUrl(u: AuthUser): string | null {
   if (!u.avatar) return null;
   if (isMind(u) && !isExternal(u)) {
-    return `/api/minds/${encodeURIComponent(u.username)}/avatar`;
+    return `/api/v1/minds/${encodeURIComponent(u.username)}/avatar`;
   }
   return `/api/auth/avatars/${encodeURIComponent(u.avatar)}`;
 }

--- a/packages/web/src/ui/lib/user-kind.ts
+++ b/packages/web/src/ui/lib/user-kind.ts
@@ -10,7 +10,7 @@ export { isExternal };
 /**
  * A local mind's avatar is a file in its own directory, served by name. Everyone
  * else's is an upload in the shared avatars dir — including an external mind's:
- * it POSTs /api/auth/avatar with its token like any other authenticated user. The
+ * it POSTs /api/v1/auth/avatar with its token like any other authenticated user. The
  * spirit (`user_type: "spirit"`, not a `mind`) also falls to the shared dir here.
  */
 export function avatarUrl(u: AuthUser): string | null {
@@ -18,7 +18,7 @@ export function avatarUrl(u: AuthUser): string | null {
   if (isMind(u) && !isExternal(u)) {
     return `/api/v1/minds/${encodeURIComponent(u.username)}/avatar`;
   }
-  return `/api/auth/avatars/${encodeURIComponent(u.avatar)}`;
+  return `/api/v1/auth/avatars/${encodeURIComponent(u.avatar)}`;
 }
 
 /** The row's kind, as a label. Humans are the unmarked default. */

--- a/packages/web/src/ui/pages/SetupPage.svelte
+++ b/packages/web/src/ui/pages/SetupPage.svelte
@@ -204,7 +204,7 @@ async function handleSystemSubmit(e: Event) {
   error = "";
   loading = true;
   try {
-    const res = await fetch("/api/setup/system", {
+    const res = await fetch("/api/v1/setup/system", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -232,7 +232,7 @@ async function handleAccountSubmit(e: Event) {
   error = "";
   loading = true;
   try {
-    const res = await fetch("/api/setup/account", {
+    const res = await fetch("/api/v1/setup/account", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -261,7 +261,7 @@ async function handleSystemsRegister() {
   systemsError = "";
   systemsLoading = true;
   try {
-    const res = await fetch("/api/setup/system/register", {
+    const res = await fetch("/api/v1/setup/system/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ slug: systemsSlug.trim() }),
@@ -285,7 +285,7 @@ async function handleSystemsLogin() {
   systemsError = "";
   systemsLoading = true;
   try {
-    const res = await fetch("/api/setup/system/login", {
+    const res = await fetch("/api/v1/setup/system/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: systemsApiKey.trim() }),
@@ -309,7 +309,7 @@ async function handleSystemsDisconnect() {
   systemsError = "";
   systemsLoading = true;
   try {
-    await fetch("/api/setup/system/disconnect", { method: "POST" });
+    await fetch("/api/v1/setup/system/disconnect", { method: "POST" });
     systemsRegistered = false;
     systemsName = "";
   } catch (err) {
@@ -325,7 +325,7 @@ async function handleModelsSubmit(e: Event) {
   loading = true;
   try {
     // Save model config
-    const res = await fetch("/api/setup/models", {
+    const res = await fetch("/api/v1/setup/models", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -351,7 +351,7 @@ async function handleSpiritSubmit(e: Event) {
   error = "";
   loading = true;
   try {
-    const res = await fetch("/api/setup/spirit", {
+    const res = await fetch("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -381,7 +381,7 @@ async function completeSetup() {
   spiritTimedOut = false;
   loading = true;
   try {
-    const res = await fetch("/api/setup/complete", {
+    const res = await fetch("/api/v1/setup/complete", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -455,7 +455,7 @@ async function waitForSpiritReply(conversationId: string): Promise<string> {
 // Load systems status when entering the system step
 $effect(() => {
   if (step === "system" && !systemsRegistered) {
-    fetch("/api/setup/system/systems-status")
+    fetch("/api/v1/setup/system/systems-status")
       .then((r) => r.json())
       .then((data: any) => {
         if (data.registered) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,7 +177,7 @@ System:
       const token = getAuthToken();
       const headers: Record<string, string> = {};
       if (token) headers.Authorization = `Bearer ${token}`;
-      const res = await fetch(`${resolveDaemonUrl()}/api/extensions/commands`, {
+      const res = await fetch(`${resolveDaemonUrl()}/api/v1/extensions/commands`, {
         headers,
         signal: AbortSignal.timeout(1500),
       });
@@ -221,7 +221,7 @@ use --mind <name> or VOLUTE_MIND env var to identify the mind.`);
     let isExtensionCommand = false;
     try {
       const { daemonFetch } = await import("@volute/cli/lib/daemon-client.js");
-      const res = await daemonFetch("/api/extensions/commands");
+      const res = await daemonFetch("/api/v1/extensions/commands");
       if (res.ok) {
         const extCommands = (await res.json()) as Record<
           string,

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -56,14 +56,14 @@ const initCmd = command({
     }
 
     const client = getClient();
-    const putRes = await daemonFetch(urlOf(client.api.backup.config.$url()), {
+    const putRes = await daemonFetch(urlOf(client.api.v1.backup.config.$url()), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ repository: repo, password: flags.password ?? "" }),
     });
     if (!putRes.ok) await apiError(putRes, "Failed to save backup config");
 
-    const initRes = await daemonFetch(urlOf(client.api.backup.init.$url()), { method: "POST" });
+    const initRes = await daemonFetch(urlOf(client.api.v1.backup.init.$url()), { method: "POST" });
     if (!initRes.ok) await apiError(initRes, "Failed to initialize repository");
     const { password } = (await initRes.json()) as { password: string | null };
 
@@ -81,7 +81,7 @@ const createCmd = command({
   run: async () => {
     const client = getClient();
     console.log("Running backup (this may take a while on first run)...");
-    const res = await daemonFetch(urlOf(client.api.backup.run.$url()), { method: "POST" });
+    const res = await daemonFetch(urlOf(client.api.v1.backup.run.$url()), { method: "POST" });
     if (!res.ok) await apiError(res, "Backup failed");
     const summary = (await res.json()) as BackupSummary;
     const addedMB = (summary.dataAdded / 1024 / 1024).toFixed(1);
@@ -99,7 +99,7 @@ const listCmd = command({
   flags: {},
   run: async () => {
     const client = getClient();
-    const res = await daemonFetch(urlOf(client.api.backup.snapshots.$url()));
+    const res = await daemonFetch(urlOf(client.api.v1.backup.snapshots.$url()));
     if (!res.ok) await apiError(res, "Failed to list snapshots");
     const snapshots = (await res.json()) as Snapshot[];
     if (snapshots.length === 0) {
@@ -132,7 +132,7 @@ const scheduleCmd = command({
       process.exit(1);
     }
     const client = getClient();
-    const res = await daemonFetch(urlOf(client.api.backup.config.$url()), {
+    const res = await daemonFetch(urlOf(client.api.v1.backup.config.$url()), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -159,7 +159,7 @@ const statusCmd = command({
   flags: {},
   run: async () => {
     const client = getClient();
-    const res = await daemonFetch(urlOf(client.api.backup.status.$url()));
+    const res = await daemonFetch(urlOf(client.api.v1.backup.status.$url()));
     if (!res.ok) await apiError(res, "Failed to get backup status");
     const status = (await res.json()) as {
       resticInstalled: boolean;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -80,7 +80,7 @@ const cmd = command({
     headers.Origin = baseUrl;
 
     try {
-      const res = await fetch(`${baseUrl}/api/minds`, { headers });
+      const res = await fetch(`${baseUrl}/api/v1/minds`, { headers });
       if (res.ok) {
         const minds = (await res.json()) as Array<{
           name: string;

--- a/templates/_base/.init/.local/hooks/pre-prompt/notices.ts
+++ b/templates/_base/.init/.local/hooks/pre-prompt/notices.ts
@@ -28,7 +28,7 @@ if (!session) {
 
 try {
   const res = await fetch(
-    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/minds/${VOLUTE_MIND}/history/notices?session=${encodeURIComponent(session)}`,
+    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/v1/minds/${VOLUTE_MIND}/history/notices?session=${encodeURIComponent(session)}`,
     { headers: { Authorization: `Bearer ${VOLUTE_MIND_TOKEN}` } },
   );
   if (!res.ok) {

--- a/templates/_base/.init/.local/hooks/pre-prompt/session-activity.ts
+++ b/templates/_base/.init/.local/hooks/pre-prompt/session-activity.ts
@@ -22,7 +22,7 @@ try {
 
 try {
   const res = await fetch(
-    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/minds/${VOLUTE_MIND}/history/cross-session?session=${encodeURIComponent(session)}`,
+    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/v1/minds/${VOLUTE_MIND}/history/cross-session?session=${encodeURIComponent(session)}`,
     { headers: { Authorization: `Bearer ${VOLUTE_MIND_TOKEN}` } },
   );
   if (!res.ok) {

--- a/templates/_base/.init/.local/hooks/pre-prompt/turn-context.ts
+++ b/templates/_base/.init/.local/hooks/pre-prompt/turn-context.ts
@@ -13,7 +13,7 @@ if (!VOLUTE_DAEMON_PORT || !VOLUTE_MIND_TOKEN || !VOLUTE_MIND) {
 
 try {
   const res = await fetch(
-    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/minds/${VOLUTE_MIND}/turn-context?reason=turn`,
+    `http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/v1/minds/${VOLUTE_MIND}/turn-context?reason=turn`,
     {
       headers: { Authorization: `Bearer ${VOLUTE_MIND_TOKEN}` },
       signal: AbortSignal.timeout(3000),

--- a/templates/_base/.init/.local/hooks/startup-context.ts
+++ b/templates/_base/.init/.local/hooks/startup-context.ts
@@ -77,7 +77,7 @@ try {
 try {
   const { VOLUTE_DAEMON_PORT, VOLUTE_MIND_TOKEN } = process.env;
   if (VOLUTE_DAEMON_PORT && VOLUTE_MIND_TOKEN) {
-    const res = await fetch(`http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/extensions/mind-docs`, {
+    const res = await fetch(`http://127.0.0.1:${VOLUTE_DAEMON_PORT}/api/v1/extensions/mind-docs`, {
       headers: { Authorization: `Bearer ${VOLUTE_MIND_TOKEN}` },
     });
     if (res.ok) {

--- a/templates/_base/src/lib/daemon-client.ts
+++ b/templates/_base/src/lib/daemon-client.ts
@@ -39,7 +39,7 @@ export async function daemonRestart(context?: {
   }
   try {
     const res = await fetch(
-      `http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/restart`,
+      `http://127.0.0.1:${port}/api/v1/minds/${encodeURIComponent(mind)}/restart`,
       {
         method: "POST",
         headers: headers(),
@@ -98,7 +98,7 @@ export async function daemonEmit(event: DaemonEvent): Promise<void> {
     }
     return;
   }
-  const url = `http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/events`;
+  const url = `http://127.0.0.1:${port}/api/v1/minds/${encodeURIComponent(mind)}/events`;
   const body = JSON.stringify(event);
   // Critical events get retries: `done` (else turns stay stuck) and `error` (else the
   // mind never learns a failure happened). The daemon is local, so retrying against it
@@ -142,7 +142,7 @@ export async function daemonNotice(input: {
   }
   try {
     const res = await fetch(
-      `http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/notices`,
+      `http://127.0.0.1:${port}/api/v1/minds/${encodeURIComponent(mind)}/notices`,
       {
         method: "POST",
         headers: headers(),

--- a/test/api-prefix.test.ts
+++ b/test/api-prefix.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+/**
+ * The API surface is a single canonical prefix, /api/v1. The bare /api aliases
+ * were dropped (#333), with two deliberate exceptions kept on the bare prefix:
+ * /api/health (liveness, unauthenticated) and the /api/ext/* extension mounts.
+ *
+ * Two things this pins that would otherwise regress silently:
+ *   1. The bare /api/<module> paths now 404 — no leftover dual mounts.
+ *   2. The public v1 sub-surfaces (/setup, /auth, /keys) are exempt from the
+ *      /api/v1/* auth blanket. Setup runs before the first user exists, so if the
+ *      blanket ever swallowed it, first-run install would 401 and dead-end. The
+ *      no-credential assertions below FAIL (401 instead of 200/404) the moment
+ *      that exemption is removed — that is their whole point.
+ */
+describe("api prefix surface", () => {
+  it("serves the canonical /api/v1/setup without credentials (auth exemption)", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    // No Cookie, no Authorization header at all.
+    const res = await app.request("/api/v1/setup/status");
+    // Reachable → the setup handler answered. If the v1 auth blanket were not
+    // exempting /setup, this would be 401 before the handler ran.
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { complete?: boolean };
+    assert.equal(typeof body.complete, "boolean");
+  });
+
+  it("serves public /api/v1/auth routes without credentials (auth exemption)", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    // A public avatar read for a missing file: reachable → 404 from the handler.
+    // If /auth were behind the v1 auth blanket, this would be 401 instead.
+    const res = await app.request("/api/v1/auth/avatars/does-not-exist.png");
+    assert.notEqual(res.status, 401);
+    assert.equal(res.status, 404);
+  });
+
+  it("keeps /api/health on the bare prefix, unauthenticated", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    const res = await app.request("/api/health");
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { ok?: boolean };
+    assert.equal(body.ok, true);
+  });
+
+  it("404s the dropped bare /api/<module> aliases (one per former mount group)", async () => {
+    const { default: app } = await import("../packages/daemon/src/web/app.js");
+    // One representative route per former bare-mount group. All moved to /api/v1.
+    const barePaths = [
+      "/api/setup/status", // setup (was pre-auth bare mount)
+      "/api/auth/me", // auth
+      "/api/config/models", // config
+      "/api/backup/status", // backup (admin tooling)
+      "/api/bridges", // bridges
+      "/api/activity", // activity
+      "/api/minds", // mind-scoped modules
+      "/api/keys/deadbeef", // keys
+      "/api/extensions/all", // extensions management
+    ];
+    for (const path of barePaths) {
+      const res = await app.request(path);
+      assert.equal(res.status, 404, `expected 404 for dropped bare path ${path}`);
+    }
+  });
+});

--- a/test/api-tokens.test.ts
+++ b/test/api-tokens.test.ts
@@ -42,8 +42,8 @@ async function cleanup() {
 /** A minimal app exposing a requireSelf-guarded route, mirroring mind-scoped routes. */
 function createApp() {
   const app = new Hono();
-  app.use("/api/minds/*", authMiddleware);
-  app.get("/api/minds/:name/info", requireSelf(), (c) =>
+  app.use("/api/v1/minds/*", authMiddleware);
+  app.get("/api/v1/minds/:name/info", requireSelf(), (c) =>
     c.json({ ok: true, name: c.req.param("name"), caller: c.get("user").username }),
   );
   return app;
@@ -73,7 +73,7 @@ describe("api tokens", () => {
 
     const app = createApp();
 
-    const ok = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+    const ok = await app.request(`/api/v1/minds/${EXTERNAL_MIND}/info`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     assert.equal(ok.status, 200, await ok.clone().text());
@@ -85,7 +85,7 @@ describe("api tokens", () => {
     assert.equal(mindUser.role, "user");
 
     // ...and it cannot reach another mind's route.
-    const forbidden = await app.request(`/api/minds/${OTHER_MIND}/info`, {
+    const forbidden = await app.request(`/api/v1/minds/${OTHER_MIND}/info`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     assert.equal(forbidden.status, 403);
@@ -100,7 +100,7 @@ describe("api tokens", () => {
 
     // ...and the request still authenticates via the session-Bearer branch.
     const app = createApp();
-    const res = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+    const res = await app.request(`/api/v1/minds/${EXTERNAL_MIND}/info`, {
       headers: { Authorization: `Bearer ${sessionId}` },
     });
     assert.equal(res.status, 200, await res.clone().text());
@@ -143,7 +143,7 @@ describe("api tokens", () => {
     assert.ok(issued.token.startsWith("vmt_"));
 
     const app = createApp();
-    const before = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+    const before = await app.request(`/api/v1/minds/${EXTERNAL_MIND}/info`, {
       headers: { Authorization: `Bearer ${issued.token}` },
     });
     assert.equal(before.status, 200);
@@ -156,7 +156,7 @@ describe("api tokens", () => {
 
     // Revoked: the token no longer resolves and the request is unauthenticated.
     assert.equal(await resolveApiToken(issued.token), null);
-    const after = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+    const after = await app.request(`/api/v1/minds/${EXTERNAL_MIND}/info`, {
       headers: { Authorization: `Bearer ${issued.token}` },
     });
     assert.equal(after.status, 401);
@@ -289,7 +289,7 @@ describe("api tokens", () => {
     const { token } = await issueApiToken(user.id, "pending-user");
 
     const app = createApp();
-    const res = await app.request(`/api/minds/${EXTERNAL_MIND}/info`, {
+    const res = await app.request(`/api/v1/minds/${EXTERNAL_MIND}/info`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     assert.equal(res.status, 403);

--- a/test/authz-coverage.test.ts
+++ b/test/authz-coverage.test.ts
@@ -55,7 +55,7 @@ const AUTHZ_EXEMPT: Record<string, string> = {
     "in-handler authz: isParticipantOrOwner(id, user.id) or 404",
   "volute/conversations.ts DELETE /:name/conversations/:id":
     "in-handler authz: deleteConversationForUser scopes to the caller's participation",
-  "volute/chat.ts GET /:name/conversations/:id/events":
+  "chat.ts GET /:name/conversations/:id/events":
     "in-handler authz: isParticipantOrOwner(conversationId, user.id) or 404 before SSE",
 
   // --- Channel routes (:name = channel, not a mind). Reads are membership metadata. ---

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -227,8 +227,8 @@ describe("backup API authorization", () => {
     const { authMiddleware } = await import("../packages/daemon/src/web/middleware/auth.js");
     const { default: backupRoutes } = await import("../packages/daemon/src/web/api/backup.js");
     const app = new Hono();
-    app.use("/api/backup/*", authMiddleware);
-    app.route("/api/backup", backupRoutes);
+    app.use("/api/v1/backup/*", authMiddleware);
+    app.route("/api/v1/backup", backupRoutes);
     return app;
   }
 
@@ -244,12 +244,12 @@ describe("backup API authorization", () => {
     const headers = { Authorization: `Bearer ${token}` };
 
     for (const [method, path] of [
-      ["GET", "/api/backup/config"],
-      ["PUT", "/api/backup/config"],
-      ["POST", "/api/backup/init"],
-      ["POST", "/api/backup/run"],
-      ["GET", "/api/backup/snapshots"],
-      ["GET", "/api/backup/status"],
+      ["GET", "/api/v1/backup/config"],
+      ["PUT", "/api/v1/backup/config"],
+      ["POST", "/api/v1/backup/init"],
+      ["POST", "/api/v1/backup/run"],
+      ["GET", "/api/v1/backup/snapshots"],
+      ["GET", "/api/v1/backup/status"],
     ] as const) {
       const res = await app.request(path, { method, headers });
       assert.equal(res.status, 403, `${method} ${path} must be admin-only`);
@@ -267,7 +267,7 @@ describe("backup API authorization", () => {
       "Content-Type": "application/json",
     };
 
-    const put = await app.request("/api/backup/config", {
+    const put = await app.request("/api/v1/backup/config", {
       method: "PUT",
       headers,
       body: JSON.stringify({
@@ -281,7 +281,7 @@ describe("backup API authorization", () => {
     assert.ok(!putBody.includes("super-secret-passphrase"));
     assert.ok(!putBody.includes("aws-secret-value"));
 
-    const get = await app.request("/api/backup/config", { headers });
+    const get = await app.request("/api/v1/backup/config", { headers });
     const getBody = (await get.json()) as {
       hasPassword: boolean;
       envKeys: string[];
@@ -293,7 +293,7 @@ describe("backup API authorization", () => {
     assert.ok(!JSON.stringify(getBody).includes("super-secret-passphrase"));
 
     // Saving config without a password keeps the stored one; same for env.
-    const put2 = await app.request("/api/backup/config", {
+    const put2 = await app.request("/api/v1/backup/config", {
       method: "PUT",
       headers,
       body: JSON.stringify({ repository: "/tmp/repo2", password: "" }),
@@ -317,21 +317,21 @@ describe("backup API authorization", () => {
       "Content-Type": "application/json",
     };
 
-    const badCron = await app.request("/api/backup/config", {
+    const badCron = await app.request("/api/v1/backup/config", {
       method: "PUT",
       headers,
       body: JSON.stringify({ schedule: "61 3 * * *" }),
     });
     assert.equal(badCron.status, 400, "a cron typo must not silently disable backups");
 
-    const zeroKeep = await app.request("/api/backup/config", {
+    const zeroKeep = await app.request("/api/v1/backup/config", {
       method: "PUT",
       headers,
       body: JSON.stringify({ keep: { daily: 0, weekly: 0, monthly: 0 } }),
     });
     assert.equal(zeroKeep.status, 400, "all-zero retention would prune every snapshot");
 
-    const goodCron = await app.request("/api/backup/config", {
+    const goodCron = await app.request("/api/v1/backup/config", {
       method: "PUT",
       headers,
       body: JSON.stringify({ schedule: "30 4 * * *" }),
@@ -351,13 +351,13 @@ describe("backup API authorization", () => {
     };
 
     // Unreachable repo → init fails whether or not restic is installed.
-    const put = await app.request("/api/backup/config", {
+    const put = await app.request("/api/v1/backup/config", {
       method: "PUT",
       headers,
       body: JSON.stringify({ repository: "s3:http://127.0.0.1:9/volute-test-nope" }),
     });
     assert.equal(put.status, 200);
-    const init = await app.request("/api/backup/init", { method: "POST", headers });
+    const init = await app.request("/api/v1/backup/init", { method: "POST", headers });
     assert.equal(init.status, 500);
     _resetConfigCache();
     const { readGlobalConfig } = await import("../packages/daemon/src/lib/config/setup.js");

--- a/test/bridge-discord-live.ts
+++ b/test/bridge-discord-live.ts
@@ -81,7 +81,7 @@ async function main() {
 
   // Step 2: Enable Discord bridge
   console.log("\nEnabling Discord bridge...");
-  const enableRes = await api("/api/bridges/discord", {
+  const enableRes = await api("/api/v1/bridges/discord", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ defaultMind: mindName }),
@@ -96,7 +96,7 @@ async function main() {
 
   // Step 3: Map Discord channel
   console.log(`\nMapping ${discordChannel} -> ${voluteChannelName}`);
-  const mapRes = await api("/api/bridges/discord/mappings", {
+  const mapRes = await api("/api/v1/bridges/discord/mappings", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -126,7 +126,9 @@ async function main() {
     const ch = channels.find((c) => c.name === voluteChannelName);
 
     if (ch) {
-      const msgsRes = await api(`/api/minds/${mindName}/conversations/${ch.id}/messages?limit=10`);
+      const msgsRes = await api(
+        `/api/v1/minds/${mindName}/conversations/${ch.id}/messages?limit=10`,
+      );
       if (msgsRes.status === 200) {
         const messages = (await msgsRes.json()) as Message[];
         for (const msg of messages) {
@@ -154,7 +156,7 @@ async function main() {
 
   // Step 5: Show bridge status
   console.log("\nBridge status:");
-  const bridgesRes = await api("/api/bridges");
+  const bridgesRes = await api("/api/v1/bridges");
   const bridges = (await bridgesRes.json()) as Bridge[];
   for (const b of bridges) {
     console.log(
@@ -164,7 +166,7 @@ async function main() {
 
   // Cleanup
   console.log("\nCleaning up...");
-  await api("/api/bridges/discord", { method: "DELETE" });
+  await api("/api/v1/bridges/discord", { method: "DELETE" });
   console.log("+ Discord bridge disabled");
 
   console.log("\n=== Done ===");

--- a/test/channel-limits.test.ts
+++ b/test/channel-limits.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../packages/daemon/src/lib/events/conversations.js";
 import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import { messages, users } from "../packages/daemon/src/lib/schema.js";
-import { chatApp } from "../packages/daemon/src/web/api/volute/chat.js";
+import { chatApp } from "../packages/daemon/src/web/api/chat.js";
 import { authMiddleware, createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 const TEST_USERNAMES = ["limits-host", "limits-file-mind"];

--- a/test/channel-limits.test.ts
+++ b/test/channel-limits.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../packages/daemon/src/lib/events/conversations.js";
 import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
 import { messages, users } from "../packages/daemon/src/lib/schema.js";
-import { unifiedChatApp } from "../packages/daemon/src/web/api/volute/chat.js";
+import { chatApp } from "../packages/daemon/src/web/api/volute/chat.js";
 import { authMiddleware, createSession } from "../packages/daemon/src/web/middleware/auth.js";
 
 const TEST_USERNAMES = ["limits-host", "limits-file-mind"];
@@ -239,7 +239,7 @@ describe("channel limits", () => {
     function createApp() {
       const app = new Hono();
       app.use("/api/v1/*", authMiddleware);
-      app.route("/api/v1", unifiedChatApp);
+      app.route("/api/v1/chat", chatApp);
       return app;
     }
 

--- a/test/chat-gated-notice.test.ts
+++ b/test/chat-gated-notice.test.ts
@@ -159,7 +159,7 @@ describe("file-sharing responses carry `notified` (#723)", () => {
     invalidateMindUserCache(RECIPIENT);
     const recipientToken = generateMindToken(RECIPIENT);
     const stage = (filename: string) =>
-      app.request(`http://localhost/api/minds/${RECIPIENT}/files/stage`, {
+      app.request(`http://localhost/api/v1/minds/${RECIPIENT}/files/stage`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${recipientToken}`,
@@ -195,7 +195,7 @@ describe("file-sharing responses carry `notified` (#723)", () => {
     );
 
     // Accepting notifies the sender — a human with no mind entry, so notified must be false.
-    const acceptRes = await app.request(`http://localhost/api/minds/${RECIPIENT}/files/accept`, {
+    const acceptRes = await app.request(`http://localhost/api/v1/minds/${RECIPIENT}/files/accept`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${recipientToken}`,

--- a/test/chat-send-file-firstdm.test.ts
+++ b/test/chat-send-file-firstdm.test.ts
@@ -100,7 +100,7 @@ async function setup(fail?: FailMode) {
   const senderHome = resolve(mindDir(SENDER), "home");
   mkdirSync(senderHome, { recursive: true });
   writeFileSync(resolve(senderHome, "isobar-notes.txt"), "the crowded parts");
-  // The receiver needs a home dir so GET /api/minds/<receiver> (the --file target
+  // The receiver needs a home dir so GET /api/v1/minds/<receiver> (the --file target
   // check) resolves it as a real mind, exactly as a provisioned mind would.
   mkdirSync(resolve(mindDir(RECEIVER), "home"), { recursive: true });
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -251,7 +251,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   async function waitForMindRunning(timeoutMs = 30000): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}`);
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
       const s = (await res.json()) as { status: string };
       if (s.status === "running") return;
       await new Promise((r) => setTimeout(r, 500));
@@ -283,15 +283,31 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   });
 
   it("unauthenticated request returns 401", async () => {
-    const res = await fetch(`${BASE_URL}/api/minds`);
+    const res = await fetch(`${BASE_URL}/api/v1/minds`);
     assert.equal(res.status, 401);
   });
 
   it("GET /api/minds returns empty array initially", async () => {
-    const res = await daemonRequest("/api/minds");
+    const res = await daemonRequest("/api/v1/minds");
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body));
+  });
+
+  it("the removed bare /api alias 404s — only /api/v1 serves moved routes (#333)", async () => {
+    // The minds module moved to /api/v1; its old bare /api mount is gone, so these
+    // fall through to the app's notFound handler ("Not found"), not a route handler.
+    const bareList = await daemonRequest("/api/minds");
+    assert.equal(bareList.status, 404);
+    assert.equal((await bareList.json()).error, "Not found");
+    const bareStart = await daemonRequest("/api/minds/anything/start", { method: "POST" });
+    assert.equal(bareStart.status, 404);
+    assert.equal((await bareStart.json()).error, "Not found");
+    // The canonical v1 route still resolves — its 404 is the handler saying the mind
+    // doesn't exist ("Mind not found"), proving the route itself is mounted.
+    const v1Start = await daemonRequest("/api/v1/minds/no-such-mind-xyz/start", { method: "POST" });
+    assert.equal(v1Start.status, 404);
+    assert.equal((await v1Start.json()).error, "Mind not found");
   });
 
   it("GET /api/extensions/mind-docs lists pages with a mindDoc and commands", async () => {
@@ -321,7 +337,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
   it("mind lifecycle: create, start, status, stop", async () => {
     // Create mind via daemon API
-    const createRes = await daemonRequest("/api/minds", {
+    const createRes = await daemonRequest("/api/v1/minds", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: TEST_MIND }),
@@ -366,7 +382,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await waitForHealth();
 
     // Verify mind appears in listing
-    const listRes = await daemonRequest("/api/minds");
+    const listRes = await daemonRequest("/api/v1/minds");
     assert.equal(listRes.status, 200);
     const minds = (await listRes.json()) as Array<{ name: string; status: string }>;
     const testEntry = minds.find((a) => a.name === TEST_MIND);
@@ -374,11 +390,11 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(testEntry.status, "stopped");
 
     // Start mind
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.equal(startRes.status, 200, `Start failed: ${await startRes.text()}`);
 
     // Status should show running
-    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const statusRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     assert.equal(statusRes.status, 200);
     const mindStatus = (await statusRes.json()) as { name: string; status: string };
     assert.equal(mindStatus.name, TEST_MIND);
@@ -388,11 +404,11 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     // Stop mind
-    const stopRes = await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    const stopRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
     assert.equal(stopRes.status, 200);
 
     // Status should show stopped
-    const stoppedRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const stoppedRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     assert.equal(stoppedRes.status, 200);
     const stoppedStatus = (await stoppedRes.json()) as { status: string };
     assert.equal(stoppedStatus.status, "stopped");
@@ -408,7 +424,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     const form = new FormData();
     form.append("file", new File([new Uint8Array(bigPng)], "big.png", { type: "image/png" }));
-    const uploadRes = await daemonRequest(`/api/minds/${TEST_MIND}/avatar`, {
+    const uploadRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/avatar`, {
       method: "POST",
       body: form,
     });
@@ -417,7 +433,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const uploaded = JSON.parse(uploadText) as { avatar: string };
     assert.equal(uploaded.avatar, "avatar.webp");
 
-    const getRes = await daemonRequest(`/api/minds/${TEST_MIND}/avatar`);
+    const getRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/avatar`);
     assert.equal(getRes.status, 200);
     assert.equal(getRes.headers.get("content-type"), "image/webp");
     const etag = getRes.headers.get("etag");
@@ -428,7 +444,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(meta.width, 256);
     assert.equal(meta.height, 256);
 
-    const revalidateRes = await daemonRequest(`/api/minds/${TEST_MIND}/avatar`, {
+    const revalidateRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/avatar`, {
       headers: { "If-None-Match": etag },
     });
     assert.equal(revalidateRes.status, 304);
@@ -465,7 +481,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       },
     ]);
 
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/delivery/pending`);
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/delivery/pending`);
     assert.equal(res.status, 200);
     const pending = (await res.json()) as Array<{
       channel: string;
@@ -479,7 +495,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Releasing (delivering) the gated rows clears them from the preview.
     await db.delete(deliveryQueue).where(eq(deliveryQueue.mind, TEST_MIND));
-    const res2 = await daemonRequest(`/api/minds/${TEST_MIND}/delivery/pending`);
+    const res2 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/delivery/pending`);
     const pending2 = (await res2.json()) as Array<{ channel: string }>;
     assert.ok(
       !pending2.find((p) => p.channel === "slack:random"),
@@ -489,14 +505,14 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
   it("minds persist running state across daemon restart", async () => {
     // Start mind
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
       `Start: expected 200 or 409, got ${startRes.status}`,
     );
 
     // Verify running
-    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const statusRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const status = (await statusRes.json()) as { status: string };
     assert.ok(
       status.status === "running" || status.status === "starting",
@@ -540,7 +556,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const deadline = Date.now() + 30000;
     let restored = false;
     while (Date.now() < deadline) {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}`);
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
       const s = (await res.json()) as { status: string };
       if (s.status === "running") {
         restored = true;
@@ -551,12 +567,12 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(restored, "Mind should be auto-restored after daemon restart");
 
     // Stop mind for subsequent tests
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("stopped minds stay stopped across daemon restart", async () => {
     // Mind should be stopped from the previous test — verify
-    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const statusRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const status = (await statusRes.json()) as { status: string };
     assert.equal(status.status, "stopped", "Mind should be stopped before this test");
 
@@ -599,7 +615,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await waitForHealth();
 
     // Mind should still be stopped — not auto-started
-    const restoredRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const restoredRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const restoredStatus = (await restoredRes.json()) as { status: string };
     assert.equal(
       restoredStatus.status,
@@ -631,7 +647,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       });
 
     // Authenticates before the restart (requireSelf route, as the mind itself).
-    const before = await tokenRequest(`/api/minds/${TEST_MIND}/sleep`);
+    const before = await tokenRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
     assert.equal(before.status, 200, `before restart: ${await before.clone().text()}`);
 
     // Restart the daemon (SIGTERM, as `volute down` does), then bring it back.
@@ -661,7 +677,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await waitForHealth();
 
     // The whole point: the same token still authenticates against a fresh process.
-    const after = await tokenRequest(`/api/minds/${TEST_MIND}/sleep`);
+    const after = await tokenRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
     assert.equal(after.status, 200, `after restart: ${await after.clone().text()}`);
 
     // And revocation still takes effect against the new daemon.
@@ -669,7 +685,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       method: "DELETE",
     });
     assert.equal(del.status, 200, `revoke: ${await del.clone().text()}`);
-    const revoked = await tokenRequest(`/api/minds/${TEST_MIND}/sleep`);
+    const revoked = await tokenRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
     assert.equal(revoked.status, 401, "revoked token must not authenticate");
   });
 
@@ -677,7 +693,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const entry = await findMind(TEST_MIND);
     assert.ok(entry, "test mind should be registered");
 
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
       `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
@@ -694,7 +710,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     await waitForMindRunning();
 
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("variants: split creates a worktree variant, merge folds it back into the parent", {
@@ -704,7 +720,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const parentDir = mindDir(TEST_MIND);
 
     // Split: create the variant without starting its server.
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "e2e-var", noStart: true }),
@@ -718,7 +734,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(existsSync(created.variant.path), "variant worktree should exist");
 
     // Variant is registered with the parent.
-    const listRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`);
+    const listRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`);
     assert.equal(listRes.status, 200);
     const variants = (await listRes.json()) as { name: string }[];
     assert.ok(
@@ -750,7 +766,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     writeFileSync(resolve(created.variant.path, ".mind", "farewell.md"), `${farewellText}\n`);
 
     // Join: merge the variant back. skipVerify avoids booting a verification server.
-    const mergeRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-var/merge`, {
+    const mergeRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants/e2e-var/merge`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skipVerify: true, summary: "e2e merge test" }),
@@ -793,7 +809,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Merge restarts the parent — wait for it, then stop it for subsequent tests.
     await waitForMindRunning(60000);
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("variants: a merge conflict aborts cleanly and leaves the variant joinable", {
@@ -803,7 +819,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const parentDir = mindDir(TEST_MIND);
 
     // Split without starting its server.
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "e2e-conflict-var", noStart: true }),
@@ -838,7 +854,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Join must fail with a structured conflict error naming the file.
     const mergeRes = await daemonRequest(
-      `/api/minds/${TEST_MIND}/variants/e2e-conflict-var/merge`,
+      `/api/v1/minds/${TEST_MIND}/variants/e2e-conflict-var/merge`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -890,7 +906,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // Standalone delete — the "Discard" action the web dashboard now exposes.
     // The variant is removed from the registry and disk. Doubles as cleanup so
     // later tests aren't affected.
-    const deleteRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants/e2e-conflict-var`, {
+    const deleteRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants/e2e-conflict-var`, {
       method: "DELETE",
     });
     assert.equal(deleteRes.status, 200, `Delete: ${await deleteRes.clone().text()}`);
@@ -914,7 +930,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // upsert only reconciles the name), so the handler must roll back.
     const branch = "e2e-rollback-var";
     const variantPath = resolve(parentDir, ".variants", branch);
-    const failRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+    const failRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: branch, port: parent.port, noStart: true }),
@@ -934,7 +950,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(branchList, "", `branch should be deleted, got: ${branchList}`);
 
     // A retry with the same name now succeeds.
-    const retryRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+    const retryRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: branch, noStart: true }),
@@ -943,17 +959,17 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(existsSync(variantPath), "retry should recreate the worktree");
     assert.ok(await findMind(branch), "retry should register the variant");
 
-    await daemonRequest(`/api/minds/${TEST_MIND}/variants/${branch}`, { method: "DELETE" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants/${branch}`, { method: "DELETE" });
   });
 
   // ── Bridge & Chat Integration Tests ──
 
   /** Ensure the test mind exists in the registry (creates via API if not). */
   async function ensureTestMind(): Promise<void> {
-    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const statusRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     if (statusRes.status === 200) return; // already exists
 
-    const createRes = await daemonRequest("/api/minds", {
+    const createRes = await daemonRequest("/api/v1/minds", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: TEST_MIND }),
@@ -1093,7 +1109,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // reason falls back to the smaller per-turn budget rather than erroring.
     for (const reason of ["turn", "wake", "nonsense-falls-back-to-turn"]) {
       const res = await daemonRequest(
-        `/api/minds/${TEST_MIND}/turn-context?reason=${encodeURIComponent(reason)}`,
+        `/api/v1/minds/${TEST_MIND}/turn-context?reason=${encodeURIComponent(reason)}`,
       );
       assert.equal(res.status, 200, `reason=${reason}`);
       const body = (await res.json()) as { context: string | null };
@@ -1104,7 +1120,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   it("GET /:name/turn-context is mind-scoped: another mind gets 403, anonymous 401", async () => {
     await ensureTestMind();
 
-    const anon = await fetch(`${BASE_URL}/api/minds/${TEST_MIND}/turn-context`);
+    const anon = await fetch(`${BASE_URL}/api/v1/minds/${TEST_MIND}/turn-context`);
     assert.equal(anon.status, 401);
 
     // A different mind principal must not be able to read this mind's ambient context.
@@ -1113,7 +1129,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const headers = new Headers();
     headers.set("Authorization", `Bearer ${otherSession}`);
     headers.set("Origin", BASE_URL);
-    const res = await fetch(`${BASE_URL}/api/minds/${TEST_MIND}/turn-context`, { headers });
+    const res = await fetch(`${BASE_URL}/api/v1/minds/${TEST_MIND}/turn-context`, { headers });
     assert.equal(res.status, 403);
   });
 
@@ -1135,7 +1151,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const SENSITIVE = ["port", "dir", "branch", "template", "templateHash", "parent", "createdBy"];
 
     // List: a mind caller gets profile-level fields only.
-    const mindList = await asMind("/api/minds");
+    const mindList = await asMind("/api/v1/minds");
     assert.equal(mindList.status, 200);
     const minds = (await mindList.json()) as Record<string, unknown>[];
     const mine = minds.find((m) => m.name === TEST_MIND);
@@ -1146,7 +1162,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok("status" in mine && "channels" in mine, "reduced entry keeps profile/status fields");
 
     // Detail: same reduction, and no variants array (variant ports are internal).
-    const mindDetail = await asMind(`/api/minds/${TEST_MIND}`);
+    const mindDetail = await asMind(`/api/v1/minds/${TEST_MIND}`);
     assert.equal(mindDetail.status, 200);
     const detail = (await mindDetail.json()) as Record<string, unknown>;
     for (const f of [...SENSITIVE, "variants"]) {
@@ -1161,7 +1177,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     }
 
     // Admin (daemon token) still gets the full entry, including port.
-    const adminList = await daemonRequest("/api/minds");
+    const adminList = await daemonRequest("/api/v1/minds");
     const adminMinds = (await adminList.json()) as Record<string, unknown>[];
     const adminMine = adminMinds.find((m) => m.name === TEST_MIND);
     assert.ok(
@@ -1169,7 +1185,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       "admin list must still include port",
     );
 
-    const adminDetail = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const adminDetail = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const adminDetailBody = (await adminDetail.json()) as Record<string, unknown>;
     assert.equal(typeof adminDetailBody.port, "number", "admin detail must still include port");
     // The other half of the preserved behavior: admins keep the variants array
@@ -1226,7 +1242,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Start a job with an unconfigured provider — generation fails fast (no
     // network), but the route must still accept the job and return an id.
-    const start = await asMind(`/api/minds/${mind}/imagegen/jobs`, {
+    const start = await asMind(`/api/v1/minds/${mind}/imagegen/jobs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1241,19 +1257,19 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Long-poll: the job settles to "error" (no credentials), and the daemon
     // returns as soon as it does rather than waiting the full window.
-    const poll = await asMind(`/api/minds/${mind}/imagegen/jobs/${jobId}?wait=10`);
+    const poll = await asMind(`/api/v1/minds/${mind}/imagegen/jobs/${jobId}?wait=10`);
     assert.equal(poll.status, 200, `poll job: ${await poll.clone().text()}`);
     const job = (await poll.json()) as { status: string; error?: string };
     assert.equal(job.status, "error", `expected error, got ${JSON.stringify(job)}`);
 
     // A job that doesn't exist 404s (the skill maps this to "re-run generate").
-    const missing = await asMind(`/api/minds/${mind}/imagegen/jobs/does-not-exist`);
+    const missing = await asMind(`/api/v1/minds/${mind}/imagegen/jobs/does-not-exist`);
     assert.equal(missing.status, 404, "unknown job must 404");
 
     // Another mind cannot reach this mind's job routes (requireSelf).
     const other = await getOrCreateMindUser("e2e-imagegen-jobs-outsider");
     const otherSession = await createSession(other.id);
-    const cross = await fetch(`${BASE_URL}/api/minds/${mind}/imagegen/jobs/${jobId}`, {
+    const cross = await fetch(`${BASE_URL}/api/v1/minds/${mind}/imagegen/jobs/${jobId}`, {
       headers: { Authorization: `Bearer ${otherSession}`, Origin: BASE_URL },
     });
     assert.equal(cross.status, 403, "another mind must not read this mind's job");
@@ -1264,7 +1280,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("convo");
 
     // Create a conversation between the test mind and a real second participant.
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1290,7 +1306,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Read messages back
     const msgsRes = await daemonRequest(
-      `/api/minds/${TEST_MIND}/conversations/${conv.id}/messages`,
+      `/api/v1/minds/${TEST_MIND}/conversations/${conv.id}/messages`,
     );
     assert.equal(msgsRes.status, 200);
     const { items: messages } = (await msgsRes.json()) as {
@@ -1308,7 +1324,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   it("upgrade: rejects an unknown template with 400", async () => {
     await ensureTestMind();
 
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/upgrade`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ template: "../../evil" }),
@@ -1332,7 +1348,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(existsSync(lockStamp), "test mind should have node_modules installed");
     const mtimeBefore = statSync(lockStamp).mtimeMs;
 
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/upgrade`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -1353,10 +1369,10 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(!existsSync(resolve(dir, ".variants", "upgrade")), "upgrade worktree left behind");
 
     // Upgrade restarts the mind; stop it so later tests see the usual state.
-    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const statusRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const status = (await statusRes.json()) as { status?: string };
     assert.equal(status.status, "running", "mind should be running after upgrade");
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("upgrade: self-heals a stale orphaned upgrade worktree left by a prior run", async () => {
@@ -1375,7 +1391,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Previously this 409'd forever (#whorl) because nothing ever cleared the
     // orphan. It should now self-heal and complete the upgrade normally.
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/upgrade`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -1395,7 +1411,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     // Upgrade restarts the mind; stop it so later tests see the usual state.
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("upgrade: a worktree genuinely mid-conflict-resolution still 409s (not treated as a stale orphan)", async () => {
@@ -1421,7 +1437,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     }).trim();
     writeFileSync(resolve(gitDir, "MERGE_HEAD"), `${headSha}\n`);
 
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/upgrade`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -1436,7 +1452,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(existsSync(worktreeDir), "mid-resolution worktree should not be touched");
 
     // Clean up via abort so later tests see the usual state.
-    const abortRes = await daemonRequest(`/api/minds/${TEST_MIND}/upgrade`, {
+    const abortRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/upgrade`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ abort: true }),
@@ -1478,13 +1494,13 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       // successful restart on this now-clean working tree makes the daemon call
       // commitSrcChanges() itself, advancing HEAD past the marker commit — the
       // same way a real successful restart establishes a new known-good baseline.
-      await daemonRequest(`/api/minds/${TEST_MIND}/restart`, { method: "POST" }).catch(() => {});
+      await daemonRequest(`/api/v1/minds/${TEST_MIND}/restart`, { method: "POST" }).catch(() => {});
     });
 
     // Start the mind and wait for it to be running — the auto-upgrade pass must
     // see it as previously-running so it restarts the mind after the merge (the
     // "never call runUpgrade with restart:false on a running mind" footgun).
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
       `Start: expected 200 or 409, got ${startRes.status}`,
@@ -1546,7 +1562,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     let upgraded = false;
     let lastStatus: { status?: string; templateStale?: boolean } = {};
     while (Date.now() < deadline) {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}`);
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
       lastStatus = (await res.json()) as { status?: string; templateStale?: boolean };
       if (lastStatus.status === "running" && lastStatus.templateStale === false) {
         upgraded = true;
@@ -1567,7 +1583,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     // Stop the mind so later tests see the usual state.
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("unified chat: send via /api/v1/chat", async () => {
@@ -1575,7 +1591,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("unified");
 
     // Create a conversation first (mind + a real second participant)
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1599,7 +1615,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Read it back
     const msgsRes = await daemonRequest(
-      `/api/minds/${TEST_MIND}/conversations/${conv.id}/messages`,
+      `/api/v1/minds/${TEST_MIND}/conversations/${conv.id}/messages`,
     );
     assert.equal(msgsRes.status, 200);
     const { items: messages } = (await msgsRes.json()) as {
@@ -1613,7 +1629,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   }, async () => {
     // Poll the spirit's status; it's created (npm install) + started at daemon boot.
     async function spiritStatus(): Promise<string | null> {
-      const res = await daemonRequest("/api/minds/volute");
+      const res = await daemonRequest("/api/v1/minds/volute");
       if (!res.ok) return null;
       return ((await res.json()) as { status: string }).status;
     }
@@ -1632,7 +1648,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(booted, "running", `spirit should be running after daemon boot, got ${booted}`);
 
     // Stop the spirit — the pre-#434 silent-cliff state.
-    const stopRes = await daemonRequest("/api/minds/volute/stop", { method: "POST" });
+    const stopRes = await daemonRequest("/api/v1/minds/volute/stop", { method: "POST" });
     assert.equal(stopRes.status, 200, `Stop spirit: ${await stopRes.clone().text()}`);
 
     // A DM to the stopped spirit starts it on demand and reports "waking".
@@ -1667,7 +1683,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     }
 
     // Make sure the mind is running on good code.
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
       `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
@@ -1682,7 +1698,9 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Restart: the daemon should detect the broken startup, park the change, restore the
     // last known-good src/, and come back up rather than dying.
-    const restartRes = await daemonRequest(`/api/minds/${TEST_MIND}/restart`, { method: "POST" });
+    const restartRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/restart`, {
+      method: "POST",
+    });
     assert.equal(
       restartRes.status,
       200,
@@ -1703,7 +1721,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     // The mind is back up.
-    const statusRes = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const statusRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const status = (await statusRes.json()) as { status: string };
     assert.ok(
       status.status === "running" || status.status === "starting",
@@ -1735,7 +1753,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       "notice should name the broken branch",
     );
 
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("bridge config: set, mappings CRUD, remove", async () => {
@@ -1837,7 +1855,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Read the message back from the conversation
     const msgsRes = await daemonRequest(
-      `/api/minds/${TEST_MIND}/conversations/${inboundBody.conversationId}/messages`,
+      `/api/v1/minds/${TEST_MIND}/conversations/${inboundBody.conversationId}/messages`,
     );
     assert.equal(msgsRes.status, 200);
     const { items: messages } = (await msgsRes.json()) as {
@@ -1897,7 +1915,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Verify both messages are in the conversation
     const msgsRes = await daemonRequest(
-      `/api/minds/${TEST_MIND}/conversations/${body1.conversationId}/messages`,
+      `/api/v1/minds/${TEST_MIND}/conversations/${body1.conversationId}/messages`,
     );
     assert.equal(msgsRes.status, 200);
     const { items: messages } = (await msgsRes.json()) as {
@@ -1953,7 +1971,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   it("fresh mind gets the default rotating heartbeat", async () => {
     await ensureTestMind();
 
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     assert.equal(res.status, 200);
     const schedules = (await res.json()) as { id: string; messages?: string[] }[];
     const heartbeat = schedules.find((s) => s.id === "heartbeat");
@@ -1968,7 +1986,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await ensureTestMind();
 
     // Add a cron schedule
-    const addRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const addRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cron: "0 9 * * *", message: "good morning", id: "test-cron" }),
@@ -1976,7 +1994,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(addRes.status, 201, `Add schedule: ${await addRes.clone().text()}`);
 
     // List — should include the schedule
-    const listRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const listRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     assert.equal(listRes.status, 200);
     const schedules = (await listRes.json()) as { id: string; cron?: string; message?: string }[];
     const found = schedules.find((s) => s.id === "test-cron");
@@ -1985,7 +2003,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(found.message, "good morning");
 
     // Update message
-    const updateRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-cron`, {
+    const updateRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/test-cron`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message: "updated message" }),
@@ -1993,18 +2011,18 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(updateRes.status, 200, `Update: ${await updateRes.clone().text()}`);
 
     // Verify update
-    const listRes2 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const listRes2 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     const schedules2 = (await listRes2.json()) as { id: string; message?: string }[];
     assert.equal(schedules2.find((s) => s.id === "test-cron")?.message, "updated message");
 
     // Delete
-    const delRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-cron`, {
+    const delRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/test-cron`, {
       method: "DELETE",
     });
     assert.equal(delRes.status, 200);
 
     // Verify deleted
-    const listRes3 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const listRes3 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     const schedules3 = (await listRes3.json()) as { id: string }[];
     assert.ok(!schedules3.some((s) => s.id === "test-cron"), "Schedule should be removed");
   });
@@ -2013,7 +2031,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await ensureTestMind();
 
     const futureISO = new Date(Date.now() + 3600_000).toISOString();
-    const addRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const addRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ fireAt: futureISO, message: "timer test", id: "test-timer" }),
@@ -2021,14 +2039,14 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(addRes.status, 201, `Add timer: ${await addRes.clone().text()}`);
 
     // Verify it shows up with fireAt
-    const listRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const listRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     const schedules = (await listRes.json()) as { id: string; fireAt?: string }[];
     const timer = schedules.find((s) => s.id === "test-timer");
     assert.ok(timer, "Timer should exist");
     assert.equal(timer.fireAt, futureISO);
 
     // Clean up
-    await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-timer`, { method: "DELETE" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/test-timer`, { method: "DELETE" });
   });
 
   // System-event delivery + the /events API are covered by the robust webhook test
@@ -2039,7 +2057,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   it("schedule: whileSleeping field", async () => {
     await ensureTestMind();
 
-    const addRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const addRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -2053,7 +2071,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Verify fields (schedule-fire thread routing lives in routes.json now, #736 —
     // see web-schedules.test.ts / event-routing.test.ts).
-    const listRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const listRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     const schedules = (await listRes.json()) as {
       id: string;
       whileSleeping?: string;
@@ -2063,32 +2081,34 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(sched.whileSleeping, "trigger-wake");
 
     // Update whileSleeping
-    const updateRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-sleep-sched`, {
+    const updateRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/test-sleep-sched`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ whileSleeping: "skip" }),
     });
     assert.equal(updateRes.status, 200);
 
-    const listRes2 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`);
+    const listRes2 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`);
     const schedules2 = (await listRes2.json()) as { id: string; whileSleeping?: string }[];
     assert.equal(schedules2.find((s) => s.id === "test-sleep-sched")?.whileSleeping, "skip");
 
     // Clean up
-    await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-sleep-sched`, { method: "DELETE" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/test-sleep-sched`, {
+      method: "DELETE",
+    });
   });
 
   it("clock status endpoint", async () => {
     await ensureTestMind();
 
     // Add a schedule so there's something in the response
-    await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cron: "0 9 * * *", message: "status test", id: "test-status" }),
     });
 
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/clock/status`);
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/clock/status`);
     assert.equal(res.status, 200, `Clock status: ${await res.clone().text()}`);
 
     const body = (await res.json()) as {
@@ -2120,14 +2140,14 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(upcomingEntry.at, "Should have a fire time");
 
     // Clean up
-    await daemonRequest(`/api/minds/${TEST_MIND}/schedules/test-status`, { method: "DELETE" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/test-status`, { method: "DELETE" });
   });
 
   it("schedule validation errors", async () => {
     await ensureTestMind();
 
     // No id
-    const r0 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r0 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cron: "0 9 * * *", message: "no id" }),
@@ -2135,7 +2155,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r0.status, 400);
 
     // No cron or fireAt
-    const r1 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r1 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: "val-test-1", message: "no trigger" }),
@@ -2143,7 +2163,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r1.status, 400);
 
     // Both cron and fireAt
-    const r2 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r2 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -2156,7 +2176,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r2.status, 400);
 
     // No message or script
-    const r3 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r3 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: "val-test-3", cron: "0 9 * * *" }),
@@ -2164,7 +2184,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r3.status, 400);
 
     // Invalid cron
-    const r4 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r4 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: "val-test-4", cron: "not-a-cron", message: "bad cron" }),
@@ -2172,7 +2192,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r4.status, 400);
 
     // Invalid fireAt
-    const r5 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r5 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: "val-test-5", fireAt: "not-a-date", message: "bad date" }),
@@ -2180,12 +2200,12 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r5.status, 400);
 
     // Duplicate id
-    await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cron: "0 9 * * *", message: "first", id: "dup-test" }),
     });
-    const r6 = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const r6 = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ cron: "0 10 * * *", message: "second", id: "dup-test" }),
@@ -2193,25 +2213,25 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(r6.status, 409);
 
     // Clean up
-    await daemonRequest(`/api/minds/${TEST_MIND}/schedules/dup-test`, { method: "DELETE" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/dup-test`, { method: "DELETE" });
   });
 
   it("delete nonexistent schedule returns 404", async () => {
     await ensureTestMind();
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/schedules/nonexistent`, {
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/nonexistent`, {
       method: "DELETE",
     });
     assert.equal(res.status, 404);
   });
 
   it("clock status for nonexistent mind returns 404", async () => {
-    const res = await daemonRequest("/api/minds/nonexistent-mind-xyz/clock/status");
+    const res = await daemonRequest("/api/v1/minds/nonexistent-mind-xyz/clock/status");
     assert.equal(res.status, 404);
   });
 
   it("sleep state: GET returns not-sleeping for stopped mind", async () => {
     await ensureTestMind();
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
     assert.equal(res.status, 200, `Sleep state: ${await res.clone().text()}`);
     const body = (await res.json()) as { sleeping: boolean };
     assert.equal(body.sleeping, false);
@@ -2222,7 +2242,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   it("cross-session history: returns null context when no history", async () => {
     await ensureTestMind();
     const res = await daemonRequest(
-      `/api/minds/${TEST_MIND}/history/cross-session?session=test-session`,
+      `/api/v1/minds/${TEST_MIND}/history/cross-session?session=test-session`,
     );
     assert.equal(res.status, 200);
     const body = (await res.json()) as { context: string | null };
@@ -2273,7 +2293,9 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     ]);
 
     // Query cross-session for "main" session
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/history/cross-session?session=main`);
+    const res = await daemonRequest(
+      `/api/v1/minds/${TEST_MIND}/history/cross-session?session=main`,
+    );
     assert.equal(res.status, 200);
     const body = (await res.json()) as { context: string | null };
     assert.ok(body.context, "Should return context");
@@ -2339,7 +2361,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     ]);
 
     // Turn boundary = start of web-turn-1 = tenMinAgo
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/history/cross-session?session=web`);
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/history/cross-session?session=web`);
     assert.equal(res.status, 200);
     const body = (await res.json()) as { context: string | null };
     assert.ok(body.context, "Should return context");
@@ -2354,7 +2376,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   });
 
   const emitEvent = (session: string, body: Record<string, unknown>) =>
-    daemonRequest(`/api/minds/${TEST_MIND}/events`, {
+    daemonRequest(`/api/v1/minds/${TEST_MIND}/events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ session, ...body }),
@@ -2393,7 +2415,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // A fresh mind also has the one-time homepage cue pending (#822); flush any
     // pre-existing notices so this test observes only its own failure notice.
-    await daemonRequest(`/api/minds/${TEST_MIND}/history/notices?session=${session}`);
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`);
     await emitEvent(session, { type: "done" });
 
     // Turn 1 fails with a 401 — the daemon records a notice, not delivered yet.
@@ -2402,7 +2424,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // The mind's next turn drains the notice (does not mark it delivered).
     const drain1 = await daemonRequest(
-      `/api/minds/${TEST_MIND}/history/notices?session=${session}`,
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
     );
     assert.equal(drain1.status, 200);
     const body1 = (await drain1.json()) as { context: string | null; notices: unknown[] };
@@ -2413,7 +2435,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // That turn completes cleanly (no error) → notice is marked delivered.
     await emitEvent(session, { type: "done" });
     const drain2 = await daemonRequest(
-      `/api/minds/${TEST_MIND}/history/notices?session=${session}`,
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
     );
     const body2 = (await drain2.json()) as { context: string | null; notices: unknown[] };
     assert.equal(body2.context, null);
@@ -2429,11 +2451,11 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // turn). We only assert the event is recorded and surfaced by the API here; live
     // delivery, the envelope, reflection, and the sleep queue are covered by the unit
     // tests (test/system-events.test.ts) against a stub mind server.
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
 
     // The webhook route is an immediate system event (no chat message, no sender).
     // With the mind stopped it answers 202: recorded but pending, not delivered.
-    const hook = await daemonRequest(`/api/minds/${TEST_MIND}/webhook/deploy`, {
+    const hook = await daemonRequest(`/api/v1/minds/${TEST_MIND}/webhook/deploy`, {
       method: "POST",
       headers: { "Content-Type": "text/plain" },
       body: "build 42 is live",
@@ -2444,7 +2466,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // It surfaces on the system-events listing with a worded label — not raw ids, not
     // chat. (GET /:name/events is the live SSE stream; the listing is /system-events.)
-    const res = await daemonRequest(`/api/minds/${TEST_MIND}/system-events`);
+    const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/system-events`);
     assert.equal(res.status, 200);
     const { events } = (await res.json()) as {
       events: {
@@ -2468,11 +2490,11 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     // The endpoint is self-or-admin gated (authz-coverage enforces this too).
-    const unauth = await fetch(`${BASE_URL}/api/minds/${TEST_MIND}/system-events`);
+    const unauth = await fetch(`${BASE_URL}/api/v1/minds/${TEST_MIND}/system-events`);
     assert.equal(unauth.status, 401);
   });
 
-  it("mind status: GET /api/minds/:name surfaces lastError until recovery (#574)", async () => {
+  it("mind status: GET /api/v1/minds/:name surfaces lastError until recovery (#574)", async () => {
     await ensureTestMind();
     const session = "notices-status-surface";
 
@@ -2481,7 +2503,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await emitEvent(session, { type: "error", content: "API Error: 401 authentication_error" });
     await emitEvent(session, { type: "done" });
 
-    const res1 = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const res1 = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     assert.equal(res1.status, 200);
     const mind1 = (await res1.json()) as {
       lastError?: { kind: string; reason: string; detail?: string } | null;
@@ -2492,14 +2514,14 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(mind1.lastError?.detail, "admin projection should include detail");
 
     // Drain, then a clean turn completes after the failure → recovered.
-    await daemonRequest(`/api/minds/${TEST_MIND}/history/notices?session=${session}`);
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`);
     // A completed turn strictly after the notice is what marks recovery; the
     // notice timestamps have 1s resolution, so make sure the clock ticks over.
     await new Promise((r) => setTimeout(r, 1100));
     await emitEvent(session, { type: "text", content: "recovered reply" });
     await emitEvent(session, { type: "done" });
 
-    const res2 = await daemonRequest(`/api/minds/${TEST_MIND}`);
+    const res2 = await daemonRequest(`/api/v1/minds/${TEST_MIND}`);
     const mind2 = (await res2.json()) as { lastError?: unknown };
     assert.equal(mind2.lastError, null, "lastError should clear after a clean turn");
   });
@@ -2514,14 +2536,18 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       await emitEvent(session, { type: "done" });
     }
 
-    const drain = await daemonRequest(`/api/minds/${TEST_MIND}/history/notices?session=${session}`);
+    const drain = await daemonRequest(
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
+    );
     const body = (await drain.json()) as { context: string; notices: unknown[] };
     assert.equal(body.notices.length, 3, "all three failures retained");
     assert.match(body.context, /3 turns failed/);
 
     // A clean turn clears them all.
     await emitEvent(session, { type: "done" });
-    const after = await daemonRequest(`/api/minds/${TEST_MIND}/history/notices?session=${session}`);
+    const after = await daemonRequest(
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
+    );
     assert.equal(((await after.json()) as { notices: unknown[] }).notices.length, 0);
   });
 
@@ -2535,7 +2561,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Turn 2 drains it (the mind reads it)...
     const drained = await daemonRequest(
-      `/api/minds/${TEST_MIND}/history/notices?session=${session}`,
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
     );
     assert.equal(((await drained.json()) as { notices: unknown[] }).notices.length, 1);
 
@@ -2545,7 +2571,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // The drained notice must survive (the turn that read it failed), plus the new one.
     const stillThere = await daemonRequest(
-      `/api/minds/${TEST_MIND}/history/notices?session=${session}`,
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
     );
     assert.equal(
       ((await stillThere.json()) as { notices: unknown[] }).notices.length,
@@ -2556,7 +2582,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // Now a genuinely clean turn clears everything.
     await emitEvent(session, { type: "done" });
     const cleared = await daemonRequest(
-      `/api/minds/${TEST_MIND}/history/notices?session=${session}`,
+      `/api/v1/minds/${TEST_MIND}/history/notices?session=${session}`,
     );
     assert.equal(((await cleared.json()) as { notices: unknown[] }).notices.length, 0);
   });
@@ -2566,7 +2592,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   }, async () => {
     await ensureTestMind();
 
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
       `Start: expected 200 or 409, got ${startRes.status} ${await startRes.clone().text()}`,
@@ -2575,7 +2601,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("delivery");
 
     // Send through the unified chat endpoint (the real CLI/web send path).
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND, brain] }),
@@ -2597,7 +2623,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const deadline = Date.now() + 30000;
     let deliveredRow: Record<string, unknown> | undefined;
     while (Date.now() < deadline && !deliveredRow) {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}/history?full=true&limit=100`);
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/history?full=true&limit=100`);
       assert.equal(res.status, 200);
       const rows = (await res.json()) as Record<string, unknown>[];
       deliveredRow = rows.find(
@@ -2614,7 +2640,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       "history rows must not carry a legacy `session` field",
     );
 
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("a sleeping mind keeps its schedules across a daemon restart (#865)", {
@@ -2633,8 +2659,8 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // markSleeping — no 120s wind-down wait for a turn the keyless CI mind
     // can't run. A far-future explicit wake pins the wake time so no cron
     // wakes the mind mid-test.
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
-    const sleepRes = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`, {
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
+    const sleepRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ wakeAt: new Date(Date.now() + 3600_000).toISOString() }),
@@ -2644,7 +2670,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const sleepDeadline = Date.now() + 20000;
     let asleep = false;
     while (Date.now() < sleepDeadline) {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
       if (((await res.json()) as { sleeping: boolean }).sleeping) {
         asleep = true;
         break;
@@ -2656,7 +2682,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // Arm a once-a-minute schedule. It queues while asleep, so every fire
     // leaves a durable system_events row — the observable that says the
     // scheduler is actually holding this mind's schedules.
-    const addRes = await daemonRequest(`/api/minds/${TEST_MIND}/schedules`, {
+    const addRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -2735,15 +2761,15 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     } finally {
       // Drop the schedule, wake the mind, and leave it stopped and awake for the
       // tests that follow.
-      await daemonRequest(`/api/minds/${TEST_MIND}/schedules/${SCHED_ID}`, { method: "DELETE" });
-      await daemonRequest(`/api/minds/${TEST_MIND}/wake`, { method: "POST" });
+      await daemonRequest(`/api/v1/minds/${TEST_MIND}/schedules/${SCHED_ID}`, { method: "DELETE" });
+      await daemonRequest(`/api/v1/minds/${TEST_MIND}/wake`, { method: "POST" });
       const wakeDeadline = Date.now() + 30000;
       while (Date.now() < wakeDeadline) {
-        const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+        const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
         if (!((await res.json()) as { sleeping: boolean }).sleeping) break;
         await new Promise((r) => setTimeout(r, 500));
       }
-      await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+      await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
     }
   });
 
@@ -2777,7 +2803,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     async function waitForStatus(target: string, timeoutMs = 30000): Promise<void> {
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const s = (await (await daemonRequest(`/api/minds/${TEST_MIND}`)).json()) as {
+        const s = (await (await daemonRequest(`/api/v1/minds/${TEST_MIND}`)).json()) as {
           status: string;
         };
         if (s.status === target) return;
@@ -2789,7 +2815,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     async function waitForSleeping(timeoutMs = 15000): Promise<void> {
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+        const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
         if (((await res.json()) as { sleeping: boolean }).sleeping) return;
         await new Promise((r) => setTimeout(r, 300));
       }
@@ -2806,15 +2832,17 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     }
 
     async function flush(): Promise<number> {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep/messages`, { method: "POST" });
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep/messages`, {
+        method: "POST",
+      });
       assert.equal(res.status, 200, `flush: ${await res.clone().text()}`);
       return ((await res.json()) as { flushed: number }).flushed;
     }
 
     // Sleep from a stopped state so no model turn runs.
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
     await waitForStatus("stopped");
-    const sleepRes = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`, { method: "POST" });
+    const sleepRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`, { method: "POST" });
     assert.equal(sleepRes.status, 200, `sleep: ${await sleepRes.clone().text()}`);
     await waitForSleeping();
 
@@ -2868,7 +2896,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const twoMsgChannel = [...byChannel.entries()].find(([, n]) => n === 2)?.[0];
     assert.ok(twoMsgChannel, "one channel should hold both of its messages");
 
-    const sleepState = (await (await daemonRequest(`/api/minds/${TEST_MIND}/sleep`)).json()) as {
+    const sleepState = (await (await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`)).json()) as {
       queuedMessageCount: number;
     };
     assert.equal(sleepState.queuedMessageCount, 3, "sleep state counts the queued backlog");
@@ -2885,7 +2913,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     // batch's turn starts, so a later channel's group may not reach it — which itself shows
     // the per-group isolation: a group that can't be delivered stays queued. Its status also
     // reads "sleeping" not "running", so wait on the port instead of status.)
-    const startRes = await daemonRequest(`/api/minds/${TEST_MIND}/start`, { method: "POST" });
+    const startRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/start`, { method: "POST" });
     assert.ok(
       startRes.status === 200 || startRes.status === 409,
       `start: ${startRes.status} ${await startRes.clone().text()}`,
@@ -2906,7 +2934,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       `at most the other channel's message remains: ${remaining.length}`,
     );
 
-    await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
+    await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
   });
 
   it("mind defaults: GET returns empty object when not configured", async () => {
@@ -3311,7 +3339,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const original = existsSync(hookPath) ? readFileSync(hookPath, "utf-8") : null;
 
     async function isSleeping(): Promise<boolean> {
-      const res = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`);
+      const res = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`);
       return ((await res.json()) as { sleeping: boolean }).sleeping;
     }
 
@@ -3341,13 +3369,15 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       // of them leave it sleeping. Sleep from a stopped state so no model turn runs
       // (CI has no real key).
       if (!(await isSleeping())) {
-        await daemonRequest(`/api/minds/${TEST_MIND}/stop`, { method: "POST" });
-        const sleepRes = await daemonRequest(`/api/minds/${TEST_MIND}/sleep`, { method: "POST" });
+        await daemonRequest(`/api/v1/minds/${TEST_MIND}/stop`, { method: "POST" });
+        const sleepRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/sleep`, {
+          method: "POST",
+        });
         assert.equal(sleepRes.status, 200, `sleep: ${await sleepRes.clone().text()}`);
         await waitForSleeping(true);
       }
 
-      const wakeRes = await daemonRequest(`/api/minds/${TEST_MIND}/wake`, { method: "POST" });
+      const wakeRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/wake`, { method: "POST" });
       assert.equal(wakeRes.status, 200, `wake: ${await wakeRes.clone().text()}`);
       await waitForSleeping(false);
 

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -720,7 +720,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const parentDir = mindDir(TEST_MIND);
 
     // Split: create the variant without starting its server.
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "e2e-var", noStart: true }),
@@ -819,7 +819,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const parentDir = mindDir(TEST_MIND);
 
     // Split without starting its server.
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "e2e-conflict-var", noStart: true }),

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -720,7 +720,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const parentDir = mindDir(TEST_MIND);
 
     // Split: create the variant without starting its server.
-    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "e2e-var", noStart: true }),
@@ -819,7 +819,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const parentDir = mindDir(TEST_MIND);
 
     // Split without starting its server.
-    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/variants`, {
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/variants`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "e2e-conflict-var", noStart: true }),
@@ -1280,7 +1280,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("convo");
 
     // Create a conversation between the test mind and a real second participant.
-    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1591,7 +1591,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("unified");
 
     // Create a conversation first (mind + a real second participant)
-    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -2601,7 +2601,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("delivery");
 
     // Send through the unified chat endpoint (the real CLI/web send path).
-    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND, brain] }),

--- a/test/daemon-e2e.test.ts
+++ b/test/daemon-e2e.test.ts
@@ -266,6 +266,32 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(body.ok, true);
   });
 
+  it("dropped bare /api/<module> aliases 404 on the real surface (#333)", async () => {
+    // The canonical prefix is /api/v1; the bare /api aliases were removed. One
+    // representative route per former mount group, requested WITH the admin token
+    // so a 404 means "not mounted" (not merely "unauthorized"). /api/health above
+    // and /api/ext/* are the only bare routes that survive.
+    const barePaths = [
+      "/api/setup/status",
+      "/api/auth/me",
+      "/api/config/models",
+      "/api/backup/status",
+      "/api/bridges",
+      "/api/activity",
+      `/api/minds/${TEST_MIND}`,
+      "/api/keys/deadbeef",
+      "/api/extensions/all",
+    ];
+    for (const path of barePaths) {
+      const res = await daemonRequest(path);
+      assert.equal(res.status, 404, `expected 404 for dropped bare path ${path}`);
+    }
+    // The v1 counterpart of one of them is reachable — proving the surface moved,
+    // not vanished.
+    const v1 = await daemonRequest("/api/v1/bridges");
+    assert.notEqual(v1.status, 404);
+  });
+
   it("daemon.json is host-readable (0644) and the admin token is owner-only (0600)", () => {
     // daemon.json (port/hostname) must be readable by a non-root host CLI on a
     // system install; the token lives in a separate 0600 file.
@@ -287,7 +313,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(res.status, 401);
   });
 
-  it("GET /api/minds returns empty array initially", async () => {
+  it("GET /api/v1/minds returns empty array initially", async () => {
     const res = await daemonRequest("/api/v1/minds");
     assert.equal(res.status, 200);
     const body = await res.json();
@@ -310,8 +336,8 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal((await v1Start.json()).error, "Mind not found");
   });
 
-  it("GET /api/extensions/mind-docs lists pages with a mindDoc and commands", async () => {
-    const res = await daemonRequest("/api/extensions/mind-docs");
+  it("GET /api/v1/extensions/mind-docs lists pages with a mindDoc and commands", async () => {
+    const res = await daemonRequest("/api/v1/extensions/mind-docs");
     assert.equal(res.status, 200);
     const body = (await res.json()) as {
       id: string;
@@ -331,7 +357,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   });
 
   it("unauthenticated mind-docs request returns 401", async () => {
-    const res = await fetch(`${BASE_URL}/api/extensions/mind-docs`);
+    const res = await fetch(`${BASE_URL}/api/v1/extensions/mind-docs`);
     assert.equal(res.status, 401);
   });
 
@@ -348,7 +374,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     );
 
     // Mind creation defaults `sleep.enabled` to true with a 00:00/08:00 UTC
-    // schedule (packages/daemon/src/web/api/minds.ts). If this suite runs inside
+    // schedule (packages/daemon/src/web/api/v1/minds.ts). If this suite runs inside
     // that window, the daemon's SleepManager would put the shared test mind to
     // sleep mid-run and derail unrelated assertions (running-status checks,
     // history/notice counts). Disable the *schedule* here so the mind never
@@ -631,7 +657,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const mindUser = await getUserByUsername(TEST_MIND);
     assert.ok(mindUser, "test mind should have a user record");
 
-    const issueRes = await daemonRequest(`/api/auth/users/${mindUser.id}/tokens`, {
+    const issueRes = await daemonRequest(`/api/v1/auth/users/${mindUser.id}/tokens`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ label: "e2e-restart" }),
@@ -681,7 +707,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(after.status, 200, `after restart: ${await after.clone().text()}`);
 
     // And revocation still takes effect against the new daemon.
-    const del = await daemonRequest(`/api/auth/users/${mindUser.id}/tokens/${tokenId}`, {
+    const del = await daemonRequest(`/api/v1/auth/users/${mindUser.id}/tokens/${tokenId}`, {
       method: "DELETE",
     });
     assert.equal(del.status, 200, `revoke: ${await del.clone().text()}`);
@@ -1133,7 +1159,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(res.status, 403);
   });
 
-  it("GET /api/minds withholds port/dir from non-privileged (mind) callers (#503)", async () => {
+  it("GET /api/v1/minds withholds port/dir from non-privileged (mind) callers (#503)", async () => {
     await ensureTestMind();
 
     // A mind principal (untrusted): resolves to a role:"user", user_type:"mind" account.
@@ -1280,7 +1306,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("convo");
 
     // Create a conversation between the test mind and a real second participant.
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1591,7 +1617,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("unified");
 
     // Create a conversation first (mind + a real second participant)
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1769,7 +1795,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     });
 
     // Add mapping via API
-    const mapRes = await daemonRequest("/api/bridges/test-platform/mappings", {
+    const mapRes = await daemonRequest("/api/v1/bridges/test-platform/mappings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1780,25 +1806,25 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.equal(mapRes.status, 200, `Map: ${await mapRes.clone().text()}`);
 
     // Read mappings
-    const mappingsRes = await daemonRequest("/api/bridges/test-platform/mappings");
+    const mappingsRes = await daemonRequest("/api/v1/bridges/test-platform/mappings");
     assert.equal(mappingsRes.status, 200);
     const mappings = (await mappingsRes.json()) as Record<string, string>;
     assert.equal(mappings["server/general"], "test-bridge-channel");
 
     // Remove mapping
     const unmapRes = await daemonRequest(
-      `/api/bridges/test-platform/mappings/${encodeURIComponent("server/general")}`,
+      `/api/v1/bridges/test-platform/mappings/${encodeURIComponent("server/general")}`,
       { method: "DELETE" },
     );
     assert.equal(unmapRes.status, 200);
 
     // Verify removed
-    const afterRes = await daemonRequest("/api/bridges/test-platform/mappings");
+    const afterRes = await daemonRequest("/api/v1/bridges/test-platform/mappings");
     const afterMappings = (await afterRes.json()) as Record<string, string>;
     assert.equal(afterMappings["server/general"], undefined);
 
     // List bridges — should include test-platform
-    const listRes = await daemonRequest("/api/bridges");
+    const listRes = await daemonRequest("/api/v1/bridges");
     assert.equal(listRes.status, 200);
     const bridges = (await listRes.json()) as { platform: string; enabled: boolean }[];
     assert.ok(
@@ -1823,7 +1849,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     });
 
     // Send an inbound message (daemon token auth — user.id === 0)
-    const inboundRes = await daemonRequest("/api/bridges/test-inbound/inbound", {
+    const inboundRes = await daemonRequest("/api/v1/bridges/test-inbound/inbound", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1841,7 +1867,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Verify puppet user in participants
     const participantsRes = await daemonRequest(
-      `/api/minds/${TEST_MIND}/conversations/${inboundBody.conversationId}/participants`,
+      `/api/v1/minds/${TEST_MIND}/conversations/${inboundBody.conversationId}/participants`,
     );
     assert.equal(participantsRes.status, 200);
     const participants = (await participantsRes.json()) as {
@@ -1881,7 +1907,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     });
 
     // Send a DM via inbound
-    const inboundRes = await daemonRequest("/api/bridges/test-dm/inbound", {
+    const inboundRes = await daemonRequest("/api/v1/bridges/test-dm/inbound", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1898,7 +1924,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     assert.ok(body1.conversationId);
 
     // Send a second DM from the same user — should reuse the conversation
-    const secondRes = await daemonRequest("/api/bridges/test-dm/inbound", {
+    const secondRes = await daemonRequest("/api/v1/bridges/test-dm/inbound", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -1930,7 +1956,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
   it("bridge enable: returns missing_env when credentials not set", async () => {
     // Try to enable discord bridge without DISCORD_TOKEN
-    const enableRes = await daemonRequest("/api/bridges/discord", {
+    const enableRes = await daemonRequest("/api/v1/bridges/discord", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ defaultMind: TEST_MIND }),
@@ -1956,7 +1982,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     });
 
     // Delete it via API
-    const delRes = await daemonRequest("/api/bridges/test-disable", { method: "DELETE" });
+    const delRes = await daemonRequest("/api/v1/bridges/test-disable", { method: "DELETE" });
     assert.equal(delRes.status, 200);
 
     // Verify it's gone (getBridgeConfig returns null for missing configs)
@@ -2601,7 +2627,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     const brain = await ensureBrainParticipant("delivery");
 
     // Send through the unified chat endpoint (the real CLI/web send path).
-    const createRes = await daemonRequest(`/api/minds/${TEST_MIND}/conversations`, {
+    const createRes = await daemonRequest(`/api/v1/minds/${TEST_MIND}/conversations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "delivery round-trip", participantNames: [TEST_MIND, brain] }),
@@ -3006,7 +3032,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       const repo = resolve(voluteSystemDir(), "e2e-restic-repo");
       rmSync(repo, { recursive: true, force: true });
 
-      const putRes = await daemonRequest("/api/backup/config", {
+      const putRes = await daemonRequest("/api/v1/backup/config", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ repository: repo }),
@@ -3014,23 +3040,23 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       assert.equal(putRes.status, 200);
 
       // Init generates a passphrase and returns it exactly once.
-      const initRes = await daemonRequest("/api/backup/init", { method: "POST" });
+      const initRes = await daemonRequest("/api/v1/backup/init", { method: "POST" });
       assert.equal(initRes.status, 200, await initRes.clone().text());
       const initBody = (await initRes.json()) as { password: string | null };
       assert.ok(initBody.password, "generated passphrase must be returned at init");
 
-      const runRes = await daemonRequest("/api/backup/run", { method: "POST" });
+      const runRes = await daemonRequest("/api/v1/backup/run", { method: "POST" });
       assert.equal(runRes.status, 200, await runRes.clone().text());
       const summary = (await runRes.json()) as { snapshotId: string; totalFilesProcessed: number };
       assert.ok(summary.snapshotId);
       assert.ok(summary.totalFilesProcessed > 0);
 
-      const listRes = await daemonRequest("/api/backup/snapshots");
+      const listRes = await daemonRequest("/api/v1/backup/snapshots");
       assert.equal(listRes.status, 200);
       const snapshots = (await listRes.json()) as { short_id: string }[];
       assert.equal(snapshots.length, 1);
 
-      const statusRes = await daemonRequest("/api/backup/status");
+      const statusRes = await daemonRequest("/api/v1/backup/status");
       assert.equal(statusRes.status, 200);
       const status = (await statusRes.json()) as {
         resticInstalled: boolean;
@@ -3223,7 +3249,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
   it("extension command endpoint ignores body.mind for non-admin callers", async () => {
     // Register a seed admin first so subsequent registrations are non-admin.
     // (The first brain user always becomes admin.)
-    await daemonRequest("/api/auth/register", {
+    await daemonRequest("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "e2e-seed-admin", password: "seed-pass-123" }),
@@ -3231,7 +3257,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
 
     // Register attacker + victim as non-admin (pending) brain users, then approve.
     async function registerAndApprove(username: string): Promise<void> {
-      const regRes = await daemonRequest("/api/auth/register", {
+      const regRes = await daemonRequest("/api/v1/auth/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password: "attack-pass-123" }),
@@ -3240,7 +3266,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
       assert.equal(regRes.status, 200, `register ${username}: ${JSON.stringify(regBody)}`);
       assert.notEqual(regBody.role, "admin", `${username} must not be the first (admin) user`);
       // Approve via daemon token (admin).
-      const apRes = await daemonRequest(`/api/auth/users/${regBody.id}/approve`, {
+      const apRes = await daemonRequest(`/api/v1/auth/users/${regBody.id}/approve`, {
         method: "POST",
       });
       assert.equal(apRes.status, 200, `approve ${username}: ${apRes.status}`);
@@ -3248,7 +3274,7 @@ describe("daemon e2e", { timeout: 420000 }, () => {
     await registerAndApprove("e2e-cmd-attacker");
 
     // Log in as attacker to obtain a non-admin session token.
-    const loginRes = await daemonRequest("/api/auth/login", {
+    const loginRes = await daemonRequest("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "e2e-cmd-attacker", password: "attack-pass-123" }),

--- a/test/docker-e2e.sh
+++ b/test/docker-e2e.sh
@@ -185,12 +185,12 @@ curl -sf -X POST \
   -H "Content-Type: application/json" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -d '{"username":"root","password":"root"}' \
-  "http://localhost:$HOST_PORT/api/auth/register" >/dev/null
+  "http://localhost:$HOST_PORT/api/v1/auth/register" >/dev/null
 LOGIN_RESP=$(curl -sf -X POST \
   -H "Content-Type: application/json" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -d '{"username":"root","password":"root"}' \
-  "http://localhost:$HOST_PORT/api/auth/login")
+  "http://localhost:$HOST_PORT/api/v1/auth/login")
 SESSION_ID=$(echo "$LOGIN_RESP" | node -e "
   process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).sessionId || '');
 ")

--- a/test/extension-command-names.test.ts
+++ b/test/extension-command-names.test.ts
@@ -10,7 +10,7 @@ import pages from "@volute/pages";
 /**
  * An extension's CLI noun is its manifest `id` — `volute <id> <subcommand>` — derived
  * dynamically at dispatch time (`src/cli.ts` looks the noun up in the map returned by
- * `/api/extensions/commands`, which is keyed by `manifest.id`). Nothing forces the
+ * `/api/v1/extensions/commands`, which is keyed by `manifest.id`). Nothing forces the
  * extension's own prose, skills, usage strings, or generated cron scripts to agree with
  * that id, so they can drift from the only name that actually works.
  *

--- a/test/extension-command-stdin.test.ts
+++ b/test/extension-command-stdin.test.ts
@@ -11,7 +11,7 @@ import { createCommands as pageCommands } from "../packages/extensions/pages/src
  * Commands now opt in with `stdin: true`, and the CLI reads stdin only for those.
  */
 describe("extension command stdin opt-in", () => {
-  it("carries `stdin` through to the CLI over /api/extensions/commands", () => {
+  it("carries `stdin` through to the CLI over /api/v1/extensions/commands", () => {
     const cmd: ExtensionCommand = {
       description: "takes piped input",
       stdin: true,

--- a/test/external-mind-registration.test.ts
+++ b/test/external-mind-registration.test.ts
@@ -87,7 +87,7 @@ function postHeaders(cookie: string) {
 
 async function register(cookie: string, body: Record<string, unknown>) {
   const { default: app } = await import("../packages/daemon/src/web/app.js");
-  return app.request("http://localhost/api/auth/minds", {
+  return app.request("http://localhost/api/v1/auth/minds", {
     method: "POST",
     headers: postHeaders(cookie),
     body: JSON.stringify(body),
@@ -226,7 +226,7 @@ describe("external mind registration", () => {
 });
 
 /**
- * `GET /api/auth/users` tags mind users with `external`. This has to be computed
+ * `GET /api/v1/auth/users` tags mind users with `external`. This has to be computed
  * daemon-side: the flag means "no `minds` row", and the mind list a client can
  * see (`GET /api/v1/minds` → readRegistry) omits variants, so a client comparing
  * against it would read every live variant as external.
@@ -240,7 +240,7 @@ describe("users list — external flag", () => {
 
   async function listUsers(cookie: string) {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("http://localhost/api/auth/users", {
+    const res = await app.request("http://localhost/api/v1/auth/users", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200, await res.clone().text());
@@ -296,7 +296,7 @@ describe("users list — external flag", () => {
     await addMind(LOCAL_MIND, 4977);
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("http://localhost/api/auth/users?type=mind", {
+    const res = await app.request("http://localhost/api/v1/auth/users?type=mind", {
       headers: { Cookie: `volute_session=${sessionId}` },
     });
     assert.equal(res.status, 200);
@@ -327,7 +327,7 @@ describe("external mind deletion", () => {
 
   async function del(cookie: string, id: number) {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    return app.request(`http://localhost/api/auth/users/${id}`, {
+    return app.request(`http://localhost/api/v1/auth/users/${id}`, {
       method: "DELETE",
       headers: { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" },
     });

--- a/test/first-week-arc.test.ts
+++ b/test/first-week-arc.test.ts
@@ -106,7 +106,7 @@ describe("sprout swaps nurture for the first-week arc", () => {
 
   async function sprout() {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    return app.request(`http://localhost/api/minds/${seedName}/sprout`, {
+    return app.request(`http://localhost/api/v1/minds/${seedName}/sprout`, {
       method: "POST",
       headers: { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" },
     });

--- a/test/integration-setup.sh
+++ b/test/integration-setup.sh
@@ -154,7 +154,7 @@ REGISTER_RESP=$(curl -sf -X POST \
   -H "Content-Type: application/json" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -d '{"username":"tester","password":"tester"}' \
-  "http://localhost:$HOST_PORT/api/auth/register" 2>&1) || true
+  "http://localhost:$HOST_PORT/api/v1/auth/register" 2>&1) || true
 
 if echo "$REGISTER_RESP" | grep -q '"role":"admin"'; then
   echo "  User 'tester' created (admin)"
@@ -168,7 +168,7 @@ ROOT_REGISTER_RESP=$(curl -sf -X POST \
   -H "Content-Type: application/json" \
   -H "Origin: http://localhost:$HOST_PORT" \
   -d '{"username":"root","password":"root"}' \
-  "http://localhost:$HOST_PORT/api/auth/register" 2>&1) || true
+  "http://localhost:$HOST_PORT/api/v1/auth/register" 2>&1) || true
 
 ROOT_USER_ID=$(echo "$ROOT_REGISTER_RESP" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
 if [[ -n "$ROOT_USER_ID" ]]; then
@@ -176,20 +176,20 @@ if [[ -n "$ROOT_USER_ID" ]]; then
   curl -sf -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Origin: http://localhost:$HOST_PORT" \
-    "http://localhost:$HOST_PORT/api/auth/users/$ROOT_USER_ID/approve" >/dev/null 2>&1 || true
+    "http://localhost:$HOST_PORT/api/v1/auth/users/$ROOT_USER_ID/approve" >/dev/null 2>&1 || true
   curl -sf -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Origin: http://localhost:$HOST_PORT" \
     -d '{"role":"admin"}' \
-    "http://localhost:$HOST_PORT/api/auth/users/$ROOT_USER_ID/role" >/dev/null 2>&1 || true
+    "http://localhost:$HOST_PORT/api/v1/auth/users/$ROOT_USER_ID/role" >/dev/null 2>&1 || true
 
   # Log in as 'root' (now approved) to get a CLI session
   LOGIN_RESP=$(curl -sf -X POST \
     -H "Content-Type: application/json" \
     -H "Origin: http://localhost:$HOST_PORT" \
     -d '{"username":"root","password":"root"}' \
-    "http://localhost:$HOST_PORT/api/auth/login" 2>&1) || true
+    "http://localhost:$HOST_PORT/api/v1/auth/login" 2>&1) || true
 
   ROOT_SESSION_ID=$(echo "$LOGIN_RESP" | grep -o '"sessionId":"[^"]*"' | head -1 | cut -d'"' -f4)
   if [[ -n "$ROOT_SESSION_ID" ]]; then
@@ -211,7 +211,7 @@ if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
     -H "Authorization: Bearer $TOKEN" \
     -H "Origin: http://localhost:$HOST_PORT" \
     -d "{\"value\":\"$OPENROUTER_API_KEY\"}" \
-    "http://localhost:$HOST_PORT/api/env/OPENROUTER_API_KEY" >/dev/null 2>&1 || true
+    "http://localhost:$HOST_PORT/api/v1/env/OPENROUTER_API_KEY" >/dev/null 2>&1 || true
   echo "  OPENROUTER_API_KEY set for minds"
 fi
 

--- a/test/mind-contacts.test.ts
+++ b/test/mind-contacts.test.ts
@@ -39,13 +39,13 @@ async function mindSession(mindName: string): Promise<string> {
 
 async function fetchContacts(mind: string, cookie: string, query = "") {
   const { default: app } = await import("../packages/daemon/src/web/app.js");
-  const res = await app.request(`/api/minds/${mind}/history/contacts${query}`, {
+  const res = await app.request(`/api/v1/minds/${mind}/history/contacts${query}`, {
     headers: { Cookie: `volute_session=${cookie}` },
   });
   return res;
 }
 
-describe("GET /api/minds/:name/history/contacts", () => {
+describe("GET /api/v1/minds/:name/history/contacts", () => {
   beforeEach(async () => {
     await cleanup();
     const admin = await createUser(ADMIN_USERNAME, "pass");
@@ -147,7 +147,7 @@ describe("GET /api/minds/:name/history/contacts", () => {
 
   it("requires authentication", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("/api/minds/test-contacts-x/history/contacts");
+    const res = await app.request("/api/v1/minds/test-contacts-x/history/contacts");
     assert.equal(res.status, 401);
   });
 });

--- a/test/mind-notices-api.test.ts
+++ b/test/mind-notices-api.test.ts
@@ -28,7 +28,7 @@ describe("POST /api/minds/:name/notices", () => {
     const token = await makeMind(name);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     try {
-      const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${name}/notices`, {
         method: "POST",
         headers: postHeaders(token),
         body: JSON.stringify({
@@ -53,7 +53,7 @@ describe("POST /api/minds/:name/notices", () => {
     const token = await makeMind(name);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     try {
-      const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${name}/notices`, {
         method: "POST",
         headers: postHeaders(token),
         body: JSON.stringify({ kind: "context_lost", message: "compaction failed", thread: "dev" }),
@@ -76,7 +76,7 @@ describe("POST /api/minds/:name/notices", () => {
     const otherToken = await makeMind(other);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     try {
-      const res = await app.request(`http://localhost/api/minds/${target}/notices`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${target}/notices`, {
         method: "POST",
         headers: postHeaders(otherToken),
         body: JSON.stringify({ kind: "context_lost", message: "forged" }),
@@ -106,7 +106,7 @@ describe("POST /api/minds/:name/notices", () => {
         { kind: "context_lost", message: "   " },
         { kind: "context_lost", message: "x", thread: 42 },
       ]) {
-        const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+        const res = await app.request(`http://localhost/api/v1/minds/${name}/notices`, {
           method: "POST",
           headers: postHeaders(token),
           body: JSON.stringify(body),
@@ -124,7 +124,7 @@ describe("POST /api/minds/:name/notices", () => {
     const token = await makeMind(name);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     try {
-      const res = await app.request(`http://localhost/api/minds/${name}/notices`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${name}/notices`, {
         method: "POST",
         headers: postHeaders(token),
         body: JSON.stringify({ kind: "context_lost", message: "y".repeat(5000) }),

--- a/test/mind-notices-api.test.ts
+++ b/test/mind-notices-api.test.ts
@@ -22,7 +22,7 @@ function postHeaders(token: string) {
   };
 }
 
-describe("POST /api/minds/:name/notices", () => {
+describe("POST /api/v1/minds/:name/notices", () => {
   it("records a mind-level notice a mind can post about itself", async () => {
     const name = `notice-api-${Date.now()}-a`;
     const token = await makeMind(name);

--- a/test/mind-turn-summaries.test.ts
+++ b/test/mind-turn-summaries.test.ts
@@ -172,7 +172,7 @@ describe("mind-authored turn summaries", () => {
     );
   });
 
-  // ── API: PUT /api/minds/:name/turn-summaries ──
+  // ── API: PUT /api/v1/minds/:name/turn-summaries ──
 
   it("PUT supersedes via the API and returns counts", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
@@ -182,7 +182,7 @@ describe("mind-authored turn summaries", () => {
     const turnId = randomUUID();
     await db.insert(turns).values({ id: turnId, mind, status: "complete" });
 
-    const res = await app.request(`/api/minds/${mind}/turn-summaries`, {
+    const res = await app.request(`/api/v1/minds/${mind}/turn-summaries`, {
       method: "PUT",
       headers: { Cookie: `volute_session=${cookie}`, "Content-Type": "application/json" },
       body: JSON.stringify({ summaries: [{ turnId, content: "My words." }] }),
@@ -202,7 +202,7 @@ describe("mind-authored turn summaries", () => {
     const bobTurn = randomUUID();
     await db.insert(turns).values({ id: bobTurn, mind: "test-turnsum-bob", status: "complete" });
 
-    const res = await app.request(`/api/minds/${mind}/turn-summaries`, {
+    const res = await app.request(`/api/v1/minds/${mind}/turn-summaries`, {
       method: "PUT",
       headers: { Cookie: `volute_session=${cookie}`, "Content-Type": "application/json" },
       body: JSON.stringify({ summaries: [{ turnId: bobTurn, content: "sneaky" }] }),
@@ -213,7 +213,7 @@ describe("mind-authored turn summaries", () => {
   it("PUT rejects a non-self mind token (another mind's route) with 403", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const cookie = await mindCookie("test-turnsum-alice");
-    const res = await app.request("/api/minds/test-turnsum-bob/turn-summaries", {
+    const res = await app.request("/api/v1/minds/test-turnsum-bob/turn-summaries", {
       method: "PUT",
       headers: { Cookie: `volute_session=${cookie}`, "Content-Type": "application/json" },
       body: JSON.stringify({ summaries: [{ turnId: randomUUID(), content: "x" }] }),
@@ -230,7 +230,7 @@ describe("mind-authored turn summaries", () => {
     await db.insert(turns).values({ id: turnId, mind, status: "complete" });
 
     const put = (body: unknown) =>
-      app.request(`/api/minds/${mind}/turn-summaries`, {
+      app.request(`/api/v1/minds/${mind}/turn-summaries`, {
         method: "PUT",
         headers: { Cookie: `volute_session=${cookie}`, "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -245,7 +245,7 @@ describe("mind-authored turn summaries", () => {
 
   it("PUT requires auth", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("/api/minds/test-turnsum-any/turn-summaries", {
+    const res = await app.request("/api/v1/minds/test-turnsum-any/turn-summaries", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ summaries: [{ turnId: randomUUID(), content: "x" }] }),
@@ -253,7 +253,7 @@ describe("mind-authored turn summaries", () => {
     assert.equal(res.status, 401);
   });
 
-  // ── GET /api/minds/:name/history?provisional=true (summary preset) ──
+  // ── GET /api/v1/minds/:name/history?provisional=true (summary preset) ──
 
   it("history?provisional=true keeps only turns not yet mind-authored, with turn_id", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
@@ -282,7 +282,7 @@ describe("mind-authored turn summaries", () => {
       },
     ]);
 
-    const res = await app.request(`/api/minds/${mind}/history?provisional=true`, {
+    const res = await app.request(`/api/v1/minds/${mind}/history?provisional=true`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -313,7 +313,7 @@ describe("mind-authored turn summaries", () => {
       },
     ]);
 
-    const res = await app.request(`/api/minds/${mind}/history`, {
+    const res = await app.request(`/api/v1/minds/${mind}/history`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -344,7 +344,7 @@ describe("mind-authored turn summaries", () => {
     });
 
     const res = await app.request(
-      `/api/minds/${mind}/history?preset=conversation&provisional=true`,
+      `/api/v1/minds/${mind}/history?preset=conversation&provisional=true`,
       {
         headers: { Cookie: `volute_session=${cookie}` },
       },
@@ -376,7 +376,7 @@ describe("mind-authored turn summaries", () => {
       },
     ]);
 
-    const res = await app.request(`/api/minds/${mind}/history?provisional=true`, {
+    const res = await app.request(`/api/v1/minds/${mind}/history?provisional=true`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);

--- a/test/orientation.test.ts
+++ b/test/orientation.test.ts
@@ -119,7 +119,7 @@ describe("seed mind creation API", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds", {
+    const res = await app.request("http://localhost/api/v1/minds", {
       method: "POST",
       headers: {
         ...postHeaders(cookie),
@@ -167,7 +167,7 @@ describe("seed gating", () => {
   it("POST schedules returns 403 for seed minds", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${mindName}/schedules`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${mindName}/schedules`, {
       method: "POST",
       headers: {
         ...postHeaders(cookie),
@@ -183,7 +183,7 @@ describe("seed gating", () => {
   it("POST variants returns 403 for seed minds", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${mindName}/variants`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${mindName}/variants`, {
       method: "POST",
       headers: {
         ...postHeaders(cookie),
@@ -252,7 +252,7 @@ describe("system commons sprout gate", () => {
     assert.ok(!members.includes(mindName), "seed should not be in the commons before sprout");
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${mindName}/sprout`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${mindName}/sprout`, {
       method: "POST",
       headers: postHeaders(cookie),
     });

--- a/test/orientation.test.ts
+++ b/test/orientation.test.ts
@@ -111,7 +111,7 @@ describe("seed mind creation API", () => {
     await cleanup();
   });
 
-  it("POST /api/minds with stage=seed creates mind with correct stage", async () => {
+  it("POST /api/v1/minds with stage=seed creates mind with correct stage", async () => {
     const mindName = `seed-test-${Date.now()}`;
     // Create the mind directory so the route doesn't fail on disk operations
     const mindsDir = resolve(voluteHome(), "minds");

--- a/test/pages-commands.test.ts
+++ b/test/pages-commands.test.ts
@@ -770,7 +770,7 @@ describe("system API routes", () => {
   // register
   // -----------------------------------------------------------------------
   describe("register", () => {
-    it("POST /api/system/register registers and saves config", async () => {
+    it("POST /api/v1/system/register registers and saves config", async () => {
       handler = async (req, res) => {
         assert.equal(req.method, "POST");
         assert.equal(req.url, "/api/register");
@@ -782,7 +782,7 @@ describe("system API routes", () => {
 
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/system/register", {
+      const res = await app.request("http://localhost/api/v1/system/register", {
         method: "POST",
         headers: adminHeaders(cookie),
         body: JSON.stringify({ name: "my-system" }),
@@ -797,11 +797,11 @@ describe("system API routes", () => {
       assert.equal(config?.system, "my-system");
     });
 
-    it("POST /api/system/register returns 400 if already registered", async () => {
+    it("POST /api/v1/system/register returns 400 if already registered", async () => {
       writeSystemsConfig({ apiKey: "vp_existing", system: "existing", apiUrl: baseUrl });
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/system/register", {
+      const res = await app.request("http://localhost/api/v1/system/register", {
         method: "POST",
         headers: adminHeaders(cookie),
         body: JSON.stringify({ name: "new-name" }),
@@ -814,7 +814,7 @@ describe("system API routes", () => {
   // login
   // -----------------------------------------------------------------------
   describe("login", () => {
-    it("POST /api/system/login validates key and saves config", async () => {
+    it("POST /api/v1/system/login validates key and saves config", async () => {
       handler = (req, res) => {
         assert.equal(req.method, "GET");
         assert.equal(req.url, "/api/whoami");
@@ -825,7 +825,7 @@ describe("system API routes", () => {
 
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/system/login", {
+      const res = await app.request("http://localhost/api/v1/system/login", {
         method: "POST",
         headers: adminHeaders(cookie),
         body: JSON.stringify({ key: "vp_mykey" }),
@@ -837,11 +837,11 @@ describe("system API routes", () => {
       assert.equal(config?.system, "test-system");
     });
 
-    it("POST /api/system/login returns 400 if already logged in", async () => {
+    it("POST /api/v1/system/login returns 400 if already logged in", async () => {
       writeSystemsConfig({ apiKey: "vp_existing", system: "existing", apiUrl: baseUrl });
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/system/login", {
+      const res = await app.request("http://localhost/api/v1/system/login", {
         method: "POST",
         headers: adminHeaders(cookie),
         body: JSON.stringify({ key: "vp_newkey" }),
@@ -854,13 +854,13 @@ describe("system API routes", () => {
   // logout
   // -----------------------------------------------------------------------
   describe("logout", () => {
-    it("POST /api/system/logout removes credentials", async () => {
+    it("POST /api/v1/system/logout removes credentials", async () => {
       writeSystemsConfig({ apiKey: "vp_key", system: "test", apiUrl: baseUrl });
       assert.ok(existsSync(configPath()));
 
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/system/logout", {
+      const res = await app.request("http://localhost/api/v1/system/logout", {
         method: "POST",
         headers: { Cookie: `volute_session=${cookie}`, Origin: "http://localhost" },
       });
@@ -874,11 +874,11 @@ describe("system API routes", () => {
   // info
   // -----------------------------------------------------------------------
   describe("info", () => {
-    it("GET /api/system/info returns system name when configured", async () => {
+    it("GET /api/v1/system/info returns system name when configured", async () => {
       writeSystemsConfig({ apiKey: "vp_key", system: "my-system", apiUrl: baseUrl });
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("/api/system/info", {
+      const res = await app.request("/api/v1/system/info", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
 
@@ -887,10 +887,10 @@ describe("system API routes", () => {
       assert.equal(data.system, "my-system");
     });
 
-    it("GET /api/system/info returns null when not configured", async () => {
+    it("GET /api/v1/system/info returns null when not configured", async () => {
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("/api/system/info", {
+      const res = await app.request("/api/v1/system/info", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
 

--- a/test/query-params.test.ts
+++ b/test/query-params.test.ts
@@ -109,8 +109,9 @@ describe("GET /api/v1/conversations/:id/messages — cursor validation (#868)", 
   it("400s on an ISO timestamp cursor instead of coercing it to a message id", async () => {
     const res = await get("?before=2026-07-18T00:00:00Z&limit=2");
     assert.equal(res.status, 400);
-    const body = await res.json();
-    assert.match(body.error, /integers/);
+    // The shared cursor validator (zValidator) rejects it with a structured zod error
+    // rather than salvaging the leading "2026" as a message id (#868).
+    assert.match(JSON.stringify(await res.json()), /non-negative integer/);
   });
 
   it("400s on a non-integer limit", async () => {

--- a/test/query-params.test.ts
+++ b/test/query-params.test.ts
@@ -175,9 +175,9 @@ describe("message cursor validation is uniform across all three routes (#868)", 
       name: "volute/conversations.ts",
       request: async (query: string) => {
         const app = new Hono();
-        app.use("/api/minds/*", authMiddleware);
-        app.route("/api/minds", voluteConversationsRoute);
-        return app.request(`/api/minds/${MIND_NAME}/conversations/${convId}/messages${query}`, {
+        app.use("/api/v1/minds/*", authMiddleware);
+        app.route("/api/v1/minds", voluteConversationsRoute);
+        return app.request(`/api/v1/minds/${MIND_NAME}/conversations/${convId}/messages${query}`, {
           headers: { Cookie: `volute_session=${cookie}` },
         });
       },

--- a/test/query-params.test.ts
+++ b/test/query-params.test.ts
@@ -185,7 +185,7 @@ describe("message cursor validation is uniform across all three routes (#868)", 
       name: "minds.ts",
       request: async (query: string) => {
         const { default: app } = await import("../packages/daemon/src/web/app.js");
-        return app.request(`/api/minds/${MIND_NAME}/conversations/${convId}/messages${query}`, {
+        return app.request(`/api/v1/minds/${MIND_NAME}/conversations/${convId}/messages${query}`, {
           headers: { Cookie: `volute_session=${cookie}` },
         });
       },

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -83,7 +83,7 @@ describe("security", () => {
     const { default: appModule } = await import("../packages/daemon/src/web/app.js");
 
     // POST without Origin header triggers CSRF rejection
-    const res = await appModule.request("/api/minds/test/start", {
+    const res = await appModule.request("/api/v1/minds/test/start", {
       method: "POST",
     });
     assert.equal(res.status, 403);

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -14,7 +14,7 @@ import {
 
 function createApp() {
   const app = new Hono();
-  app.route("/api/auth", auth);
+  app.route("/api/v1/auth", auth);
   return app;
 }
 
@@ -48,15 +48,15 @@ describe("security", () => {
     assert.equal(await getSessionUserId(sessionId), undefined);
   });
 
-  it("expired session returns 401 on /api/auth/me", async () => {
+  it("expired session returns 401 on /api/v1/auth/me", async () => {
     const app = createApp();
     // Register and login
-    await app.request("/api/auth/register", {
+    await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "expuser", password: "pass" }),
     });
-    const loginRes = await app.request("/api/auth/login", {
+    const loginRes = await app.request("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "expuser", password: "pass" }),
@@ -69,7 +69,7 @@ describe("security", () => {
     // Delete the session to simulate expiry
     await deleteSession(sessionId);
 
-    const meRes = await app.request("/api/auth/me", {
+    const meRes = await app.request("/api/v1/auth/me", {
       headers: { Cookie: `volute_session=${sessionId}` },
     });
     assert.equal(meRes.status, 401);

--- a/test/seed-check.test.ts
+++ b/test/seed-check.test.ts
@@ -580,7 +580,7 @@ describe("sprout endpoint cleans up nurture schedule", () => {
 
   afterEach(cleanup);
 
-  it("POST /api/minds/:name/sprout sets stage to sprouted", async () => {
+  it("POST /api/v1/minds/:name/sprout sets stage to sprouted", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     const res = await app.request(`http://localhost/api/v1/minds/${seedName}/sprout`, {
@@ -615,7 +615,7 @@ describe("profile endpoint", () => {
 
   afterEach(cleanup);
 
-  it("PATCH /api/minds/:name/profile updates profile", async () => {
+  it("PATCH /api/v1/minds/:name/profile updates profile", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     const res = await app.request(`http://localhost/api/v1/minds/${mindName}/profile`, {
@@ -640,7 +640,7 @@ describe("profile endpoint", () => {
     assert.equal(config?.profile?.description, "A test mind");
   });
 
-  it("PATCH /api/minds/:name/profile returns 404 for unknown mind", async () => {
+  it("PATCH /api/v1/minds/:name/profile returns 404 for unknown mind", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     const res = await app.request("http://localhost/api/v1/minds/nonexistent-mind/profile", {

--- a/test/seed-check.test.ts
+++ b/test/seed-check.test.ts
@@ -77,7 +77,7 @@ describe("seed check endpoint", () => {
     await addMind(seedName, 4200);
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -87,7 +87,7 @@ describe("seed check endpoint", () => {
 
   it("returns status when seed needs attention", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -106,7 +106,7 @@ describe("seed check endpoint", () => {
     );
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -131,7 +131,7 @@ describe("seed check endpoint", () => {
     );
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -146,7 +146,7 @@ describe("seed check endpoint", () => {
     writeFileSync(resolve(dir, "home/MEMORY.md"), "   \n");
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -157,7 +157,7 @@ describe("seed check endpoint", () => {
 
   it("returns 404 for unknown mind", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("http://localhost/api/minds/nonexistent-xyz/seed-check", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent-xyz/seed-check", {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 404);
@@ -175,7 +175,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -193,7 +193,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -210,7 +210,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -241,7 +241,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -265,7 +265,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -282,7 +282,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check?force=1`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check?force=1`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -303,7 +303,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const first = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const first = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const firstBody = (await first.json()) as { output: string };
@@ -317,7 +317,7 @@ describe("seed check endpoint", () => {
       minutesAgo: 0,
     });
 
-    const second = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const second = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const secondBody = (await second.json()) as { output: string };
@@ -342,7 +342,7 @@ describe("seed check endpoint", () => {
     });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     const body = (await res.json()) as { output: string };
@@ -378,7 +378,7 @@ describe("seed check endpoint", () => {
       });
 
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const sib = await app.request(`http://localhost/api/minds/${escName}/seed-check`, {
+      const sib = await app.request(`http://localhost/api/v1/minds/${escName}/seed-check`, {
         headers: postHeaders(cookie),
       });
       const sibBody = (await sib.json()) as { output: string };
@@ -394,7 +394,7 @@ describe("seed check endpoint", () => {
         content: `Seed: ${escName}\nLast message to ${escName}: 35 minutes ago (from some-human)`,
         minutesAgo: 1,
       });
-      const exact = await app.request(`http://localhost/api/minds/${escName}/seed-check`, {
+      const exact = await app.request(`http://localhost/api/v1/minds/${escName}/seed-check`, {
         headers: postHeaders(cookie),
       });
       const exactBody = (await exact.json()) as { output: string };
@@ -439,7 +439,7 @@ describe("seed check endpoint", () => {
       ]);
 
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
         headers: postHeaders(cookie),
       });
       assert.equal(res.status, 200);
@@ -463,7 +463,7 @@ describe("seed check endpoint", () => {
       });
 
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
         headers: postHeaders(cookie),
       });
       assert.equal(res.status, 200);
@@ -508,7 +508,7 @@ describe("seed check nurture gate vs. forced host check", () => {
 
   it("stays silent under the nurture gate when recently attended to", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -525,7 +525,7 @@ describe("seed check nurture gate vs. forced host check", () => {
       .where(and(eq(mindHistory.mind, seedName), eq(mindHistory.sender, "volute")));
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -535,7 +535,7 @@ describe("seed check nurture gate vs. forced host check", () => {
 
   it("forces the readiness state for a manual host check (?force=1)", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check?force=1`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check?force=1`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -549,7 +549,7 @@ describe("seed check nurture gate vs. forced host check", () => {
     await addMind(seedName, 4203);
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request(`http://localhost/api/minds/${seedName}/seed-check?force=1`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/seed-check?force=1`, {
       headers: postHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -583,7 +583,7 @@ describe("sprout endpoint cleans up nurture schedule", () => {
   it("POST /api/minds/:name/sprout sets stage to sprouted", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${seedName}/sprout`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${seedName}/sprout`, {
       method: "POST",
       headers: postHeaders(cookie),
     });
@@ -618,7 +618,7 @@ describe("profile endpoint", () => {
   it("PATCH /api/minds/:name/profile updates profile", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${mindName}/profile`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${mindName}/profile`, {
       method: "PATCH",
       headers: {
         ...postHeaders(cookie),
@@ -643,7 +643,7 @@ describe("profile endpoint", () => {
   it("PATCH /api/minds/:name/profile returns 404 for unknown mind", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/nonexistent-mind/profile", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent-mind/profile", {
       method: "PATCH",
       headers: {
         ...postHeaders(cookie),

--- a/test/setup-status.test.ts
+++ b/test/setup-status.test.ts
@@ -10,13 +10,13 @@ import setup from "../packages/daemon/src/web/api/setup.js";
 
 // Guards the fields `volute login` relies on to detect the login-before-wizard
 // case (packages/cli/src/commands/login.ts): when setup is incomplete and no
-// brain account exists, /api/setup/status must report complete:false + hasAccount:false.
+// brain account exists, /api/v1/setup/status must report complete:false + hasAccount:false.
 
 const TEST_USERNAME = "setupstatususer";
 
 function createApp() {
   const app = new Hono();
-  app.route("/api/setup", setup);
+  app.route("/api/v1/setup", setup);
   return app;
 }
 
@@ -30,7 +30,7 @@ async function cleanup() {
   writeGlobalConfig(config);
 }
 
-describe("GET /api/setup/status", () => {
+describe("GET /api/v1/setup/status", () => {
   beforeEach(cleanup);
   afterEach(cleanup);
 
@@ -41,7 +41,7 @@ describe("GET /api/setup/status", () => {
     config.setupCompleted = false;
     writeGlobalConfig(config);
 
-    const res = await createApp().request("/api/setup/status");
+    const res = await createApp().request("/api/v1/setup/status");
     assert.equal(res.status, 200);
     const body = (await res.json()) as { complete: boolean; hasAccount: boolean };
     assert.equal(body.complete, false);
@@ -57,7 +57,7 @@ describe("GET /api/setup/status", () => {
 
     await createUser(TEST_USERNAME, "pass123");
 
-    const res = await createApp().request("/api/setup/status");
+    const res = await createApp().request("/api/v1/setup/status");
     assert.equal(res.status, 200);
     const body = (await res.json()) as { complete: boolean; hasAccount: boolean };
     assert.equal(body.complete, false);

--- a/test/spirit-soul.test.ts
+++ b/test/spirit-soul.test.ts
@@ -286,7 +286,7 @@ describe("startup-context hook reads system.json", () => {
   });
 });
 
-describe("PUT /api/system/info notifies the spirit only on a real change", () => {
+describe("PUT /api/v1/system/info notifies the spirit only on a real change", () => {
   afterEach(async () => {
     await removeMind("volute");
     rmSync(spiritDir(), { recursive: true, force: true });
@@ -294,7 +294,7 @@ describe("PUT /api/system/info notifies the spirit only on a real change", () =>
 
   async function putName(cookie: string, name: string): Promise<number> {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("/api/system/info", {
+    const res = await app.request("/api/v1/system/info", {
       method: "PUT",
       headers: {
         Cookie: `volute_session=${cookie}`,

--- a/test/template-daemon-notice.test.ts
+++ b/test/template-daemon-notice.test.ts
@@ -48,7 +48,7 @@ describe("template daemonNotice", () => {
     assert.equal(received.length, 1);
     const req = received[0];
     assert.equal(req.method, "POST");
-    assert.equal(req.url, "/api/minds/tpl-mind/notices");
+    assert.equal(req.url, "/api/v1/minds/tpl-mind/notices");
     assert.equal(req.auth, "Bearer tpl-token");
     assert.deepEqual(req.body, { kind: "context_lost", message: "session gone", thread: "main" });
   });

--- a/test/typing.test.ts
+++ b/test/typing.test.ts
@@ -130,7 +130,7 @@ describe("typing routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds/test-mind/typing?channel=discord:123", {
+    const res = await app.request("/api/v1/minds/test-mind/typing?channel=discord:123", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -143,7 +143,7 @@ describe("typing routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     // POST active:true
-    const postRes = await app.request("http://localhost/api/minds/test-mind/typing", {
+    const postRes = await app.request("http://localhost/api/v1/minds/test-mind/typing", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -157,7 +157,7 @@ describe("typing routes", () => {
     assert.deepEqual(postBody, { ok: true });
 
     // GET to verify sender appears
-    const getRes = await app.request("/api/minds/test-mind/typing?channel=discord:123", {
+    const getRes = await app.request("/api/v1/minds/test-mind/typing?channel=discord:123", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(getRes.status, 200);
@@ -170,7 +170,7 @@ describe("typing routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     // Set typing
-    await app.request("http://localhost/api/minds/test-mind/typing", {
+    await app.request("http://localhost/api/v1/minds/test-mind/typing", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -181,7 +181,7 @@ describe("typing routes", () => {
     });
 
     // Clear typing
-    const clearRes = await app.request("http://localhost/api/minds/test-mind/typing", {
+    const clearRes = await app.request("http://localhost/api/v1/minds/test-mind/typing", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -193,7 +193,7 @@ describe("typing routes", () => {
     assert.equal(clearRes.status, 200);
 
     // Verify cleared
-    const getRes = await app.request("/api/minds/test-mind/typing?channel=discord:123", {
+    const getRes = await app.request("/api/v1/minds/test-mind/typing?channel=discord:123", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(getRes.status, 200);
@@ -205,7 +205,7 @@ describe("typing routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds/test-mind/typing", {
+    const res = await app.request("/api/v1/minds/test-mind/typing", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 400);
@@ -217,7 +217,7 @@ describe("typing routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/test-mind/typing", {
+    const res = await app.request("http://localhost/api/v1/minds/test-mind/typing", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,

--- a/test/upgrade-e2e.test.ts
+++ b/test/upgrade-e2e.test.ts
@@ -161,7 +161,7 @@ async function waitForMindRunning(timeoutMs = 60000): Promise<void> {
   let last = "unknown";
   while (Date.now() < deadline) {
     try {
-      const res = await req(`/api/minds/${MIND}`);
+      const res = await req(`/api/v1/minds/${MIND}`);
       last = ((await res.json()) as { status?: string }).status ?? "unknown";
       if (last === "running") return;
     } catch {
@@ -356,7 +356,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
     assert.equal(version.version, PRIOR_VERSION, "prior daemon should report the prior version");
 
     // Create a mind from the prior release's template.
-    const createRes = await req("/api/minds", {
+    const createRes = await req("/api/v1/minds", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: MIND }),
@@ -383,7 +383,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
     await waitForHealth(); // the long sync install may have dropped keep-alives
 
     // A schedule (persisted to the mind's volute.json).
-    const schedRes = await req(`/api/minds/${MIND}/schedules`, {
+    const schedRes = await req(`/api/v1/minds/${MIND}/schedules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: "e2e-morning", cron: "0 8 * * *", message: "good morning" }),
@@ -406,7 +406,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
 
     // Start the mind and let it come up, so the registry records running:true —
     // that's what the working-tree daemon auto-restores after the upgrade.
-    const startRes = await req(`/api/minds/${MIND}/start`, { method: "POST" });
+    const startRes = await req(`/api/v1/minds/${MIND}/start`, { method: "POST" });
     assert.equal(startRes.status, 200, `start mind: ${await startRes.clone().text()}`);
     await waitForMindRunning();
 
@@ -512,7 +512,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
     await waitForMindRunning();
 
     // History survived: the message stored by the prior daemon reads back.
-    const msgsRes = await req(`/api/minds/${MIND}/conversations/${conversationId}/messages`);
+    const msgsRes = await req(`/api/v1/minds/${MIND}/conversations/${conversationId}/messages`);
     assert.equal(msgsRes.status, 200, `read messages: ${await msgsRes.clone().text()}`);
     const { items } = (await msgsRes.json()) as {
       items: { content: { type: string; text?: string }[] }[];
@@ -526,7 +526,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
 
     // Config + schedules survived: the mind's volute.json still carries the
     // schedule the prior release added.
-    const schedRes = await req(`/api/minds/${MIND}/schedules`);
+    const schedRes = await req(`/api/v1/minds/${MIND}/schedules`);
     assert.equal(schedRes.status, 200, `read schedules: ${await schedRes.clone().text()}`);
     const schedules = (await schedRes.json()) as { id: string }[];
     assert.ok(
@@ -542,7 +542,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
     // working tree's. The merge is the assertion; a failed `npm install` step
     // afterwards (e.g. an unpublished dep in an offline environment) surfaces as
     // a non-fatal warning and doesn't mean the upgrade merge failed.
-    const res = await req(`/api/minds/${MIND}/upgrade`, {
+    const res = await req(`/api/v1/minds/${MIND}/upgrade`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -725,7 +725,7 @@ describe("cross-version upgrade e2e", { timeout: 600000 }, () => {
     const channelSlug = `#${defaultChannel[0].name}`; // delivery slug follows the channel's name
 
     // Trigger "X has joined" by creating a fresh sprouted mind through the API.
-    const createRes = await req("/api/minds", {
+    const createRes = await req("/api/v1/minds", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: NEW_MIND }),

--- a/test/variant-delete-cleanup.test.ts
+++ b/test/variant-delete-cleanup.test.ts
@@ -18,7 +18,7 @@ import mindsApp from "../packages/daemon/src/web/api/minds.js";
 import { type AuthEnv, authMiddleware } from "../packages/daemon/src/web/middleware/auth.js";
 import { cleanGitEnv } from "./helpers/test-git-env.js";
 
-// Regression test for #650: `DELETE /api/minds/:name` on a variant name used to
+// Regression test for #650: `DELETE /api/v1/minds/:name` on a variant name used to
 // stop the process and drop the DB row without ever calling cleanupVariant,
 // stranding the git worktree and branch. This exercises the real route (not
 // just cleanupVariant directly) so it catches a regression in the routing

--- a/test/variant-merge.test.ts
+++ b/test/variant-merge.test.ts
@@ -332,7 +332,7 @@ describe("findUnresolvedHomeFiles / formatUnresolvedHomeFilesMessage (#656)", ()
       "the new file must be detected before anything destructive runs",
     );
 
-    // The production join flow (web/api/variants.ts, web/api/minds.ts) checks this
+    // The production join flow (web/api/v1/variants.ts, web/api/v1/minds.ts) checks this
     // and — finding something — returns/notices instead of calling cleanupVariant.
     // Simulate that decision directly: skip cleanup entirely.
     if (unresolved.totalCount === 0) {

--- a/test/web-auth.test.ts
+++ b/test/web-auth.test.ts
@@ -15,7 +15,7 @@ const TEST_USERNAMES = ["admin", "dupe", "loginuser", "meuser", "logoutuser"];
 
 function createApp() {
   const app = new Hono();
-  app.route("/api/auth", auth);
+  app.route("/api/v1/auth", auth);
   return app;
 }
 
@@ -37,9 +37,9 @@ describe("web auth routes", () => {
   beforeEach(cleanup);
   afterEach(cleanup);
 
-  it("POST /api/auth/register — first user becomes admin with session", async () => {
+  it("POST /api/v1/auth/register — first user becomes admin with session", async () => {
     const app = createApp();
-    const res = await app.request("/api/auth/register", {
+    const res = await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "admin", password: "pass123" }),
@@ -54,14 +54,14 @@ describe("web auth routes", () => {
     if (cookie) await deleteSession(cookie);
   });
 
-  it("POST /api/auth/register — duplicate username returns 409", async () => {
+  it("POST /api/v1/auth/register — duplicate username returns 409", async () => {
     const app = createApp();
-    await app.request("/api/auth/register", {
+    await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "dupe", password: "pass" }),
     });
-    const res = await app.request("/api/auth/register", {
+    const res = await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "dupe", password: "pass2" }),
@@ -69,16 +69,16 @@ describe("web auth routes", () => {
     assert.equal(res.status, 409);
   });
 
-  it("POST /api/auth/login — valid credentials returns session cookie", async () => {
+  it("POST /api/v1/auth/login — valid credentials returns session cookie", async () => {
     const app = createApp();
     // Register first
-    await app.request("/api/auth/register", {
+    await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "loginuser", password: "pass123" }),
     });
     // Login
-    const res = await app.request("/api/auth/login", {
+    const res = await app.request("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "loginuser", password: "pass123" }),
@@ -91,14 +91,14 @@ describe("web auth routes", () => {
     if (cookie) await deleteSession(cookie);
   });
 
-  it("POST /api/auth/login — invalid credentials returns 401", async () => {
+  it("POST /api/v1/auth/login — invalid credentials returns 401", async () => {
     const app = createApp();
-    await app.request("/api/auth/register", {
+    await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "loginuser", password: "pass123" }),
     });
-    const res = await app.request("/api/auth/login", {
+    const res = await app.request("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "loginuser", password: "wrong" }),
@@ -106,15 +106,15 @@ describe("web auth routes", () => {
     assert.equal(res.status, 401);
   });
 
-  it("GET /api/auth/me — with valid session cookie", async () => {
+  it("GET /api/v1/auth/me — with valid session cookie", async () => {
     const app = createApp();
-    await app.request("/api/auth/register", {
+    await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "meuser", password: "pass" }),
     });
     // Login to get session cookie
-    const loginRes = await app.request("/api/auth/login", {
+    const loginRes = await app.request("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "meuser", password: "pass" }),
@@ -122,7 +122,7 @@ describe("web auth routes", () => {
     const cookie = extractCookie(loginRes, "volute_session");
     assert.ok(cookie);
 
-    const res = await app.request("/api/auth/me", {
+    const res = await app.request("/api/v1/auth/me", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -131,20 +131,20 @@ describe("web auth routes", () => {
     if (cookie) await deleteSession(cookie);
   });
 
-  it("GET /api/auth/me — without session returns 401", async () => {
+  it("GET /api/v1/auth/me — without session returns 401", async () => {
     const app = createApp();
-    const res = await app.request("/api/auth/me");
+    const res = await app.request("/api/v1/auth/me");
     assert.equal(res.status, 401);
   });
 
-  it("POST /api/auth/logout — clears session", async () => {
+  it("POST /api/v1/auth/logout — clears session", async () => {
     const app = createApp();
-    await app.request("/api/auth/register", {
+    await app.request("/api/v1/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "logoutuser", password: "pass" }),
     });
-    const loginRes = await app.request("/api/auth/login", {
+    const loginRes = await app.request("/api/v1/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "logoutuser", password: "pass" }),
@@ -152,14 +152,14 @@ describe("web auth routes", () => {
     const cookie = extractCookie(loginRes, "volute_session");
     assert.ok(cookie);
 
-    const logoutRes = await app.request("/api/auth/logout", {
+    const logoutRes = await app.request("/api/v1/auth/logout", {
       method: "POST",
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(logoutRes.status, 200);
 
     // Session should be invalid now
-    const meRes = await app.request("/api/auth/me", {
+    const meRes = await app.request("/api/v1/auth/me", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(meRes.status, 401);

--- a/test/web-channels.test.ts
+++ b/test/web-channels.test.ts
@@ -49,7 +49,7 @@ describe("web channels routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     const res = await app.request(
-      "http://localhost/api/minds/nonexistent-ch-mind/channels/create",
+      "http://localhost/api/v1/minds/nonexistent-ch-mind/channels/create",
       {
         method: "POST",
         headers: postHeaders(cookie),
@@ -65,7 +65,7 @@ describe("web channels routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     // 'system' has no driver
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/channels/create`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/channels/create`, {
       method: "POST",
       headers: postHeaders(cookie),
       body: JSON.stringify({ platform: "system", participants: ["user1"] }),
@@ -82,7 +82,7 @@ describe("web channels routes", () => {
     addMind(TEST_MIND, 4160);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/channels/send`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/channels/send`, {
       method: "POST",
       headers: postHeaders(cookie),
       body: JSON.stringify({ platform: "discord", uri: "test:chan", message: "hi" }),
@@ -96,7 +96,7 @@ describe("web channels routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     const res = await app.request(
-      `/api/minds/${TEST_MIND}/channels/read?platform=discord&uri=test`,
+      `/api/v1/minds/${TEST_MIND}/channels/read?platform=discord&uri=test`,
       { headers: { Cookie: `volute_session=${cookie}` } },
     );
     assert.equal(res.status, 404);
@@ -107,7 +107,7 @@ describe("web channels routes", () => {
     addMind(TEST_MIND, 4160);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/channels/list`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/channels/list`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 404);
@@ -118,7 +118,7 @@ describe("web channels routes", () => {
     addMind(TEST_MIND, 4160);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/channels/users?platform=discord`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/channels/users?platform=discord`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 404);

--- a/test/web-conversations.test.ts
+++ b/test/web-conversations.test.ts
@@ -26,8 +26,8 @@ let userId: number;
 
 function createApp() {
   const app = new Hono();
-  app.use("/api/minds/*", authMiddleware);
-  app.route("/api/minds", conversationsRoute);
+  app.use("/api/v1/minds/*", authMiddleware);
+  app.route("/api/v1/minds", conversationsRoute);
   return app;
 }
 
@@ -71,7 +71,7 @@ describe("web conversations routes", () => {
     });
     await addMessage(conv.id, "user", "conv-admin", [{ type: "text", text: "Hello" }]);
 
-    const res = await app.request("/api/minds/test-mind/conversations", {
+    const res = await app.request("/api/v1/minds/test-mind/conversations", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -94,7 +94,7 @@ describe("web conversations routes", () => {
     await addMessage(conv.id, "user", "conv-admin", blocks);
     await addMessage(conv.id, "assistant", "test-mind", [{ type: "text", text: "Response" }]);
 
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}/messages`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/messages`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -123,7 +123,7 @@ describe("web conversations routes", () => {
     // A sender with no matching user record resolves to null.
     await addMessage(conv.id, "user", "ghost-user", [{ type: "text", text: "Boo" }]);
 
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}/messages`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/messages`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -182,7 +182,7 @@ describe("web conversations routes", () => {
     }
 
     const res = await app.request(
-      `/api/minds/test-mind/conversations/${conv.id}/messages?limit=2`,
+      `/api/v1/minds/test-mind/conversations/${conv.id}/messages?limit=2`,
       { headers: { Cookie: `volute_session=${cookie}` } },
     );
     assert.equal(res.status, 200);
@@ -209,7 +209,7 @@ describe("web conversations routes", () => {
     }
 
     const res = await app.request(
-      `/api/minds/test-mind/conversations/${conv.id}/messages?before=${ids[3]}&limit=10`,
+      `/api/v1/minds/test-mind/conversations/${conv.id}/messages?before=${ids[3]}&limit=10`,
       { headers: { Cookie: `volute_session=${cookie}` } },
     );
     assert.equal(res.status, 200);
@@ -229,7 +229,7 @@ describe("web conversations routes", () => {
     });
 
     const res = await app.request(
-      `/api/minds/test-mind/conversations/${conv.id}/messages?limit=abc`,
+      `/api/v1/minds/test-mind/conversations/${conv.id}/messages?limit=abc`,
       { headers: { Cookie: `volute_session=${cookie}` } },
     );
     assert.equal(res.status, 400);
@@ -246,7 +246,7 @@ describe("web conversations routes", () => {
     });
     await addMessage(conv.id, "user", "conv-admin", [{ type: "text", text: "To delete" }]);
 
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}`, {
       method: "DELETE",
       headers: { Cookie: `volute_session=${cookie}` },
     });
@@ -255,7 +255,7 @@ describe("web conversations routes", () => {
     assert.ok(body.ok);
 
     // Verify conversation is gone (returns 404)
-    const msgsRes = await app.request(`/api/minds/test-mind/conversations/${conv.id}/messages`, {
+    const msgsRes = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/messages`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(msgsRes.status, 404);
@@ -263,7 +263,7 @@ describe("web conversations routes", () => {
 
   it("GET /:name/conversations — requires auth", async () => {
     const app = createApp();
-    const res = await app.request("/api/minds/test-mind/conversations");
+    const res = await app.request("/api/v1/minds/test-mind/conversations");
     assert.equal(res.status, 401);
   });
 
@@ -282,13 +282,13 @@ describe("web conversations routes", () => {
     const cookie2 = await createSession(user2.id);
 
     // Second user should not see the first user's conversation
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}/messages`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/messages`, {
       headers: { Cookie: `volute_session=${cookie2}` },
     });
     assert.equal(res.status, 404);
 
     // First user can still see it
-    const res2 = await app.request(`/api/minds/test-mind/conversations/${conv.id}/messages`, {
+    const res2 = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/messages`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res2.status, 200);
@@ -310,14 +310,14 @@ describe("web conversations routes", () => {
     const cookie2 = await createSession(user2.id);
 
     // Second user cannot delete
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}`, {
       method: "DELETE",
       headers: { Cookie: `volute_session=${cookie2}` },
     });
     assert.equal(res.status, 404);
 
     // First user can still delete
-    const res2 = await app.request(`/api/minds/test-mind/conversations/${conv.id}`, {
+    const res2 = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}`, {
       method: "DELETE",
       headers: { Cookie: `volute_session=${cookie}` },
     });
@@ -334,7 +334,7 @@ describe("web conversations routes", () => {
       participantIds: [userId],
     });
 
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}/participants`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/participants`, {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -358,7 +358,7 @@ describe("web conversations routes", () => {
     await approveUser(user2.id);
     const cookie2 = await createSession(user2.id);
 
-    const res = await app.request(`/api/minds/test-mind/conversations/${conv.id}/participants`, {
+    const res = await app.request(`/api/v1/minds/test-mind/conversations/${conv.id}/participants`, {
       headers: { Cookie: `volute_session=${cookie2}` },
     });
     assert.equal(res.status, 404);
@@ -375,7 +375,7 @@ describe("web conversations routes", () => {
     const user2 = await createUser("group-member", "pass");
     await approveUser(user2.id);
 
-    const res = await app.request("/api/minds/test-mind/conversations", {
+    const res = await app.request("/api/v1/minds/test-mind/conversations", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -398,7 +398,7 @@ describe("web conversations routes", () => {
     process.env.VOLUTE_DAEMON_TOKEN = "conv-daemon-token";
     try {
       const app = createApp();
-      const res = await app.request("/api/minds/volute/conversations", {
+      const res = await app.request("/api/v1/minds/volute/conversations", {
         method: "POST",
         headers: {
           Authorization: "Bearer conv-daemon-token",
@@ -419,7 +419,7 @@ describe("web conversations routes", () => {
     const cookie = await setupAuth();
     const app = createApp();
 
-    const res = await app.request("/api/minds/test-mind/conversations", {
+    const res = await app.request("/api/v1/minds/test-mind/conversations", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -438,7 +438,7 @@ describe("web conversations routes", () => {
     const cookie = await setupAuth();
     const app = createApp();
 
-    const res = await app.request("/api/minds/test-mind/conversations", {
+    const res = await app.request("/api/v1/minds/test-mind/conversations", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie}`,

--- a/test/web-conversations.test.ts
+++ b/test/web-conversations.test.ts
@@ -135,9 +135,9 @@ describe("web conversations routes", () => {
   });
 
   it("GET /:name/conversations/:id/messages?limit=N — full app annotates display names (paginated branch)", async () => {
-    // Exercises the route `volute chat read` actually hits: in the composed app,
-    // minds.ts shadows the volute conversations route, and chat read always
-    // paginates (?limit=50), so this pins the paginated branch of minds.ts.
+    // Exercises the route `volute chat read` actually hits: minds.ts serves the
+    // canonical /api/v1/minds/:name/conversations/:id/messages, and chat read
+    // always paginates (?limit=50), so this pins the paginated branch of minds.ts.
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const db = await getDb();
@@ -157,7 +157,7 @@ describe("web conversations routes", () => {
     await addMessage(conv.id, "user", "conv-admin", [{ type: "text", text: "Hi" }]);
 
     const res = await app.request(
-      `/api/minds/conv-display-mind/conversations/${conv.id}/messages?limit=10`,
+      `/api/v1/minds/conv-display-mind/conversations/${conv.id}/messages?limit=10`,
       { headers: { Cookie: `volute_session=${cookie}` } },
     );
     assert.equal(res.status, 200);

--- a/test/web-env.test.ts
+++ b/test/web-env.test.ts
@@ -266,7 +266,7 @@ describe("web env routes — shared", () => {
   beforeEach(cleanup);
   afterEach(cleanup);
 
-  it("GET /api/env — returns shared env dict", async () => {
+  it("GET /api/v1/env — returns shared env dict", async () => {
     const cookie = await setupAuth();
     writeEnv(sharedEnvPath(), { GLOBAL_KEY: "global_val" });
 
@@ -280,7 +280,7 @@ describe("web env routes — shared", () => {
     assert.equal(body.GLOBAL_KEY, "global_val");
   });
 
-  it("GET /api/env — returns empty object when no env set", async () => {
+  it("GET /api/v1/env — returns empty object when no env set", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 

--- a/test/web-env.test.ts
+++ b/test/web-env.test.ts
@@ -65,7 +65,7 @@ describe("web env routes — mind-scoped", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/env`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/env`, {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -81,7 +81,7 @@ describe("web env routes — mind-scoped", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds/nonexistent-env-mind/env", {
+    const res = await app.request("/api/v1/minds/nonexistent-env-mind/env", {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 404);
@@ -95,7 +95,7 @@ describe("web env routes — mind-scoped", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/env/MY_KEY`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/env/MY_KEY`, {
       method: "PUT",
       headers: postHeaders(cookie),
       body: JSON.stringify({ value: "my_value" }),
@@ -116,7 +116,7 @@ describe("web env routes — mind-scoped", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/env/TEST_VAR`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/env/TEST_VAR`, {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -130,7 +130,7 @@ describe("web env routes — mind-scoped", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/env/NONEXISTENT_KEY`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/env/NONEXISTENT_KEY`, {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 404);
@@ -143,7 +143,7 @@ describe("web env routes — mind-scoped", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/env/FROM_SHARED`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/env/FROM_SHARED`, {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -158,7 +158,7 @@ describe("web env routes — mind-scoped", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/env/TO_DELETE`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/env/TO_DELETE`, {
       method: "DELETE",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -177,7 +177,7 @@ describe("web env routes — mind-scoped", () => {
     addMind(TEST_MIND, 4150);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/env/NONEXISTENT`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/env/NONEXISTENT`, {
       method: "DELETE",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -192,7 +192,7 @@ describe("web env routes — mind-scoped", () => {
     addMind(TEST_MIND, 4150);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/env/KEY`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/env/KEY`, {
       method: "PUT",
       headers: postHeaders(cookie),
       body: JSON.stringify({}),
@@ -206,7 +206,7 @@ describe("web env routes — mind-scoped", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/nonexistent-env-mind/env/KEY", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent-env-mind/env/KEY", {
       method: "PUT",
       headers: postHeaders(cookie),
       body: JSON.stringify({ value: "val" }),
@@ -218,7 +218,7 @@ describe("web env routes — mind-scoped", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/nonexistent-env-mind/env/KEY", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent-env-mind/env/KEY", {
       method: "DELETE",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -231,7 +231,7 @@ describe("web env routes — mind-scoped", () => {
   it("PUT /:name/env/:key — requires auth (401 without cookie)", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/env/KEY`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/env/KEY`, {
       method: "PUT",
       headers: { Origin: "http://localhost", "Content-Type": "application/json" },
       body: JSON.stringify({ value: "val" }),
@@ -248,7 +248,7 @@ describe("web env routes — mind-scoped", () => {
     addMind(TEST_MIND, 4150);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${TEST_MIND}/env/KEY`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${TEST_MIND}/env/KEY`, {
       method: "PUT",
       headers: {
         Cookie: `volute_session=${cookie2}`,
@@ -272,7 +272,7 @@ describe("web env routes — shared", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/env", {
+    const res = await app.request("/api/v1/env", {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -284,7 +284,7 @@ describe("web env routes — shared", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/env", {
+    const res = await app.request("/api/v1/env", {
       headers: getHeaders(cookie),
     });
     assert.equal(res.status, 200);
@@ -292,11 +292,11 @@ describe("web env routes — shared", () => {
     assert.deepEqual(body, {});
   });
 
-  it("PUT /api/env/:key — sets shared env var", async () => {
+  it("PUT /api/v1/env/:key — sets shared env var", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/NEW_KEY", {
+    const res = await app.request("http://localhost/api/v1/env/NEW_KEY", {
       method: "PUT",
       headers: postHeaders(cookie),
       body: JSON.stringify({ value: "new_value" }),
@@ -310,13 +310,13 @@ describe("web env routes — shared", () => {
     assert.equal(env.NEW_KEY, "new_value");
   });
 
-  it("DELETE /api/env/:key — removes shared env var", async () => {
+  it("DELETE /api/v1/env/:key — removes shared env var", async () => {
     const cookie = await setupAuth();
     writeEnv(sharedEnvPath(), { DEL_KEY: "to_delete" });
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/DEL_KEY", {
+    const res = await app.request("http://localhost/api/v1/env/DEL_KEY", {
       method: "DELETE",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -329,11 +329,11 @@ describe("web env routes — shared", () => {
     assert.equal(env.DEL_KEY, undefined);
   });
 
-  it("DELETE /api/env/:key — 404 for nonexistent key", async () => {
+  it("DELETE /api/v1/env/:key — 404 for nonexistent key", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/NONEXISTENT", {
+    const res = await app.request("http://localhost/api/v1/env/NONEXISTENT", {
       method: "DELETE",
       headers: {
         Cookie: `volute_session=${cookie}`,
@@ -343,11 +343,11 @@ describe("web env routes — shared", () => {
     assert.equal(res.status, 404);
   });
 
-  it("PUT /api/env/:key — 400 for missing value field", async () => {
+  it("PUT /api/v1/env/:key — 400 for missing value field", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/KEY", {
+    const res = await app.request("http://localhost/api/v1/env/KEY", {
       method: "PUT",
       headers: postHeaders(cookie),
       body: JSON.stringify({ wrong: "field" }),
@@ -355,10 +355,10 @@ describe("web env routes — shared", () => {
     assert.equal(res.status, 400);
   });
 
-  it("PUT /api/env/:key — requires auth (401 without cookie)", async () => {
+  it("PUT /api/v1/env/:key — requires auth (401 without cookie)", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/KEY", {
+    const res = await app.request("http://localhost/api/v1/env/KEY", {
       method: "PUT",
       headers: { Origin: "http://localhost", "Content-Type": "application/json" },
       body: JSON.stringify({ value: "val" }),
@@ -366,17 +366,17 @@ describe("web env routes — shared", () => {
     assert.equal(res.status, 401);
   });
 
-  it("DELETE /api/env/:key — requires auth (401 without cookie)", async () => {
+  it("DELETE /api/v1/env/:key — requires auth (401 without cookie)", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/KEY", {
+    const res = await app.request("http://localhost/api/v1/env/KEY", {
       method: "DELETE",
       headers: { Origin: "http://localhost" },
     });
     assert.equal(res.status, 401);
   });
 
-  it("PUT /api/env/:key — non-admin user gets 403", async () => {
+  it("PUT /api/v1/env/:key — non-admin user gets 403", async () => {
     await setupAuth();
     const user2 = await createUser("regular-shared-user", "pass");
     await approveUser(user2.id);
@@ -384,7 +384,7 @@ describe("web env routes — shared", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/env/KEY", {
+    const res = await app.request("http://localhost/api/v1/env/KEY", {
       method: "PUT",
       headers: {
         Cookie: `volute_session=${cookie2}`,
@@ -407,14 +407,14 @@ describe("web env routes — shared", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/minds/${TEST_MIND}/env`, {
+    const res = await app.request(`/api/v1/minds/${TEST_MIND}/env`, {
       headers: getHeaders(cookie2),
     });
     assert.equal(res.status, 403);
     await deleteSession(cookie2);
   });
 
-  it("GET /api/env/ — non-admin user gets 403 (no shared secret read)", async () => {
+  it("GET /api/v1/env/ — non-admin user gets 403 (no shared secret read)", async () => {
     await setupAuth();
     writeEnv(sharedEnvPath(), { SHARED_KEY: "shared_secret" });
     const user2 = await createUser("regular-shared-user", "pass");
@@ -423,7 +423,7 @@ describe("web env routes — shared", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/env", {
+    const res = await app.request("/api/v1/env", {
       headers: getHeaders(cookie2),
     });
     assert.equal(res.status, 403);

--- a/test/web-env.test.ts
+++ b/test/web-env.test.ts
@@ -198,8 +198,8 @@ describe("web env routes — mind-scoped", () => {
       body: JSON.stringify({}),
     });
     assert.equal(res.status, 400);
-    const body = (await res.json()) as { error: string };
-    assert.ok(body.error.includes("value"));
+    // zValidator returns a structured zod error naming the missing "value" field.
+    assert.match(JSON.stringify(await res.json()), /value/);
   });
 
   it("PUT /:name/env/:key — 404 for nonexistent mind", async () => {

--- a/test/web-file-sharing.test.ts
+++ b/test/web-file-sharing.test.ts
@@ -21,8 +21,8 @@ let sessionId: string;
 
 function createApp() {
   const app = new Hono();
-  app.use("/api/minds/*", authMiddleware);
-  app.route("/api/minds", fileSharing);
+  app.use("/api/v1/minds/*", authMiddleware);
+  app.route("/api/v1/minds", fileSharing);
   return app;
 }
 
@@ -82,7 +82,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-sender/files/send", {
+    const res = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
@@ -105,7 +105,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/nonexistent/files/send", {
+    const res = await app.request("/api/v1/minds/nonexistent/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
@@ -119,7 +119,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-sender/files/send", {
+    const res = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "nonexistent", filePath: "notes.md" }),
@@ -133,7 +133,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-sender/files/send", {
+    const res = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "../etc/passwd" }),
@@ -147,7 +147,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-sender/files/send", {
+    const res = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "nonexistent.txt" }),
@@ -162,13 +162,13 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     // Send a file first to create a pending entry
-    await app.request("/api/minds/fs-sender/files/send", {
+    await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
     });
 
-    const res = await app.request("/api/minds/fs-receiver/files/pending", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/pending", {
       headers: reqHeaders(cookie, false),
     });
 
@@ -184,7 +184,7 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     // Send a file
-    const sendRes = await app.request("/api/minds/fs-sender/files/send", {
+    const sendRes = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
@@ -192,7 +192,7 @@ describe("web file-sharing routes", () => {
     const { id } = (await sendRes.json()) as { id: string };
 
     // Accept it
-    const res = await app.request("/api/minds/fs-receiver/files/accept", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/accept", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ id }),
@@ -217,7 +217,7 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     // Send a file
-    const sendRes = await app.request("/api/minds/fs-sender/files/send", {
+    const sendRes = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
@@ -225,7 +225,7 @@ describe("web file-sharing routes", () => {
     const { id } = (await sendRes.json()) as { id: string };
 
     // Accept with custom dest
-    const res = await app.request("/api/minds/fs-receiver/files/accept", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/accept", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ id, dest: "custom/incoming" }),
@@ -243,7 +243,7 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     // Send a file
-    const sendRes = await app.request("/api/minds/fs-sender/files/send", {
+    const sendRes = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
@@ -251,7 +251,7 @@ describe("web file-sharing routes", () => {
     const { id } = (await sendRes.json()) as { id: string };
 
     // Reject it
-    const res = await app.request("/api/minds/fs-receiver/files/reject", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/reject", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ id }),
@@ -270,7 +270,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-receiver/files/accept", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/accept", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ id: "nonexistent-id" }),
@@ -285,7 +285,7 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     const fileData = Buffer.from("test file content").toString("base64");
-    const res = await app.request("/api/minds/fs-receiver/files/stage", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/stage", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({
@@ -312,7 +312,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-receiver/files/stage", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/stage", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ sender: "human-user" }), // missing filename and data
@@ -327,7 +327,7 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     const fileData = Buffer.from("test").toString("base64");
-    const res = await app.request("/api/minds/fs-receiver/files/stage", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/stage", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({
@@ -346,7 +346,7 @@ describe("web file-sharing routes", () => {
     const app = createApp();
 
     // Send a file first
-    const sendRes = await app.request("/api/minds/fs-sender/files/send", {
+    const sendRes = await app.request("/api/v1/minds/fs-sender/files/send", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ targetMind: "fs-receiver", filePath: "notes.md" }),
@@ -354,7 +354,7 @@ describe("web file-sharing routes", () => {
     const { id } = (await sendRes.json()) as { id: string };
 
     // Accept with path traversal dest
-    const res = await app.request("/api/minds/fs-receiver/files/accept", {
+    const res = await app.request("/api/v1/minds/fs-receiver/files/accept", {
       method: "POST",
       headers: reqHeaders(cookie),
       body: JSON.stringify({ id, dest: "../../etc" }),
@@ -367,7 +367,7 @@ describe("web file-sharing routes", () => {
     setupMinds();
     const app = createApp();
 
-    const res = await app.request("/api/minds/fs-receiver/files/pending");
+    const res = await app.request("/api/v1/minds/fs-receiver/files/pending");
     assert.equal(res.status, 401);
   });
 });

--- a/test/web-history.test.ts
+++ b/test/web-history.test.ts
@@ -290,7 +290,7 @@ describe("web history routes", () => {
     assert.equal(res.status, 401);
   });
 
-  it("GET /api/minds/:name/history — annotates senders with display names", async () => {
+  it("GET /api/v1/minds/:name/history — annotates senders with display names", async () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     const db = await getDb();
@@ -315,7 +315,7 @@ describe("web history routes", () => {
       content: "boo",
     });
 
-    const res = await app.request("/api/minds/test-history-mind1/history?full=true", {
+    const res = await app.request("/api/v1/minds/test-history-mind1/history?full=true", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);

--- a/test/web-keys.test.ts
+++ b/test/web-keys.test.ts
@@ -29,7 +29,7 @@ describe("web keys routes", () => {
   it("GET /:fingerprint — returns public key for matching fingerprint", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`/api/keys/${fingerprint}`);
+    const res = await app.request(`/api/v1/keys/${fingerprint}`);
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.publicKey, publicKeyPem);
@@ -40,7 +40,7 @@ describe("web keys routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     const res = await app.request(
-      "/api/keys/0000000000000000000000000000000000000000000000000000000000000000",
+      "/api/v1/keys/0000000000000000000000000000000000000000000000000000000000000000",
     );
     assert.equal(res.status, 404);
     const body = await res.json();
@@ -51,7 +51,7 @@ describe("web keys routes", () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
     // No Cookie header — should still work
-    const res = await app.request(`/api/keys/${fingerprint}`);
+    const res = await app.request(`/api/v1/keys/${fingerprint}`);
     assert.equal(res.status, 200);
   });
 });

--- a/test/web-minds-spirit-restart.test.ts
+++ b/test/web-minds-spirit-restart.test.ts
@@ -60,7 +60,7 @@ describe("spirit start/restart directory gate (#620)", () => {
       await addSpirit(SPIRIT_OK, 4999, "claude", spiritDir);
       const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-      const res = await app.request(`http://localhost/api/minds/${SPIRIT_OK}/${route}`, {
+      const res = await app.request(`http://localhost/api/v1/minds/${SPIRIT_OK}/${route}`, {
         method: "POST",
         headers: postHeaders(cookie),
       });
@@ -85,7 +85,7 @@ describe("spirit start/restart directory gate (#620)", () => {
     await addSpirit(SPIRIT_MISSING, 4998, "claude", join(spiritDir, "does-not-exist"));
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request(`http://localhost/api/minds/${SPIRIT_MISSING}/restart`, {
+    const res = await app.request(`http://localhost/api/v1/minds/${SPIRIT_MISSING}/restart`, {
       method: "POST",
       headers: postHeaders(cookie),
     });

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -39,7 +39,7 @@ describe("web minds routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds", {
+    const res = await app.request("/api/v1/minds", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -51,7 +51,7 @@ describe("web minds routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds/nonexistent-mind-xyz", {
+    const res = await app.request("/api/v1/minds/nonexistent-mind-xyz", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 404);
@@ -63,7 +63,7 @@ describe("web minds routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/nonexistent-mind-xyz/start", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent-mind-xyz/start", {
       method: "POST",
       headers: postHeaders(cookie),
     });
@@ -74,7 +74,7 @@ describe("web minds routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/nonexistent-mind-xyz/stop", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent-mind-xyz/stop", {
       method: "POST",
       headers: postHeaders(cookie),
     });
@@ -84,7 +84,7 @@ describe("web minds routes", () => {
   it("GET / — requires auth (401 without cookie)", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds");
+    const res = await app.request("/api/v1/minds");
     assert.equal(res.status, 401);
   });
 
@@ -94,7 +94,7 @@ describe("web minds routes", () => {
     process.env.VOLUTE_DAEMON_TOKEN = token;
     try {
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("/api/minds", {
+      const res = await app.request("/api/v1/minds", {
         headers: { Authorization: `Bearer ${token}` },
       });
       assert.equal(res.status, 200);
@@ -114,7 +114,7 @@ describe("web minds routes", () => {
     process.env.VOLUTE_DAEMON_TOKEN = "real-token";
     try {
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("/api/minds", {
+      const res = await app.request("/api/v1/minds", {
         headers: { Authorization: "Bearer wrong-token" },
       });
       assert.equal(res.status, 401);
@@ -130,7 +130,7 @@ describe("web minds routes", () => {
   it("POST /:name/start — blocked by CSRF without origin", async () => {
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds/test/start", {
+    const res = await app.request("/api/v1/minds/test/start", {
       method: "POST",
     });
     // CSRF middleware rejects POSTs without matching origin
@@ -147,7 +147,7 @@ describe("web minds routes", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("http://localhost/api/minds/nonexistent/start", {
+    const res = await app.request("http://localhost/api/v1/minds/nonexistent/start", {
       method: "POST",
       headers: {
         Cookie: `volute_session=${cookie2}`,
@@ -181,7 +181,7 @@ describe("web minds routes", () => {
       writeGlobalConfig({ ...readGlobalConfig(), maxMinds: count });
 
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/minds", {
+      const res = await app.request("http://localhost/api/v1/minds", {
         method: "POST",
         headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
         body: JSON.stringify({ name: `cap-over-${Date.now()}` }),
@@ -212,7 +212,7 @@ describe("web minds routes", () => {
       assert.equal(isAiConfigured(), false);
 
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("http://localhost/api/minds", {
+      const res = await app.request("http://localhost/api/v1/minds", {
         method: "POST",
         headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
         body: JSON.stringify({ name: `noprovider-${Date.now()}` }),
@@ -238,7 +238,7 @@ describe("web minds routes", () => {
     const savedConfig = readGlobalConfig();
 
     async function aiConfigured(): Promise<boolean> {
-      const res = await app.request("http://localhost/api/system/info", {
+      const res = await app.request("http://localhost/api/v1/system/info", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(res.status, 200);
@@ -267,7 +267,7 @@ describe("web minds routes", () => {
     const savedConfig = readGlobalConfig();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     try {
-      const putRes = await app.request("http://localhost/api/system/max-minds", {
+      const putRes = await app.request("http://localhost/api/v1/system/max-minds", {
         method: "PUT",
         headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
         body: JSON.stringify({ maxMinds: 42 }),
@@ -277,14 +277,14 @@ describe("web minds routes", () => {
       assert.equal(putBody.maxMinds, 42);
       assert.equal(typeof putBody.count, "number");
 
-      const getRes = await app.request("http://localhost/api/system/max-minds", {
+      const getRes = await app.request("http://localhost/api/v1/system/max-minds", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(getRes.status, 200);
       assert.equal(((await getRes.json()) as { maxMinds: number | null }).maxMinds, 42);
 
       // null clears the cap (unlimited)
-      const clearRes = await app.request("http://localhost/api/system/max-minds", {
+      const clearRes = await app.request("http://localhost/api/v1/system/max-minds", {
         method: "PUT",
         headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
         body: JSON.stringify({ maxMinds: null }),
@@ -302,7 +302,7 @@ describe("web minds routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
     for (const bad of [0, -1, 1.5]) {
-      const res = await app.request("http://localhost/api/system/max-minds", {
+      const res = await app.request("http://localhost/api/v1/system/max-minds", {
         method: "PUT",
         headers: { ...postHeaders(cookie), "Content-Type": "application/json" },
         body: JSON.stringify({ maxMinds: bad }),
@@ -317,7 +317,7 @@ describe("web minds routes", () => {
     await approveUser(user2.id);
     const cookie2 = await createSession(user2.id);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("http://localhost/api/system/max-minds", {
+    const res = await app.request("http://localhost/api/v1/system/max-minds", {
       method: "PUT",
       headers: {
         Cookie: `volute_session=${cookie2}`,
@@ -338,7 +338,7 @@ describe("web minds routes", () => {
     await approveUser(user2.id);
     const cookie2 = await createSession(user2.id);
     const { default: app } = await import("../packages/daemon/src/web/app.js");
-    const res = await app.request("http://localhost/api/system/max-minds", {
+    const res = await app.request("http://localhost/api/v1/system/max-minds", {
       headers: { Cookie: `volute_session=${cookie2}` },
     });
     assert.equal(res.status, 403);
@@ -349,7 +349,7 @@ describe("web minds routes", () => {
     const cookie = await setupAuth();
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds/nonexistent-mind-xyz/history/export", {
+    const res = await app.request("/api/v1/minds/nonexistent-mind-xyz/history/export", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 404);
@@ -363,7 +363,7 @@ describe("web minds routes", () => {
 
     const { default: app } = await import("../packages/daemon/src/web/app.js");
 
-    const res = await app.request("/api/minds", {
+    const res = await app.request("/api/v1/minds", {
       headers: { Cookie: `volute_session=${cookie2}` },
     });
     assert.equal(res.status, 200);
@@ -402,7 +402,7 @@ describe("web minds routes", () => {
     try {
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request("/api/minds", {
+      const res = await app.request("/api/v1/minds", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(res.status, 200);
@@ -414,7 +414,7 @@ describe("web minds routes", () => {
       // Drift the mind's framework code and confirm the API flips to stale.
       const agent = resolve(dir, "src", "agent.ts");
       writeFileSync(agent, `${readFileSync(agent, "utf-8")}\n// drift\n`);
-      const res2 = await app.request("/api/minds", {
+      const res2 = await app.request("/api/v1/minds", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       const body2 = (await res2.json()) as Array<{ name: string; templateStale?: boolean }>;
@@ -452,7 +452,7 @@ describe("web minds routes", () => {
     try {
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request(`/api/minds/${name}`, {
+      const res = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(res.status, 200);
@@ -469,7 +469,7 @@ describe("web minds routes", () => {
       const user2 = await createUser("regular-user2", "pass");
       await approveUser(user2.id);
       const cookie2 = await createSession(user2.id);
-      const res2 = await app.request(`/api/minds/${name}`, {
+      const res2 = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie2}` },
       });
       assert.equal(res2.status, 200);
@@ -509,7 +509,7 @@ describe("web minds routes", () => {
     try {
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request(`/api/minds/${name}`, {
+      const res = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(res.status, 200);
@@ -532,7 +532,7 @@ describe("web minds routes", () => {
       const user2 = await createUser("regular-user2", "pass");
       await approveUser(user2.id);
       const cookie2 = await createSession(user2.id);
-      const res2 = await app.request(`/api/minds/${name}`, {
+      const res2 = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie2}` },
       });
       const body2 = (await res2.json()) as { seedChecklist?: { soulWritten: boolean } };
@@ -542,7 +542,7 @@ describe("web minds routes", () => {
 
       // The dashboard renders the card from the list route (data.minds), a
       // separate call site from GET /:name — assert the checklist rides it too.
-      const listRes = await app.request("/api/minds", {
+      const listRes = await app.request("/api/v1/minds", {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(listRes.status, 200);
@@ -581,7 +581,7 @@ describe("web minds routes", () => {
     try {
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request(`/api/minds/${name}`, {
+      const res = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(res.status, 200);
@@ -598,7 +598,7 @@ describe("web minds routes", () => {
       const user2 = await createUser("regular-user2", "pass");
       await approveUser(user2.id);
       const cookie2 = await createSession(user2.id);
-      const res2 = await app.request(`/api/minds/${name}`, {
+      const res2 = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie2}` },
       });
       assert.equal(res2.status, 200);
@@ -631,7 +631,7 @@ describe("web minds routes", () => {
     try {
       const cookie = await setupAuth();
       const { default: app } = await import("../packages/daemon/src/web/app.js");
-      const res = await app.request(`/api/minds/${name}`, {
+      const res = await app.request(`/api/v1/minds/${name}`, {
         headers: { Cookie: `volute_session=${cookie}` },
       });
       assert.equal(res.status, 200);

--- a/test/web-minds.test.ts
+++ b/test/web-minds.test.ts
@@ -228,7 +228,7 @@ describe("web minds routes", () => {
     }
   });
 
-  it("GET /api/system/info — aiConfigured tracks whether a model is enabled", async () => {
+  it("GET /api/v1/system/info — aiConfigured tracks whether a model is enabled", async () => {
     const cookie = await setupAuth();
     const { setEnabledModels } = await import("../packages/daemon/src/lib/ai-service.js");
     const { readGlobalConfig, writeGlobalConfig, _resetConfigCache } = await import(
@@ -259,7 +259,7 @@ describe("web minds routes", () => {
     }
   });
 
-  it("GET/PUT /api/system/max-minds — roundtrips the cap and reports the count", async () => {
+  it("GET/PUT /api/v1/system/max-minds — roundtrips the cap and reports the count", async () => {
     const cookie = await setupAuth();
     const { readGlobalConfig, writeGlobalConfig } = await import(
       "../packages/daemon/src/lib/config/setup.js"
@@ -296,7 +296,7 @@ describe("web minds routes", () => {
     }
   });
 
-  it("PUT /api/system/max-minds — rejects non-positive and non-integer caps (400)", async () => {
+  it("PUT /api/v1/system/max-minds — rejects non-positive and non-integer caps (400)", async () => {
     // The Zod schema is the real trust boundary: a cap of 0 would silently block
     // ALL mind creation, so 0/-1/1.5 must never persist.
     const cookie = await setupAuth();
@@ -311,7 +311,7 @@ describe("web minds routes", () => {
     }
   });
 
-  it("PUT /api/system/max-minds — non-admin gets 403", async () => {
+  it("PUT /api/v1/system/max-minds — non-admin gets 403", async () => {
     await setupAuth();
     const user2 = await createUser("regular-user", "pass");
     await approveUser(user2.id);
@@ -330,7 +330,7 @@ describe("web minds routes", () => {
     await deleteSession(cookie2);
   });
 
-  it("GET /api/system/max-minds — non-admin gets 403", async () => {
+  it("GET /api/v1/system/max-minds — non-admin gets 403", async () => {
     // requireAdmin guards GET too, but authz-coverage.test.ts only protects
     // /:name routes, so exercise this literal route directly.
     await setupAuth();

--- a/test/web-request-validation.test.ts
+++ b/test/web-request-validation.test.ts
@@ -130,53 +130,53 @@ describe("request-body validation (#333 zValidator sweep)", () => {
     await expectZod400("PUT", "/api/v1/skills/auto-update", { enabled: "yes" });
   });
 
-  // ── file-sharing.ts (bare /api/minds) ──
+  // ── file-sharing.ts (canonical /api/v1/minds) ──
   it("POST /:name/files/send — missing filePath", async () => {
-    await expectZod400("POST", `/api/minds/${MIND}/files/send`, { targetMind: "x" });
+    await expectZod400("POST", `/api/v1/minds/${MIND}/files/send`, { targetMind: "x" });
   });
   it("POST /:name/files/accept — missing id", async () => {
-    await expectZod400("POST", `/api/minds/${MIND}/files/accept`, {});
+    await expectZod400("POST", `/api/v1/minds/${MIND}/files/accept`, {});
   });
   it("POST /:name/files/reject — missing id", async () => {
-    await expectZod400("POST", `/api/minds/${MIND}/files/reject`, {});
+    await expectZod400("POST", `/api/v1/minds/${MIND}/files/reject`, {});
   });
   it("POST /:name/files/stage — missing data", async () => {
-    await expectZod400("POST", `/api/minds/${MIND}/files/stage`, {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/files/stage`, {
       sender: "x",
       filename: "y",
     });
   });
 
-  // ── channels.ts (bare /api/minds) ──
+  // ── channels.ts (canonical /api/v1/minds) ──
   it("POST /:name/channels/create — missing platform", async () => {
-    await expectZod400("POST", `/api/minds/${MIND}/channels/create`, { participants: [] });
+    await expectZod400("POST", `/api/v1/minds/${MIND}/channels/create`, { participants: [] });
   });
 
-  // ── extensions.ts (bare /api/extensions) ──
+  // ── extensions.ts (canonical /api/v1/extensions) ──
   it("PUT /extensions/:id/enabled — non-boolean enabled", async () => {
-    await expectZod400("PUT", "/api/extensions/some-ext/enabled", { enabled: "yes" });
+    await expectZod400("PUT", "/api/v1/extensions/some-ext/enabled", { enabled: "yes" });
   });
   it("POST /extensions/install — missing package", async () => {
-    await expectZod400("POST", "/api/extensions/install", {});
+    await expectZod400("POST", "/api/v1/extensions/install", {});
   });
 
-  // ── setup.ts (bare /api/setup, no auth — zValidator runs before the setup-state guard) ──
+  // ── setup.ts (canonical /api/v1/setup, no auth — zValidator runs before the setup-state guard) ──
   it("POST /setup/system — missing name", async () => {
-    await expectZod400("POST", "/api/setup/system", {}, false);
+    await expectZod400("POST", "/api/v1/setup/system", {}, false);
   });
   it("POST /setup/system/register — missing slug", async () => {
-    await expectZod400("POST", "/api/setup/system/register", {}, false);
+    await expectZod400("POST", "/api/v1/setup/system/register", {}, false);
   });
   it("POST /setup/system/login — missing key", async () => {
-    await expectZod400("POST", "/api/setup/system/login", {}, false);
+    await expectZod400("POST", "/api/v1/setup/system/login", {}, false);
   });
   it("POST /setup/account — missing password", async () => {
-    await expectZod400("POST", "/api/setup/account", { username: "x" }, false);
+    await expectZod400("POST", "/api/v1/setup/account", { username: "x" }, false);
   });
   it("POST /setup/models — missing spiritModel", async () => {
-    await expectZod400("POST", "/api/setup/models", { models: ["a"] }, false);
+    await expectZod400("POST", "/api/v1/setup/models", { models: ["a"] }, false);
   });
   it("POST /setup/spirit — missing name", async () => {
-    await expectZod400("POST", "/api/setup/spirit", {}, false);
+    await expectZod400("POST", "/api/v1/setup/spirit", {}, false);
   });
 });

--- a/test/web-request-validation.test.ts
+++ b/test/web-request-validation.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq } from "drizzle-orm";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import { addMind, removeMind } from "../packages/daemon/src/lib/mind/registry.js";
+import { users } from "../packages/daemon/src/lib/schema.js";
+import { createSession, deleteSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+// Bad-payload coverage for the zValidator sweep (#333). Each case asserts a 400 whose
+// body carries the zod envelope (`success: false`) — the structured error zValidator
+// emits. Asserting on `success` (rather than just the status) is what makes each test a
+// reverted-feature check: drop the validator and the route no longer produces that
+// envelope, so the assertion fails.
+//
+// Path convention (see the brief): routes on a module with a v1 mount use /api/v1/…;
+// the bare-/api modules on this base — setup, extensions, and the mind-scoped
+// channels/file-sharing under /api/minds — use their bare path.
+
+const ADMIN = "reqval-admin";
+const MIND = "reqval-mind";
+const MIND_PORT = 4820;
+
+let adminCookie: string;
+const sessions: string[] = [];
+
+async function cleanup() {
+  const db = await getDb();
+  await db.delete(users).where(eq(users.username, ADMIN));
+  try {
+    await removeMind(MIND);
+  } catch {
+    // not registered
+  }
+}
+
+function headers() {
+  return {
+    Cookie: `volute_session=${adminCookie}`,
+    Origin: "http://localhost",
+    "Content-Type": "application/json",
+  };
+}
+
+async function loadApp() {
+  const { default: app } = await import("../packages/daemon/src/web/app.js");
+  return app;
+}
+
+/** Send a malformed body and assert a structured zod 400. */
+async function expectZod400(method: string, path: string, body: unknown, withAuth = true) {
+  const app = await loadApp();
+  const res = await app.request(`http://localhost${path}`, {
+    method,
+    headers: withAuth
+      ? headers()
+      : { Origin: "http://localhost", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  assert.equal(res.status, 400, `${method} ${path} — expected 400 for ${JSON.stringify(body)}`);
+  const json = (await res.json()) as { success?: boolean };
+  assert.equal(
+    json.success,
+    false,
+    `${method} ${path} — expected a zod envelope (success:false), got ${JSON.stringify(json)}`,
+  );
+}
+
+describe("request-body validation (#333 zValidator sweep)", () => {
+  beforeEach(async () => {
+    await cleanup();
+    // First human user is auto-admin — passes requireSelf and requireAdmin.
+    const admin = await createUser(ADMIN, "pass");
+    adminCookie = await createSession(admin.id);
+    sessions.push(adminCookie);
+    await addMind(MIND, MIND_PORT);
+  });
+  afterEach(async () => {
+    while (sessions.length) deleteSession(sessions.pop()!);
+    await cleanup();
+  });
+
+  // ── minds.ts (v1) ──
+  it("PATCH /:name/profile — non-string avatar", async () => {
+    await expectZod400("PATCH", `/api/v1/minds/${MIND}/profile`, { avatar: 123 });
+  });
+  it("POST /:name/gates/decline — missing channel", async () => {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/gates/decline`, {});
+  });
+  it("POST /:name/gates/accept — missing channel", async () => {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/gates/accept`, { thread: "x" });
+  });
+  it("POST /:name/ai/complete — missing message", async () => {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/ai/complete`, { systemPrompt: "x" });
+  });
+  it("POST /:name/events — missing type", async () => {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/events`, { channel: "x" });
+  });
+  it("POST /:name/history — missing content", async () => {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/history`, { channel: "x" });
+  });
+  it("POST /import — non-string field", async () => {
+    await expectZod400("POST", "/api/v1/minds/import", { name: 123 });
+  });
+
+  // ── schedules.ts (v1) ──
+  it("POST /:name/schedules — non-string id", async () => {
+    await expectZod400("POST", `/api/v1/minds/${MIND}/schedules`, { id: 123 });
+  });
+  it("PUT /:name/schedules/:id — non-array messages", async () => {
+    await expectZod400("PUT", `/api/v1/minds/${MIND}/schedules/some-id`, { messages: "nope" });
+  });
+  it("PUT /:name/sleep/config — non-boolean enabled", async () => {
+    await expectZod400("PUT", `/api/v1/minds/${MIND}/sleep/config`, { enabled: "yes" });
+  });
+  it("PUT /:name/sleep/config — schedule missing wake", async () => {
+    await expectZod400("PUT", `/api/v1/minds/${MIND}/sleep/config`, {
+      schedule: { sleep: "0 22 * * *" },
+    });
+  });
+
+  // ── skills.ts (v1) ──
+  it("PUT /skills/defaults/list — non-array skills", async () => {
+    await expectZod400("PUT", "/api/v1/skills/defaults/list", { skills: "not-an-array" });
+  });
+  it("POST /skills/defaults/list — missing skill", async () => {
+    await expectZod400("POST", "/api/v1/skills/defaults/list", {});
+  });
+  it("PUT /skills/auto-update — non-boolean enabled", async () => {
+    await expectZod400("PUT", "/api/v1/skills/auto-update", { enabled: "yes" });
+  });
+
+  // ── file-sharing.ts (bare /api/minds) ──
+  it("POST /:name/files/send — missing filePath", async () => {
+    await expectZod400("POST", `/api/minds/${MIND}/files/send`, { targetMind: "x" });
+  });
+  it("POST /:name/files/accept — missing id", async () => {
+    await expectZod400("POST", `/api/minds/${MIND}/files/accept`, {});
+  });
+  it("POST /:name/files/reject — missing id", async () => {
+    await expectZod400("POST", `/api/minds/${MIND}/files/reject`, {});
+  });
+  it("POST /:name/files/stage — missing data", async () => {
+    await expectZod400("POST", `/api/minds/${MIND}/files/stage`, {
+      sender: "x",
+      filename: "y",
+    });
+  });
+
+  // ── channels.ts (bare /api/minds) ──
+  it("POST /:name/channels/create — missing platform", async () => {
+    await expectZod400("POST", `/api/minds/${MIND}/channels/create`, { participants: [] });
+  });
+
+  // ── extensions.ts (bare /api/extensions) ──
+  it("PUT /extensions/:id/enabled — non-boolean enabled", async () => {
+    await expectZod400("PUT", "/api/extensions/some-ext/enabled", { enabled: "yes" });
+  });
+  it("POST /extensions/install — missing package", async () => {
+    await expectZod400("POST", "/api/extensions/install", {});
+  });
+
+  // ── setup.ts (bare /api/setup, no auth — zValidator runs before the setup-state guard) ──
+  it("POST /setup/system — missing name", async () => {
+    await expectZod400("POST", "/api/setup/system", {}, false);
+  });
+  it("POST /setup/system/register — missing slug", async () => {
+    await expectZod400("POST", "/api/setup/system/register", {}, false);
+  });
+  it("POST /setup/system/login — missing key", async () => {
+    await expectZod400("POST", "/api/setup/system/login", {}, false);
+  });
+  it("POST /setup/account — missing password", async () => {
+    await expectZod400("POST", "/api/setup/account", { username: "x" }, false);
+  });
+  it("POST /setup/models — missing spiritModel", async () => {
+    await expectZod400("POST", "/api/setup/models", { models: ["a"] }, false);
+  });
+  it("POST /setup/spirit — missing name", async () => {
+    await expectZod400("POST", "/api/setup/spirit", {}, false);
+  });
+});

--- a/test/web-schedules.test.ts
+++ b/test/web-schedules.test.ts
@@ -198,7 +198,7 @@ describe("schedules API rotating messages", () => {
     const app = await getApp();
     assert.equal(
       (
-        await app.request(`/api/minds/${mindName}/schedules/dream`, {
+        await app.request(`/api/v1/minds/${mindName}/schedules/dream`, {
           method: "DELETE",
           headers: jsonHeaders(),
         })

--- a/test/web-schedules.test.ts
+++ b/test/web-schedules.test.ts
@@ -110,8 +110,16 @@ describe("schedules API rotating messages", () => {
     for (const messages of ["not-an-array", ["ok", ""], ["ok", "   "], [42]]) {
       const res = await postSchedule({ id: "hb", cron: "0 12 * * *", messages });
       assert.equal(res.status, 400, `expected 400 for messages=${JSON.stringify(messages)}`);
-      const body = (await res.json()) as { error: string };
-      assert.ok(body.error.includes("messages"));
+      // A malformed *type* (non-array, non-string element) now trips the zValidator
+      // schema → structured zod 400 (`success: false`). A present-but-empty/whitespace
+      // element still trips the in-handler validateMessages → `{ error: "…messages…" }`.
+      // Both are 400s about `messages`; accept either shape.
+      const body = (await res.json()) as { success?: boolean; error?: unknown };
+      assert.ok(
+        body.success === false ||
+          (typeof body.error === "string" && body.error.includes("messages")),
+        `expected a messages validation error, got ${JSON.stringify(body)}`,
+      );
     }
   });
 

--- a/test/web-schedules.test.ts
+++ b/test/web-schedules.test.ts
@@ -43,7 +43,7 @@ async function getApp() {
 
 async function fetchSchedules(): Promise<Schedule[]> {
   const app = await getApp();
-  const res = await app.request(`/api/minds/${mindName}/schedules`, {
+  const res = await app.request(`/api/v1/minds/${mindName}/schedules`, {
     headers: { Cookie: `volute_session=${cookie}` },
   });
   assert.equal(res.status, 200);
@@ -52,7 +52,7 @@ async function fetchSchedules(): Promise<Schedule[]> {
 
 async function postSchedule(body: Record<string, unknown>) {
   const app = await getApp();
-  return app.request(`/api/minds/${mindName}/schedules`, {
+  return app.request(`/api/v1/minds/${mindName}/schedules`, {
     method: "POST",
     headers: jsonHeaders(),
     body: JSON.stringify(body),
@@ -61,7 +61,7 @@ async function postSchedule(body: Record<string, unknown>) {
 
 async function putSchedule(id: string, body: Record<string, unknown>) {
   const app = await getApp();
-  return app.request(`/api/minds/${mindName}/schedules/${id}`, {
+  return app.request(`/api/v1/minds/${mindName}/schedules/${id}`, {
     method: "PUT",
     headers: jsonHeaders(),
     body: JSON.stringify(body),

--- a/test/web-setup.test.ts
+++ b/test/web-setup.test.ts
@@ -18,7 +18,7 @@ const PNG_B64 =
 
 function createApp() {
   const app = new Hono();
-  app.route("/api/setup", setup);
+  app.route("/api/v1/setup", setup);
   return app;
 }
 
@@ -31,37 +31,37 @@ function clearConfig() {
 describe("web setup routes", () => {
   beforeEach(clearConfig);
 
-  it("GET /api/setup/status — reports incomplete when no config", async () => {
+  it("GET /api/v1/setup/status — reports incomplete when no config", async () => {
     const app = createApp();
-    const res = await app.request("/api/setup/status");
+    const res = await app.request("/api/v1/setup/status");
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.complete, false);
     assert.equal(body.config, undefined);
   });
 
-  it("GET /api/setup/status — reports complete after setup", async () => {
+  it("GET /api/v1/setup/status — reports complete after setup", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: true,
     });
     const app = createApp();
-    const res = await app.request("/api/setup/status");
+    const res = await app.request("/api/v1/setup/status");
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.complete, true);
     assert.ok(body.config);
   });
 
-  it("POST /api/setup/spirit — stores name and temperament", async () => {
+  it("POST /api/v1/setup/spirit — stores name and temperament", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: false,
     });
     const app = createApp();
-    const res = await app.request("/api/setup/spirit", {
+    const res = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris", temperament: "warm, wry" }),
@@ -73,12 +73,12 @@ describe("web setup routes", () => {
     assert.equal(config.setup?.spiritTemperament, "warm, wry");
 
     // Status now offers the name for wizard resume
-    const status = await app.request("/api/setup/status");
+    const status = await app.request("/api/v1/setup/status");
     const body = await status.json();
     assert.equal(body.spiritName, "iris");
   });
 
-  it("POST /api/setup/spirit — rejects invalid names", async () => {
+  it("POST /api/v1/setup/spirit — rejects invalid names", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
@@ -86,7 +86,7 @@ describe("web setup routes", () => {
     });
     const app = createApp();
     for (const name of ["", "system", "has spaces", "-dash"]) {
-      const res = await app.request("/api/setup/spirit", {
+      const res = await app.request("/api/v1/setup/spirit", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name }),
@@ -95,14 +95,14 @@ describe("web setup routes", () => {
     }
   });
 
-  it("POST /api/setup/spirit — stashes an uploaded avatar and description", async () => {
+  it("POST /api/v1/setup/spirit — stashes an uploaded avatar and description", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: false,
     });
     const app = createApp();
-    const res = await app.request("/api/setup/spirit", {
+    const res = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -126,14 +126,14 @@ describe("web setup routes", () => {
     rmSync(stashed);
   });
 
-  it("POST /api/setup/spirit — resubmitting without an avatar clears the stash", async () => {
+  it("POST /api/v1/setup/spirit — resubmitting without an avatar clears the stash", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: false,
     });
     const app = createApp();
-    const upload = await app.request("/api/setup/spirit", {
+    const upload = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris", avatar: `data:image/png;base64,${PNG_B64}` }),
@@ -142,7 +142,7 @@ describe("web setup routes", () => {
     const stashedName = readGlobalConfig().setup?.spiritAvatar;
     assert.ok(stashedName);
 
-    const resubmit = await app.request("/api/setup/spirit", {
+    const resubmit = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris" }),
@@ -152,14 +152,14 @@ describe("web setup routes", () => {
     assert.ok(!existsSync(resolve(voluteSystemDir(), stashedName)), "stash file removed");
   });
 
-  it("POST /api/setup/spirit — rejects a non-image data URI", async () => {
+  it("POST /api/v1/setup/spirit — rejects a non-image data URI", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: false,
     });
     const app = createApp();
-    const res = await app.request("/api/setup/spirit", {
+    const res = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris", avatar: "data:text/html;base64,PGI+" }),
@@ -167,14 +167,14 @@ describe("web setup routes", () => {
     assert.equal(res.status, 400);
   });
 
-  it("POST /api/setup/spirit — a rejected upload leaves an existing stash intact", async () => {
+  it("POST /api/v1/setup/spirit — a rejected upload leaves an existing stash intact", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: false,
     });
     const app = createApp();
-    const upload = await app.request("/api/setup/spirit", {
+    const upload = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris", avatar: `data:image/png;base64,${PNG_B64}` }),
@@ -183,7 +183,7 @@ describe("web setup routes", () => {
     const stashedName = readGlobalConfig().setup?.spiritAvatar;
     assert.ok(stashedName);
 
-    const bad = await app.request("/api/setup/spirit", {
+    const bad = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris", avatar: "data:text/html;base64,PGI+" }),
@@ -195,9 +195,9 @@ describe("web setup routes", () => {
     rmSync(stashed);
   });
 
-  it("POST /api/setup/spirit — requires the system step first", async () => {
+  it("POST /api/v1/setup/spirit — requires the system step first", async () => {
     const app = createApp();
-    const res = await app.request("/api/setup/spirit", {
+    const res = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris" }),
@@ -205,14 +205,14 @@ describe("web setup routes", () => {
     assert.equal(res.status, 400);
   });
 
-  it("POST /api/setup/spirit — rejects after setup is complete", async () => {
+  it("POST /api/v1/setup/spirit — rejects after setup is complete", async () => {
     writeGlobalConfig({
       name: "test",
       setup: { type: "local", mindsDir: "/tmp/minds", isolation: "sandbox", service: false },
       setupCompleted: true,
     });
     const app = createApp();
-    const res = await app.request("/api/setup/spirit", {
+    const res = await app.request("/api/v1/setup/spirit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "iris" }),
@@ -220,9 +220,9 @@ describe("web setup routes", () => {
     assert.equal(res.status, 400);
   });
 
-  it("POST /api/setup/models — rejects empty model list", async () => {
+  it("POST /api/v1/setup/models — rejects empty model list", async () => {
     const app = createApp();
-    const res = await app.request("/api/setup/models", {
+    const res = await app.request("/api/v1/setup/models", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ models: [], spiritModel: "anthropic:claude-sonnet-4" }),
@@ -230,9 +230,9 @@ describe("web setup routes", () => {
     assert.equal(res.status, 400);
   });
 
-  it("POST /api/setup/models — rejects missing spirit model", async () => {
+  it("POST /api/v1/setup/models — rejects missing spirit model", async () => {
     const app = createApp();
-    const res = await app.request("/api/setup/models", {
+    const res = await app.request("/api/v1/setup/models", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ models: ["anthropic:claude-sonnet-4"], spiritModel: "" }),

--- a/test/web-user-kind.test.ts
+++ b/test/web-user-kind.test.ts
@@ -37,9 +37,9 @@ describe("user kind", () => {
   it("serves an external mind's avatar from the shared dir, not the mind dir", () => {
     // The bug this pins: external minds authenticate as ordinary users and can
     // POST /api/auth/avatar, so discarding their avatar loses real data — and
-    // /api/minds/:name/avatar would 404, since they have no directory.
+    // /api/v1/minds/:name/avatar would 404, since they have no directory.
     assert.equal(avatarUrl(externalMind), "/api/auth/avatars/avatar-8.webp");
-    assert.equal(avatarUrl(localMind), "/api/minds/bardo/avatar");
+    assert.equal(avatarUrl(localMind), "/api/v1/minds/bardo/avatar");
     assert.equal(avatarUrl(human), "/api/auth/avatars/avatar-1.webp");
   });
 
@@ -51,7 +51,7 @@ describe("user kind", () => {
   it("escapes names and filenames into the URL", () => {
     assert.equal(
       avatarUrl(user({ username: "a b", user_type: "mind", avatar: "x" })),
-      "/api/minds/a%20b/avatar",
+      "/api/v1/minds/a%20b/avatar",
     );
     assert.equal(avatarUrl(user({ avatar: "a b.webp" })), "/api/auth/avatars/a%20b.webp");
   });

--- a/test/web-user-kind.test.ts
+++ b/test/web-user-kind.test.ts
@@ -36,11 +36,11 @@ describe("user kind", () => {
 
   it("serves an external mind's avatar from the shared dir, not the mind dir", () => {
     // The bug this pins: external minds authenticate as ordinary users and can
-    // POST /api/auth/avatar, so discarding their avatar loses real data — and
+    // POST /api/v1/auth/avatar, so discarding their avatar loses real data — and
     // /api/v1/minds/:name/avatar would 404, since they have no directory.
-    assert.equal(avatarUrl(externalMind), "/api/auth/avatars/avatar-8.webp");
+    assert.equal(avatarUrl(externalMind), "/api/v1/auth/avatars/avatar-8.webp");
     assert.equal(avatarUrl(localMind), "/api/v1/minds/bardo/avatar");
-    assert.equal(avatarUrl(human), "/api/auth/avatars/avatar-1.webp");
+    assert.equal(avatarUrl(human), "/api/v1/auth/avatars/avatar-1.webp");
   });
 
   it("has no avatar URL when there is no avatar", () => {
@@ -53,7 +53,7 @@ describe("user kind", () => {
       avatarUrl(user({ username: "a b", user_type: "mind", avatar: "x" })),
       "/api/v1/minds/a%20b/avatar",
     );
-    assert.equal(avatarUrl(user({ avatar: "a b.webp" })), "/api/auth/avatars/a%20b.webp");
+    assert.equal(avatarUrl(user({ avatar: "a b.webp" })), "/api/v1/auth/avatars/a%20b.webp");
   });
 
   it("labels minds by locality and leaves humans unmarked", () => {

--- a/test/web-variants.test.ts
+++ b/test/web-variants.test.ts
@@ -28,9 +28,9 @@ async function setupAuth() {
 // Build a test app that mirrors the variants route but uses mind name lookup
 function createApp(mindExists: boolean) {
   const app = new Hono();
-  app.use("/api/minds/*", authMiddleware);
+  app.use("/api/v1/minds/*", authMiddleware);
 
-  app.get("/api/minds/:name/variants", async (c) => {
+  app.get("/api/v1/minds/:name/variants", async (c) => {
     if (!mindExists) return c.json({ error: "Mind not found" }, 404);
 
     const variants = await findVariants(testMind);
@@ -52,7 +52,7 @@ describe("web variants routes", () => {
     const cookie = await setupAuth();
     const app = createApp(false);
 
-    const res = await app.request("/api/minds/nonexistent-mind/variants", {
+    const res = await app.request("/api/v1/minds/nonexistent-mind/variants", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 404);
@@ -63,7 +63,7 @@ describe("web variants routes", () => {
     await addMind(testMind, 4300);
     const app = createApp(true);
 
-    const res = await app.request("/api/minds/test-mind/variants", {
+    const res = await app.request("/api/v1/minds/test-mind/variants", {
       headers: { Cookie: `volute_session=${cookie}` },
     });
     assert.equal(res.status, 200);
@@ -74,7 +74,7 @@ describe("web variants routes", () => {
 
   it("GET /:name/variants — requires auth", async () => {
     const app = createApp(false);
-    const res = await app.request("/api/minds/test-mind/variants");
+    const res = await app.request("/api/v1/minds/test-mind/variants");
     assert.equal(res.status, 401);
   });
 });

--- a/website/src/content/docs/docs/api.md
+++ b/website/src/content/docs/docs/api.md
@@ -5,11 +5,11 @@ description: Daemon REST API reference.
 
 The Volute daemon exposes a REST API that the CLI, web dashboard, and external integrations use. All endpoints are served from the daemon port (default 1618). A typed client library lives in `packages/api/` (`@volute/api`) and is the intended way to call the API from TypeScript.
 
-Prefer the versioned `/api/v1/*` surface for anything outside the daemon itself — it's the stable, external-facing API. The other `/api/*` routes back the web dashboard and CLI and may change.
+Every route lives under the single canonical prefix `/api/v1/*`. The only bare `/api` routes are `/api/health` (liveness) and the `/api/ext/{id}/*` extension mounts.
 
 ## Authentication
 
-Every route except `/api/health` and `/api/setup` requires authentication, via either a cookie or a Bearer token.
+`/api/v1/*` is authenticated, via either a cookie or a Bearer token. The public exceptions are `/api/health`, `/api/v1/setup/*` (first-run setup, before any user exists), the public `/api/v1/auth/*` routes (login/register/me/logout/avatars), and `/api/v1/keys/*` (public identity-key lookup).
 
 - **Cookie** — the web dashboard authenticates with a `volute_session` cookie set at login. Cookie requests are CSRF-protected.
 - **Bearer token** — `Authorization: Bearer <token>` is used by the CLI, Electron app, and minds. A Bearer request can carry one of three token kinds:
@@ -26,17 +26,17 @@ Accounts with `role: "pending"` are rejected with `403`. Authorization beyond "a
 | `requireAdminOrSystem` | Admin or the system user |
 | `requireAdmin` | Admin only |
 
-Mind-scoped routes (`/api/minds/:name/*`) enforce `requireSelf` so one mind can't read or modify another's data. User types are `"human"` or `"mind"`.
+Mind-scoped routes (`/api/v1/minds/:name/*`) enforce `requireSelf` so one mind can't read or modify another's data. User types are `"human"` or `"mind"`.
 
-### Auth routes (`/api/auth`)
+### Auth routes (`/api/v1/auth`)
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| POST | `/api/auth/register` | Register a user (first user becomes admin) |
-| POST | `/api/auth/login` | Log in, receive a session cookie |
-| POST | `/api/auth/logout` | Clear the session |
-| GET | `/api/auth/me` | Current authenticated user |
-| GET | `/api/auth/avatars/:filename` | Serve a human avatar image |
+| POST | `/api/v1/auth/register` | Register a user (first user becomes admin) |
+| POST | `/api/v1/auth/login` | Log in, receive a session cookie |
+| POST | `/api/v1/auth/logout` | Clear the session |
+| GET | `/api/v1/auth/me` | Current authenticated user |
+| GET | `/api/v1/auth/avatars/:filename` | Serve a human avatar image |
 
 ## Health
 
@@ -46,7 +46,7 @@ Unauthenticated. Returns `{ ok: true, version }`, plus `updateAvailable` and `la
 
 ## V1 API
 
-The stable surface, mounted under `/api/v1` (all authenticated).
+Every module is mounted once under `/api/v1` (authenticated except for the public sub-surfaces noted above).
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -54,11 +54,11 @@ The stable surface, mounted under `/api/v1` (all authenticated).
 | GET | `/api/v1/events` | SSE stream of conversation events |
 | GET | `/api/v1/feed` | Home feed (recent non-private conversations + lifecycle events) |
 | GET | `/api/v1/feed/digest` | Daily digest |
-| GET/POST | `/api/v1/conversations` | List / create conversations (also at `/api/conversations`) |
+| GET/POST | `/api/v1/conversations` | List / create conversations |
 | GET/PATCH | `/api/v1/channels/:name` | Read / update channel settings |
 | GET | `/api/v1/history` | Mind history (messages, activity, summaries) |
 
-Existing mind, system, prompt, skill, and env modules are re-mounted under `/api/v1/minds`, `/api/v1/system`, `/api/v1/prompts`, `/api/v1/skills`, and `/api/v1/env` so external clients can reach them through the versioned prefix (e.g. `GET /api/v1/minds`, `POST /api/v1/minds/:name/start`).
+The mind, system, prompt, skill, and env modules mount under `/api/v1/minds`, `/api/v1/system`, `/api/v1/prompts`, `/api/v1/skills`, and `/api/v1/env` (e.g. `GET /api/v1/minds`, `POST /api/v1/minds/:name/start`).
 
 ### POST /api/v1/chat
 
@@ -89,70 +89,70 @@ All fields optional; only provided fields are updated.
 
 ## Minds
 
-Mounted at both `/api/minds` and `/api/v1/minds`. Each `/:name` route is `requireSelf`-guarded.
+Mounted at `/api/v1/minds`. Each `/:name` route is `requireSelf`-guarded.
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/api/minds` | List registered minds with status |
-| POST | `/api/minds/:name/start` | Start a mind |
-| POST | `/api/minds/:name/stop` | Stop a mind |
-| POST | `/api/minds/:name/restart` | Restart a mind |
-| POST | `/api/minds/:name/message` | Send a message to a mind |
-| POST | `/api/minds/:name/sleep` | Put a mind to sleep |
-| POST | `/api/minds/:name/wake` | Wake a sleeping mind |
-| POST | `/api/minds/:name/sprout` | Grow a seed into a full mind |
-| GET | `/api/minds/:name/logs` | Stream logs (`follow` for real-time) |
-| GET | `/api/minds/:name/avatar` | Serve the mind's avatar |
-| GET | `/api/minds/:name/budget` | Token budget info |
-| GET | `/api/minds/:name/conversations/:id/events` | Per-conversation SSE stream |
-| GET/PUT | `/api/minds/:name/files/*path` | Read / write a file in the mind's directory |
-| GET/POST/DELETE | `/api/minds/:name/skills[/:skill]` | Manage a mind's skills |
-| GET/POST/DELETE | `/api/minds/:name/schedules[/:id]` | Manage schedules |
-| GET | `/api/minds/:name/variants` | List variants with health status |
-| GET | `/api/minds/:name/typing` | Typing indicators |
+| GET | `/api/v1/minds` | List registered minds with status |
+| POST | `/api/v1/minds/:name/start` | Start a mind |
+| POST | `/api/v1/minds/:name/stop` | Stop a mind |
+| POST | `/api/v1/minds/:name/restart` | Restart a mind |
+| POST | `/api/v1/minds/:name/message` | Send a message to a mind |
+| POST | `/api/v1/minds/:name/sleep` | Put a mind to sleep |
+| POST | `/api/v1/minds/:name/wake` | Wake a sleeping mind |
+| POST | `/api/v1/minds/:name/sprout` | Grow a seed into a full mind |
+| GET | `/api/v1/minds/:name/logs` | Stream logs (`follow` for real-time) |
+| GET | `/api/v1/minds/:name/avatar` | Serve the mind's avatar |
+| GET | `/api/v1/minds/:name/budget` | Token budget info |
+| GET | `/api/v1/minds/:name/conversations/:id/events` | Per-conversation SSE stream |
+| GET/PUT | `/api/v1/minds/:name/files/*path` | Read / write a file in the mind's directory |
+| GET/POST/DELETE | `/api/v1/minds/:name/skills[/:skill]` | Manage a mind's skills |
+| GET/POST/DELETE | `/api/v1/minds/:name/schedules[/:id]` | Manage schedules |
+| GET | `/api/v1/minds/:name/variants` | List variants with health status |
+| GET | `/api/v1/minds/:name/typing` | Typing indicators |
 
 ## Bridges
 
-Bridges are system-wide (`/api/bridges/*`, authenticated).
+Bridges are system-wide (`/api/v1/bridges/*`, authenticated).
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/api/bridges` | List bridges and status |
-| POST | `/api/bridges/:platform` | Enable a bridge (`{ defaultMind }`) |
-| DELETE | `/api/bridges/:platform` | Disable a bridge |
-| GET/PUT | `/api/bridges/:platform/mappings` | List / set channel mappings |
-| DELETE | `/api/bridges/:platform/mappings/:external` | Remove a mapping |
+| GET | `/api/v1/bridges` | List bridges and status |
+| POST | `/api/v1/bridges/:platform` | Enable a bridge (`{ defaultMind }`) |
+| DELETE | `/api/v1/bridges/:platform` | Disable a bridge |
+| GET/PUT | `/api/v1/bridges/:platform/mappings` | List / set channel mappings |
+| DELETE | `/api/v1/bridges/:platform/mappings/:external` | Remove a mapping |
 
 ## Config, backup, and system
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/api/config` | AI/system config (authenticated, no admin required — minds may read) |
-| — | `/api/backup/*` | Backup config, snapshots, and runs (authenticated) |
-| GET | `/api/system/update` | Check for updates |
-| — | `/api/system/*` | System info, status, and AI-service configuration |
+| GET | `/api/v1/config` | AI/system config (authenticated, no admin required — minds may read) |
+| — | `/api/v1/backup/*` | Backup config, snapshots, and runs (authenticated) |
+| GET | `/api/v1/system/update` | Check for updates |
+| — | `/api/v1/system/*` | System info, status, and AI-service configuration |
 
 ## Environment, keys, and prompts
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET/POST | `/api/minds/:name/env` | Get / set a mind's environment variables |
-| — | `/api/env/*` | Shared (system-wide) environment variables |
-| GET | `/api/keys/:fingerprint` | Look up a mind's public key by fingerprint |
-| GET | `/api/prompts/:name` | Configured prompts for a mind |
+| GET/POST | `/api/v1/minds/:name/env` | Get / set a mind's environment variables |
+| — | `/api/v1/env/*` | Shared (system-wide) environment variables |
+| GET | `/api/v1/keys/:fingerprint` | Look up a mind's public key by fingerprint |
+| GET | `/api/v1/prompts/:name` | Configured prompts for a mind |
 
 ## Extensions and setup
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/api/extensions` | List installed extensions |
-| GET | `/api/setup/status` | Whether setup is complete (unauthenticated) |
-| POST | `/api/setup` | Complete initial setup (unauthenticated) |
+| GET | `/api/v1/extensions` | List installed extensions |
+| GET | `/api/v1/setup/status` | Whether setup is complete (unauthenticated) |
+| POST | `/api/v1/setup` | Complete initial setup (unauthenticated) |
 
 Extensions mount their own routes under `/api/ext/{id}/`. The **Pages** feature, for example, is an extension — its endpoints live under `/api/ext/pages/`, not in the core API.
 
 ## Activity
 
-### GET /api/activity
+### GET /api/v1/activity
 
 SSE stream of activity events (mind start/stop/active/idle).

--- a/website/src/content/docs/docs/concepts/identity.md
+++ b/website/src/content/docs/docs/concepts/identity.md
@@ -20,7 +20,7 @@ The keypair signs messages in inter-mind communication. A signature covers the m
 
 ## Discovery and verification
 
-Within a system, minds look up each other's public keys by fingerprint (the SHA-256 hash of the public key) to verify signatures. The daemon exposes `GET /api/keys/:fingerprint`, which searches the registry and returns the matching mind's public key.
+Within a system, minds look up each other's public keys by fingerprint (the SHA-256 hash of the public key) to verify signatures. The daemon exposes `GET /api/v1/keys/:fingerprint`, which searches the registry and returns the matching mind's public key.
 
 If your system is connected to [volute.systems](/docs/commands/systems/), each mind's public key is also published there automatically — on creation, import, or identity regeneration — so minds on other systems can discover and verify it. This happens on its own; `volute systems register` connects your **system** to volute.systems (it registers a system account), it does not publish an individual mind's key.
 


### PR DESCRIPTION
## Summary

Uniform `zValidator` adoption across the daemon API, stacked on #900 (prefix collapse).

- **8 modules** migrated from hand-rolled validation to `zValidator("json", schema)`
- **19 `c.req.json()` casts** eliminated (down from 25 on the base; env/variants were done in #899)
- **27 bad-payload tests** added with fail-on-revert guards

## Commits

- `b57d519` — channels + extensions bodies
- `c014478` — file-sharing bodies
- `e1ba16b` — schedule + sleep-config bodies
- `95e0f7b` — setup-flow bodies (runs before first user — extra care)
- `fd5f1e2` — skills-defaults bodies
- `a7164e0` — minds.ts bodies (the big one: 8 casts → 0)
- `2079c1e` — bad-payload test coverage
- `42a37c5` — schedule message zod-envelope acceptance

## Path collision note

The validation builder wrote tests using bare `/api/*` paths per its brief (those routes
weren't on `/api/v1` at dispatch time). After rebasing onto #900, I updated them to
`/api/v1/*` and amended the relevant commit.

## Test plan

- [x] npm run typecheck
- [x] npm test (3350 tests, +27 from #900)
- [ ] npm run test:e2e (pending — unit coverage is complete)

🤖 Generated with [Claude Code](https://claude.ai/code)