### PR TITLE
fix(templates): route mind-template daemon calls through /api/v1 (#900 follow-up)

### DIFF
--- a/templates/_base/src/lib/daemon-client.ts
+++ b/templates/_base/src/lib/daemon-client.ts
@@ -167,7 +167,7 @@ export async function daemonSendFile(
     throw new Error("[volute] daemonSendFile: VOLUTE_DAEMON_PORT or VOLUTE_MIND not set");
   }
   const res = await fetch(
-    `http://127.0.0.1:${port}/api/minds/${encodeURIComponent(mind)}/files/send`,
+    `http://127.0.0.1:${port}/api/v1/minds/${encodeURIComponent(mind)}/files/send`,
     {
       method: "POST",
       headers: headers(),

--- a/templates/_base/src/lib/volute-server.ts
+++ b/templates/_base/src/lib/volute-server.ts
@@ -68,7 +68,7 @@ async function fetchPublicKey(fingerprint: string): Promise<string | null> {
 
   try {
     const res = await fetch(
-      `http://127.0.0.1:${daemonPort}/api/keys/${encodeURIComponent(fingerprint)}`,
+      `http://127.0.0.1:${daemonPort}/api/v1/keys/${encodeURIComponent(fingerprint)}`,
       { headers: { Authorization: `Bearer ${daemonToken}` }, signal: AbortSignal.timeout(2000) },
     );
     if (!res.ok) return null;

--- a/test/template-api-prefix.test.ts
+++ b/test/template-api-prefix.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Guard: every daemon-bound `/api/` URL in the mind templates must use the
+ * `/api/v1/` prefix.
+ *
+ * PR #900 collapsed the daemon's HTTP surface to a single `/api/v1` prefix and
+ * deleted the bare `/api/<module>` mounts (they now 404). The sweep covered
+ * `packages/` and `test/` but missed `templates/`, the source copied into every
+ * mind's own directory — so two template call sites kept hitting the deleted
+ * surface (#900 follow-up). A wrong prefix is just a string, so `tsc` and biome
+ * pass and no runtime test exercises template client code against a live daemon;
+ * this static check is the only thing that catches it.
+ *
+ * Scope is deliberately `templates/` only. Do NOT widen to `packages/`: there are
+ * legitimate non-v1 `/api/` calls there aimed at *remote* services
+ * (`config.apiUrl`/`systems.apiUrl` → `/api/register`, `/api/whoami`,
+ * `/api/pages/*`, `/api/mail/*`, and `lib/mind/identity.ts`'s `/api/keys/` which
+ * targets the hosted systems service), plus deliberate local survivors
+ * (`/api/health`, `/api/ext/*`). Every daemon-bound URL in `templates/` is built
+ * as `http://127.0.0.1:${...}/api/...`, so keying on that host prefix keeps the
+ * guard free of false positives.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = resolve(here, "..", "templates");
+
+/** Every `.ts` file under `templates/`, recursively, skipping `node_modules`. */
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+// Match a daemon-bound URL: http://127.0.0.1:<port>/api/<path...>. The port is
+// always an interpolation (`${...}`) in the templates. Capture the path segment
+// beginning at `/api/` up to the first delimiter (quote, backtick, whitespace, `)`).
+const DAEMON_API_URL = /127\.0\.0\.1:\$\{[^}]*\}(\/api\/[^\s"'`)]*)/g;
+
+describe("template daemon /api URLs use the /api/v1 prefix", () => {
+  it("has no daemon-bound /api/ call in templates/ that skips /api/v1/", () => {
+    const violations: string[] = [];
+
+    for (const file of collectTsFiles(TEMPLATES_DIR)) {
+      const source = readFileSync(file, "utf-8");
+      const lines = source.split("\n");
+      lines.forEach((line, i) => {
+        for (const match of line.matchAll(DAEMON_API_URL)) {
+          const path = match[1];
+          if (!path.startsWith("/api/v1/")) {
+            const rel = relative(TEMPLATES_DIR, file);
+            violations.push(`templates/${rel}:${i + 1}: ${path} (must start with /api/v1/)`);
+          }
+        }
+      });
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `Daemon-bound /api/ URLs in templates/ must use the /api/v1/ prefix ` +
+        `(PR #900 deleted the bare /api/<module> mounts):\n${violations.join("\n")}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a regression from #900: two daemon call sites in `templates/_base/` were still hitting the deleted bare `/api/` paths (now 404).

- `daemon-client.ts:daemonSendFile()` → `/api/v1/minds/:name/files/send`
- `volute-server.ts:fetchPublicKey()` → `/api/v1/keys/:fingerprint`

The keys break was the serious one: 404 made `fetchPublicKey` return null, so every signed request was silently stamped `verified=false` — signature verification failing shut.

## Guard

`test/template-api-prefix.test.ts` statically scans `templates/` for daemon-bound URLs and asserts they use `/api/v1/`. Verified: reverting the keys fix → test fails with the exact file:line.

## Test plan

- [x] npm run typecheck
- [x] npm test (3351 tests)

Existing minds get the fix on `volute mind upgrade`.

🤖 Generated with [Claude Code](https://claude.ai/code)