### PR TITLE
fix(web): unshadow GET /minds/:name/files/pending + guard the class

### DIFF
--- a/packages/cli/src/commands/chat/accept.ts
+++ b/packages/cli/src/commands/chat/accept.ts
@@ -1,5 +1,5 @@
 import { command } from "../../lib/command.js";
-import { daemonFetch } from "../../lib/daemon-client.js";
+import { daemonErrorMessage, daemonFetch } from "../../lib/daemon-client.js";
 import { resolveMindName } from "../../lib/resolve-mind-name.js";
 
 const cmd = command({
@@ -20,8 +20,7 @@ const cmd = command({
     });
 
     if (!res.ok) {
-      const data = (await res.json()) as { error?: string };
-      console.error(data.error ?? `Failed to accept file: ${res.status}`);
+      console.error(await daemonErrorMessage(res, `Failed to accept file: ${res.status}`));
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/chat/files.ts
+++ b/packages/cli/src/commands/chat/files.ts
@@ -1,6 +1,6 @@
 import { formatFileSize } from "@volute/daemon/lib/chat/file-sharing.js";
 import { command } from "../../lib/command.js";
-import { daemonFetch } from "../../lib/daemon-client.js";
+import { daemonErrorMessage, daemonFetch } from "../../lib/daemon-client.js";
 import { resolveMindName } from "../../lib/resolve-mind-name.js";
 
 const cmd = command({
@@ -15,8 +15,7 @@ const cmd = command({
     const res = await daemonFetch(`/api/v1/minds/${encodeURIComponent(mind)}/files/pending`);
 
     if (!res.ok) {
-      const data = (await res.json()) as { error?: string };
-      console.error(data.error ?? `Failed to list pending files: ${res.status}`);
+      console.error(await daemonErrorMessage(res, `Failed to list pending files: ${res.status}`));
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/chat/reject.ts
+++ b/packages/cli/src/commands/chat/reject.ts
@@ -1,5 +1,5 @@
 import { command } from "../../lib/command.js";
-import { daemonFetch } from "../../lib/daemon-client.js";
+import { daemonErrorMessage, daemonFetch } from "../../lib/daemon-client.js";
 import { resolveMindName } from "../../lib/resolve-mind-name.js";
 
 const cmd = command({
@@ -19,8 +19,7 @@ const cmd = command({
     });
 
     if (!res.ok) {
-      const data = (await res.json()) as { error?: string };
-      console.error(data.error ?? `Failed to reject file: ${res.status}`);
+      console.error(await daemonErrorMessage(res, `Failed to reject file: ${res.status}`));
       process.exit(1);
     }
 

--- a/packages/cli/src/lib/daemon-client.ts
+++ b/packages/cli/src/lib/daemon-client.ts
@@ -144,6 +144,25 @@ export function getAuthToken(): string | undefined {
   return process.env.VOLUTE_MIND_TOKEN ?? readCliSession()?.sessionId;
 }
 
+/**
+ * Extract a one-line error message from a failed daemon response. The daemon
+ * usually returns `{ error }` JSON, but a route miss (e.g. a wildcard swallowing
+ * a more-specific sibling) can return a text/plain body like "Not found".
+ * Parsing that as JSON throws SyntaxError; this reads the body once as text,
+ * prefers the JSON `error` field when present, and otherwise falls back to the
+ * raw text (or `fallback` when the body is empty). Never throws.
+ */
+export async function daemonErrorMessage(res: Response, fallback: string): Promise<string> {
+  const text = await res.text().catch(() => "");
+  if (!text) return fallback;
+  try {
+    const data = JSON.parse(text) as { error?: string };
+    return data.error ?? text;
+  } catch {
+    return text;
+  }
+}
+
 export async function daemonFetch(path: string, options?: RequestInit): Promise<Response> {
   const url = resolveDaemonUrl();
   const headers = new Headers(options?.headers);

--- a/packages/daemon/src/web/app.ts
+++ b/packages/daemon/src/web/app.ts
@@ -153,10 +153,16 @@ const v1 = new Hono<AuthEnv>()
   .route("/minds", logs)
   .route("/minds", typing)
   .route("/minds", variants)
+  // fileSharing must mount before files: the admin file-browser registers the
+  // wildcard GET /minds/:name/files/* (files.ts), and Hono dispatches to the
+  // first matching route, so any more-specific sibling like GET
+  // /minds/:name/files/pending has to be registered first or the wildcard
+  // swallows it (#900 re-ordering regression). The admin file-browser wildcard
+  // must stay last among /minds/:name/files/* registrants; test/route-shadowing.test.ts guards this.
+  .route("/minds", fileSharing)
   .route("/minds", files)
   .route("/minds", envRoutes)
   .route("/minds", mindSkills)
-  .route("/minds", fileSharing)
   .route("/minds", channels)
   .route("/minds", conversations)
   .route("/env", sharedEnvApp)

--- a/test/route-shadowing.test.ts
+++ b/test/route-shadowing.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { eq, like } from "drizzle-orm";
+import { createUser } from "../packages/daemon/src/lib/auth.js";
+import { getDb } from "../packages/daemon/src/lib/db.js";
+import {
+  addMind,
+  mindDir,
+  removeMind,
+  stateDir,
+} from "../packages/daemon/src/lib/mind/registry.js";
+import { users } from "../packages/daemon/src/lib/schema.js";
+import app from "../packages/daemon/src/web/app.js";
+import { createSession } from "../packages/daemon/src/web/middleware/auth.js";
+
+// Hono exposes the composed route table in registration order. A route is
+// "shadowed" when an EARLIER, strictly-more-general registrant swallows it —
+// Hono dispatches to the first pattern that matches, so a wildcard/param
+// segment mounted first eats a more-specific literal sibling mounted later.
+// This is exactly the class of bug that made GET /minds/:name/files/pending
+// 404 after #900 re-ordered its module below the file-browser wildcard.
+type RouterRoute = { method: string; path: string };
+
+// Only concrete HTTP verbs are terminal handlers. Every method === "ALL" entry
+// in this app comes from app.use() cross-cutting middleware (there are no
+// .all() route handlers), which is broad by design and never a shadow.
+const CONCRETE_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
+
+// Intentional overlaps, if any ever exist: "<EARLIER method path> >> <LATER method path>".
+// A pair belongs here ONLY with a comment explaining why the earlier, more-general
+// route is meant to win. Do NOT add entries just to make the test pass — that
+// re-hides the bug this guards against. Currently there are none.
+const INTENTIONAL_SHADOWS = new Set<string>([]);
+
+/** Replace `:param`/`*` segments with fixed literals so a pattern becomes a concrete path. */
+function literalize(path: string): string {
+  return path
+    .split("/")
+    .map((seg) => (seg === "*" ? "_wild_" : seg.startsWith(":") ? "_param_" : seg))
+    .join("/");
+}
+
+/** Compile a Hono path pattern to a regex: `:param` → one segment, `*` → any suffix. */
+function toRegex(path: string): RegExp {
+  const parts = path.split("/").map((seg) => {
+    if (seg === "*") return "(?:.*)";
+    if (seg.startsWith(":")) return "[^/]+";
+    return seg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  });
+  return new RegExp(`^${parts.join("/")}$`);
+}
+
+/**
+ * Walk the composed route table and return each shadowing pair as a readable
+ * string. E shadows R when both are the same concrete method, E was registered
+ * first, E's pattern matches a concrete instance of R, and R's pattern does NOT
+ * match a concrete instance of E — i.e. E is strictly the more general of the
+ * two at the point where they overlap.
+ */
+function findShadows(routes: RouterRoute[]): string[] {
+  // Collapse the per-handler duplicates Hono emits (one row per middleware in a
+  // route's chain) to the first registration index of each (method, path).
+  const seen = new Set<string>();
+  const uniq: RouterRoute[] = [];
+  for (const r of routes) {
+    if (!CONCRETE_METHODS.has(r.method)) continue;
+    const key = `${r.method} ${r.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    uniq.push({ method: r.method, path: r.path });
+  }
+
+  const shadows: string[] = [];
+  for (let j = 0; j < uniq.length; j++) {
+    const R = uniq[j];
+    for (let i = 0; i < j; i++) {
+      const E = uniq[i];
+      if (E.method !== R.method || E.path === R.path) continue;
+      const eCoversR = toRegex(E.path).test(literalize(R.path));
+      const rCoversE = toRegex(R.path).test(literalize(E.path));
+      if (eCoversR && !rCoversE) {
+        const pair = `${E.method} ${E.path} >> ${R.method} ${R.path}`;
+        if (!INTENTIONAL_SHADOWS.has(pair)) {
+          shadows.push(`${E.method} ${E.path}  shadows  ${R.method} ${R.path}`);
+        }
+      }
+    }
+  }
+  return shadows;
+}
+
+describe("route shadowing", () => {
+  it("no earlier route shadows a more-specific sibling", () => {
+    const routes = (app as unknown as { routes: RouterRoute[] }).routes;
+    const shadows = findShadows(routes);
+    assert.deepEqual(
+      shadows,
+      [],
+      `Shadowed routes (earlier general route swallows a later specific one):\n  ${shadows.join(
+        "\n  ",
+      )}\nReorder the mounts so the specific route registers first, or (only if the ` +
+        "overlap is intentional) add the pair to INTENTIONAL_SHADOWS with a reason.",
+    );
+  });
+});
+
+describe("route shadowing — file-sharing reachability", () => {
+  const MIND = "rs-receiver";
+
+  async function cleanup() {
+    const db = await getDb();
+    await db.delete(users).where(like(users.username, "rs-admin-%"));
+    const dir = mindDir(MIND);
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+    const state = stateDir(MIND);
+    if (existsSync(state)) rmSync(state, { recursive: true });
+    try {
+      removeMind(MIND);
+    } catch {
+      // ignore
+    }
+  }
+
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("GET /api/v1/minds/:name/files/pending reaches the file-sharing handler, not the file-browser wildcard", async () => {
+    // Authenticate as an admin so requireSelf() on the file-sharing route passes.
+    const user = await createUser(`rs-admin-${Date.now()}`, "pass");
+    const db = await getDb();
+    await db.update(users).set({ role: "admin" }).where(eq(users.id, user.id));
+    const sessionId = await createSession(user.id);
+
+    await addMind(MIND, 14200);
+    mkdirSync(stateDir(MIND), { recursive: true });
+
+    const res = await app.request(`/api/v1/minds/${MIND}/files/pending`, {
+      headers: { Cookie: `volute_session=${sessionId}`, Origin: "http://localhost" },
+    });
+
+    // Before the fix this hit the wildcard GET /:name/files/* (file browser) and
+    // 404'd. The file-sharing handler returns the (empty) pending list as JSON.
+    assert.notEqual(res.status, 404, "pending listing was shadowed by the file-browser wildcard");
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body), "expected an array of pending files");
+  });
+});


### PR DESCRIPTION
## Summary

#900 (the prefix collapse) re-ordered the `/api/v1/minds` mounts so the admin file-browser wildcard `GET /:name/files/*` registered before the file-sharing sibling `GET /:name/files/pending`. Hono dispatches to the first matching route, so the wildcard swallowed the pending listing — breaking `volute chat files`, the documented way to see incoming file offers.

- `app.ts`: mount `fileSharing` before `files` so the specific route wins, with a comment pinning the constraint
- `test/route-shadowing.test.ts`: walk the composed app.routes table and fail on any earlier, strictly-more-general route that shadows a later specific sibling (catches this class, not just this path)
- CLI: `chat/files.ts`, `chat/accept.ts`, `chat/reject.ts` parsed the response body as JSON in the `!res.ok` branch, so a text/plain error ("Not found") became an uncaught SyntaxError. New `daemonErrorMessage()` helper reads the body once, prefers the JSON `error` field, and falls back to raw text

## Test plan

- [x] 3353/3353 tests green (2 new)
- [x] Fail-on-revert verified: reverting the `app.ts` mount order change causes `route shadowing` tests to fail with exact shadows named
- [x] Integration path: `GET /api/v1/minds/:name/files/pending` returns 200 + JSON array (not 404)

🤖 Generated with [Claude Code](https://claude.ai/code)